### PR TITLE
Fix thermal validation

### DIFF
--- a/antarest/storage/repository/filesystem/config/files.py
+++ b/antarest/storage/repository/filesystem/config/files.py
@@ -102,7 +102,7 @@ class ConfigPathBuilder:
         list_ini = IniReader().read(
             root / f"input/thermal/clusters/{area}/list.ini"
         )
-        return list(list_ini.keys())
+        return [key.lower() for key in list(list_ini.keys())]
 
     @staticmethod
     def _parse_links(root: Path, area: str) -> Dict[str, Link]:


### PR DESCRIPTION
In the examples (https://github.com/AntaresSimulatorTeam/Antares_Simulator_Examples/tree/master/024%20Hurdle%20costs%20-%201/input/thermal) it seems that the name of the cluster are lower cased