### PR TITLE
fix(desktop): correct date parsing in localized environment

### DIFF
--- a/antarest/study/storage/utils.py
+++ b/antarest/study/storage/utils.py
@@ -265,7 +265,7 @@ def assert_permission(
 
 MATRIX_INPUT_DAYS_COUNT = 365
 
-MONTHS = [
+MONTHS = (
     "January",
     "February",
     "March",
@@ -278,9 +278,9 @@ MONTHS = [
     "October",
     "November",
     "December",
-]
+)
 
-DAY_NAMES = [
+DAY_NAMES = (
     "Monday",
     "Tuesday",
     "Wednesday",
@@ -288,7 +288,7 @@ DAY_NAMES = [
     "Friday",
     "Saturday",
     "Sunday",
-]
+)
 
 
 def get_start_date(

--- a/antarest/study/storage/utils.py
+++ b/antarest/study/storage/utils.py
@@ -265,7 +265,7 @@ def assert_permission(
 
 MATRIX_INPUT_DAYS_COUNT = 365
 
-ENGLISH_MONTHS = [
+MONTHS = [
     "January",
     "February",
     "March",
@@ -280,7 +280,7 @@ ENGLISH_MONTHS = [
     "December",
 ]
 
-ENGLISH_DAY_NAMES = [
+DAY_NAMES = [
     "Monday",
     "Tuesday",
     "Wednesday",
@@ -313,13 +313,13 @@ def get_start_date(
     start_offset = cast(int, config.get("simulation.start"))
     end = cast(int, config.get("simulation.end"))
 
-    starting_month_index = ENGLISH_MONTHS.index(starting_month.title()) + 1
+    starting_month_index = MONTHS.index(starting_month.title()) + 1
+    starting_day_index = DAY_NAMES.index(starting_day.title())
     target_year = 2000
     while True:
         if leapyear == calendar.isleap(target_year):
             first_day = datetime(target_year, starting_month_index, 1)
-            first_day_name = ENGLISH_DAY_NAMES[first_day.weekday()]
-            if first_day_name == starting_day.title():
+            if first_day.weekday() == starting_day_index:
                 break
         target_year += 1
 
@@ -349,11 +349,11 @@ def get_start_date(
         else:
             steps = (13 - start_date.month) + end_date.month
 
+    first_week_day_index = DAY_NAMES.index(first_week_day)
     first_week_offset = 0
     for first_week_offset in range(7):
         first_day = start_date + timedelta(days=first_week_offset)
-        first_day_name = ENGLISH_DAY_NAMES[first_day.weekday()]
-        if first_day_name == first_week_day.title():
+        if first_day.weekday() == first_week_day_index:
             break
     first_week_size = first_week_offset if first_week_offset != 0 else 7
 

--- a/antarest/worker/archive_worker.py
+++ b/antarest/worker/archive_worker.py
@@ -9,7 +9,6 @@ from antarest.core.tasks.model import TaskResult
 from antarest.core.utils.utils import unzip, StopWatch
 from antarest.worker.worker import AbstractWorker, WorkerTaskCommand
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -20,6 +19,14 @@ class ArchiveTaskArgs(BaseModel):
 
 
 class ArchiveWorker(AbstractWorker):
+    """
+    The Antares archive worker is a task that runs in the background$
+    to automatically unarchive simulation results.
+
+    The worker is notified by the web application via EventBus to initiate
+    asynchronous unarchiving of the results.
+    """
+
     TASK_TYPE = "unarchive"
 
     def __init__(
@@ -54,7 +61,7 @@ class ArchiveWorker(AbstractWorker):
             )
             stopwatch.log_elapsed(
                 lambda t: logger.info(
-                    f"Successfuly extracted {src} into {dest} in {t}s"
+                    f"Successfully extracted {src} into {dest} in {t}s"
                 )
             )
             return TaskResult(success=True, message="")

--- a/resources/deploy/README.md
+++ b/resources/deploy/README.md
@@ -1,18 +1,41 @@
 # Antares Web
 
-| WARNING: AntaresWeb/AntaresWebServer and AntaresWeb/antares_solver/antares-<version>-solver must be set as executable on *LINUX* |
-|----------------------------------------------------------------------------------------------------------------------------------|
+> WARNING: in Linux environment, the following files must be executable.
+> To do this, you can run the following commands:
+>
+> ```shell
+> chmod +x AntaresWeb/AntaresTool
+> chmod +x AntaresWeb/AntaresWebServer
+> chmod +x AntaresWebWorker
+> ```
 
-To launch the Antares Web, run the command
-```
+To launch the Antares Web, run the command:
+
+```shell
 ./AntaresWeb/AntaresWebServer
 ```
-Then go to http://localhost:8080
+
+Then go to http://127.0.0.1:8080
 
 ## Variant manager tool
 
-To use the variant manager tool, run the command
+To use the variant manager tool, run the command:
+
 ```
-./AntaresWeb/AntaresTool
+./AntaresWeb/AntaresTool --help
 ```
+
 Further instruction will be provided by the command output.
+
+## Archive worker
+
+The Antares archive manager is a command that runs in the background to automatically unarchive simulation results.
+The worker is notified by the web application via EventBus to initiate asynchronous unarchiving of the results.
+
+To launch the archive worker, run the command:
+
+```
+./AntaresWebWorker -c config.yaml -w default
+```
+
+Further instructions can be found in the online help. Use the `--help' option.


### PR DESCRIPTION
Date parsing with `strptime(starting_month, "%B")` and date formatting with `strftime("%A")` depend on the locale, but the "FR" locale is used on the server.

We need to use locale-independent functions, as the configuration is in English.