### PR TITLE
fix(web): change API response_model to avoid ValidationError

### DIFF
--- a/antarest/study/web/watcher_blueprint.py
+++ b/antarest/study/web/watcher_blueprint.py
@@ -40,7 +40,7 @@ def create_watcher_routes(
         "/watcher/_scan",
         summary="Launch scan in selected directory",
         tags=[APITag.study_raw_data],
-        response_model=List[str],
+        response_model=str,
     )
     def scan_dir(
         path: str,


### PR DESCRIPTION
Even though the watcher worked, it raised a HTTP 500 Exception due to a Validation Error. Modifying the response_model solves this issue.