### PR TITLE
build(git): remove `antares-launcher` submodule 

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -14,10 +14,8 @@ jobs:
         python-version: [ 3.8 ]
 
     steps:
-      - name: Checkout github repo (+ download lfs dependencies)
+      - name: Checkout github repo
         uses: actions/checkout@v2
-        with:
-          submodules: recursive
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Checkout github repo (+ download lfs dependencies)
         uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 0
       - name: Install wget for windows
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout github repo (+ download lfs dependencies)
         uses: actions/checkout@v2
-        with:
-          submodules: recursive
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
@@ -41,8 +39,6 @@ jobs:
     steps:
       - name: Checkout github repo (+ download lfs dependencies)
         uses: actions/checkout@v2
-        with:
-          submodules: recursive
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "antares-launcher"]
-	path = antares-launcher
-	url = https://github.com/AntaresSimulatorTeam/antares-launcher.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,6 @@ COPY ./scripts /scripts
 COPY ./alembic /alembic
 COPY ./alembic.ini /alembic.ini
 
-# > IMPORTANT: The `antares-launcher` project (source files) is no longer needed,
-# > because the `Antares-Launcher` Python library is now declared as a dependency
-# > in the `requirements.txt` file.
-# > In other words, we can dispense with the creation of the symbolic link.
-
-# COPY ./antares-launcher /antares-launcher
-# RUN ln -s /antares-launcher/antareslauncher /antareslauncher
-# RUN mkdir /conf/antares-launcher
-# RUN cp /antares-launcher/requirements.txt /conf/antares-launcher/requirements.txt
-
 RUN ./scripts/install-debug.sh
 
 RUN pip3 install --upgrade pip \

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ First clone the projet:
 ```shell script
 git clone https://github.com/AntaresSimulatorTeam/AntaREST.git
 cd AntaREST
-git submodule init
-git submodule update
 ```
 
 Install back dependencies

--- a/docs/install/0-INSTALL.md
+++ b/docs/install/0-INSTALL.md
@@ -14,8 +14,6 @@ Requirements :
 ```
 git clone https://github.com/AntaresSimulatorTeam/AntaREST.git
 cd AntaREST
-git submodule init
-git submodule update
 ```
 
 2. Install back dependencies

--- a/docs/install/2-DEPLOY.md
+++ b/docs/install/2-DEPLOY.md
@@ -28,8 +28,8 @@ Requirements:
 
 These steps should work on any linux system with docker and docker-compose installed.
 
-1. First, the steps 1 and 3 of the [quick start build](0-INSTALL.md#quick-start) must have been done. So this guide will assume that you have previously cloned the [code repository](https://github.com/AntaresSimulatorTeam/AntaREST)
-   (don't forget the git submodule), the frontend built and that your working directory is at the root of the project.
+1. First, the steps 1 and 3 of the [quick start build](0-INSTALL.md#quick-start) must have been done. So this guide will assume that you have previously cloned the [code repository](https://github.com/AntaresSimulatorTeam/AntaREST),
+   the frontend built and that your working directory is at the root of the project.
 
 2. Then download and unzip AntaresSimulator binaries:
 


### PR DESCRIPTION
Since version v2.12, Antares Launcher is used as a Python library (it is a dependency). The purpose of this PR is to remove the `antares-launcher` Git submodule that is no longer used to build the application.

> A Git submodule is a feature that allows a Git repository to include another Git repository as a subdirectory. This allows you to include one Git repository as a part of another repository, making it easier to manage and track changes across multiple projects.

resolves #1335 