### PR TITLE
fix(study): fixing case sensitivity issues in reading study configuration

### DIFF
--- a/antarest/study/business/adequacy_patch_management.py
+++ b/antarest/study/business/adequacy_patch_management.py
@@ -1,13 +1,14 @@
 from enum import Enum
-from typing import Optional, List, Any, Dict
+from typing import Any, Dict, List, Optional
 
 from pydantic.types import StrictBool, confloat
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
+    GENERAL_DATA_PATH,
+    FieldInfo,
     FormFieldsBaseModel,
     execute_or_add_commands,
-    FieldInfo,
-    GENERAL_DATA_PATH,
 )
 from antarest.study.model import Study
 from antarest.study.storage.storage_service import StudyStorageService
@@ -16,7 +17,7 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class PriceTakingOrder(str, Enum):
+class PriceTakingOrder(EnumIgnoreCase):
     DENS = "DENS"
     LOAD = "Load"
 

--- a/antarest/study/business/advanced_parameters_management.py
+++ b/antarest/study/business/advanced_parameters_management.py
@@ -1,14 +1,16 @@
 import re
-from typing import Optional, List, Any, Dict, TypedDict
 from enum import Enum
+from typing import Any, Dict, List, Optional, TypedDict
 
 from pydantic import validator
 from pydantic.types import StrictInt, StrictStr
+
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    FormFieldsBaseModel,
-    execute_or_add_commands,
     GENERAL_DATA_PATH,
     FieldInfo,
+    FormFieldsBaseModel,
+    execute_or_add_commands,
 )
 from antarest.study.model import Study
 from antarest.study.storage.storage_service import StudyStorageService
@@ -17,42 +19,42 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class InitialReservoirLevel(str, Enum):
+class InitialReservoirLevel(EnumIgnoreCase):
     COLD_START = "cold start"
     HOT_START = "hot start"
 
 
-class HydroHeuristicPolicy(str, Enum):
+class HydroHeuristicPolicy(EnumIgnoreCase):
     ACCOMMODATE_RULES_CURVES = "accommodate rule curves"
     MAXIMIZE_GENERATION = "maximize generation"
 
 
-class HydroPricingMode(str, Enum):
+class HydroPricingMode(EnumIgnoreCase):
     FAST = "fast"
     ACCURATE = "accurate"
 
 
-class PowerFluctuation(str, Enum):
+class PowerFluctuation(EnumIgnoreCase):
     FREE_MODULATIONS = "free modulations"
     MINIMIZE_EXCURSIONS = "minimize excursions"
     MINIMIZE_RAMPING = "minimize ramping"
 
 
-class SheddingPolicy(str, Enum):
+class SheddingPolicy(EnumIgnoreCase):
     SHAVE_PEAKS = "shave peaks"
     MINIMIZE_DURATION = "minimize duration"
 
 
-class ReserveManagement(str, Enum):
+class ReserveManagement(EnumIgnoreCase):
     GLOBAL = "global"
 
 
-class UnitCommitmentMode(str, Enum):
+class UnitCommitmentMode(EnumIgnoreCase):
     FAST = "fast"
     ACCURATE = "accurate"
 
 
-class SimulationCore(str, Enum):
+class SimulationCore(EnumIgnoreCase):
     MINIMUM = "minimum"
     LOW = "low"
     MEDIUM = "medium"
@@ -60,7 +62,7 @@ class SimulationCore(str, Enum):
     MAXIMUM = "maximum"
 
 
-class RenewableGenerationModeling(str, Enum):
+class RenewableGenerationModeling(EnumIgnoreCase):
     AGGREGATED = "aggregated"
     CLUSTERS = "clusters"
 

--- a/antarest/study/business/areas/properties_management.py
+++ b/antarest/study/business/areas/properties_management.py
@@ -1,13 +1,14 @@
 import re
 from builtins import sorted
 from enum import Enum
-from typing import Optional, Dict, Any, cast, List, Set, Iterable
+from typing import Any, Dict, Iterable, List, Optional, Set, cast
 
