### PR TITLE
fix(fastapi): correct URL inconsistency between the webapp and the API

### DIFF
--- a/antarest/core/version_info.py
+++ b/antarest/core/version_info.py
@@ -1,9 +1,11 @@
 """
 Python module that is dedicated to printing application version and dependencies information
 """
+import os
 import subprocess
 from pathlib import Path
 from typing import Dict
+import sys
 
 from pydantic import BaseModel
 
@@ -57,11 +59,9 @@ def get_commit_id(resources_dir: Path) -> str:
 
 def get_last_commit_from_git() -> str:
     """Returns the commit ID of the current Git HEAD, or ""."""
-    command = "git log -1 HEAD --format=%H"
+    command = ["git", "log", "-1", "HEAD", "--format=%H"]
     try:
-        return subprocess.check_output(
-            command, encoding="utf-8", shell=True
-        ).strip()
+        return subprocess.check_output(command, encoding="utf-8").strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return ""
 
@@ -80,7 +80,8 @@ def get_dependencies() -> Dict[str, str]:
             If the `pip freeze` command fails for some reason.
     """
     # fmt: off
-    output = subprocess.check_output("pip freeze", encoding="utf-8", shell=True)
+    args = [sys.executable, "-m", "pip", "freeze"]
+    output = subprocess.check_output(args, encoding="utf-8")
     lines = (
         line
         for line in output.splitlines(keepends=False)

--- a/antarest/matrixstore/model.py
+++ b/antarest/matrixstore/model.py
@@ -1,23 +1,40 @@
+import datetime
 import uuid
-from datetime import datetime
-from typing import Any, List, Optional, Union
-
-from pydantic import BaseModel
-from sqlalchemy import Column, String, Enum, DateTime, Table, ForeignKey, Integer, Boolean  # type: ignore
-from sqlalchemy.orm import relationship  # type: ignore
-from sqlalchemy.orm.collections import attribute_mapped_collection  # type: ignore
+from typing import Any, List, Union
 
 from antarest.core.persistence import Base
 from antarest.login.model import GroupDTO, Identity, UserInfo
+from pydantic import BaseModel
+from sqlalchemy import (  # type: ignore
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+)
+from sqlalchemy.orm import relationship  # type: ignore
 
 
 class Matrix(Base):  # type: ignore
+    """
+    Represents a matrix object in the database.
+
+    Attributes:
+        id: A SHA256 hash for the matrix data (primary key).
+        width: Number of columns in the matrix.
+        height: Number of rows in the matrix.
+        created_at: Creation date of the matrix (unknown usage).
+    """
+
+    # noinspection SpellCheckingInspection
     __tablename__ = "matrix"
 
-    id = Column(String(64), primary_key=True)
-    width = Column(Integer)
-    height = Column(Integer)
-    created_at = Column(DateTime)
+    id: str = Column(String(64), primary_key=True)
+    width: int = Column(Integer)
+    height: int = Column(Integer)
+    created_at: datetime.datetime = Column(DateTime)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Matrix):
@@ -59,19 +76,23 @@ groups_dataset_relation = Table(
 
 
 class MatrixDataSetRelation(Base):  # type: ignore
+    # noinspection SpellCheckingInspection
     __tablename__ = "dataset_matrices"
-    dataset_id = Column(
+
+    # noinspection SpellCheckingInspection
+    dataset_id: str = Column(
         String,
         ForeignKey("dataset.id", name="fk_matrixdatasetrelation_dataset_id"),
         primary_key=True,
     )
-    matrix_id = Column(
+    # noinspection SpellCheckingInspection
+    matrix_id: str = Column(
         String,
         ForeignKey("matrix.id", name="fk_matrixdatasetrelation_matrix_id"),
         primary_key=True,
     )
-    name = Column(String, primary_key=True)
-    matrix = relationship(Matrix)
+    name: str = Column(String, primary_key=True)
+    matrix: Matrix = relationship(Matrix)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, MatrixDataSetRelation):
@@ -87,24 +108,43 @@ class MatrixDataSetRelation(Base):  # type: ignore
 
 
 class MatrixDataSet(Base):  # type: ignore
+    """
+    Represents a user dataset containing matrices in the database.
+
+    Attributes:
+        id: The unique identifier of the dataset (primary key).
+        name: The name of the dataset.
+        owner_id: The foreign key referencing the owner's identity.
+        public: Indicates whether the dataset is public or not.
+        created_at: The creation date of the dataset.
+        updated_at: The last update date of the dataset.
+
+    Relationships:
+        owner (Identity): The relationship to the owner's identity.
+        groups (List[Group]): The relationship to groups associated with the dataset.
+        matrices (List[MatrixDataSetRelation]): The relationship to matrix dataset relations.
+    """
+
+    # noinspection SpellCheckingInspection
     __tablename__ = "dataset"
 
-    id = Column(
+    id: str = Column(
         String(36),
         primary_key=True,
         default=lambda: str(uuid.uuid4()),
         unique=True,
     )
-    name = Column(String)
-    owner_id = Column(
+    name: str = Column(String)
+    # noinspection SpellCheckingInspection
+    owner_id: int = Column(
         Integer,
         ForeignKey("identities.id", name="fk_matrixdataset_identities_id"),
     )
-    public = Column(Boolean, default=False)
-    created_at = Column(DateTime)
-    updated_at = Column(DateTime)
+    public: bool = Column(Boolean, default=False)
+    created_at: datetime.datetime = Column(DateTime)
+    updated_at: datetime.datetime = Column(DateTime)
 
-    owner = relationship(Identity)
+    owner: Identity = relationship(Identity)
     groups = relationship(
         "Group",
         secondary=lambda: groups_dataset_relation,

--- a/antarest/matrixstore/repository.py
+++ b/antarest/matrixstore/repository.py
@@ -67,7 +67,7 @@ class MatrixDataSetRepository:
         """
         query = db.session.query(MatrixDataSet)
         if name is not None:
