### PR TITLE
fix(api): scan endpoint serialization type

### DIFF
--- a/antarest/study/web/watcher_blueprint.py
+++ b/antarest/study/web/watcher_blueprint.py
@@ -40,7 +40,7 @@ def create_watcher_routes(
         "/watcher/_scan",
         summary="Launch scan in selected directory",
         tags=[APITag.study_raw_data],
-        response_model=List[str],
+        response_model=str,
     )
     def scan_dir(
         path: str,


### PR DESCRIPTION
When calling the scan endpoint, the api return an error since it tries to serialize a string into an json array.