### PR TITLE
feat(backend): Demonstrate metrics

### DIFF
--- a/antarest/core/config.py
+++ b/antarest/core/config.py
@@ -621,11 +621,7 @@ class MetricsConfig:
 
     @classmethod
     def from_dict(cls, data: JSON) -> "MetricsConfig":
-        return cls(
-            prometheus=PrometheusConfig.from_dict(data["prometheus"])
-            if "prometheus" in data
-            else None
-        )
+        return cls(prometheus=PrometheusConfig.from_dict(data["prometheus"]) if "prometheus" in data else None)
 
 
 @dataclass(frozen=True)

--- a/antarest/core/config.py
+++ b/antarest/core/config.py
@@ -599,6 +599,36 @@ class ServerConfig:
 
 
 @dataclass(frozen=True)
+class PrometheusConfig:
+    """
+    Sub config object dedicated to prometheus metrics
+    """
+
+    multiprocess: bool = False
+
+    @classmethod
+    def from_dict(cls, data: JSON) -> "PrometheusConfig":
+        return cls(multiprocess=bool(data["multiprocess"]))
+
+
+@dataclass(frozen=True)
+class MetricsConfig:
+    """
+    Sub config object dedicated to metrics
+    """
+
+    prometheus: Optional[PrometheusConfig] = None
+
+    @classmethod
+    def from_dict(cls, data: JSON) -> "MetricsConfig":
+        return cls(
+            prometheus=PrometheusConfig.from_dict(data["prometheus"])
+            if "prometheus" in data
+            else None
+        )
+
+
+@dataclass(frozen=True)
 class Config:
     """
     Root server config
@@ -616,6 +646,7 @@ class Config:
     eventbus: EventBusConfig = EventBusConfig()
     cache: CacheConfig = CacheConfig()
     tasks: TaskConfig = TaskConfig()
+    metrics: MetricsConfig = MetricsConfig()
     root_path: str = ""
     api_prefix: str = ""
     desktop_mode: bool = False
@@ -645,6 +676,7 @@ class Config:
             root_path=data.get("root_path", defaults.root_path),
             api_prefix=data.get("api_prefix", defaults.api_prefix),
             desktop_mode=desktop_mode,
+            metrics=MetricsConfig.from_dict(data["metrics"]) if "metrics" in data else MetricsConfig(),
         )
 
     @classmethod

--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -847,3 +847,10 @@ class OutputAggregationError(HTTPException):
     def __init__(self, output_id: str, message: str) -> None:
         msg = f"Could not aggregate output data for output '{output_id}' : {message}."
         super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, msg)
+
+
+class ConfigurationError(RuntimeError):
+    """
+    Raised when some configuration is invalid.
+    """
+    pass

--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -853,4 +853,5 @@ class ConfigurationError(RuntimeError):
     """
     Raised when some configuration is invalid.
     """
+
     pass

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -25,9 +25,9 @@ from prometheus_client import (
     make_asgi_app,
     multiprocess,
 )
-from sqlalchemy import Pool, PoolProxiedConnection
+from sqlalchemy import Engine, Pool, PoolProxiedConnection
 from sqlalchemy.event import listens_for
-from sqlalchemy.orm import Session, SessionTransaction
+from sqlalchemy.orm import Session, SessionTransaction, sessionmaker
 from sqlalchemy.pool import ConnectionPoolEntry
 from starlette.requests import Request
 from typing_extensions import override
@@ -52,10 +52,11 @@ def _add_db_metrics(registry: CollectorRegistry = prometheus_client.REGISTRY) ->
     _add_db_session_metrics(registry)
 
 
-def _add_db_connection_metrics(registry: CollectorRegistry) -> None:
+def _add_db_connection_metrics(registry: CollectorRegistry, engine: Engine | None = None) -> None:
     """
     Register connection-level (low level) DB metrics
     """
+    target = engine or Pool
 
     dbconn_durations_histo = Histogram(
         "dbconn_duration_seconds",
@@ -88,7 +89,7 @@ def _add_db_connection_metrics(registry: CollectorRegistry) -> None:
 
     dbconn_gauge.labels(WORKER_ID).set(0)
 
-    @listens_for(Pool, "checkin")
+    @listens_for(target, "checkin")
     def on_checkin(dbapi_con: Any, connection_record: ConnectionPoolEntry) -> None:
         checkin_counter.labels(WORKER_ID).inc()
         try:
@@ -99,7 +100,7 @@ def _add_db_connection_metrics(registry: CollectorRegistry) -> None:
 
         dbconn_durations_histo.labels(WORKER_ID).observe(time.time() - start_time)
 
-    @listens_for(Pool, "checkout")
+    @listens_for(target, "checkout")
     def on_checkout(
         dbapi_con: Any, connection_record: ConnectionPoolEntry, connection_proxy: PoolProxiedConnection
     ) -> None:
@@ -109,23 +110,20 @@ def _add_db_connection_metrics(registry: CollectorRegistry) -> None:
         connection_record.info["start_time"] = time.time()
 
 
-def _add_db_session_metrics(registry: CollectorRegistry) -> None:
+def _add_db_session_metrics(registry: CollectorRegistry, session_factory: sessionmaker[Session] | None = None) -> None:
     """