-            query = query.filter(MatrixDataSet.name.ilike(f"%{name}%"))
+            query = query.filter(MatrixDataSet.name.ilike(f"%{name}%"))  # type: ignore
         if owner is not None:
             query = query.filter(MatrixDataSet.owner_id == owner)
         datasets: List[MatrixDataSet] = query.distinct().all()

--- a/antarest/study/business/adequacy_patch_management.py
+++ b/antarest/study/business/adequacy_patch_management.py
@@ -1,13 +1,14 @@
 from enum import Enum
-from typing import Optional, List, Any, Dict
+from typing import Any, Dict, List, Optional
 
 from pydantic.types import StrictBool, confloat
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
+    GENERAL_DATA_PATH,
+    FieldInfo,
     FormFieldsBaseModel,
     execute_or_add_commands,
-    FieldInfo,
-    GENERAL_DATA_PATH,
 )
 from antarest.study.model import Study
 from antarest.study.storage.storage_service import StudyStorageService
@@ -16,7 +17,7 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class PriceTakingOrder(str, Enum):
+class PriceTakingOrder(EnumIgnoreCase):
     DENS = "DENS"
     LOAD = "Load"
 

--- a/antarest/study/business/advanced_parameters_management.py
+++ b/antarest/study/business/advanced_parameters_management.py
@@ -1,14 +1,16 @@
 import re
-from typing import Optional, List, Any, Dict, TypedDict
 from enum import Enum
+from typing import Any, Dict, List, Optional, TypedDict
 
 from pydantic import validator
 from pydantic.types import StrictInt, StrictStr
+
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    FormFieldsBaseModel,
-    execute_or_add_commands,
     GENERAL_DATA_PATH,
     FieldInfo,
+    FormFieldsBaseModel,
+    execute_or_add_commands,
 )
 from antarest.study.model import Study
 from antarest.study.storage.storage_service import StudyStorageService
@@ -17,42 +19,42 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class InitialReservoirLevel(str, Enum):
+class InitialReservoirLevel(EnumIgnoreCase):
     COLD_START = "cold start"
     HOT_START = "hot start"
 
 
-class HydroHeuristicPolicy(str, Enum):
+class HydroHeuristicPolicy(EnumIgnoreCase):
     ACCOMMODATE_RULES_CURVES = "accommodate rule curves"
     MAXIMIZE_GENERATION = "maximize generation"
 
 
-class HydroPricingMode(str, Enum):
+class HydroPricingMode(EnumIgnoreCase):
     FAST = "fast"
     ACCURATE = "accurate"
 
 
-class PowerFluctuation(str, Enum):
+class PowerFluctuation(EnumIgnoreCase):
     FREE_MODULATIONS = "free modulations"
     MINIMIZE_EXCURSIONS = "minimize excursions"
     MINIMIZE_RAMPING = "minimize ramping"
 
 