-from pydantic import root_validator, Field
+from pydantic import Field, root_validator
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    FormFieldsBaseModel,
     FieldInfo,
+    FormFieldsBaseModel,
     execute_or_add_commands,
 )
 from antarest.study.model import Study
@@ -65,7 +66,7 @@ def decode_filter(
     return ", ".join(sort_filter_options(encoded_value))
 
 
-class AdequacyPatchMode(str, Enum):
+class AdequacyPatchMode(EnumIgnoreCase):
     OUTSIDE = "outside"
     INSIDE = "inside"
     VIRTUAL = "virtual"

--- a/antarest/study/business/areas/renewable_management.py
+++ b/antarest/study/business/areas/renewable_management.py
@@ -2,6 +2,9 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, Dict, List, Optional
 
+from pydantic import Field
+
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
     FieldInfo,
     FormFieldsBaseModel,
@@ -12,10 +15,9 @@ from antarest.study.storage.storage_service import StudyStorageService
 from antarest.study.storage.variantstudy.model.command.update_config import (
     UpdateConfig,
 )
-from pydantic import Field
 
 
-class TimeSeriesInterpretation(str, Enum):
+class TimeSeriesInterpretation(EnumIgnoreCase):
     POWER_GENERATION = "power-generation"
     PRODUCTION_FACTOR = "production-factor"
 

--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -1,12 +1,13 @@
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Optional, Dict, Any, List, cast
+from typing import Any, Dict, List, Optional, cast
 
-from pydantic import StrictStr, StrictBool
+from pydantic import StrictBool, StrictStr
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    FormFieldsBaseModel,
     FieldInfo,
+    FormFieldsBaseModel,
     execute_or_add_commands,
 )
 from antarest.study.model import Study
@@ -16,13 +17,13 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class TimeSeriesGenerationOption(str, Enum):
+class TimeSeriesGenerationOption(EnumIgnoreCase):
     USE_GLOBAL_PARAMETER = "use global parameter"
     FORCE_NO_GENERATION = "force no generation"
     FORCE_GENERATION = "force generation"
 
 
-class LawOption(str, Enum):
+class LawOption(EnumIgnoreCase):
     UNIFORM = "uniform"
     GEOMETRIC = "geometric"
 

--- a/antarest/study/business/enum_ignore_case.py
+++ b/antarest/study/business/enum_ignore_case.py
@@ -2,13 +2,13 @@ import enum
 import typing
 
 
