### PR TITLE
fix(storage): fix INI file writing anomaly in Antares study update

### DIFF
--- a/antarest/study/storage/rawstudy/io/writer/ini_writer.py
+++ b/antarest/study/storage/rawstudy/io/writer/ini_writer.py
@@ -1,7 +1,7 @@
 import ast
 from configparser import RawConfigParser
 from pathlib import Path
-from typing import List, Optional, Any
+from typing import Any, List, Optional
 
 from antarest.core.model import JSON
 from antarest.study.storage.rawstudy.io.reader import IniReader
@@ -12,6 +12,7 @@ class IniConfigParser(RawConfigParser):
         super().__init__()
         self.special_keys = special_keys
 
+    # noinspection SpellCheckingInspection
     def optionxform(self, optionstr: str) -> str:
         return optionstr
 
@@ -40,7 +41,7 @@ class IniConfigParser(RawConfigParser):
             value = delimiter + str(value).replace("\n", "\n\t")
         else:
             value = ""
-        fp.write("{}{}\n".format(key, value))
+        fp.write(f"{key}{value}\n")
 
     def _write_section(  # type:ignore
         self,
@@ -49,8 +50,8 @@ class IniConfigParser(RawConfigParser):
         section_items,
         delimiter,
     ) -> None:
-        """Write a single section to the specified `fp'."""
-        fp.write("[{}]\n".format(section_name))
+        """Write a single section to the specified `fp`."""
+        fp.write(f"[{section_name}]\n")
         for key, value in section_items:
             if (
                 self.special_keys
@@ -68,7 +69,7 @@ class IniConfigParser(RawConfigParser):
 
 class IniWriter:
     """
-    Standard .ini writer
+    Standard INI writer.
     """
 
     def __init__(self, special_keys: Optional[List[str]] = None):
@@ -76,26 +77,30 @@ class IniWriter:
 
     def write(self, data: JSON, path: Path) -> None:
         """
-        Write .ini file fro json content
+        Write `.ini` file from JSON content
+
         Args:
-            data: json content
-            path: .ini file
-
-        Returns:
-
+            data: JSON content.
+            path: path to `.ini` file.
         """
         config_parser = IniConfigParser(special_keys=self.special_keys)
         config_parser.read_dict(data)
-        config_parser.write(path.open("w"))
+        with path.open("w") as fp:
+            config_parser.write(fp)
 
 
 class SimpleKeyValueWriter(IniWriter):
+    """
+    Simple key/value INI writer.
+    """
+
     def write(self, data: JSON, path: Path) -> None:
         """
-        Write .ini file from json content
+        Write `.ini` file from JSON content
+
         Args:
-            data: json content
-            path: .ini file
+            data: JSON content.
+            path: path to `.ini` file.
         """
         with path.open("w") as fp:
             for key, value in data.items():


### PR DESCRIPTION
## Description
This pull request addresses an anomaly related to INI file writing during the update process of an Antares study. The fix introduces the usage of a context manager to ensure proper closure of the file after the update is complete. Additionally, unit tests have been added to validate the behavior and include additional examples.

## Changes Made
- Used a `with` statement for opening the INI file during the study update process, to ensure the INI file is properly closed at the end of the update.
- Added unit tests to validate the behavior of the updated code.
- Included additional examples in the unit tests to cover various scenarios.

## Motivation and Impact
The current implementation of the Antares study update process lacks proper file closure after writing to the INI file. This can lead to potential issues such as resource leaks or data corruption. The introduced fix ensures that the file is correctly closed, mitigating these problems.

## Testing
Unit tests have been added to verify the behavior of the updated code.

Please review this pull request and provide any feedback or suggestions for improvement.