-class SheddingPolicy(str, Enum):
+class SheddingPolicy(EnumIgnoreCase):
     SHAVE_PEAKS = "shave peaks"
     MINIMIZE_DURATION = "minimize duration"
 
 
-class ReserveManagement(str, Enum):
+class ReserveManagement(EnumIgnoreCase):
     GLOBAL = "global"
 
 
-class UnitCommitmentMode(str, Enum):
+class UnitCommitmentMode(EnumIgnoreCase):
     FAST = "fast"
     ACCURATE = "accurate"
 
 
-class SimulationCore(str, Enum):
+class SimulationCore(EnumIgnoreCase):
     MINIMUM = "minimum"
     LOW = "low"
     MEDIUM = "medium"
@@ -60,7 +62,7 @@ class SimulationCore(str, Enum):
     MAXIMUM = "maximum"
 
 
-class RenewableGenerationModeling(str, Enum):
+class RenewableGenerationModeling(EnumIgnoreCase):
     AGGREGATED = "aggregated"
     CLUSTERS = "clusters"
 

--- a/antarest/study/business/areas/properties_management.py
+++ b/antarest/study/business/areas/properties_management.py
@@ -1,13 +1,14 @@
 import re
 from builtins import sorted
 from enum import Enum
-from typing import Optional, Dict, Any, cast, List, Set, Iterable
+from typing import Any, Dict, Iterable, List, Optional, Set, cast
 
-from pydantic import root_validator, Field
+from pydantic import Field, root_validator
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    FormFieldsBaseModel,
     FieldInfo,
+    FormFieldsBaseModel,
     execute_or_add_commands,
 )
 from antarest.study.model import Study
@@ -65,7 +66,7 @@ def decode_filter(
     return ", ".join(sort_filter_options(encoded_value))
 
 
-class AdequacyPatchMode(str, Enum):
+class AdequacyPatchMode(EnumIgnoreCase):
     OUTSIDE = "outside"
     INSIDE = "inside"
     VIRTUAL = "virtual"

--- a/antarest/study/business/areas/renewable_management.py
+++ b/antarest/study/business/areas/renewable_management.py
@@ -2,6 +2,9 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, Dict, List, Optional
 
+from pydantic import Field
+
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
     FieldInfo,
     FormFieldsBaseModel,
@@ -12,10 +15,9 @@ from antarest.study.storage.storage_service import StudyStorageService
 from antarest.study.storage.variantstudy.model.command.update_config import (
     UpdateConfig,
 )
-from pydantic import Field
 
 
-class TimeSeriesInterpretation(str, Enum):
+class TimeSeriesInterpretation(EnumIgnoreCase):
     POWER_GENERATION = "power-generation"
     PRODUCTION_FACTOR = "production-factor"
 

--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -1,12 +1,13 @@
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Optional, Dict, Any, List, cast
+from typing import Any, Dict, List, Optional, cast
 
-from pydantic import StrictStr, StrictBool
+from pydantic import StrictBool, StrictStr
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    FormFieldsBaseModel,
     FieldInfo,
+    FormFieldsBaseModel,
     execute_or_add_commands,
 )
 from antarest.study.model import Study
@@ -16,13 +17,13 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class TimeSeriesGenerationOption(str, Enum):
+class TimeSeriesGenerationOption(EnumIgnoreCase):
     USE_GLOBAL_PARAMETER = "use global parameter"
     FORCE_NO_GENERATION = "force no generation"
     FORCE_GENERATION = "force generation"
 
 
-class LawOption(str, Enum):
+class LawOption(EnumIgnoreCase):
     UNIFORM = "uniform"
     GEOMETRIC = "geometric"
 

--- a/antarest/study/business/enum_ignore_case.py
+++ b/antarest/study/business/enum_ignore_case.py
@@ -1,0 +1,34 @@
+import enum
+import typing
+
+
+class EnumIgnoreCase(str, enum.Enum):
+    """
+    Case-insensitive enum base class
+
+    Usage:
+
+    >>> class WeekDay(EnumIgnoreCase):
+    ...     MONDAY = "Monday"
+    ...     TUESDAY = "Tuesday"
+    ...     WEDNESDAY = "Wednesday"
+    ...     THURSDAY = "Thursday"
+    ...     FRIDAY = "Friday"
+    ...     SATURDAY = "Saturday"
+    ...     SUNDAY = "Sunday"
+    >>> WeekDay("monday")
+    <WeekDay.MONDAY: 'Monday'>
+    >>> WeekDay("MONDAY")
+    <WeekDay.MONDAY: 'Monday'>
+    """
+
+    @classmethod
+    def _missing_(cls, value: object) -> typing.Optional["EnumIgnoreCase"]:
+        if isinstance(value, str):
+            for member in cls:
+                # noinspection PyUnresolvedReferences
+                if member.value.upper() == value.upper():
+                    # noinspection PyTypeChecker
+                    return member
+        # `value` is not a valid
+        return None

