### PR TITLE
fix(api): add missing "annual" key on correlation config for new areas

### DIFF
--- a/antarest/study/storage/variantstudy/model/command/create_area.py
+++ b/antarest/study/storage/variantstudy/model/command/create_area.py
@@ -93,6 +93,7 @@ class CreateArea(ICommand):
 
         # fmt: off
         hydro_config = study_data.tree.get(["input", "hydro", "hydro"])
+        correlation_config = study_data.tree.get(["input", "hydro", "prepro", "correlation"])
         get_or_create_section(hydro_config, "inter-daily-breakdown")[area_id] = 1
         get_or_create_section(hydro_config, "intra-daily-modulation")[area_id] = 24
         get_or_create_section(hydro_config, "inter-monthly-breakdown")[area_id] = 1
@@ -223,6 +224,14 @@ class CreateArea(ICommand):
                 },
             }
         }
+
+        # Ensure the "annual" key exists in the hydro prepro configuration for new areas, as it's the default mode for hydro correlations.
+        # If not present, it might lead to incorrect setup.
+        new_correlation = correlation_config.copy()
+        new_correlation.setdefault("annual", {})
+        new_area_data["input"]["hydro"]["prepro"][
+            "correlation"
+        ] = new_correlation
 
         if version > 650:
             # fmt: off

--- a/antarest/study/storage/variantstudy/model/command/create_area.py
+++ b/antarest/study/storage/variantstudy/model/command/create_area.py
@@ -93,7 +93,6 @@ class CreateArea(ICommand):
 
         # fmt: off
         hydro_config = study_data.tree.get(["input", "hydro", "hydro"])
-        correlation_config = study_data.tree.get(["input", "hydro", "prepro", "correlation"])
         get_or_create_section(hydro_config, "inter-daily-breakdown")[area_id] = 1
         get_or_create_section(hydro_config, "intra-daily-modulation")[area_id] = 24
         get_or_create_section(hydro_config, "inter-monthly-breakdown")[area_id] = 1
@@ -225,13 +224,12 @@ class CreateArea(ICommand):
             }
         }
 
-        # Ensure the "annual" key exists in the hydro prepro configuration for new areas, as it's the default mode for hydro correlations.
-        # If not present, it might lead to incorrect setup.
-        new_correlation = correlation_config.copy()
+        # Ensure the "annual" key exists in the hydro correlation configuration to avoid incorrect setup
+        # fmt: off
+        new_correlation = study_data.tree.get(["input", "hydro", "prepro", "correlation"])
         new_correlation.setdefault("annual", {})
-        new_area_data["input"]["hydro"]["prepro"][
-            "correlation"
-        ] = new_correlation
+        new_area_data["input"]["hydro"]["prepro"]["correlation"] = new_correlation
+        # fmt: on
 
         if version > 650:
             # fmt: off

--- a/tests/variantstudy/model/command/test_create_area.py
+++ b/tests/variantstudy/model/command/test_create_area.py
@@ -66,6 +66,16 @@ class TestCreateArea:
             assert int(hydro["leeway up"][area_id]) == 1
             assert int(hydro["pumping efficiency"][area_id]) == 1
 
+        # fmt: off
+        correlation = configparser.ConfigParser()
+        correlation.read(study_path / "input" / "hydro" / "prepro" / "correlation.ini")
+        correlation_dict = {k: v for k, v in correlation.items() if k != "DEFAULT"}
+        assert correlation_dict == {
+            "general": {"mode": "annual"},
+            "annual": {},
+        }
+        # fmt: on
+
         # Allocation
         assert (
             study_path / "input" / "hydro" / "allocation" / f"{area_id}.ini"


### PR DESCRIPTION
fix #1595 