### PR TITLE
fix(renewable): fixing issue with missing display of renewable cluster form

### DIFF
--- a/antarest/study/business/renewable_management.py
+++ b/antarest/study/business/renewable_management.py
@@ -1,19 +1,18 @@
 from enum import Enum
-from pathlib import Path, PurePosixPath
-from typing import Union, Optional, Dict, TypedDict, Any, List
-
-from pydantic import StrictFloat, StrictInt, StrictStr, StrictBool
+from pathlib import PurePosixPath
+from typing import Any, Dict, List, Optional
 
 from antarest.study.business.utils import (
-    execute_or_add_commands,
-    FormFieldsBaseModel,
     FieldInfo,
+    FormFieldsBaseModel,
+    execute_or_add_commands,
 )
 from antarest.study.model import Study
 from antarest.study.storage.storage_service import StudyStorageService
 from antarest.study.storage.variantstudy.model.command.update_config import (
     UpdateConfig,
 )
+from pydantic import Field
 
 
 class TimeSeriesInterpretation(str, Enum):
@@ -25,12 +24,18 @@ RENEWABLE_PATH = "input/renewables/clusters/{area}/list/{cluster}"
 
 
 class RenewableFormFields(FormFieldsBaseModel):
-    group: Optional[StrictStr]
-    name: Optional[StrictStr]
+    """
+    Pydantic model representing renewable cluster configuration form fields.
+    """
+
+    # fmt: off
+    group: Optional[str]
+    name: Optional[str]
     ts_interpretation: Optional[TimeSeriesInterpretation]
