### PR TITLE
fix(api-slurm): avoid raising FileNotFound error when retrieving outputs

### DIFF
--- a/antarest/study/storage/patch_service.py
+++ b/antarest/study/storage/patch_service.py
@@ -27,13 +27,12 @@ class PatchService:
         self, study: Union[RawStudy, VariantStudy], get_from_file: bool = False
     ) -> Patch:
         if not get_from_file:
-            try:
-                return Patch.parse_raw(study.additional_data.patch)
-            except Exception as e:
-                logger.warning("Failed to parse patch data", exc_info=e)
+            # the `study.additional_data.patch` field is optional
+            if patch_data := study.additional_data.patch:
+                return Patch.parse_raw(patch_data)
 
         patch = Patch()
-        patch_path = (Path(study.path)) / "patch.json"
+        patch_path = Path(study.path) / "patch.json"
         if patch_path.exists():
             patch = Patch.parse_file(patch_path)
 

--- a/tests/storage/business/test_patch_service.py
+++ b/tests/storage/business/test_patch_service.py
@@ -1,17 +1,26 @@
+import contextlib
 import json
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
-
+from antarest.core.model import PublicMode
+from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.study.model import (
+    DEFAULT_WORKSPACE_NAME,
     Patch,
-    PatchStudy,
     PatchArea,
     PatchOutputs,
+    PatchStudy,
+    RawStudy,
+    Study,
+    StudyAdditionalData,
 )
 from antarest.study.repository import StudyMetadataRepository
 from antarest.study.storage.patch_service import PatchService
+from tests.conftest import with_db_context
 
 PATCH_CONTENT = """ 
 {
@@ -37,60 +46,204 @@ PATCH_CONTENT = """
 
 
 @pytest.mark.unit_test
-def test_get(tmp_path: str):
-    patch_json_path = Path(tmp_path) / "patch.json"
-    patch_json_path.write_text(PATCH_CONTENT)
-    raw_study = Mock()
-    raw_study.path = tmp_path
+class TestPatchService:
+    @with_db_context
+    @pytest.mark.parametrize("get_from_file", [True, False])
+    @pytest.mark.parametrize("file_data", ["", PATCH_CONTENT])
+    @pytest.mark.parametrize("patch_data", ["", PATCH_CONTENT])
+    def test_get(
+        self,
+        tmp_path: Path,
+        get_from_file: bool,
+        file_data: str,
+        patch_data: str,
+    ):
+        study_id = str(uuid.uuid4())
 
-    expected_patch = Patch(
-        study=PatchStudy(scenario="BAU2025"),
-        areas={"a1": PatchArea(country="FR")},
-        outputs=PatchOutputs(reference="20210588-eco-1532"),
-    )
+        if file_data:
+            # create a "patch.json" file
+            patch_json = tmp_path.joinpath("patch.json")
+            patch_json.write_text(file_data, encoding="utf-8")
 
-    patch_service = PatchService(repository=Mock(spec=StudyMetadataRepository))
-    patch = patch_service.get(raw_study)
-    assert patch == expected_patch
+        # Prepare a RAW study
+        # noinspection PyArgumentList
+        raw_study = RawStudy(
+            id=study_id,
+            name="my_study",
+            workspace=DEFAULT_WORKSPACE_NAME,
+            path=str(tmp_path),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            version="840",
+            additional_data=StudyAdditionalData(
+                author="john.doe",
+                horizon="foo-horizon",
+                patch=patch_data,
+            ),
+            archived=False,
+            owner=None,
+            groups=[],
+            public_mode=PublicMode.NONE,
+        )
 
+        # Make sure the session is closed to avoid reusing DB objects
+        with contextlib.closing(db.session):
+            db.session.add(raw_study)
+            db.session.commit()
 
-@pytest.mark.unit_test
-def test_save(tmp_path: str):
-    patch = Patch(
-        study=PatchStudy(scenario="BAU2025"),
-        areas={"a1": PatchArea(country="FR")},
-        outputs=PatchOutputs(reference="20210588-eco-1532"),
-    )
-    expected_json = json.dumps(json.loads(PATCH_CONTENT))
+        # The study must be fetched from the database
+        raw_study: RawStudy = db.session.query(Study).get(study_id)
 
-    raw_study = Mock()
-    raw_study.path = tmp_path
+        # Create a PatchService which use a StudyMetadataRepository with a mocked cache
+        patch_service = PatchService(
+            repository=StudyMetadataRepository(Mock())
+        )
+        patch = patch_service.get(raw_study, get_from_file=get_from_file)
 
-    patch_service = PatchService(repository=Mock(spec=StudyMetadataRepository))
-    patch_service.save(raw_study, patch)
+        # check the result
+        if (get_from_file and file_data) or (
+            not get_from_file and (patch_data or file_data)
+        ):
+            expected_patch = Patch(
+                study=PatchStudy(scenario="BAU2025"),
+                areas={"a1": PatchArea(country="FR")},
+                outputs=PatchOutputs(reference="20210588-eco-1532"),
+            )
+        else:
+            expected_patch = Patch()
 
-    assert (Path(tmp_path) / "patch.json").read_text() == expected_json
+        assert patch == expected_patch
 
+    @with_db_context
+    def test_save(self, tmp_path):
+        study_id = str(uuid.uuid4())
 