-    Register ORM-level DB metrics
+    Register ORM-level DB metrics:
+     -
     """
+    target = session_factory or Session
 
-    transaction_create_counter = Counter(
-        "transaction_create_count",
-        "Transaction creations",
+    transactions_current_gauge = Gauge(
+        "transaction_current",
+        "Transaction in progress",
         ["worker_id"],
         registry=registry,
     )
-    transaction_end_counter = Counter(
-        "transaction_end_count",
-        "Transaction ends",
-        ["worker_id"],
-        registry=registry,
-    )
+    transactions_current_gauge.labels(WORKER_ID).set(0)
 
     transaction_duration_histo = Histogram(
         "transaction_duration_seconds",
@@ -141,26 +139,26 @@ def _add_db_session_metrics(registry: CollectorRegistry) -> None:
         registry=registry,
     )
 
-    @listens_for(Session, "after_begin")
+    @listens_for(target, "after_begin")
     def after_begin(session: Session, connection: Any, transaction: Any) -> None:
         events_counter.labels(WORKER_ID, "begin").inc()
 
-    @listens_for(Session, "after_commit")
+    @listens_for(target, "after_commit")
     def after_commit(session: Session) -> None:
         events_counter.labels(WORKER_ID, "commit").inc()
 
-    @listens_for(Session, "after_rollback")
+    @listens_for(target, "after_rollback")
     def after_rollback(session: Session) -> None:
         events_counter.labels(WORKER_ID, "rollback").inc()
 
-    @listens_for(Session, "after_transaction_create")
+    @listens_for(target, "after_transaction_create")
     def after_transaction_create(session: Session, transaction: SessionTransaction) -> None:
-        transaction_create_counter.labels(WORKER_ID).inc()
+        transactions_current_gauge.labels(WORKER_ID).inc()
         session.info["start_time"] = time.time()
 
-    @listens_for(Session, "after_transaction_end")
+    @listens_for(target, "after_transaction_end")
     def after_transaction_end(session: Session, transaction: SessionTransaction) -> None:
-        transaction_end_counter.labels(WORKER_ID).inc()
+        transactions_current_gauge.labels(WORKER_ID).dec()
         if "start_time" in session.info:
             transaction_duration_histo.labels(WORKER_ID).observe(time.time() - session.info["start_time"])
             del session.info["start_time"]

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -1,0 +1,91 @@
+import logging
+import os
+import time
+
+import prometheus_client
+from fastapi import FastAPI
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Histogram,
+    make_asgi_app,
+)
+from prometheus_client import multiprocess
+from starlette.requests import Request
+
+from antarest.core.config import Config
+from antarest.core.exceptions import ConfigurationError
+
+logger = logging.getLogger(__name__)
+
+
+_PROMETHEUS_MULTIPROCESS_ENV_VAR = "PROMETHEUS_MULTIPROC_DIR"
+
+
+def _add_metrics_middleware(
+    application: FastAPI, registry: CollectorRegistry, worker_id: str
+):
+    """
+    Registers an HTTP middleware to report metrics about requests count and duration
+    """
+
+    request_counter = Counter(
+        "request_count",
+        "App Request Count",
+        ["worker_id", "method", "endpoint", "http_status"],
+        registry=registry,
+    )
+    request_duration_histo = Histogram(
+        "request_duration_seconds",
+        "Request duration",
+        ["worker_id", "method", "endpoint", "http_status"],
+        registry=registry,
+    )
+
+    @application.middleware("http")
+    async def add_metrics(request: Request, call_next):
+        start_time = time.time()
+        response = await call_next(request)
+        process_time = time.time() - start_time
+
+        if "route" in request.scope:
+            request_path = (
+                request.scope["root_path"] + request.scope["route"].path
+            )
+        else:
+            request_path = request.url.path
+
+        request_counter.labels(
+            worker_id, request.method, request_path, response.status_code
+        ).inc()
+        request_duration_histo.labels(
+            worker_id, request.method, request_path, response.status_code
+        ).observe(process_time)
+        return response
+
+
+def add_metrics(application: FastAPI, config: Config) -> None:
+    """
+    If configured, adds "/metrics" endpoint to report metrics to prometheus.
+    Also registers metrics for HTTP requests.
+    """
+    prometheus_config = config.metrics.prometheus
+    if not prometheus_config:
+        return
+
+    if prometheus_config.multiprocess:
+        if _PROMETHEUS_MULTIPROCESS_ENV_VAR not in os.environ:
+            raise ConfigurationError(
+                f"Environment variable {_PROMETHEUS_MULTIPROCESS_ENV_VAR} must be defined for use of prometheus in a multiprocess environment"
+            )
+        registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(registry)
+        worker_id = os.environ["APP_WORKER_ID"]
+    else:
+        registry = prometheus_client.REGISTRY
+        worker_id = "0"
+
+    metrics_app = make_asgi_app(registry=registry)
+    application.mount("/metrics", metrics_app)
+
+    _add_metrics_middleware(application, registry, worker_id)

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -68,19 +68,20 @@ def add_metrics(application: FastAPI, config: Config) -> None:
     if not prometheus_config:
         return
 
+    process_registry = prometheus_client.REGISTRY
     if prometheus_config.multiprocess:
         if _PROMETHEUS_MULTIPROCESS_ENV_VAR not in os.environ:
             raise ConfigurationError(
                 f"Environment variable {_PROMETHEUS_MULTIPROCESS_ENV_VAR} must be defined for use of prometheus in a multiprocess environment"
             )
-        registry = CollectorRegistry(auto_describe=True)
-        multiprocess.MultiProcessCollector(registry)  # type: ignore
+        global_registry = CollectorRegistry(auto_describe=True)
+        multiprocess.MultiProcessCollector(process_registry)  # type: ignore
         worker_id = str(os.getpid())
     else:
-        registry = prometheus_client.REGISTRY
+        global_registry = prometheus_client.REGISTRY
         worker_id = "0"
 
-    metrics_app = make_asgi_app(registry=registry)
+    metrics_app = make_asgi_app(registry=global_registry)
     application.mount("/metrics", metrics_app)
 
-    _add_metrics_middleware(application, registry, worker_id)
+    _add_metrics_middleware(application, process_registry, worker_id)

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
 import logging
 import os
 import time
@@ -8,22 +20,152 @@ from fastapi import FastAPI
 from prometheus_client import (
     CollectorRegistry,
     Counter,
+    Gauge,
     Histogram,
     make_asgi_app,
     multiprocess,
 )
+from sqlalchemy import Pool, PoolProxiedConnection
+from sqlalchemy.event import listens_for
+from sqlalchemy.orm import Session, SessionTransaction
+from sqlalchemy.pool import ConnectionPoolEntry
 from starlette.requests import Request
+from typing_extensions import override
 
 from antarest.core.config import Config
 from antarest.core.exceptions import ConfigurationError
+from antarest.core.tasks.service import TaskServiceListener
 
 logger = logging.getLogger(__name__)
 
 
 _PROMETHEUS_MULTIPROCESS_ENV_VAR = "PROMETHEUS_MULTIPROC_DIR"
 
+WORKER_ID = str(os.getpid())
 
-def _add_metrics_middleware(application: FastAPI, registry: CollectorRegistry, worker_id: str) -> None:
+
+def _add_db_metrics() -> None:
+    """
+    Registers metrics related to database activity.
+    """
+    _add_db_connection_metrics()
+    _add_db_session_metrics()
+
+
+def _add_db_connection_metrics() -> None:
+    """
+    Register connection-level (low level) DB metrics
+    """
+
+    dbconn_durations_histo = Histogram(
+        "dbconn_duration_seconds",
+        "DB connection duration",
+        ["worker_id"],
+        registry=prometheus_client.REGISTRY,
+    )
+
+    dbconn_gauge = Gauge(
+        "dbconn_in_use",
+        "DB connection count",
+        ["worker_id"],
+        registry=prometheus_client.REGISTRY,
+    )
+
+    checkout_counter = Counter(
+        "dbconn_checkout_count",
+        "DB connection checkouts",
+        ["worker_id"],
+        registry=prometheus_client.REGISTRY,
+    )
+
+    checkin_counter = Counter(
+        "dbconn_checkin_count",
+        "DB connection checkins",
+        ["worker_id"],
+        registry=prometheus_client.REGISTRY,
+    )
+
+    dbconn_gauge.labels(WORKER_ID).set(0)
+
+    @listens_for(Pool, "checkin")
+    def on_checkin(dbapi_con: Any, connection_record: ConnectionPoolEntry) -> None:
+        checkin_counter.labels(WORKER_ID).inc()
+        try:
+            start_time = connection_record.info["start_time"]
+        except KeyError:
+            return
+        dbconn_gauge.labels(WORKER_ID).dec()
+
+        dbconn_durations_histo.labels(WORKER_ID).observe(time.time() - start_time)
+
+    @listens_for(Pool, "checkout")
+    def on_checkout(
+        dbapi_con: Any, connection_record: ConnectionPoolEntry, connection_proxy: PoolProxiedConnection
+    ) -> None:
+        checkout_counter.labels(WORKER_ID).inc()
+        dbconn_gauge.labels(WORKER_ID).inc()
+
+        connection_record.info["start_time"] = time.time()
+
+
+def _add_db_session_metrics() -> None:
+    """
+    Register ORM-level DB metrics
+    """
+
+    transaction_create_counter = Counter(
+        "transaction_create_count",
+        "Transaction creations",
+        ["worker_id"],
+        registry=prometheus_client.REGISTRY,
+    )
+    transaction_end_counter = Counter(
+        "transaction_end_count",
+        "Transaction ends",
+        ["worker_id"],
+        registry=prometheus_client.REGISTRY,
+    )
+
+    transaction_duration_histo = Histogram(
+        "transaction_duration_seconds",
+        "Transaction ends",
+        ["worker_id"],
+        registry=prometheus_client.REGISTRY,
+    )
+
+    events_counter = Counter(
+        "dbsession_events",
+        "Begins counter",
+        ["worker_id", "event_type"],
+        registry=prometheus_client.REGISTRY,
+    )
+
+    @listens_for(Session, "after_begin")
+    def after_begin(session: Session, connection: Any, transaction: Any) -> None:
+        events_counter.labels(WORKER_ID, "begin").inc()
+
+    @listens_for(Session, "after_begin")
+    def after_commit(session: Session, connection: Any, transaction: Any) -> None:
+        events_counter.labels(WORKER_ID, "commit").inc()
+
+    @listens_for(Session, "after_begin")
+    def after_rollbacks(session: Session, connection: Any, transaction: Any) -> None:
+        events_counter.labels(WORKER_ID, "rollback").inc()
+
+    @listens_for(Session, "after_transaction_create")
+    def after_transaction_create(session: Session, transaction: SessionTransaction) -> None:
+        transaction_create_counter.labels(WORKER_ID).inc()
+        session.info["start_time"] = time.time()
+
+    @listens_for(Session, "after_transaction_end")
+    def after_transaction_end(session: Session, transaction: SessionTransaction) -> None:
+        transaction_end_counter.labels(WORKER_ID).inc()
+        if "start_time" in session.info:
+            transaction_duration_histo.labels(WORKER_ID).observe(time.time() - session.info["start_time"])
+            del session.info["start_time"]
+
+
+def _add_metrics_middleware(application: FastAPI) -> None:
     """
     Registers an HTTP middleware to report metrics about requests count and duration
     """
@@ -32,13 +174,13 @@ def _add_metrics_middleware(application: FastAPI, registry: CollectorRegistry, w
         "request_count",
         "App Request Count",
         ["worker_id", "method", "endpoint", "http_status"],
-        registry=registry,
+        registry=prometheus_client.REGISTRY,
     )
     request_duration_histo = Histogram(
         "request_duration_seconds",
         "Request duration",
         ["worker_id", "method", "endpoint", "http_status"],
-        registry=registry,
+        registry=prometheus_client.REGISTRY,
     )
 
     @application.middleware("http")
@@ -52,8 +194,8 @@ def _add_metrics_middleware(application: FastAPI, registry: CollectorRegistry, w
         else:
             request_path = request.url.path
 
-        request_counter.labels(worker_id, request.method, request_path, response.status_code).inc()
-        request_duration_histo.labels(worker_id, request.method, request_path, response.status_code).observe(
+        request_counter.labels(WORKER_ID, request.method, request_path, response.status_code).inc()
+        request_duration_histo.labels(WORKER_ID, request.method, request_path, response.status_code).observe(
             process_time
         )
         return response
@@ -68,7 +210,8 @@ def add_metrics(application: FastAPI, config: Config) -> None:
     if not prometheus_config:
         return
 
-    process_registry = prometheus_client.REGISTRY
+    prometheus_client.disable_created_metrics()  # type: ignore
+
     if prometheus_config.multiprocess:
         if _PROMETHEUS_MULTIPROCESS_ENV_VAR not in os.environ:
             raise ConfigurationError(
@@ -76,12 +219,65 @@ def add_metrics(application: FastAPI, config: Config) -> None:
             )
         global_registry = CollectorRegistry(auto_describe=True)
         multiprocess.MultiProcessCollector(global_registry)  # type: ignore
-        worker_id = str(os.getpid())
     else:
         global_registry = prometheus_client.REGISTRY
-        worker_id = "0"
 
     metrics_app = make_asgi_app(registry=global_registry)
     application.mount("/metrics", metrics_app)
 
-    _add_metrics_middleware(application, process_registry, worker_id)
+    _add_metrics_middleware(application)
+    _add_db_metrics()
+
+
+class TasksMetricsRecorder(TaskServiceListener):
+    """
+    Exports metrics for tasks: wait time before execution, duration, ...
+    """
+
+    def __init__(self, registry: CollectorRegistry) -> None:
+        self._duration_histo = Histogram(
+            "tasks_duration_seconds",
+            "Tasks duration in seconds",
+            ["worker_id"],
+            registry=registry,
+        )
+        self._wait_time_histo = Histogram(
+            "tasks_wait_seconds",
+            "Tasks duration in seconds",
+            ["worker_id"],
+            registry=registry,
+        )
+        self._running_gauge = Gauge(
+            "tasks_running",
+            "Count of running tasks",
+            ["worker_id"],
+            registry=registry,
+        )
+        self._pending_gauge = Gauge(
+            "tasks_pending",
+            "Count of pending tasks",
+            ["worker_id"],
+            registry=registry,
+        )
+
+        self._submit_times: dict[str, float] = {}
+        self._start_times: dict[str, float] = {}
+
+    @override
+    def on_task_submit(self, task_id: str) -> None:
+        self._pending_gauge.labels(WORKER_ID).inc()
+        self._submit_times[task_id] = time.time()
+
+    @override
+    def on_task_start(self, task_id: str) -> None:
+        self._pending_gauge.labels(WORKER_ID).dec()
+        self._running_gauge.labels(WORKER_ID).inc()
+        self._wait_time_histo.labels(WORKER_ID).observe(time.time() - self._submit_times[task_id])
+        del self._submit_times[task_id]
+        self._start_times[task_id] = time.time()
+
+    @override
+    def on_task_end(self, task_id: str) -> None:
+        self._running_gauge.labels(WORKER_ID).dec()
+        self._duration_histo.labels(WORKER_ID).observe(time.time() - self._start_times[task_id])
+        del self._start_times[task_id]

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -75,7 +75,7 @@ def add_metrics(application: FastAPI, config: Config) -> None:
                 f"Environment variable {_PROMETHEUS_MULTIPROCESS_ENV_VAR} must be defined for use of prometheus in a multiprocess environment"
             )
         global_registry = CollectorRegistry(auto_describe=True)
-        multiprocess.MultiProcessCollector(process_registry)  # type: ignore
+        multiprocess.MultiProcessCollector(global_registry)  # type: ignore
         worker_id = str(os.getpid())
     else:
         global_registry = prometheus_client.REGISTRY

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -69,6 +69,7 @@ def _add_db_connection_metrics(registry: CollectorRegistry, engine: Engine | Non
         "dbconn_in_use",
         "DB connection count",
         ["worker_id"],
+        multiprocess_mode="liveall",
         registry=registry,
     )
     dbconn_gauge.labels(WORKER_ID).set(0)
@@ -121,6 +122,7 @@ def _add_db_session_metrics(registry: CollectorRegistry, session_factory: sessio
         "transaction_current",
         "Transaction in progress",
         ["worker_id"],
+        multiprocess_mode="liveall",
         registry=registry,
     )
     transactions_current_gauge.labels(WORKER_ID).set(0)
@@ -250,12 +252,14 @@ class TasksMetricsRecorder(TaskServiceListener):
             "tasks_running",
             "Count of running tasks",
             ["worker_id"],
+            multiprocess_mode="liveall",
             registry=registry,
         )
         self._pending_gauge = Gauge(
             "tasks_pending",
             "Count of pending tasks",
             ["worker_id"],
+            multiprocess_mode="liveall",
             registry=registry,
         )
 

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+from typing import Any
 
 import prometheus_client
 from fastapi import FastAPI
@@ -9,8 +10,8 @@ from prometheus_client import (
     Counter,
     Histogram,
     make_asgi_app,
+    multiprocess,
 )
-from prometheus_client import multiprocess
 from starlette.requests import Request
 
 from antarest.core.config import Config
@@ -22,9 +23,7 @@ logger = logging.getLogger(__name__)
 _PROMETHEUS_MULTIPROCESS_ENV_VAR = "PROMETHEUS_MULTIPROC_DIR"
 
 
-def _add_metrics_middleware(
-    application: FastAPI, registry: CollectorRegistry, worker_id: str
-):
+def _add_metrics_middleware(application: FastAPI, registry: CollectorRegistry, worker_id: str) -> None:
     """
     Registers an HTTP middleware to report metrics about requests count and duration
     """
@@ -43,24 +42,20 @@ def _add_metrics_middleware(
     )
 
     @application.middleware("http")
-    async def add_metrics(request: Request, call_next):
+    async def add_metrics(request: Request, call_next: Any) -> Any:
         start_time = time.time()
         response = await call_next(request)
         process_time = time.time() - start_time
 
         if "route" in request.scope:
-            request_path = (
-                request.scope["root_path"] + request.scope["route"].path
-            )
+            request_path = request.scope["root_path"] + request.scope["route"].path
         else:
             request_path = request.url.path
 
-        request_counter.labels(
-            worker_id, request.method, request_path, response.status_code
-        ).inc()
-        request_duration_histo.labels(
-            worker_id, request.method, request_path, response.status_code
-        ).observe(process_time)
+        request_counter.labels(worker_id, request.method, request_path, response.status_code).inc()
+        request_duration_histo.labels(worker_id, request.method, request_path, response.status_code).observe(
+            process_time
+        )
         return response
 
 
@@ -79,8 +74,8 @@ def add_metrics(application: FastAPI, config: Config) -> None:
                 f"Environment variable {_PROMETHEUS_MULTIPROCESS_ENV_VAR} must be defined for use of prometheus in a multiprocess environment"
             )
         registry = CollectorRegistry()
-        multiprocess.MultiProcessCollector(registry)
-        worker_id = os.environ["APP_WORKER_ID"]
+        multiprocess.MultiProcessCollector(registry)  # type: ignore
+        worker_id = str(os.getpid())
     else:
         registry = prometheus_client.REGISTRY
         worker_id = "0"

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -44,15 +44,15 @@ _PROMETHEUS_MULTIPROCESS_ENV_VAR = "PROMETHEUS_MULTIPROC_DIR"
 WORKER_ID = str(os.getpid())
 
 
-def _add_db_metrics() -> None:
+def _add_db_metrics(registry: CollectorRegistry = prometheus_client.REGISTRY) -> None:
     """
     Registers metrics related to database activity.
     """
-    _add_db_connection_metrics()
-    _add_db_session_metrics()
+    _add_db_connection_metrics(registry)
+    _add_db_session_metrics(registry)
 
 
-def _add_db_connection_metrics() -> None:
+def _add_db_connection_metrics(registry: CollectorRegistry) -> None:
     """
     Register connection-level (low level) DB metrics
     """
@@ -61,28 +61,29 @@ def _add_db_connection_metrics() -> None:
         "dbconn_duration_seconds",
         "DB connection duration",
         ["worker_id"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
 
     dbconn_gauge = Gauge(
         "dbconn_in_use",
         "DB connection count",
         ["worker_id"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
+    dbconn_gauge.labels(WORKER_ID).set(0)
 
     checkout_counter = Counter(
         "dbconn_checkout_count",
         "DB connection checkouts",
         ["worker_id"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
 
     checkin_counter = Counter(
         "dbconn_checkin_count",
         "DB connection checkins",
         ["worker_id"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
 
     dbconn_gauge.labels(WORKER_ID).set(0)
@@ -108,7 +109,7 @@ def _add_db_connection_metrics() -> None:
         connection_record.info["start_time"] = time.time()
 
 
-def _add_db_session_metrics() -> None:
+def _add_db_session_metrics(registry: CollectorRegistry) -> None:
     """
     Register ORM-level DB metrics
     """
@@ -117,39 +118,39 @@ def _add_db_session_metrics() -> None:
         "transaction_create_count",
         "Transaction creations",
         ["worker_id"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
     transaction_end_counter = Counter(
         "transaction_end_count",
         "Transaction ends",
         ["worker_id"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
 
     transaction_duration_histo = Histogram(
         "transaction_duration_seconds",
         "Transaction ends",
         ["worker_id"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
 
     events_counter = Counter(
         "dbsession_events",
         "Begins counter",
         ["worker_id", "event_type"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
 
     @listens_for(Session, "after_begin")
     def after_begin(session: Session, connection: Any, transaction: Any) -> None:
         events_counter.labels(WORKER_ID, "begin").inc()
 
-    @listens_for(Session, "after_begin")
-    def after_commit(session: Session, connection: Any, transaction: Any) -> None:
+    @listens_for(Session, "after_commit")
+    def after_commit(session: Session) -> None:
         events_counter.labels(WORKER_ID, "commit").inc()
 
-    @listens_for(Session, "after_begin")
-    def after_rollbacks(session: Session, connection: Any, transaction: Any) -> None:
+    @listens_for(Session, "after_rollback")
+    def after_rollback(session: Session) -> None:
         events_counter.labels(WORKER_ID, "rollback").inc()
 
     @listens_for(Session, "after_transaction_create")

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -73,7 +73,7 @@ def add_metrics(application: FastAPI, config: Config) -> None:
             raise ConfigurationError(
                 f"Environment variable {_PROMETHEUS_MULTIPROCESS_ENV_VAR} must be defined for use of prometheus in a multiprocess environment"
             )
-        registry = CollectorRegistry()
+        registry = CollectorRegistry(auto_describe=True)
         multiprocess.MultiProcessCollector(registry)  # type: ignore
         worker_id = str(os.getpid())
     else:

--- a/antarest/core/tasks/main.py
+++ b/antarest/core/tasks/main.py
@@ -12,11 +12,14 @@
 
 from typing import Optional
 
+import prometheus_client
+
 from antarest.core.application import AppBuildContext
 from antarest.core.config import Config
 from antarest.core.interfaces.eventbus import DummyEventBusService, IEventBus
+from antarest.core.metrics import TasksMetricsRecorder
 from antarest.core.tasks.repository import TaskJobRepository
-from antarest.core.tasks.service import ITaskService, TaskJobService
+from antarest.core.tasks.service import ITaskService, TaskJobService, TaskServiceListener
 from antarest.core.tasks.web import create_tasks_api
 
 
@@ -26,7 +29,12 @@ def build_taskjob_manager(
     event_bus: IEventBus = DummyEventBusService(),
 ) -> ITaskService:
     repository = TaskJobRepository()
-    service = TaskJobService(config, repository, event_bus)
+
+    listeners: list[TaskServiceListener] = []
+    if config.metrics.prometheus:
+        listeners.append(TasksMetricsRecorder(prometheus_client.REGISTRY))
+
+    service = TaskJobService(config, repository, event_bus, listeners=listeners)
 
     if app_ctxt:
         app_ctxt.api_root.include_router(create_tasks_api(service, config))

--- a/antarest/core/tasks/main.py
+++ b/antarest/core/tasks/main.py
@@ -19,7 +19,7 @@ from antarest.core.config import Config
 from antarest.core.interfaces.eventbus import DummyEventBusService, IEventBus
 from antarest.core.metrics import TasksMetricsRecorder
 from antarest.core.tasks.repository import TaskJobRepository
-from antarest.core.tasks.service import ITaskService, TaskJobService, TaskServiceListener
+from antarest.core.tasks.service import ITaskService, TaskJobService
 from antarest.core.tasks.web import create_tasks_api
 
 
@@ -30,7 +30,7 @@ def build_taskjob_manager(
 ) -> ITaskService:
     repository = TaskJobRepository()
 
-    listeners: list[TaskServiceListener] = []
+    listeners = []
     if config.metrics.prometheus:
         listeners.append(TasksMetricsRecorder(prometheus_client.REGISTRY))
 

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -16,7 +16,7 @@ import time
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
 from http import HTTPStatus
-from typing import Awaitable, Callable, Dict, List, Optional, TypeAlias
+from typing import Awaitable, Callable, Dict, List, Optional, Sequence, TypeAlias
 
 from fastapi import HTTPException
 from prometheus_client import CollectorRegistry, Gauge, Histogram
@@ -180,7 +180,7 @@ class TaskJobService(ITaskService):
         config: Config,
         repository: TaskJobRepository,
         event_bus: IEventBus,
-        listeners: list[TaskServiceListener] | None = None,
+        listeners: Sequence[TaskServiceListener] | None = None,
     ):
         self.config = config
         self.repo = repository
@@ -189,7 +189,7 @@ class TaskJobService(ITaskService):
         self.threadpool = ThreadPoolExecutor(max_workers=config.tasks.max_workers, thread_name_prefix="taskjob_")
         self.event_bus.add_listener(self.create_task_event_callback(), [EventType.TASK_CANCEL_REQUEST])
         self.remote_workers = config.tasks.remote_workers
-        self._listeners = listeners or []
+        self._listeners = list(listeners) if listeners else []
 
     def _create_worker_task(
         self,

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -19,6 +19,7 @@ from http import HTTPStatus
 from typing import Awaitable, Callable, Dict, List, Optional, TypeAlias
 
 from fastapi import HTTPException
+from prometheus_client import CollectorRegistry, Gauge, Histogram
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 from typing_extensions import override
@@ -159,12 +160,27 @@ class TaskLogAndProgressRecorder(ITaskNotifier):
         )
 
 
+class TaskServiceListener(ABC):
+    @abstractmethod
+    def on_task_submit(self, task_id: str) -> None:
+        pass
+
+    @abstractmethod
+    def on_task_start(self, task_id: str) -> None:
+        pass
+
+    @abstractmethod
+    def on_task_end(self, task_id: str) -> None:
+        pass
+
+
 class TaskJobService(ITaskService):
     def __init__(
         self,
         config: Config,
         repository: TaskJobRepository,
         event_bus: IEventBus,
+        listeners: list[TaskServiceListener] | None = None,
     ):
         self.config = config
         self.repo = repository
@@ -173,6 +189,7 @@ class TaskJobService(ITaskService):
         self.threadpool = ThreadPoolExecutor(max_workers=config.tasks.max_workers, thread_name_prefix="taskjob_")
         self.event_bus.add_listener(self.create_task_event_callback(), [EventType.TASK_CANCEL_REQUEST])
         self.remote_workers = config.tasks.remote_workers
+        self._listeners = listeners or []
 
     def _create_worker_task(
         self,
@@ -293,6 +310,10 @@ class TaskJobService(ITaskService):
                 permissions=PermissionInfo(owner=user.impersonator),
             )
         )
+
+        for listener in self._listeners:
+            listener.on_task_submit(task.id)
+
         future = self.threadpool.submit(self._run_task, action, task.id, user, custom_event_messages)
         self.tasks[task.id] = future
 
@@ -395,6 +416,9 @@ class TaskJobService(ITaskService):
         # We need to catch all exceptions so that the calling thread is guaranteed
         # to not die
         try:
+            for listener in self._listeners:
+                listener.on_task_start(task_id)
+
             # attention: this function is executed in a thread, not in the main process
             with task_context(task_id=task_id, user=jwt_user):
                 with db():
@@ -509,6 +533,9 @@ class TaskJobService(ITaskService):
                     f"An exception occurred while handling execution error of task {task_id}: {inner_exc}",
                     exc_info=inner_exc,
                 )
+        finally:
+            for listener in self._listeners:
+                listener.on_task_end(task_id)
 
     def get_task_progress(self, task_id: str) -> Optional[int]:
         task = self.repo.get_or_raise(task_id)
@@ -517,3 +544,32 @@ class TaskJobService(ITaskService):
             return task.progress
         else:
             raise UserHasNotPermissionError()
+
+    def _register_metrics(self, registry: CollectorRegistry) -> None:
+        self._duration_histo = Histogram(
+            "tasks_duration_seconds",
+            "Tasks duration in seconds",
+            ["worker_id"],
+            registry=registry,
+        )
+        self._wait_time_histo = Histogram(
+            "tasks_duration_seconds",
+            "Tasks duration in seconds",
+            ["worker_id"],
+            registry=registry,
+        )
+        self._running_gauge = Gauge(
+            "tasks_running",
+            "Count of running tasks",
+            ["worker_id"],
+            registry=registry,
+        )
+        self._pending_gauge = Gauge(
+            "tasks_pending",
+            "Count of pending tasks",
+            ["worker_id"],
+            registry=registry,
+        )
+
+        self._submit_times: dict[str, float] = {}
+        self._start_times: dict[str, float] = {}

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -562,12 +562,14 @@ class TaskJobService(ITaskService):
             "tasks_running",
             "Count of running tasks",
             ["worker_id"],
+            multiprocess_mode="liveall",
             registry=registry,
         )
         self._pending_gauge = Gauge(
             "tasks_pending",
             "Count of pending tasks",
             ["worker_id"],
+            multiprocess_mode="liveall",
             registry=registry,
         )
 

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -37,6 +37,7 @@ from antarest.core.config import Config
 from antarest.core.core_blueprint import create_utils_routes
 from antarest.core.filesystem_blueprint import create_file_system_blueprint
 from antarest.core.logging.utils import LoggingMiddleware, configure_logger
+from antarest.core.metrics import add_metrics
 from antarest.core.requests import RATE_LIMIT_CONFIG
 from antarest.core.swagger import customize_openapi
 from antarest.core.tasks.model import cancel_orphan_tasks
@@ -288,6 +289,8 @@ def fastapi_app(
         services.auto_archiver.start()
 
     customize_openapi(application)
+
+    add_metrics(application, config)
 
     if mount_front:
         add_front_app(application, res, config.api_prefix)

--- a/conf/gunicorn-single.py
+++ b/conf/gunicorn-single.py
@@ -1,0 +1,12 @@
+"""
+Configuration for notifying prometheus exporter that workers have been killed.
+"""
+
+from prometheus_client import multiprocess
+
+
+def child_exit(server, worker):
+    """
+    Notify prometheus that this worker has been stopped
+    """
+    multiprocess.mark_process_dead(worker.pid)

--- a/conf/gunicorn.py
+++ b/conf/gunicorn.py
@@ -2,6 +2,7 @@
 
 import multiprocessing
 import os
+from prometheus_client import multiprocess
 
 bind = "0.0.0.0:5000"
 
@@ -28,3 +29,17 @@ loglevel = "info"
 errorlog = "-"
 accesslog = "-"
 preload_app = False
+
+
+def post_fork(server, worker):
+    """
+    Put the worker_id into an env variable for further use within the app.
+    """
+    os.environ["APP_WORKER_ID"] = str(worker.age)
+
+
+def child_exit(server, worker):
+    """
+    Notify prometheus that this worker stops
+    """
+    multiprocess.mark_process_dead(worker.pid)

--- a/conf/gunicorn.py
+++ b/conf/gunicorn.py
@@ -2,6 +2,7 @@
 
 import multiprocessing
 import os
+
 from prometheus_client import multiprocess
 
 bind = "0.0.0.0:5000"
@@ -29,13 +30,6 @@ loglevel = "info"
 errorlog = "-"
 accesslog = "-"
 preload_app = False
-
-
-def post_fork(server, worker):
-    """
-    Put the worker_id into an env variable for further use within the app.
-    """
-    os.environ["APP_WORKER_ID"] = str(worker.age)
 
 
 def child_exit(server, worker):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,9 +49,13 @@ services:
     volumes:
       - ./resources/deploy/db:/var/lib/postgresql/data
     command: [ "postgres", "-c", "log_statement=all", "-c", "log_destination=stderr" ]
+    ports:
+      - 5432:5432
   redis:
     image: redis:latest
     container_name : redis
+    ports:
+      - 6379:6379
   nginx:
     image: nginx:latest
     container_name: nginx
@@ -63,3 +67,4 @@ services:
       - ./resources/deploy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./webapp/dist:/www
       - ./resources/deploy/web.config.json:/www/config.json:ro
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ plyer~=2.0.0
 psycopg2-binary~=2.9.9
 pyarrow~=21.0.0
 py7zr~=0.20.6
-prometheus-client~=0.16.0
+prometheus-client==0.23.1
 python-json-logger~=2.0.7
 PyYAML~=6.0.3
 redis~=6.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ plyer~=2.0.0
 psycopg2-binary~=2.9.9
 pyarrow~=21.0.0
 py7zr~=0.20.6
+prometheus-client~=0.16.0
 python-json-logger~=2.0.7
 PyYAML~=6.0.3
 redis~=6.4.0

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -40,6 +40,12 @@ do
     fi
 done
 
+if [[ -v PROMETHEUS_MULTIPROC_DIR ]]; then
+  rm ${PROMETHEUS_MULTIPROC_DIR}/*.db
+  mkdir -p ${PROMETHEUS_MULTIPROC_DIR}
+  echo "Concatenating metrics into ${PROMETHEUS_MULTIPROC_DIR}"
+fi
+
 if [ -z "$1" ] ; then
   sh $CUR_DIR/pre-start.sh
   gunicorn --config $BASE_DIR/conf/gunicorn.py --worker-class=uvicorn.workers.UvicornWorker antarest.wsgi:app

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -61,7 +61,8 @@ elif [ "$use_uvicorn" = true ]; then
              --workers=1 \
              --log-level info \
              --timeout 1200 \
-              antarest.wsgi:app &
+             --config $BASE_DIR/conf/gunicorn-single.py \
+            antarest.wsgi:app &
     pids+=($!) # Store background process IDs
   done
   for pid in ${pids[*]};

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -41,7 +41,7 @@ do
 done
 
 if [[ -v PROMETHEUS_MULTIPROC_DIR ]]; then
-  rm ${PROMETHEUS_MULTIPROC_DIR}/*.db
+  rm -f ${PROMETHEUS_MULTIPROC_DIR}/*.db
   mkdir -p ${PROMETHEUS_MULTIPROC_DIR}
   echo "Concatenating metrics into ${PROMETHEUS_MULTIPROC_DIR}"
 fi

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+from prometheus_client import CollectorRegistry
+
+from antarest.core.metrics import TasksMetricsRecorder
+
+
+def test_task_metric_srecorder():
+    metrics_registry = CollectorRegistry()
+    recorder = TasksMetricsRecorder(metrics_registry)
+    metrics = {m.name: m for m in metrics_registry.collect()}
+    assert metrics.keys() == {"tasks_duration_seconds", "tasks_wait_seconds", "tasks_running", "tasks_pending"}
+
+    recorder.on_task_submit("task1")
+    metrics = {m.name: m for m in metrics_registry.collect()}
+    assert metrics["tasks_running"].samples == []
+    assert len(metrics["tasks_pending"].samples) == 1
+    assert metrics["tasks_pending"].samples[0].value == 1
+    assert metrics["tasks_duration_seconds"].samples == []
+    assert metrics["tasks_wait_seconds"].samples == []
+
+    recorder.on_task_start("task1")
+    metrics = {m.name: m for m in metrics_registry.collect()}
+    assert len(metrics["tasks_running"].samples) == 1
+    assert metrics["tasks_running"].samples[0].value == 1
+    assert len(metrics["tasks_pending"].samples) == 1
+    assert metrics["tasks_pending"].samples[0].value == 0
+    assert metrics["tasks_duration_seconds"].samples == []
+    assert len(metrics["tasks_wait_seconds"].samples) > 0
+
+    recorder.on_task_end("task1")
+    metrics = {m.name: m for m in metrics_registry.collect()}
+    assert len(metrics["tasks_running"].samples) == 1
+    assert metrics["tasks_running"].samples[0].value == 0
+    assert len(metrics["tasks_pending"].samples) == 1
+    assert metrics["tasks_pending"].samples[0].value == 0
+    assert len(metrics["tasks_duration_seconds"].samples) > 0
+    assert len(metrics["tasks_wait_seconds"].samples) > 0

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -10,31 +10,58 @@
 #
 # This file is part of the Antares project.
 import prometheus_client
-from prometheus_client import CollectorRegistry
+from prometheus_client import CollectorRegistry, Metric
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
-from antarest.core.metrics import TasksMetricsRecorder, _add_db_metrics
+from antarest.core.metrics import (
+    TasksMetricsRecorder,
+    _add_db_connection_metrics,
+    _add_db_session_metrics,
+)
 
 
-def _is_subset(small_dict: dict[str, str], big_dict: dict[str, str]):
+def _is_subset(small_dict: dict[str, str], big_dict: dict[str, str]) -> bool:
     return all(item in big_dict.items() for item in small_dict.items())
 
 
-def _get_metric(registry: CollectorRegistry, name: str):
-    return next(m for m in registry.collect() if m.name == name)
+def _get_metric(registry: CollectorRegistry, name: str) -> Metric | None:
+    try:
+        return next(m for m in registry.collect() if m.name == name)
+    except StopIteration:
+        return None
 
 
-def _get_value(registry: CollectorRegistry, name: str, labels: dict[str, str] | None = None):
+def _get_value(registry: CollectorRegistry, name: str, labels: dict[str, str] | None = None) -> float | None:
     """
     Returns the value of the first (unique) sample of the metric matching the given name and labels.
     """
     metric = _get_metric(registry, name)
+    if not metric:
+        return None
     if not labels:
-        return metric.samples[0].value
+        return metric.samples[0].value if metric.samples else None
     else:
-        sample = next(s for s in metric.samples if _is_subset(labels, s.labels))
+        try:
+            sample = next(s for s in metric.samples if _is_subset(labels, s.labels))
+            return sample.value
+        except StopIteration:
+            return None
+
+
+def _get_histo_count(registry: CollectorRegistry, name: str) -> float | None:
+    """
+    Returns the count of values for a histogram metric.
+    """
+    count_sample_name = f"{name}_count"
+    metric = _get_metric(registry, name)
+    if not metric:
+        return None
+    try:
+        sample = next(s for s in metric.samples if s.name == count_sample_name)
         return sample.value
+    except StopIteration:
+        return None
 
 
 def test_task_metrics_recorder():
@@ -70,42 +97,11 @@ def test_task_metrics_recorder():
     assert len(metrics["tasks_wait_seconds"].samples) > 0
 
 
-def test_db_metrics():
-    engine = create_engine("sqlite:///:memory:")
-
-    registry = CollectorRegistry()
-    _add_db_metrics(registry)
-
-    metrics_names = {m.name for m in registry.collect()}
-    assert metrics_names == {
-        "dbconn_duration_seconds",
-        "dbconn_in_use",
-        "dbconn_checkout_count",
-        "dbconn_checkin_count",
-        "transaction_create_count",
-        "transaction_end_count",
-        "transaction_duration_seconds",
-        "dbsession_events",
-    }
-
-    assert _get_value(registry, "dbconn_in_use") == 0
-
-    with engine.connect() as conn:
-        conn.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
-        conn.commit()
-
-        assert _get_value(registry, "dbconn_in_use") == 1
-
-    assert _get_value(registry, "dbconn_in_use") == 0
-    assert _get_value(registry, "dbconn_checkout_count") == 1
-    assert _get_value(registry, "dbconn_checkin_count") == 1
-
-
 def test_db_connection_metrics():
     engine = create_engine("sqlite:///:memory:")
 
     registry = CollectorRegistry()
-    _add_db_metrics(registry)
+    _add_db_connection_metrics(registry, engine)
 
     metrics_names = {m.name for m in registry.collect()}
     assert metrics_names == {
@@ -113,10 +109,6 @@ def test_db_connection_metrics():
         "dbconn_in_use",
         "dbconn_checkout_count",
         "dbconn_checkin_count",
-        "transaction_create_count",
-        "transaction_end_count",
-        "transaction_duration_seconds",
-        "dbsession_events",
     }
 
     assert _get_value(registry, "dbconn_in_use") == 0
@@ -130,52 +122,56 @@ def test_db_connection_metrics():
     assert _get_value(registry, "dbconn_in_use") == 0
     assert _get_value(registry, "dbconn_checkout_count") == 1
     assert _get_value(registry, "dbconn_checkin_count") == 1
+    assert _get_histo_count(registry, "dbconn_duration_seconds") == 1
 
 
 def test_db_session_metrics():
     prometheus_client.disable_created_metrics()
     engine = create_engine("sqlite:///:memory:")
+    session_factory = sessionmaker(bind=engine)
 
     registry = CollectorRegistry()
-    _add_db_metrics(registry)
+    _add_db_session_metrics(registry, session_factory)
 
     metrics_names = {m.name for m in registry.collect()}
     assert metrics_names == {
-        "dbconn_duration_seconds",
-        "dbconn_in_use",
-        "dbconn_checkout_count",
-        "dbconn_checkin_count",
-        "transaction_create_count",
-        "transaction_end_count",
+        "transaction_current",
         "transaction_duration_seconds",
         "dbsession_events",
     }
 
-    assert _get_value(registry, "dbconn_in_use") == 0
-
-    session_factory = sessionmaker(bind=engine)
+    assert _get_value(registry, "transaction_current") == 0
+    assert _get_histo_count(registry, "transaction_duration_seconds") is None
+    assert _get_value(registry, "dbsession_events", labels={"event_type": "begin"}) is None
+    assert _get_value(registry, "dbsession_events", labels={"event_type": "rollback"}) is None
+    assert _get_value(registry, "dbsession_events", labels={"event_type": "commit"}) is None
 
     with session_factory() as session:
         session.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
-        assert _get_value(registry, "dbconn_in_use") == 1
         assert _get_value(registry, "dbsession_events", labels={"event_type": "begin"}) == 1
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "rollback"}) is None
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "commit"}) is None
+        assert _get_value(registry, "transaction_current") == 1
+        assert _get_histo_count(registry, "transaction_duration_seconds") is None
 
         session.rollback()
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "begin"}) == 1
         assert _get_value(registry, "dbsession_events", labels={"event_type": "rollback"}) == 1
-        assert _get_value(registry, "dbconn_in_use") == 0
-
-    assert _get_value(registry, "dbconn_in_use") == 0
-    assert _get_value(registry, "dbconn_checkout_count") == 1
-    assert _get_value(registry, "dbconn_checkin_count") == 1
-    assert _get_value(registry, "transaction_create_count") == 1
-    assert _get_value(registry, "transaction_end_count") == 1
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "commit"}) is None
+        assert _get_value(registry, "transaction_current") == 0
+        assert _get_histo_count(registry, "transaction_duration_seconds") == 1
 
     with session_factory() as session:
         session.execute(text("CREATE TABLE test2 (id INTEGER PRIMARY KEY)"))
-        assert _get_value(registry, "dbconn_in_use") == 1
         assert _get_value(registry, "dbsession_events", labels={"event_type": "begin"}) == 2
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "rollback"}) == 1
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "commit"}) is None
+        assert _get_value(registry, "transaction_current") == 1
+        assert _get_histo_count(registry, "transaction_duration_seconds") == 1
 
         session.commit()
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "begin"}) == 2
         assert _get_value(registry, "dbsession_events", labels={"event_type": "rollback"}) == 1
         assert _get_value(registry, "dbsession_events", labels={"event_type": "commit"}) == 1
-        assert _get_value(registry, "dbconn_in_use") == 0
+        assert _get_value(registry, "transaction_current") == 0
+        assert _get_histo_count(registry, "transaction_duration_seconds") == 2

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -9,12 +9,32 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+import prometheus_client
 from prometheus_client import CollectorRegistry
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
 
-from antarest.core.metrics import TasksMetricsRecorder
+from antarest.core.metrics import TasksMetricsRecorder, _add_db_metrics
 
 
-def test_task_metric_srecorder():
+def _is_subset(small_dict: dict[str, str], big_dict: dict[str, str]):
+    return all(item in big_dict.items() for item in small_dict.items())
+
+
+def _get_metric(registry: CollectorRegistry, name: str):
+    return next(m for m in registry.collect() if m.name == name)
+
+
+def _get_value(registry: CollectorRegistry, name: str, labels: dict[str, str] | None = None):
+    metric = _get_metric(registry, name)
+    if not labels:
+        return metric.samples[0].value
+    else:
+        sample = next(s for s in metric.samples if _is_subset(labels, s.labels))
+        return sample.value
+
+
+def test_task_metrics_recorder():
     metrics_registry = CollectorRegistry()
     recorder = TasksMetricsRecorder(metrics_registry)
     metrics = {m.name: m for m in metrics_registry.collect()}
@@ -45,3 +65,114 @@ def test_task_metric_srecorder():
     assert metrics["tasks_pending"].samples[0].value == 0
     assert len(metrics["tasks_duration_seconds"].samples) > 0
     assert len(metrics["tasks_wait_seconds"].samples) > 0
+
+
+def test_db_metrics():
+    engine = create_engine("sqlite:///:memory:")
+
+    registry = CollectorRegistry()
+    _add_db_metrics(registry)
+
+    metrics_names = {m.name for m in registry.collect()}
+    assert metrics_names == {
+        "dbconn_duration_seconds",
+        "dbconn_in_use",
+        "dbconn_checkout_count",
+        "dbconn_checkin_count",
+        "transaction_create_count",
+        "transaction_end_count",
+        "transaction_duration_seconds",
+        "dbsession_events",
+    }
+
+    assert _get_value(registry, "dbconn_in_use") == 0
+
+    with engine.connect() as conn:
+        conn.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
+        conn.commit()
+
+        assert _get_value(registry, "dbconn_in_use") == 1
+
+    assert _get_value(registry, "dbconn_in_use") == 0
+    assert _get_value(registry, "dbconn_checkout_count") == 1
+    assert _get_value(registry, "dbconn_checkin_count") == 1
+
+
+def test_db_connection_metrics():
+    engine = create_engine("sqlite:///:memory:")
+
+    registry = CollectorRegistry()
+    _add_db_metrics(registry)
+
+    metrics_names = {m.name for m in registry.collect()}
+    assert metrics_names == {
+        "dbconn_duration_seconds",
+        "dbconn_in_use",
+        "dbconn_checkout_count",
+        "dbconn_checkin_count",
+        "transaction_create_count",
+        "transaction_end_count",
+        "transaction_duration_seconds",
+        "dbsession_events",
+    }
+
+    assert _get_value(registry, "dbconn_in_use") == 0
+
+    with engine.connect() as conn:
+        conn.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
+        conn.commit()
+
+        assert _get_value(registry, "dbconn_in_use") == 1
+
+    assert _get_value(registry, "dbconn_in_use") == 0
+    assert _get_value(registry, "dbconn_checkout_count") == 1
+    assert _get_value(registry, "dbconn_checkin_count") == 1
+
+
+def test_db_session_metrics():
+    prometheus_client.disable_created_metrics()
+    engine = create_engine("sqlite:///:memory:")
+
+    registry = CollectorRegistry()
+    _add_db_metrics(registry)
+
+    metrics_names = {m.name for m in registry.collect()}
+    assert metrics_names == {
+        "dbconn_duration_seconds",
+        "dbconn_in_use",
+        "dbconn_checkout_count",
+        "dbconn_checkin_count",
+        "transaction_create_count",
+        "transaction_end_count",
+        "transaction_duration_seconds",
+        "dbsession_events",
+    }
+
+    assert _get_value(registry, "dbconn_in_use") == 0
+
+    session_factory = sessionmaker(bind=engine)
+
+    with session_factory() as session:
+        session.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
+        assert _get_value(registry, "dbconn_in_use") == 1
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "begin"}) == 1
+
+        session.rollback()
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "rollback"}) == 1
+        assert _get_value(registry, "dbconn_in_use") == 0
+
+    assert _get_value(registry, "dbconn_in_use") == 0
+    assert _get_value(registry, "dbconn_checkout_count") == 1
+    assert _get_value(registry, "dbconn_checkin_count") == 1
+    assert _get_value(registry, "transaction_create_count") == 1
+    assert _get_value(registry, "transaction_end_count") == 1
+
+    with session_factory() as session:
+        session.execute(text("CREATE TABLE test2 (id INTEGER PRIMARY KEY)"))
+        assert _get_value(registry, "dbconn_in_use") == 1
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "begin"}) == 2
+
+        session.commit()
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "rollback"}) == 1
+        assert _get_value(registry, "dbsession_events", labels={"event_type": "commit"}) == 1
+        assert _get_value(registry, "dbconn_in_use") == 0

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -26,6 +26,9 @@ def _get_metric(registry: CollectorRegistry, name: str):
 
 
 def _get_value(registry: CollectorRegistry, name: str, labels: dict[str, str] | None = None):
+    """
+    Returns the value of the first (unique) sample of the metric matching the given name and labels.
+    """
     metric = _get_metric(registry, name)
     if not labels:
         return metric.samples[0].value


### PR DESCRIPTION
**Description** 

This is a draft for defining metrics and exposing them to a prometheus instance, in order to improve the application observability.

The only metrics that are defined fro now are metrics about HTTP requests (count, duration).

Some technical details:
- metrics are exposed at the /metrics endpoint
- a "worker_id" label is used to enable the distinction between workers
- since our app works with multiple processes (workers), we need to aggregate the workers metrics. For that purpose we use the facility provided by prometheus client, which uses a temporary folder to store individual workers metrics and then aggregate them. This requires the definition of an additional env variable.


In the future, we could add metrics about various things: DB sessions, tasks durations, ...


In the long run, using [opentelemetry](https://opentelemetry.io/docs/instrumentation/python/) could be an alternative.


As a very basic illustration of grah in grafana:
![image](https://user-images.githubusercontent.com/6557571/235152417-3a9347c7-2669-4c80-8985-48fd9980449f.png)

