### PR TITLE
fix(model): raise an error if the "about-the-study/parameters.ini" file is missing in the ZIP file

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/config/files.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/files.py
@@ -241,7 +241,13 @@ def parse_simulation_zip(path: Path) -> Simulation:
     ) as output_dir:
         try:
             with zipfile.ZipFile(path) as zf:
-                zf.extract(ini_path, output_dir)
+                try:
+                    zf.extract(ini_path, output_dir)
+                except KeyError:
+                    raise SimulationParsingError(
+                        path,
+                        f"Parameters file '{ini_path}' not found",
+                    ) from None
                 if xpansion_path in zf.namelist():
                     zf.extract(xpansion_path, output_dir)
                 if integrity_path in zf.namelist():

--- a/tests/storage/repository/filesystem/config/test_files.py
+++ b/tests/storage/repository/filesystem/config/test_files.py
@@ -1,0 +1,84 @@
+import zipfile
+from pathlib import Path
+from unittest.mock import patch, Mock
+
+import pytest
+
+from antarest.study.storage.rawstudy.model.filesystem.config.exceptions import (
+    SimulationParsingError,
+)
+from antarest.study.storage.rawstudy.model.filesystem.config.files import (
+    parse_simulation_zip,
+)
+from antarest.study.storage.rawstudy.model.filesystem.config.model import (
+    Simulation,
+)
+
+PARSE_SIMULATION_NAME = "antarest.study.storage.rawstudy.model.filesystem.config.files.parse_simulation"
+
+
+class TestParseSimulationZip:
+    def test_parse_simulation_zip__nominal(self, tmp_path: Path):
+        # prepare a ZIP file with the following files
+        archived_files = [
+            "about-the-study/parameters.ini",
+            "expansion/out.json",
+            "checkIntegrity.txt",
+        ]
+        zip_path = tmp_path.joinpath("dummy.zip")
+        with zipfile.ZipFile(
+            zip_path, mode="w", compression=zipfile.ZIP_DEFLATED
+        ) as zf:
+            for name in archived_files:
+                zf.writestr(name, b"dummy data")
+
+        def my_parse_simulation(path: Path, canonical_name: str) -> Simulation:
+            """
+            Mock function of the function `parse_simulation`, which is used to:
+            - avoid calling the original function which do a lot of stuff,
+            - check that the required files exist in a temporary directory.
+            """
+            assert path.is_dir()
+            assert canonical_name == zip_path.stem
+            for name_ in archived_files:
+                uncompressed = path.joinpath(name_)
+                assert uncompressed.is_file(), f"Missing {name_}"
+            return Mock(spec=Simulation)
+
+        # Call the `parse_simulation_zip` but using `my_parse_simulation`
+        with patch(PARSE_SIMULATION_NAME, new=my_parse_simulation):
+            actual = parse_simulation_zip(zip_path)
+
+        # check the result
+        assert actual.archived is True
+
+    def test_parse_simulation_zip__missing_required_files(
+        self, tmp_path: Path
+    ):
+        # prepare a ZIP file with the following files
+        archived_files = [
+            # "about-the-study/parameters.ini",  # <- required
+            "expansion/out.json",  # optional
+            "checkIntegrity.txt",  # optional
+        ]
+        zip_path = tmp_path.joinpath("dummy.zip")
+        with zipfile.ZipFile(
+            zip_path, mode="w", compression=zipfile.ZIP_DEFLATED
+        ) as zf:
+            for name in archived_files:
+                zf.writestr(name, b"dummy data")
+
+        # Call the `parse_simulation_zip` but using `my_parse_simulation`
+        with patch(PARSE_SIMULATION_NAME):
+            with pytest.raises(SimulationParsingError):
+                parse_simulation_zip(zip_path)
+
+    def test_parse_simulation_zip__bad_zip_file(self, tmp_path: Path):
+        # prepare a bad ZIP file
+        zip_path = tmp_path.joinpath("dummy.zip")
+        zip_path.write_bytes(b"PK")
+
+        # Call the `parse_simulation_zip` but using `my_parse_simulation`
+        with patch(PARSE_SIMULATION_NAME):
+            with pytest.raises(SimulationParsingError):
+                parse_simulation_zip(zip_path)


### PR DESCRIPTION
This PR avoid a 500 Error (`KeyError`) we loading the configuration of a study.

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/uvicorn/protocols/http/httptools_impl.py", line 375, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/usr/local/lib/python3.8/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/fastapi/applications.py", line 212, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.8/site-packages/ratelimit/core.py", line 82, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/cors.py", line 84, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/base.py", line 63, in __call__
    response = await self.dispatch_func(request, call_next)
  File "/antarest/core/logging/utils.py", line 168, in dispatch
    response = await call_next(request)
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/base.py", line 44, in call_next
    raise app_exc
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/base.py", line 34, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/base.py", line 63, in __call__
    response = await self.dispatch_func(request, call_next)
  File "/antarest/core/utils/fastapi_sqlalchemy/middleware.py", line 56, in dispatch
    response = await call_next(request)
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/base.py", line 44, in call_next
    raise app_exc
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/base.py", line 34, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "/usr/local/lib/python3.8/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc
  File "/usr/local/lib/python3.8/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 656, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 259, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 61, in app
    response = await func(request)
  File "/usr/local/lib/python3.8/site-packages/fastapi/routing.py", line 226, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.8/site-packages/fastapi/routing.py", line 161, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/usr/local/lib/python3.8/site-packages/starlette/concurrency.py", line 39, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "/usr/local/lib/python3.8/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/usr/local/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/usr/local/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/antarest/study/web/studies_blueprint.py", line 270, in get_study_synthesis
    return study_service.get_study_synthesis(study_id, params)
  File "/antarest/study/service.py", line 794, in get_study_synthesis
    return self.storage_service.get_storage(study).get_synthesis(
  File "/antarest/study/storage/rawstudy/raw_study_service.py", line 210, in get_synthesis
    study = self.study_factory.create_from_fs(study_path, metadata.id)
  File "/antarest/study/storage/rawstudy/model/filesystem/factory.py", line 64, in create_from_fs
    config = build(path, study_id, output_path)
  File "/antarest/study/storage/rawstudy/model/filesystem/config/files.py", line 74, in build
    outputs=_parse_outputs(output_path or study_path / "output"),
  File "/antarest/study/storage/rawstudy/model/filesystem/config/files.py", line 223, in _parse_outputs
    if simulation := parse_simulation_zip(path):
  File "/antarest/study/storage/rawstudy/model/filesystem/config/files.py", line 244, in parse_simulation_zip
    zf.extract(ini_path, output_dir)
  File "/usr/local/lib/python3.8/zipfile.py", line 1630, in extract
    return self._extract_member(member, path, pwd)
  File "/usr/local/lib/python3.8/zipfile.py", line 1669, in _extract_member
    member = self.getinfo(member)
  File "/usr/local/lib/python3.8/zipfile.py", line 1441, in getinfo
    raise KeyError(
KeyError: "There is no item named 'about-the-study/parameters.ini' in the archive"
```