--- a/antarest/study/business/general_management.py
+++ b/antarest/study/business/general_management.py
@@ -1,12 +1,13 @@
 from enum import Enum
-from typing import Optional, Dict, Any, List, cast
+from typing import Any, Dict, List, Optional, cast
 
-from pydantic import StrictBool, conint, PositiveInt, root_validator
+from pydantic import PositiveInt, StrictBool, conint, root_validator
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    FormFieldsBaseModel,
-    FieldInfo,
     GENERAL_DATA_PATH,
+    FieldInfo,
+    FormFieldsBaseModel,
     execute_or_add_commands,
 )
 from antarest.study.model import Study
@@ -20,13 +21,13 @@ from antarest.study.storage.variantstudy.model.command_context import (
 )
 
 
-class Mode(str, Enum):
+class Mode(EnumIgnoreCase):
     ECONOMY = "Economy"
     ADEQUACY = "Adequacy"
     DRAFT = "draft"
 
 
-class Month(str, Enum):
+class Month(EnumIgnoreCase):
     JANUARY = "january"
     FEBRUARY = "february"
     MARCH = "march"
@@ -41,7 +42,7 @@ class Month(str, Enum):
     DECEMBER = "december"
 
 
-class WeekDay(str, Enum):
+class WeekDay(EnumIgnoreCase):
     MONDAY = "Monday"
     TUESDAY = "Tuesday"
     WEDNESDAY = "Wednesday"
@@ -51,7 +52,7 @@ class WeekDay(str, Enum):
     SUNDAY = "Sunday"
 
 
-class BuildingMode(str, Enum):
+class BuildingMode(EnumIgnoreCase):
     AUTOMATIC = "Automatic"
     CUSTOM = "Custom"
     DERATED = "Derated"

--- a/antarest/study/business/optimization_management.py
+++ b/antarest/study/business/optimization_management.py
@@ -1,13 +1,14 @@
 from enum import Enum
-from typing import Optional, Union, List, Any, Dict, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from pydantic.types import StrictBool
 
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
+    GENERAL_DATA_PATH,
+    FieldInfo,
     FormFieldsBaseModel,
     execute_or_add_commands,
-    FieldInfo,
-    GENERAL_DATA_PATH,
 )
 from antarest.study.model import Study
 from antarest.study.storage.storage_service import StudyStorageService
@@ -16,11 +17,11 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class LegacyTransmissionCapacities(str, Enum):
+class LegacyTransmissionCapacities(EnumIgnoreCase):
     INFINITE = "infinite"
 
 
-class TransmissionCapacities(str, Enum):
+class TransmissionCapacities(EnumIgnoreCase):
     LOCAL_VALUES = "local-values"
     NULL_FOR_ALL_LINKS = "null-for-all-links"
     INFINITE_FOR_ALL_LINKS = "infinite-for-all-links"
@@ -28,14 +29,14 @@ class TransmissionCapacities(str, Enum):
     INFINITE_FOR_PHYSICAL_LINKS = "infinite-for-physical-links"
 
 
-class UnfeasibleProblemBehavior(str, Enum):
+class UnfeasibleProblemBehavior(EnumIgnoreCase):
     WARNING_DRY = "warning-dry"
     WARNING_VERBOSE = "warning-verbose"
     ERROR_DRY = "error-dry"
     ERROR_VERBOSE = "error-verbose"
 
 
-class SimplexOptimizationRange(str, Enum):
+class SimplexOptimizationRange(EnumIgnoreCase):
     DAY = "day"
     WEEK = "week"
 

--- a/antarest/study/business/table_mode_management.py
+++ b/antarest/study/business/table_mode_management.py
@@ -1,19 +1,9 @@
 from enum import Enum
-from typing import (
-    Optional,
-    Dict,
-    TypedDict,
-    Union,
-    Any,
-    List,
-)
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 from pydantic import StrictFloat
-from pydantic.types import StrictStr, StrictInt, StrictBool
+from pydantic.types import StrictBool, StrictInt, StrictStr
 
