### PR TITLE
feat: standardize log messsage formats

### DIFF
--- a/antarest/main.py
+++ b/antarest/main.py
@@ -1,8 +1,7 @@
 import argparse
 import logging
-import sys
 from pathlib import Path
-from typing import Tuple, Any, Optional, Dict, cast
+from typing import Any, Dict, Optional, Tuple, cast
 
 import sqlalchemy.ext.baked  # type: ignore
 import uvicorn  # type: ignore
@@ -20,7 +19,7 @@ from starlette.templating import Jinja2Templates
 from antarest import __version__
 from antarest.core.config import Config
 from antarest.core.core_blueprint import create_utils_routes
-from antarest.core.logging.utils import configure_logger, LoggingMiddleware
+from antarest.core.logging.utils import LoggingMiddleware, configure_logger
 from antarest.core.requests import RATE_LIMIT_CONFIG
 from antarest.core.swagger import customize_openapi
 from antarest.core.utils.utils import get_local_path
@@ -33,14 +32,45 @@ from antarest.singleton_services import SingletonServices
 from antarest.study.storage.auto_archive_service import AutoArchiveService
 from antarest.study.storage.rawstudy.watcher import Watcher
 from antarest.tools.admin_lib import clean_locks
-from antarest.utils import (
-    Module,
-    get_default_config_path_or_raise,
-    init_db,
-    create_services,
-)
+from antarest.utils import Module, create_services, init_db
 
 logger = logging.getLogger(__name__)
+
+
+class PathType:
+    """file or directory path type for `argparse` parser"""
+
+    def __init__(
+        self, exists: bool = False, file_ok: bool = False, dir_ok: bool = False
+    ) -> None:
+        if not (file_ok or dir_ok):
+            msg = "Either `file_ok` or `dir_ok` must be set at a minimum."
+            raise ValueError(msg)
+        self.exists = exists
+        self.file_ok = file_ok
+        self.dir_ok = dir_ok
+
+    def __call__(self, string: str) -> Path:
+        file_path = Path(string).expanduser()
+        if not self.exists:
+            return file_path
+        if self.file_ok and self.dir_ok:
+            if file_path.exists():
+                return file_path
+            msg = f"The file or directory path does not exist: '{file_path}'"
+            raise argparse.ArgumentTypeError(msg)
+        elif self.file_ok:
+            if file_path.is_file():
+                return file_path
+            msg = f"The file path does not exist: '{file_path}'"
+            raise argparse.ArgumentTypeError(msg)
+        elif self.dir_ok:
+            if file_path.is_dir():
+                return file_path
+            msg = f"The directory path does not exist: '{file_path}'"
+            raise argparse.ArgumentTypeError(msg)
+        else:
+            raise NotImplementedError((self.file_ok, self.dir_ok))
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -48,66 +78,43 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "-c",
         "--config",
+        type=PathType(exists=True, file_ok=True),
         dest="config_file",
-        help="path to the config file",
+        help="path to the config file [default: '%(default)s']",
+        default="./config.yaml",
     )
     parser.add_argument(
         "-v",
         "--version",
-        dest="version",
-        help="Server version",
-        action="store_true",
-        required=False,
+        action="version",
+        help="Display the server version and exit",
+        version=__version__,
     )
     parser.add_argument(
         "--no-front",
         dest="no_front",
-        help="Not embed the front build",
+        help="Exclude the embedding of the front-end build",
         action="store_true",
-        required=False,
+        default=False,
     )
     parser.add_argument(
         "--auto-upgrade-db",
         dest="auto_upgrade_db",
         help="Automatically upgrade db",
         action="store_true",
-        required=False,
+        default=False,
     )
+    # noinspection PyUnresolvedReferences
     parser.add_argument(
         "--module",
+        type=Module,
         dest="module",
-        help="Select a module to run (default is the application server)",
+        help="Select a module to run [default: application server]",
         choices=[mod.value for mod in Module],
         action="store",
         default=Module.APP.value,
-        required=False,
     )
     return parser.parse_args()
