### PR TITLE
style(ui): correct spelling mistake in webapp code

### DIFF
--- a/webapp/src/components/App/Singlestudy/explore/Modelization/DebugView/StudyDataView/StudyFileView.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/DebugView/StudyDataView/StudyFileView.tsx
@@ -32,7 +32,7 @@ function StudyFileView(props: PropTypes) {
   const [data, setData] = useState<string>();
   const [loaded, setLoaded] = useState(false);
   const [isEditable, setEditable] = useState<boolean>(true);
-  const [formatedPath, setFormatedPath] = useState<string>("");
+  const [formattedPath, setFormattedPath] = useState<string>("");
   const [openImportDialog, setOpenImportDialog] = useState(false);
 
   const loadFileData = async () => {
@@ -54,7 +54,7 @@ function StudyFileView(props: PropTypes) {
 
   const onImport = async (file: File) => {
     try {
-      await importFile(file, study, formatedPath);
+      await importFile(file, study, formattedPath);
     } catch (e) {
       logErr("Failed to import file", file, e);
       enqueueErrorSnackbar(t("studies.error.saveData"), e as AxiosError);
@@ -68,7 +68,7 @@ function StudyFileView(props: PropTypes) {
   useEffect(() => {
     const urlParts = url.split("/");
     const tmpUrl = urlParts.filter((item) => item);
-    setFormatedPath(tmpUrl.join("/"));
+    setFormattedPath(tmpUrl.join("/"));
     if (tmpUrl.length > 0) {
       setEditable(!filterOut.includes(tmpUrl[0]));
     }

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/DebugView/StudyDataView/StudyMatrixView/StudyMatrixView.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/DebugView/StudyDataView/StudyMatrixView/StudyMatrixView.tsx
@@ -46,13 +46,13 @@ function StudyMatrixView(props: PropTypes) {
   const [toggleView, setToggleView] = useState(true);
   const [openImportDialog, setOpenImportDialog] = useState(false);
   const [isEditable, setEditable] = useState(true);
-  const [formatedPath, setFormatedPath] = useState("");
+  const [formattedPath, setFormattedPath] = useState("");
 
   const { data: matrixIndex } = usePromiseWithSnackbarError(
-    () => getStudyMatrixIndex(study, formatedPath),
+    () => getStudyMatrixIndex(study, formattedPath),
     {
       errorMessage: t("matrix.error.failedToRetrieveIndex"),
-      deps: [study, formatedPath],
+      deps: [study, formattedPath],
     }
   );
 
@@ -88,7 +88,7 @@ function StudyMatrixView(props: PropTypes) {
     if (source !== "loadData" && source !== "updateData") {
       try {
         if (change.length > 0) {
-          await editMatrix(study, formatedPath, change);
+          await editMatrix(study, formattedPath, change);
           enqueueSnackbar(t("matrix.success.matrixUpdate"), {
             variant: "success",
           });
@@ -101,7 +101,7 @@ function StudyMatrixView(props: PropTypes) {
 
   const handleImport = async (file: File) => {
     try {
-      await importFile(file, study, formatedPath);
+      await importFile(file, study, formattedPath);
     } catch (e) {
       logErr("Failed to import file", file, e);
       enqueueErrorSnackbar(t("variants.error.import"), e as AxiosError);
@@ -116,7 +116,7 @@ function StudyMatrixView(props: PropTypes) {
   useEffect(() => {
     const urlParts = url.split("/");
     const tmpUrl = urlParts.filter((item) => item);
-    setFormatedPath(tmpUrl.join("/"));
+    setFormattedPath(tmpUrl.join("/"));
     if (tmpUrl.length > 0) {
       setEditable(!filterOut.includes(tmpUrl[0]));
     }

--- a/webapp/src/components/common/EditableMatrix/index.tsx
+++ b/webapp/src/components/common/EditableMatrix/index.tsx
@@ -59,7 +59,9 @@ function EditableMatrix(props: PropTypes) {
   const { data = [], columns = [], index = [] } = matrix;
   const prependIndex = index.length > 0 && matrixTime;
   const [grid, setGrid] = useState<Array<CellType>>([]);
-  const [formatedColumns, setFormatedColumns] = useState<ColumnSettings[]>([]);
+  const [formattedColumns, setFormattedColumns] = useState<ColumnSettings[]>(
+    []
+  );
   const hotTableComponent = useRef<HotTable>(null);
 
   ////////////////////////////////////////////////////////////////
@@ -99,7 +101,7 @@ function EditableMatrix(props: PropTypes) {
   };
 
   useEffect(() => {
-    setFormatedColumns([
+    setFormattedColumns([
       ...(prependIndex ? [{ title: "Time", readOnly: true, width: 130 }] : []),
       ...columns.map((col, index) => ({
         title: columnsNames?.[index] || formatColumnName(col),
@@ -164,7 +166,7 @@ function EditableMatrix(props: PropTypes) {
             onUpdate && handleSlice(change || [], source)
           }
           beforeKeyDown={(e) => handleKeyDown(e)}
-          columns={formatedColumns}
+          columns={formattedColumns}
           rowHeaders={matrixRowNames || true}
           manualColumnResize
         />

--- a/webapp/src/components/common/FormGenerator/AutoSubmitGenerator.tsx
+++ b/webapp/src/components/common/FormGenerator/AutoSubmitGenerator.tsx
@@ -22,11 +22,11 @@ export default function AutoSubmitGeneratorForm<T extends FieldValues>(
 ) {
   const { saveField, jsonTemplate } = props;
 
-  const formatedJsonTemplate: IFormGenerator<T> = useMemo(
+  const formattedJsonTemplate: IFormGenerator<T> = useMemo(
     () =>
       jsonTemplate.map((fieldset) => {
         const { fields, ...otherProps } = fieldset;
-        const formatedFields: IFieldsetType<T>["fields"] = fields.map(
+        const formattedFields: IFieldsetType<T>["fields"] = fields.map(
           (field) => ({
             ...field,
             rules: (name, path, required, defaultValues) => ({
@@ -36,10 +36,10 @@ export default function AutoSubmitGeneratorForm<T extends FieldValues>(
           })
         );
 
-        return { fields: formatedFields, ...otherProps };
+        return { fields: formattedFields, ...otherProps };
       }),
     [jsonTemplate, saveField]
   );
 
-  return <FormGenerator jsonTemplate={formatedJsonTemplate} />;
+  return <FormGenerator jsonTemplate={formattedJsonTemplate} />;
 }

--- a/webapp/src/components/common/FormGenerator/index.tsx
+++ b/webapp/src/components/common/FormGenerator/index.tsx
@@ -69,15 +69,15 @@ export interface FormGeneratorProps<T extends FieldValues> {
 
 function formateFieldset<T extends FieldValues>(fieldset: IFieldsetType<T>) {
   const { fields, ...otherProps } = fieldset;
-  const formatedFields = fields.map((field) => ({ ...field, id: uuidv4() }));
-  return { ...otherProps, fields: formatedFields, id: uuidv4() };
+  const formattedFields = fields.map((field) => ({ ...field, id: uuidv4() }));
+  return { ...otherProps, fields: formattedFields, id: uuidv4() };
 }
 
 export default function FormGenerator<T extends FieldValues>(
   props: FormGeneratorProps<T>
 ) {
   const { jsonTemplate } = props;
-  const formatedTemplate = useMemo(
+  const formattedTemplate = useMemo(
     () => jsonTemplate.map(formateFieldset),
     [jsonTemplate]
   );
@@ -89,7 +89,7 @@ export default function FormGenerator<T extends FieldValues>(
 
   return (
     <>
-      {formatedTemplate.map((fieldset) => (
+      {formattedTemplate.map((fieldset) => (
         <Fieldset
           key={fieldset.id}
           legend={


### PR DESCRIPTION
Replace "formated" by ["formatted"](https://www.wordreference.com/definition/formatted), with 2 Ts.