### PR TITLE
build(launcher): use Antares-Launcher v1.3.0 to preserve "output"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Antares-Launcher~=1.2.4
+Antares-Launcher~=1.3.0
 
 aiofiles~=0.8.0
 alembic~=1.7.5


### PR DESCRIPTION
use Antares-Launcher v1.3.0 which preserve the "output" directory required by the `--step=sensitivity` Xpansion option