-from antarest.study.business.binding_constraint_management import (
-    BindingConstraintManager,
-)
 from antarest.study.business.areas.properties_management import (
     AdequacyPatchMode,
 )
@@ -21,21 +11,25 @@ from antarest.study.business.areas.renewable_management import (
     TimeSeriesInterpretation,
 )
 from antarest.study.business.areas.thermal_management import (
-    TimeSeriesGenerationOption,
     LawOption,
+    TimeSeriesGenerationOption,
 )
+from antarest.study.business.binding_constraint_management import (
+    BindingConstraintManager,
+)
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
     FormFieldsBaseModel,
     execute_or_add_commands,
 )
+from antarest.study.common.default_values import (
+    FilteringOptions,
+    LinkProperties,
+    NodalOptimization,
+)
 from antarest.study.model import RawStudy
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.storage_service import StudyStorageService
-from antarest.study.common.default_values import (
-    NodalOptimization,
-    FilteringOptions,
-    LinkProperties,
-)
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.command.update_binding_constraint import (
     UpdateBindingConstraint,
@@ -45,7 +39,7 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class TableTemplateType(str, Enum):
+class TableTemplateType(EnumIgnoreCase):
     AREA = "area"
     LINK = "link"
     CLUSTER = "cluster"
@@ -53,7 +47,7 @@ class TableTemplateType(str, Enum):
     BINDING_CONSTRAINT = "binding constraint"
 
 
-class AssetType(str, Enum):
+class AssetType(EnumIgnoreCase):
     AC = "ac"
     DC = "dc"
     GAZ = "gaz"
@@ -61,19 +55,19 @@ class AssetType(str, Enum):
     OTHER = "other"
 
 
-class TransmissionCapacity(str, Enum):
+class TransmissionCapacity(EnumIgnoreCase):
     INFINITE = "infinite"
     IGNORE = "ignore"
     ENABLED = "enabled"
 
 
-class BindingConstraintType(str, Enum):
+class BindingConstraintType(EnumIgnoreCase):
     HOURLY = "hourly"
     DAILY = "daily"
     WEEKLY = "weekly"
 
 
-class BindingConstraintOperator(str, Enum):
+class BindingConstraintOperator(EnumIgnoreCase):
     LESS = "less"
     GREATER = "greater"
     BOTH = "both"

--- a/antarest/study/business/timeseries_config_management.py
+++ b/antarest/study/business/timeseries_config_management.py
@@ -1,18 +1,14 @@
 from enum import Enum
-from typing import Dict, Optional, List
+from typing import Dict, List, Optional
 
-from pydantic import (
-    root_validator,
-    validator,
-    StrictBool,
-    StrictInt,
-)
+from pydantic import StrictBool, StrictInt, root_validator, validator
 
 from antarest.core.model import JSON
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import (
-    execute_or_add_commands,
-    FormFieldsBaseModel,
     GENERAL_DATA_PATH,
+    FormFieldsBaseModel,
+    execute_or_add_commands,
 )
 from antarest.study.model import Study
 from antarest.study.storage.rawstudy.model.filesystem.config.model import (
@@ -25,7 +21,7 @@ from antarest.study.storage.variantstudy.model.command.update_config import (
 )
 
 
-class TSType(str, Enum):
+class TSType(EnumIgnoreCase):
     LOAD = "load"
     HYDRO = "hydro"
     THERMAL = "thermal"
@@ -35,7 +31,7 @@ class TSType(str, Enum):
     NTC = "ntc"
 
 
-class SeasonCorrelation(str, Enum):
+class SeasonCorrelation(EnumIgnoreCase):
     MONTHLY = "monthly"
     ANNUAL = "annual"
 

--- a/antarest/study/business/xpansion_management.py
+++ b/antarest/study/business/xpansion_management.py
@@ -3,15 +3,16 @@ import shutil
 from enum import Enum
 from http import HTTPStatus
 from io import BytesIO
-from typing import Optional, Union, List, cast
-from zipfile import ZipFile, BadZipFile
+from typing import List, Optional, Union, cast
+from zipfile import BadZipFile, ZipFile
 
 from fastapi import HTTPException, UploadFile
-from pydantic import Field, BaseModel, validator
+from pydantic import BaseModel, Field, validator
 
 from antarest.core.exceptions import BadZipBinary
 from antarest.core.model import JSON
 from antarest.core.utils.utils import suppress_exception
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.model import Study
 from antarest.study.storage.rawstudy.model.filesystem.bucket_node import (
     BucketNode,
@@ -30,35 +31,35 @@ from antarest.study.storage.utils import fix_study_root
 logger = logging.getLogger(__name__)
 
 
-class XpansionResourceFileType(str, Enum):
+class XpansionResourceFileType(EnumIgnoreCase):
     CAPACITIES = "capacities"
     WEIGHTS = "weights"
     CONSTRAINTS = "constraints"
 
 
-class UcType(str, Enum):
+class UcType(EnumIgnoreCase):
     EXPANSION_FAST = "expansion_fast"
     EXPANSION_ACCURATE = "expansion_accurate"
 
 
-class Master(str, Enum):
+class Master(EnumIgnoreCase):
     INTEGER = "integer"
     RELAXED = "relaxed"
 
 
-class CutType(str, Enum):
+class CutType(EnumIgnoreCase):
     AVERAGE = "average"
     YEARLY = "yearly"
     WEEKLY = "weekly"
 
 
-class Solver(str, Enum):
+class Solver(EnumIgnoreCase):
     CBC = "Cbc"
     COIN = "Coin"
     XPRESS = "Xpress"
 
 
-class MaxIteration(str, Enum):
+class MaxIteration(EnumIgnoreCase):
     INF = "+Inf"
 
 

--- a/resources/deploy/config.yaml
+++ b/resources/deploy/config.yaml
@@ -47,16 +47,13 @@ launcher:
 #    slurm_script_path: /path/to/launchantares_v1.1.3.sh
 #    db_primary_key: name
 #    antares_versions_on_remote_server :
-#      - "610"
-#      - "700"
-#      - "710"
-#      - "720"
-#      - "800"
+#      - "840"
+#      - "850"
 
 
 debug: false
 
-root_path: ""
+root_path: "api"
 
 #tasks:
 #  max_workers: 5
@@ -64,7 +61,7 @@ server:
   worker_threadpool_size: 12
   services:
     - watcher
-    
+
 logging:
   level: INFO
   logfile: ./tmp/antarest.log

--- a/tests/core/test_version_info.py
+++ b/tests/core/test_version_info.py
@@ -22,14 +22,18 @@ class TestVersionInfo:
 
     @pytest.mark.unit_test
     def test_get_commit_id__commit_id__exist(self, tmp_path) -> None:
+        # fmt: off
         path_commit_id = tmp_path.joinpath("commit_id")
-        path_commit_id.write_text("fake_commit")
-        assert get_commit_id(tmp_path) == "fake_commit"
+        path_commit_id.write_text("6d891aba6e4a1c3a6f43b8ca00b021a20d319091")
+        assert (get_commit_id(tmp_path) == "6d891aba6e4a1c3a6f43b8ca00b021a20d319091")
+        # fmt: on
 
     @pytest.mark.unit_test
-    def test_get_commit_id__commit_id__missing(self, tmp_path) -> None:
-        with patch(
-            "antarest.core.version_info.get_last_commit_from_git",
-            return_value="mock commit",
-        ):
-            assert get_commit_id(tmp_path) == "mock commit"
+    def test_get_commit_id__git_call_ok(self, tmp_path) -> None:
+        actual = get_commit_id(tmp_path)
+        assert re.fullmatch(r"[0-9a-fA-F]{40}", actual)
+
+    @pytest.mark.unit_test
+    def test_get_commit_id__git_call_failed(self, tmp_path) -> None:
+        with patch("subprocess.check_output", side_effect=FileNotFoundError):
+            assert not get_commit_id(tmp_path)


### PR DESCRIPTION
L'objectif de cette PR est de corriger les problèmes d’URL entre la webapp et l'API Swagger, lorsque la webapp est directement embarquée dans l'application et servie sous la format d'une page statique depuis le point d'entrée `/static`, comme c'est le cas avec la version Desktop.

J'ai donc apporté les modifications suivantes :

- Toutes les requêtes qui ne sont pas des requêtes de l'API sont redirigées vers la page `index.html` de la webapp qui s'occupe d'interpréter la route de l'URL (le path et les paramètres de la requête).
- La configuration de l'application _packagée_ par PyInstaller est modifiée afin d'avoir  `root_path = 'api'`, ce qui permet d'avoir des URL d'API qui commencent toutes par "/api"

J'ai déjà testé la version Desktop sous Ubuntu et cela fonctionne bien.