-class EnumIgnoreCase(enum.Enum):
+class EnumIgnoreCase(str, enum.Enum):
     """
     Case-insensitive enum base class
 
     Usage:
 
-    >>> class WeekDay(str, EnumIgnoreCase):
+    >>> class WeekDay(EnumIgnoreCase):
     ...     MONDAY = "Monday"
     ...     TUESDAY = "Tuesday"
     ...     WEDNESDAY = "Wednesday"
@@ -26,7 +26,9 @@ class EnumIgnoreCase(enum.Enum):
     def _missing_(cls, value: object) -> typing.Optional["EnumIgnoreCase"]:
         if isinstance(value, str):
             for member in cls:
+                # noinspection PyUnresolvedReferences
                 if member.value.upper() == value.upper():
+                    # noinspection PyTypeChecker
                     return member
         # `value` is not a valid
         return None

--- a/antarest/study/business/enum_ignore_case.py
+++ b/antarest/study/business/enum_ignore_case.py
@@ -1,0 +1,32 @@
+import enum
+import typing
+
+
+class EnumIgnoreCase(enum.Enum):
+    """
+    Case-insensitive enum base class
+
+    Usage:
+
+    >>> class WeekDay(str, EnumIgnoreCase):
+    ...     MONDAY = "Monday"
+    ...     TUESDAY = "Tuesday"
+    ...     WEDNESDAY = "Wednesday"
+    ...     THURSDAY = "Thursday"
+    ...     FRIDAY = "Friday"
+    ...     SATURDAY = "Saturday"
+    ...     SUNDAY = "Sunday"
+    >>> WeekDay("monday")
+    <WeekDay.MONDAY: 'Monday'>
+    >>> WeekDay("MONDAY")
+    <WeekDay.MONDAY: 'Monday'>
+    """
+
+    @classmethod
+    def _missing_(cls, value: object) -> typing.Optional["EnumIgnoreCase"]:
+        if isinstance(value, str):
+            for member in cls:
+                if member.value.upper() == value.upper():
+                    return member
+        # `value` is not a valid
+        return None

--- a/antarest/study/business/general_management.py
+++ b/antarest/study/business/general_management.py
@@ -1,12 +1,13 @@
 from enum import Enum
-from typing import Optional, Dict, Any, List, cast
+from typing import Any, Dict, List, Optional, cast
 
-from pydantic import StrictBool, conint, PositiveInt, root_validator
+from pydantic import PositiveInt, StrictBool, conint, root_validator
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    FormFieldsBaseModel,
-    FieldInfo,
     GENERAL_DATA_PATH,
+    FieldInfo,
+    FormFieldsBaseModel,
     execute_or_add_commands,
 )
 from antarest.study.model import Study
@@ -20,13 +21,13 @@ from antarest.study.storage.variantstudy.model.command_context import (
 )
 
 
-class Mode(str, Enum):
+class Mode(EnumIgnoreCase):
     ECONOMY = "Economy"
     ADEQUACY = "Adequacy"
     DRAFT = "draft"
 
 
-class Month(str, Enum):
+class Month(EnumIgnoreCase):
     JANUARY = "january"
     FEBRUARY = "february"
     MARCH = "march"
@@ -41,7 +42,7 @@ class Month(str, Enum):
     DECEMBER = "december"
 
 
-class WeekDay(str, Enum):
+class WeekDay(EnumIgnoreCase):
     MONDAY = "Monday"
     TUESDAY = "Tuesday"
     WEDNESDAY = "Wednesday"
@@ -51,7 +52,7 @@ class WeekDay(str, Enum):
     SUNDAY = "Sunday"
 
 
-class BuildingMode(str, Enum):
+class BuildingMode(EnumIgnoreCase):
     AUTOMATIC = "Automatic"
     CUSTOM = "Custom"
     DERATED = "Derated"

--- a/antarest/study/business/optimization_management.py
+++ b/antarest/study/business/optimization_management.py
@@ -1,13 +1,14 @@
 from enum import Enum
-from typing import Optional, Union, List, Any, Dict, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from pydantic.types import StrictBool
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
+    GENERAL_DATA_PATH,
+    FieldInfo,
     FormFieldsBaseModel,
     execute_or_add_commands,
-    FieldInfo,
-    GENERAL_DATA_PATH,
 )
 from antarest.study.model import Study
 from antarest.study.storage.storage_service import StudyStorageService
@@ -16,11 +17,11 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class LegacyTransmissionCapacities(str, Enum):
+class LegacyTransmissionCapacities(EnumIgnoreCase):
     INFINITE = "infinite"
 
 
-class TransmissionCapacities(str, Enum):
+class TransmissionCapacities(EnumIgnoreCase):
     LOCAL_VALUES = "local-values"
     NULL_FOR_ALL_LINKS = "null-for-all-links"
     INFINITE_FOR_ALL_LINKS = "infinite-for-all-links"
@@ -28,14 +29,14 @@ class TransmissionCapacities(str, Enum):
     INFINITE_FOR_PHYSICAL_LINKS = "infinite-for-physical-links"
 
 
-class UnfeasibleProblemBehavior(str, Enum):
+class UnfeasibleProblemBehavior(EnumIgnoreCase):
     WARNING_DRY = "warning-dry"
     WARNING_VERBOSE = "warning-verbose"
     ERROR_DRY = "error-dry"
     ERROR_VERBOSE = "error-verbose"
 
 
-class SimplexOptimizationRange(str, Enum):
+class SimplexOptimizationRange(EnumIgnoreCase):
     DAY = "day"
     WEEK = "week"
 

--- a/antarest/study/business/table_mode_management.py
+++ b/antarest/study/business/table_mode_management.py
@@ -1,19 +1,9 @@
 from enum import Enum
-from typing import (
-    Optional,
-    Dict,
-    TypedDict,
-    Union,
-    Any,
-    List,
-)
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 from pydantic import StrictFloat
-from pydantic.types import StrictStr, StrictInt, StrictBool
+from pydantic.types import StrictBool, StrictInt, StrictStr
 
-from antarest.study.business.binding_constraint_management import (
-    BindingConstraintManager,
-)
 from antarest.study.business.areas.properties_management import (
     AdequacyPatchMode,
 )
@@ -21,21 +11,25 @@ from antarest.study.business.areas.renewable_management import (
     TimeSeriesInterpretation,
 )
 from antarest.study.business.areas.thermal_management import (
-    TimeSeriesGenerationOption,
     LawOption,
+    TimeSeriesGenerationOption,
 )
+from antarest.study.business.binding_constraint_management import (
+    BindingConstraintManager,
+)
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
     FormFieldsBaseModel,
     execute_or_add_commands,
 )
+from antarest.study.common.default_values import (
+    FilteringOptions,
+    LinkProperties,
+    NodalOptimization,
+)
 from antarest.study.model import RawStudy
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.storage_service import StudyStorageService
-from antarest.study.common.default_values import (
-    NodalOptimization,
-    FilteringOptions,
-    LinkProperties,
-)
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.command.update_binding_constraint import (
     UpdateBindingConstraint,
@@ -45,7 +39,7 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class TableTemplateType(str, Enum):
+class TableTemplateType(EnumIgnoreCase):
     AREA = "area"
     LINK = "link"
     CLUSTER = "cluster"
@@ -53,7 +47,7 @@ class TableTemplateType(str, Enum):
     BINDING_CONSTRAINT = "binding constraint"
 
 
-class AssetType(str, Enum):
+class AssetType(EnumIgnoreCase):
     AC = "ac"
     DC = "dc"
     GAZ = "gaz"
@@ -61,19 +55,19 @@ class AssetType(str, Enum):
     OTHER = "other"
 
 
-class TransmissionCapacity(str, Enum):
+class TransmissionCapacity(EnumIgnoreCase):
     INFINITE = "infinite"
     IGNORE = "ignore"
     ENABLED = "enabled"
 
 
-class BindingConstraintType(str, Enum):
+class BindingConstraintType(EnumIgnoreCase):
     HOURLY = "hourly"
     DAILY = "daily"
     WEEKLY = "weekly"
 
 
-class BindingConstraintOperator(str, Enum):
+class BindingConstraintOperator(EnumIgnoreCase):
     LESS = "less"
     GREATER = "greater"
     BOTH = "both"

--- a/antarest/study/business/timeseries_config_management.py
+++ b/antarest/study/business/timeseries_config_management.py
@@ -1,18 +1,14 @@
 from enum import Enum
-from typing import Dict, Optional, List
+from typing import Dict, List, Optional
 
-from pydantic import (
-    root_validator,
-    validator,
-    StrictBool,
-    StrictInt,
-)
+from pydantic import StrictBool, StrictInt, root_validator, validator
 
 from antarest.core.model import JSON
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    execute_or_add_commands,
-    FormFieldsBaseModel,
     GENERAL_DATA_PATH,
+    FormFieldsBaseModel,
+    execute_or_add_commands,
 )
 from antarest.study.model import Study
 from antarest.study.storage.rawstudy.model.filesystem.config.model import (
@@ -25,7 +21,7 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class TSType(str, Enum):
+class TSType(EnumIgnoreCase):
     LOAD = "load"
     HYDRO = "hydro"
     THERMAL = "thermal"
@@ -35,7 +31,7 @@ class TSType(str, Enum):
     NTC = "ntc"
 
 
-class SeasonCorrelation(str, Enum):
+class SeasonCorrelation(EnumIgnoreCase):
     MONTHLY = "monthly"
     ANNUAL = "annual"
 

--- a/antarest/study/business/xpansion_management.py
+++ b/antarest/study/business/xpansion_management.py
@@ -3,15 +3,16 @@ import shutil
 from enum import Enum
 from http import HTTPStatus
 from io import BytesIO
-from typing import Optional, Union, List, cast
-from zipfile import ZipFile, BadZipFile
+from typing import List, Optional, Union, cast
+from zipfile import BadZipFile, ZipFile
 
 from fastapi import HTTPException, UploadFile
-from pydantic import Field, BaseModel, validator
+from pydantic import BaseModel, Field, validator
 
 from antarest.core.exceptions import BadZipBinary
 from antarest.core.model import JSON
 from antarest.core.utils.utils import suppress_exception
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.model import Study
 from antarest.study.storage.rawstudy.model.filesystem.bucket_node import (
     BucketNode,
@@ -30,35 +31,35 @@ from antarest.study.storage.utils import fix_study_root
 logger = logging.getLogger(__name__)
 
 
-class XpansionResourceFileType(str, Enum):
+class XpansionResourceFileType(EnumIgnoreCase):
     CAPACITIES = "capacities"
     WEIGHTS = "weights"
     CONSTRAINTS = "constraints"
 
 
-class UcType(str, Enum):
+class UcType(EnumIgnoreCase):
     EXPANSION_FAST = "expansion_fast"
     EXPANSION_ACCURATE = "expansion_accurate"
 
 
-class Master(str, Enum):
+class Master(EnumIgnoreCase):
     INTEGER = "integer"
     RELAXED = "relaxed"
 
 
-class CutType(str, Enum):
+class CutType(EnumIgnoreCase):
     AVERAGE = "average"
     YEARLY = "yearly"
     WEEKLY = "weekly"
 
 
-class Solver(str, Enum):
+class Solver(EnumIgnoreCase):
     CBC = "Cbc"
     COIN = "Coin"
     XPRESS = "Xpress"
 
 
-class MaxIteration(str, Enum):
+class MaxIteration(EnumIgnoreCase):
     INF = "+Inf"
 
 


### PR DESCRIPTION
This pull request introduces a new class called `EnumIgnoreCase` that enables case-insensitive behavior when converting string values to enumerated types (`Enum`). The `EnumIgnoreCase` class serves as a base class for enumerated types used within forms.

Motivation:

Currently, Antares Web encounters issues when there are discrepancies in the case sensitivity of enumerated types during configuration file reading. This pull request aims to address this problem by providing a solution that allows for case-insensitive conversion of enumerated types.

Changes Made:

1. Added the `EnumIgnoreCase` class, which inherits from `Enum`, to the Antares Web codebase.
2. Implemented the necessary logic within the `EnumIgnoreCase` class to handle case-insensitive comparisons and conversions.
3. Modified the relevant forms to use the `EnumIgnoreCase` class as the base class for enumerated types.

This change concerns the following forms:

- `PropertiesFormFields`: field `adequacy_patch_mode` (v8.3);
- `RenewableFormFields`: field `ts_interpretation`;
- `ThermalFormFields`: fields `gen_ts`, `law_forced` and `law_planned`;
- `AdequacyPatchFormFields`: field `price_taking_order`;
- `AdvancedParamsFormFields`: fields `initial_reservoir_levels`, `hydro_heuristic_policy`, `hydro_pricing_mode`, `power_fluctuations`, `shedding_policy`, `day_ahead_reserve_management`, `unit_commitment_mode`, `number_of_cores_mode`, and `renewable_generation_modelling`;
- `GeneralFormFields`: fields `mode`, `first_month`, `first_week_day`, `first_january`, and `building_mode`;
- `OptimizationFormFields`: fields `transmission_capacities`, `unfeasible_problem_behavior`, and `simplex_optimization_range`;
- `TableTemplateType`: used in table mode:
  - `LinkColumns`: fields `asset_type`, and `transmission_capacities`,
  - `BindingConstraintColumns`: fields `type`, and `operator`;
- `TSType`: used in time series:
  - `TSFormFieldsForType`: field `season_correlation`
- `XpansionResourceFileType`: used in Xpansion configuration:
  - `XpansionSettingsDTO`: fields `uc_type`, `master`, `cut_type`, `solver`, and `max_iteration`.