-    unit_count: Optional[StrictInt]
-    enabled: Optional[StrictBool]
-    nominal_capacity: Optional[StrictInt]
+    unit_count: Optional[int] = Field(description="Unit count", ge=1)
+    enabled: Optional[bool] = Field(description="Enable flag")
+    nominal_capacity: Optional[float] = Field(description="Nominal capacity (MW)", ge=0)
+    # fmt: on
 
 
 FIELDS_INFO: Dict[str, FieldInfo] = {
@@ -48,7 +53,7 @@ FIELDS_INFO: Dict[str, FieldInfo] = {
     },
     "unit_count": {
         "path": f"{RENEWABLE_PATH}/unitcount",
-        "default_value": 0,
+        "default_value": 1,
     },
     "enabled": {
         "path": f"{RENEWABLE_PATH}/enabled",

--- a/antarest/study/storage/rawstudy/io/writer/ini_writer.py
+++ b/antarest/study/storage/rawstudy/io/writer/ini_writer.py
@@ -1,7 +1,7 @@
 import ast
 from configparser import RawConfigParser
 from pathlib import Path
-from typing import List, Optional, Any
+from typing import Any, List, Optional
 
 from antarest.core.model import JSON
 from antarest.study.storage.rawstudy.io.reader import IniReader
@@ -12,6 +12,7 @@ class IniConfigParser(RawConfigParser):
         super().__init__()
         self.special_keys = special_keys
 
+    # noinspection SpellCheckingInspection
     def optionxform(self, optionstr: str) -> str:
         return optionstr
 
@@ -40,7 +41,7 @@ class IniConfigParser(RawConfigParser):
             value = delimiter + str(value).replace("\n", "\n\t")
         else:
             value = ""
-        fp.write("{}{}\n".format(key, value))
+        fp.write(f"{key}{value}\n")
 
     def _write_section(  # type:ignore
         self,
@@ -49,8 +50,8 @@ class IniConfigParser(RawConfigParser):
         section_items,
         delimiter,
     ) -> None:
-        """Write a single section to the specified `fp'."""
-        fp.write("[{}]\n".format(section_name))
+        """Write a single section to the specified `fp`."""
+        fp.write(f"[{section_name}]\n")
         for key, value in section_items:
             if (
                 self.special_keys
@@ -68,7 +69,7 @@ class IniConfigParser(RawConfigParser):
 
 class IniWriter:
     """
-    Standard .ini writer
+    Standard INI writer.
     """
 
     def __init__(self, special_keys: Optional[List[str]] = None):
@@ -76,26 +77,30 @@ class IniWriter:
 
     def write(self, data: JSON, path: Path) -> None:
         """
-        Write .ini file fro json content
+        Write `.ini` file from JSON content
+
         Args:
-            data: json content
-            path: .ini file
-
-        Returns:
-
+            data: JSON content.
+            path: path to `.ini` file.
         """
         config_parser = IniConfigParser(special_keys=self.special_keys)
         config_parser.read_dict(data)
-        config_parser.write(path.open("w"))
+        with path.open("w") as fp:
+            config_parser.write(fp)
 
 
 class SimpleKeyValueWriter(IniWriter):
+    """
+    Simple key/value INI writer.
+    """
+
     def write(self, data: JSON, path: Path) -> None:
         """
-        Write .ini file from json content
+        Write `.ini` file from JSON content
+
         Args:
-            data: json content
-            path: .ini file
+            data: JSON content.
+            path: path to `.ini` file.
         """
         with path.open("w") as fp:
             for key, value in data.items():

--- a/tests/storage/repository/filesystem/test_ini_file_node.py
+++ b/tests/storage/repository/filesystem/test_ini_file_node.py
@@ -1,9 +1,10 @@
+import shutil
+import textwrap
 from pathlib import Path
 from typing import Tuple
 from unittest.mock import Mock
 
 import pytest
-
 from antarest.core.model import JSON
 from antarest.study.storage.rawstudy.model.filesystem.config.model import (
     FileStudyTreeConfig,
@@ -13,9 +14,10 @@ from antarest.study.storage.rawstudy.model.filesystem.ini_file_node import (
 )
 
 
-def build_dataset(tmp_path: str) -> Tuple[Path, JSON]:
-    path = Path(tmp_path) / "test.ini"
-    ini_content = """
+def build_dataset(study_dir: Path) -> Tuple[Path, JSON]:
+    ini_path = study_dir.joinpath("test.ini")
+    ini_content = textwrap.dedent(
+        """\
         [part1]
         key_int = 1
         key_float = 2.1
@@ -24,21 +26,28 @@ def build_dataset(tmp_path: str) -> Tuple[Path, JSON]:
         [part2]
         key_bool = True
         key_bool2 = False
-    """
-    types = {
-        "part1": {"key_int": int, "key_float": float, "key_str": str},
+        """
+    )
+    section_types = {
+        "part1": {
+            "key_int": int,
+            "key_float": float,
+            "key_str": str,
+        },
         "part2": {
             "key_bool": bool,
             "key_bool2": bool,
         },
     }
-    path.write_text(ini_content)
-    return path, types
+    ini_path.write_text(ini_content)
+    return ini_path, section_types
 
 
 @pytest.mark.unit_test
-def test_get(tmp_path: str) -> None:
-    path, types = build_dataset(tmp_path)
+def test_get(tmp_path: Path) -> None:
+    study_dir = tmp_path.joinpath("my_study")
+    study_dir.mkdir()
+    ini_path, types = build_dataset(study_dir)
 
     expected_json = {
         "part1": {"key_int": 1, "key_str": "value1", "key_float": 2.1},
@@ -47,11 +56,11 @@ def test_get(tmp_path: str) -> None:
     node = IniFileNode(
         context=Mock(),
         config=FileStudyTreeConfig(
-            study_path=path,
-            path=path,
+            study_path=ini_path,
+            path=ini_path,
             version=-1,
-            areas=dict(),
-            outputs=dict(),
+            areas={},
+            outputs={},
             study_id="id",
         ),
         types=types,
@@ -60,10 +69,38 @@ def test_get(tmp_path: str) -> None:
     assert node.get(["part2"]) == {"key_bool": True, "key_bool2": False}
     assert node.get(["part2", "key_bool"])
 
+    base_name = str(tmp_path.joinpath("archived"))
+    zipped_path = Path(
+        shutil.make_archive(
+            base_name,
+            format="zip",
+            root_dir=study_dir,
+        )
+    )
+
+    zipped_node = IniFileNode(
+        context=Mock(),
+        config=FileStudyTreeConfig(
+            study_path=tmp_path.joinpath("archived", ini_path.name),
+            path=tmp_path.joinpath("archived", ini_path.name),
+            version=-1,
+            areas={},
+            outputs={},
+            study_id="id",
+            zip_path=zipped_path,
+        ),
+        types=types,
+    )
+    assert zipped_node.get([]) == expected_json
+    assert zipped_node.get(["part2"]) == {"key_bool": True, "key_bool2": False}
+    assert zipped_node.get(["part2", "key_bool"])
+
 
 @pytest.mark.unit_test
-def test_get_depth(tmp_path: str) -> None:
-    path, types = build_dataset(tmp_path)
+def test_get_depth(tmp_path: Path) -> None:
+    study_dir = tmp_path.joinpath("my_study")
+    study_dir.mkdir()
+    ini_path, types = build_dataset(study_dir)
 
     expected_json = {
         "part1": {},
@@ -72,16 +109,40 @@ def test_get_depth(tmp_path: str) -> None:
     node = IniFileNode(
         context=Mock(),
         config=FileStudyTreeConfig(
-            study_path=path,
-            path=path,
+            study_path=ini_path,
+            path=ini_path,
             version=-1,
-            areas=dict(),
-            outputs=dict(),
+            areas={},
+            outputs={},
             study_id="id",
         ),
         types=types,
     )
     assert node.get(depth=1) == expected_json
+
+    base_name = str(tmp_path.joinpath("archived"))
+    zipped_path = Path(
+        shutil.make_archive(
+            base_name,
+            format="zip",
+            root_dir=study_dir,
+        )
+    )
+
+    zipped_node = IniFileNode(
+        context=Mock(),
+        config=FileStudyTreeConfig(
+            study_path=tmp_path.joinpath("archived", ini_path.name),
+            path=tmp_path.joinpath("archived", ini_path.name),
+            version=-1,
+            areas={},
+            outputs={},
+            study_id="id",
+            zip_path=zipped_path,
+        ),
+        types=types,
+    )
+    assert zipped_node.get(depth=1) == expected_json
 
 
 @pytest.mark.unit_test
@@ -127,40 +188,107 @@ def test_validate_section():
 
 
 @pytest.mark.unit_test
-def test_save(tmp_path: str) -> None:
-    path = Path(tmp_path) / "test.ini"
+def test_save(tmp_path: Path) -> None:
+    ini_path = tmp_path.joinpath("test.ini")
 
-    ini_content = """[part1]
-key_int = 1
-key_float = 2.1
-key_str = value1
-    """
-    path.write_text(ini_content)
-
-    exp = """[part1]
-key_int = 10
-key_str = value10
-key_float = 3.14
-
-"""
-
-    types = {"part1": {"key_int": int, "key_float": float, "key_str": str}}
+    types = {
+        "part1": {
+            "key_int": int,
+            "key_float": float,
+            "key_str": str,
+            "key_bool": bool,
+        },
+        "part2": {
+            "key_int": int,
+            "key_float": float,
+            "key_str": str,
+            "key_bool": bool,
+        },
+    }
 
     node = IniFileNode(
         context=Mock(),
         config=FileStudyTreeConfig(
-            study_path=path,
-            path=path,
+            study_path=tmp_path,
+            path=ini_path,
             version=-1,
             study_id="id",
-            areas=dict(),
-            outputs=dict(),
+            areas={},
+            outputs={},
         ),
         types=types,
     )
+
+    # The example below allows for creating an INI file from scratch by providing
+    # a dictionary of sections to write. The dictionary order is preserved.
     data = {
-        "part1": {"key_int": 10, "key_str": "value10", "key_float": 2.1},
+        "part1": {
+            "key_float": 2.1,
+            "key_int": 1,
+            "key_str": "value1",
+        },
+        "part2": {
+            "key_float": 18,
+            "key_int": 5,
+            "key_str": "value2",
+        },
     }
     node.save(data)
+    expected = textwrap.dedent(
+        """\
+        [part1]
+        key_float = 2.1
+        key_int = 1
+        key_str = value1
+
+        [part2]
+        key_float = 18
+        key_int = 5
+        key_str = value2
+        """
+    )
+    assert ini_path.read_text().strip() == expected.strip()
+
+    # The example below allows for updating the parameters of a **section** in an INI file.
+    # The update simply involves replacing all the parameters with the values defined
+    # in the key/value dictionary. The previous values are removed, and new values can be added.
+    # Note: this update only affects a specific section, leaving other sections unaffected.
+    data = {
+        # "key_int": 10,  # <- removed
+        "key_str": "value10",
+        "key_float": 2.1,
+        "key_bool": True,  # <- inserted
+    }
+    node.save(data, url=["part1"])
+    # note: the order of the keys is preserved in the output
+    expected = textwrap.dedent(
+        """\
+        [part1]
+        key_str = value10
+        key_float = 2.1
+        key_bool = True
+
+        [part2]
+        key_float = 18
+        key_int = 5
+        key_str = value2
+        """
+    )
+    assert ini_path.read_text().strip() == expected.strip()
+
+    # The exemple below allows for updating a single parameter, the others are unaffected.
     node.save(3.14, url=["part1", "key_float"])
-    assert exp == path.read_text()
+    expected = textwrap.dedent(
+        """\
+        [part1]
+        key_str = value10
+        key_float = 3.14
+        key_bool = True
+
+        [part2]
+        key_float = 18
+        key_int = 5
+        key_str = value2
+        """
+    )
+    assert ini_path.read_text().strip() == expected.strip()


### PR DESCRIPTION
## Description:

This pull request addresses the issue where the characteristics of renewable clusters are not being displayed, although they are visible in debug mode.

## Changes Made:
- Corrected the Renewable Cluster Form fields by modifying the field type and adding constraints.
- Set the default value of the `unit_count` field to 1 instead of 0.

These changes address the issue by updating the `RenewableFormFields` class.
