### PR TITLE
fix(api): fix uncaught exceptions in slurm launcher loop

### DIFF
--- a/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
+++ b/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
@@ -148,7 +148,13 @@ class SlurmLauncher(AbstractLauncher):
 
     def _loop(self) -> None:
         while self.check_state:
-            self._check_studies_state()
+            try:
+                self._check_studies_state()
+            except Exception:
+                logger.error(
+                    "An uncaught exception occurred in slurm_launcher loop",
+                    exc_info=True,
+                )
             time.sleep(2)
 
     def start(self) -> None:
@@ -406,7 +412,6 @@ class SlurmLauncher(AbstractLauncher):
                 study.name, JobStatus.FAILED, msg, None
             )
             logger.error(msg, exc_info=e)
-            raise
         else:
             msg = "Simulation failed (even if some output results may be available)"
             self.callbacks.append_after_log(study.name, msg)
@@ -444,7 +449,6 @@ class SlurmLauncher(AbstractLauncher):
                 study.name, JobStatus.FAILED, msg, None
             )
             logger.error(msg, exc_info=e)
-            raise
         else:
             self.callbacks.update_status(
                 study.name, JobStatus.SUCCESS, None, output_id


### PR DESCRIPTION
**Description**

Fixes #1476.
In order to avoid the end of monitoring loopt:
- Exceptions are caught in result handling
- As a last resort, all exceptions are caught in the monitoring loop