-
-
-def get_arguments() -> Tuple[Path, bool, bool, bool, Module]:
-    arguments = parse_arguments()
-
-    display_version = arguments.version or False
-    if display_version:
-        return (
-            Path("."),
-            display_version,
-            arguments.no_front,
-            arguments.auto_upgrade_db,
-            Module.APP,
-        )
-
-    config_file = Path(
-        arguments.config_file or get_default_config_path_or_raise()
-    )
-    return (
-        config_file,
-        display_version,
-        arguments.no_front,
-        arguments.auto_upgrade_db,
-        Module(arguments.module),
-    )
 
 
 def fastapi_app(
@@ -179,8 +186,8 @@ def fastapi_app(
 
     @application.on_event("startup")
     def set_default_executor() -> None:
-        from concurrent.futures import ThreadPoolExecutor
         import asyncio
+        from concurrent.futures import ThreadPoolExecutor
 
         loop = asyncio.get_running_loop()
         loop.set_default_executor(
@@ -273,27 +280,21 @@ def fastapi_app(
     return application, services
 
 
-if __name__ == "__main__":
-    (
-        config_file,
-        display_version,
-        no_front,
-        auto_upgrade_db,
-        module,
-    ) = get_arguments()
-
-    if display_version:
-        print(__version__)
-        sys.exit()
+def main() -> None:
+    arguments = parse_arguments()
+    if arguments.module == Module.APP:
+        clean_locks(arguments.config_file)
+        app = fastapi_app(
+            arguments.config_file,
+            mount_front=not arguments.no_front,
+            auto_upgrade_db=arguments.auto_upgrade_db,
+        )[0]
+        # noinspection PyTypeChecker
+        uvicorn.run(app, host="0.0.0.0", port=8080)
     else:
-        if module == Module.APP:
-            clean_locks(config_file)
-            app, _ = fastapi_app(
-                config_file,
-                mount_front=not no_front,
-                auto_upgrade_db=auto_upgrade_db,
-            )
-            uvicorn.run(app, host="0.0.0.0", port=8080)
-        else:
-            services = SingletonServices(config_file, [module])
-            services.start()
+        services = SingletonServices(arguments.config_file, [arguments.module])
+        services.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -38,10 +38,38 @@ logger = logging.getLogger(__name__)
 
 
 class PathType:
-    """file or directory path type for `argparse` parser"""
+    """file or directory path type for `argparse` parser
+
+    The `PathType` class represents a type of argument that can be used
+    with the `argparse` library.
+    This class takes three boolean arguments, `exists`, `file_ok`, and `dir_ok`,
+    which specify whether the path argument must exist, whether it can be a file,
+    and whether it can be a directory, respectively.
+
+    Example Usage:
+
+    ```python
+    import argparse
+    from antarest.main import PathType
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input', type=PathType(file_ok=True, exists=True))
+    args = parser.parse_args()
+
+    print(args.input)
+    ```
+
+    In the above example, `PathType` is used to specify the type of the `--input`
+    argument for the `argparse` parser. The argument must be an existing file path.
+    If the given path is not an existing file, the argparse library raises an error.
+    The Path object representing the given path is then printed to the console.
+    """
 
     def __init__(
-        self, exists: bool = False, file_ok: bool = False, dir_ok: bool = False
+        self,
+        exists: bool = False,
+        file_ok: bool = False,
+        dir_ok: bool = False,
     ) -> None:
         if not (file_ok or dir_ok):
             msg = "Either `file_ok` or `dir_ok` must be set at a minimum."
@@ -51,6 +79,25 @@ class PathType:
         self.dir_ok = dir_ok
 
     def __call__(self, string: str) -> Path:
+        """
+        Check whether the given string represents a valid path.
+
+        If `exists` is `False`, the method simply returns the given path.
+        If `exists` is True, it checks whether the path exists and whether it is
+        a file or a directory, depending on the values of `file_ok` and `dir_ok`.
+        If the path exists and is of the correct type, the method returns the path;
+        otherwise, it raises an :class:`argparse.ArgumentTypeError` with an
+        appropriate error message.
+
+        Args:
+            string: file or directory path
+
+        Returns:
+            the file or directory path
+
+        Raises
+            argparse.ArgumentTypeError: if the path is invalid
+        """
         file_path = Path(string).expanduser()
         if not self.exists:
             return file_path
@@ -62,14 +109,20 @@ class PathType:
         elif self.file_ok:
             if file_path.is_file():
                 return file_path
-            msg = f"The file path does not exist: '{file_path}'"
+            elif file_path.exists():
+                msg = f"The path is not a regular file: '{file_path}'"
+            else:
+                msg = f"The file path does not exist: '{file_path}'"
             raise argparse.ArgumentTypeError(msg)
         elif self.dir_ok:
             if file_path.is_dir():
                 return file_path
-            msg = f"The directory path does not exist: '{file_path}'"
+            elif file_path.exists():
+                msg = f"The path is not a directory: '{file_path}'"
+            else:
+                msg = f"The directory path does not exist: '{file_path}'"
             raise argparse.ArgumentTypeError(msg)
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError((self.file_ok, self.dir_ok))
 
 

--- a/antarest/singleton_services.py
+++ b/antarest/singleton_services.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import Dict, List
 
 from antarest.core.config import Config
 from antarest.core.interfaces.service import IService
@@ -10,12 +10,12 @@ from antarest.core.utils.utils import get_local_path
 from antarest.study.storage.auto_archive_service import AutoArchiveService
 from antarest.utils import (
     Module,
-    init_db,
-    create_watcher,
-    create_matrix_gc,
     create_archive_worker,
     create_core_services,
+    create_matrix_gc,
     create_simulator_worker,
+    create_watcher,
+    init_db,
 )
 
 logger = logging.getLogger(__name__)

--- a/antarest/utils.py
+++ b/antarest/utils.py
@@ -1,7 +1,7 @@
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import Tuple, Any, Optional, Dict
+from typing import Any, Dict, Optional, Tuple
 
 import redis
 import sqlalchemy.ext.baked  # type: ignore
@@ -26,11 +26,7 @@ from antarest.core.persistence import upgrade_db
 from antarest.core.tasks.main import build_taskjob_manager
 from antarest.core.tasks.service import ITaskService
 from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware
-from antarest.core.utils.utils import (
-    get_default_config_path,
-    get_local_path,
-    new_redis_instance,
-)
+from antarest.core.utils.utils import get_local_path, new_redis_instance
 from antarest.eventbus.main import build_eventbus
 from antarest.launcher.main import build_launcher
 from antarest.login.main import build_login
@@ -59,15 +55,6 @@ class Module(str, Enum):
     ARCHIVE_WORKER = "archive_worker"
     AUTO_ARCHIVER = "auto_archiver"
     SIMULATOR_WORKER = "simulator_worker"
-
-
-def get_default_config_path_or_raise() -> Path:
-    config_path = get_default_config_path()
-    if not config_path:
-        raise ValueError(
-            "Config file not found. Set it by '-c' with command line or place it at ./config.yaml, ../config.yaml or ~/.antares/config.yaml"
-        )
-    return config_path
 
 
 def init_db(


### PR DESCRIPTION
Avec cette modification, les messages auront le même format, par exemple:

```text
[2023-03-29 15:26:57,025] [47926] [antarest.matrixstore.matrix_garbage_collector] - None - MatrixGarbageCollector - None - None - INFO - Getting all matrices used in datasets
[2023-03-29 15:26:57,026] [47926] [antarest.matrixstore.matrix_garbage_collector] - None - MatrixGarbageCollector - None - None - INFO - Deleting unused saved matrices:
[2023-03-29 15:26:57,026] [47926] [antarest.matrixstore.matrix_garbage_collector] - None - MatrixGarbageCollector - None - None - INFO - Finished cleaning matrices in 0.0054471492767333984s
[2023-03-29 15:26:57,026] [47926] [antarest.matrixstore.matrix_garbage_collector] - None - MatrixGarbageCollector - None - None - INFO - Sleeping for 3600s
[2023-03-29 15:26:57,046] [47926] INFO:      Started server process [47926]
[2023-03-29 15:26:57,046] [47926] INFO:      Waiting for application startup.
[2023-03-29 15:26:57,046] [47926] INFO:      Application startup complete.
[2023-03-29 15:26:57,047] [47926] INFO:      Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
[2023-03-29 15:26:57,046] [47926] [uvicorn.error] - None - MainThread - None - None - INFO - Started server process [47926]
[2023-03-29 15:26:57,046] [47926] [uvicorn.error] - None - MainThread - None - None - INFO - Waiting for application startup.
[2023-03-29 15:26:57,046] [47926] [uvicorn.error] - None - MainThread - None - None - INFO - Application startup complete.
[2023-03-29 15:26:57,047] [47926] [uvicorn.error] - None - MainThread - None - None - INFO - Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```
