### PR TITLE
fix(worker): archive worker must be kept alive for processing

### DIFF
--- a/antarest/core/interfaces/eventbus.py
+++ b/antarest/core/interfaces/eventbus.py
@@ -82,9 +82,7 @@ class IEventBus(ABC):
         pass
 
     @abstractmethod
-    def add_queue_consumer(
-        self, listener: EventListener, queue: str
-    ) -> str:
+    def add_queue_consumer(self, listener: EventListener, queue: str) -> str:
         """
         Adds a consumer for events on the specified queue.
         """

--- a/antarest/core/interfaces/eventbus.py
+++ b/antarest/core/interfaces/eventbus.py
@@ -52,19 +52,42 @@ class Event(BaseModel):
     channel: str = ""
 
 
+EventListener = Callable[[Event], Awaitable[None]]
+
+
 class IEventBus(ABC):
+    """
+    Interface for the event bus.
+
+    The event bus provides 2 communication mechanisms:
+      - a broadcasting mechanism, where events are pushed to all
+        registered listeners
+      - a message queue mechanism: a message can be pushed to
+        a specified queue. Only consumers registered for that
+        queue will be called to handle those messages.
+    """
+
     @abstractmethod
     def push(self, event: Event) -> None:
+        """
+        Pushes an event to registered listeners.
+        """
         pass
 
     @abstractmethod
     def queue(self, event: Event, queue: str) -> None:
+        """
+        Queues an event at the end of the specified queue.
+        """
         pass
 
     @abstractmethod
     def add_queue_consumer(
-        self, listener: Callable[[Event], Awaitable[None]], queue: str
+        self, listener: EventListener, queue: str
     ) -> str:
+        """
+        Adds a consumer for events on the specified queue.
+        """
         pass
 
     @abstractmethod
@@ -74,7 +97,7 @@ class IEventBus(ABC):
     @abstractmethod
     def add_listener(
         self,
-        listener: Callable[[Event], Awaitable[None]],
+        listener: EventListener,
         type_filter: Optional[List[EventType]] = None,
     ) -> str:
         """

--- a/antarest/core/interfaces/service.py
+++ b/antarest/core/interfaces/service.py
@@ -3,16 +3,28 @@ from abc import abstractmethod, ABC
 
 
 class IService(ABC):
-    def __init__(self) -> None:
-        self.thread = threading.Thread(
-            target=self._loop,
-            name=self.__class__.__name__,
-            daemon=True,
-        )
+    """
+    A base class for long running processing services.
+
+    Processing may be started either in a background thread or in current thread.
+    Implementations must implement the `_loop` method.
+    """
 
     def start(self, threaded: bool = True) -> None:
+        """
+        Starts the processing loop.
+
+        Args:
+            threaded: if True, the loop is started in a daemon thread,
+                      else in this thread
+        """
         if threaded:
-            self.thread.start()
+            thread = threading.Thread(
+                target=self._loop,
+                name=self.__class__.__name__,
+                daemon=True,
+            )
+            thread.start()
         else:
             self._loop()
 

--- a/antarest/worker/archive_worker.py
+++ b/antarest/worker/archive_worker.py
@@ -38,7 +38,7 @@ class ArchiveWorker(AbstractWorker):
             [f"{ArchiveWorker.TASK_TYPE}_{workspace}"],
         )
 
-    def execute_task(self, task_info: WorkerTaskCommand) -> TaskResult:
+    def _execute_task(self, task_info: WorkerTaskCommand) -> TaskResult:
         logger.info(f"Executing task {task_info.json()}")
         try:
             # sourcery skip: extract-method

--- a/antarest/worker/simulator_worker.py
+++ b/antarest/worker/simulator_worker.py
@@ -59,7 +59,7 @@ class SimulatorWorker(AbstractWorker):
             cache=LocalCache(),
         )
 
-    def execute_task(self, task_info: WorkerTaskCommand) -> TaskResult:
+    def _execute_task(self, task_info: WorkerTaskCommand) -> TaskResult:
         if task_info.task_type == GENERATE_TIMESERIES_TASK_NAME:
             return self.execute_timeseries_generation_task(task_info)
         elif task_info.task_type == GENERATE_KIRSHOFF_CONSTRAINTS_TASK_NAME:

--- a/antarest/worker/worker.py
+++ b/antarest/worker/worker.py
@@ -49,7 +49,8 @@ class _WorkerTaskEndedCallback:
             type=EventType.WORKER_TASK_ENDED,
             payload=WorkerTaskResult(
                 task_id=self._task_id, task_result=result
-            ),  # Use `NONE` for internal events
+            ),
+            # Use `NONE` for internal events
             permissions=PermissionInfo(public_mode=PublicMode.NONE),
         )
         self._event_bus.push(event)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,11 +94,11 @@ def assert_study(a: SUB_JSON, b: SUB_JSON) -> None:
 
 
 def auto_retry_assert(
-    predicate: Callable[..., bool], timeout: int = 2
+    predicate: Callable[..., bool], timeout: int = 2, delay: float = 0.2
 ) -> None:
     threshold = datetime.now(timezone.utc) + timedelta(seconds=timeout)
     while datetime.now(timezone.utc) < threshold:
         if predicate():
             return
-        time.sleep(0.2)
+        time.sleep(delay)
     raise AssertionError()

--- a/tests/core/test_tasks.py
+++ b/tests/core/test_tasks.py
@@ -275,7 +275,7 @@ class DummyWorker(AbstractWorker):
         super().__init__("test", event_bus, accept)
         self.tmp_path = tmp_path
 
-    def execute_task(self, task_info: WorkerTaskCommand) -> TaskResult:
+    def _execute_task(self, task_info: WorkerTaskCommand) -> TaskResult:
         # simulate a "long" task ;-)
         time.sleep(0.01)
         relative_path = task_info.task_args["file"]

--- a/tests/worker/test_archive_worker.py
+++ b/tests/worker/test_archive_worker.py
@@ -44,7 +44,7 @@ def test_archive_worker_action(tmp_path: Path):
             "remove_src": True,
         },
     )
-    archive_worker.execute_task(task_info)
+    archive_worker._execute_task(task_info)
 
     assert not zip_file.exists()
     assert expected_output.exists()

--- a/tests/worker/test_simulator_worker.py
+++ b/tests/worker/test_simulator_worker.py
@@ -40,14 +40,14 @@ def test_execute_task(logger_mock: Mock, tmp_path: Path):
     worker.study_factory = Mock()
 
     with pytest.raises(NotImplementedError):
-        worker.execute_task(
+        worker._execute_task(
             task_info=WorkerTaskCommand(
                 task_id="task_id", task_type="unknown", task_args={}
             )
         )
 
     with pytest.raises(NotImplementedError):
-        worker.execute_task(
+        worker._execute_task(
             task_info=WorkerTaskCommand(
                 task_id="task_id",
                 task_type=GENERATE_KIRSHOFF_CONSTRAINTS_TASK_NAME,
@@ -55,7 +55,7 @@ def test_execute_task(logger_mock: Mock, tmp_path: Path):
             )
         )
     study_path = tmp_path / "study"
-    result = worker.execute_task(
+    result = worker._execute_task(
         task_info=WorkerTaskCommand(
             task_id="task_id",
             task_type=GENERATE_TIMESERIES_TASK_NAME,


### PR DESCRIPTION
**Description**

The archive worker currently stops processing because it exits as soon as it's started, causing the program to exit.

As a fix, we simply keep it alive artificially, although it does not perform work by itself.