-@pytest.mark.unit_test
-def test_set_output_ref(tmp_path: str):
-    patch = Patch(
-        study=PatchStudy(scenario="BAU2025"),
-        areas={"a1": PatchArea(country="FR")},
-        outputs=PatchOutputs(reference="20210588-eco-1532"),
-    )
+        # Prepare a RAW study
+        # noinspection PyArgumentList
+        raw_study = RawStudy(
+            id=study_id,
+            name="my_study",
+            workspace=DEFAULT_WORKSPACE_NAME,
+            path=str(tmp_path),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            version="840",
+            additional_data=StudyAdditionalData(
+                author="john.doe",
+                horizon="foo-horizon",
+                patch="",
+            ),
+            archived=False,
+            owner=None,
+            groups=[],
+            public_mode=PublicMode.NONE,
+        )
 
-    raw_study = Mock()
-    raw_study_patch = Patch(outputs=PatchOutputs(reference="some id"))
+        # Make sure the session is closed to avoid reusing DB objects
+        with contextlib.closing(db.session):
+            db.session.add(raw_study)
+            db.session.commit()
 
-    patch_service = PatchService(repository=Mock(spec=StudyMetadataRepository))
-    patch_service.get = Mock(return_value=raw_study_patch)
-    patch_service.save = Mock()
+        # The study must be fetched from the database
+        raw_study: RawStudy = db.session.query(Study).get(study_id)
 
-    expected = Patch(outputs=PatchOutputs(reference="output-id"))
-    patch_service.set_reference_output(raw_study, "output-id", True)
-    patch_service.save.assert_called_with(raw_study, expected)
+        # Create a PatchService which use a StudyMetadataRepository with a mocked cache
+        patch_service = PatchService(
+            repository=StudyMetadataRepository(Mock())
+        )
 
-    expected = Patch(outputs=PatchOutputs(reference=None))
-    patch_service.set_reference_output(raw_study, "output-id", False)
-    patch_service.save.assert_called_with(raw_study, expected)
+        patch = Patch(
+            study=PatchStudy(scenario="BAU2025"),
+            areas={"a1": PatchArea(country="FR")},
+            outputs=PatchOutputs(reference="20210588-eco-1532"),
+        )
+        patch_service.save(raw_study, patch)
+
+        # check the result
+        actual_obj = json.loads(
+            tmp_path.joinpath("patch.json").read_text(encoding="utf-8")
+        )
+        expected_obj = json.loads(PATCH_CONTENT)
+        assert actual_obj == expected_obj
+
+    @with_db_context
+    def test_set_output_ref(self, tmp_path: Path):
+        study_id = str(uuid.uuid4())
+
+        patch_outputs = PatchOutputs(reference="some id")
+
+        # Prepare a RAW study
+        # noinspection PyArgumentList
+        raw_study = RawStudy(
+            id=study_id,
+            name="my_study",
+            workspace=DEFAULT_WORKSPACE_NAME,
+            path=str(tmp_path),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            version="840",
+            additional_data=StudyAdditionalData(
+                author="john.doe",
+                horizon="foo-horizon",
+                patch=patch_outputs.json(),
+            ),
+            archived=False,
+            owner=None,
+            groups=[],
+            public_mode=PublicMode.NONE,
+        )
+
+        # Make sure the session is closed to avoid reusing DB objects
+        with contextlib.closing(db.session):
+            db.session.add(raw_study)
+            db.session.commit()
+
+        # The study must be fetched from the database
+        raw_study: RawStudy = db.session.query(Study).get(study_id)
+
+        # Create a PatchService which use a StudyMetadataRepository with a mocked cache
+        patch_service = PatchService(
+            repository=StudyMetadataRepository(Mock())
+        )
+
+        # run with status=True
+        patch_service.set_reference_output(raw_study, "output-id", status=True)
+
+        # check the result
+        actual_obj = json.loads(
+            tmp_path.joinpath("patch.json").read_text(encoding="utf-8")
+        )
+        expected_obj = json.loads(
+            """
+            {
+              "areas": null,
+              "outputs": {
+                "reference": "output-id"
+              },
+              "study": null,
+              "thermal_clusters": null
+            }
+            """
+        )
+        assert actual_obj == expected_obj
+
+        # run with status=False
+        patch_service.set_reference_output(
+            raw_study, "output-id", status=False
+        )
+        actual_obj = json.loads(
+            tmp_path.joinpath("patch.json").read_text(encoding="utf-8")
+        )
+        expected_obj = json.loads(
+            """
+            {
+              "areas": null,
+              "outputs": {
+                "reference": null
+              },
+              "study": null,
+              "thermal_clusters": null
+            }
+            """
+        )
+        assert actual_obj == expected_obj


### PR DESCRIPTION
Lorsqu'une simulation se termine par une erreur (erreur d'Antares Solver, Xpansion, Adequacy Patch...), Antares Web tente de récupérer le dossier `output' qui contient les résultats du calcul. Cependant, ceci n'est généralement pas possible car, en cas d'échec, il n'y a pas de résultats de calcul.

Le but de cette PR est d'éviter de lever l'exception `FileNotFoundError` lorsque le répertoire `output` n'existe pas. En revanche, en cas de succès, il est nécessaire de lever une exception afin de diagnostiquer l'origine de l'erreur.

