### PR TITLE
chore: the section name in the INI file is the cluster ID, not the cluster name

### DIFF
--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -115,6 +115,8 @@ class CreateCluster(ICommand):
         cluster_list_config = study_data.tree.get(
             ["input", "thermal", "clusters", self.area_id, "list"]
         )
+        # fixme: rigorously, the section name in the INI file is the cluster ID, not the cluster name
+        #  cluster_list_config[transform_name_to_id(self.cluster_name)] = self.parameters
         cluster_list_config[self.cluster_name] = self.parameters
 
         self.parameters["name"] = self.cluster_name

--- a/antarest/study/storage/variantstudy/model/command/create_renewables_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_renewables_cluster.py
@@ -96,6 +96,8 @@ class CreateRenewablesCluster(ICommand):
         # default values
         if "ts-interpretation" not in self.parameters:
             self.parameters["ts-interpretation"] = "power-generation"
+        # fixme: rigorously, the section name in the INI file is the cluster ID, not the cluster name
+        #  cluster_list_config[transform_name_to_id(self.cluster_name)] = self.parameters
         cluster_list_config[self.cluster_name] = self.parameters
 
         self.parameters["name"] = self.cluster_name


### PR DESCRIPTION
Cette PR, actuellement en mode "brouillon", a pour objectif de corriger la confusion qu'il y a actuellement entre l'ID et le nom d'un cluster thermique ou renouvelable.

En effet, dans la configuration (le fichier `list.ini`), la section représente l'identifiant du cluster alors que l'option `name` représente le nom. Il va s'en dire que l'on peut facilement passer du nom à l'ID en utilisant la fonction `transform_name_to_id` (mais pas dans l'autre sens).

```ini
[sb]           # <- Cluster ID
name = sb      # <- Cluster Name
group = Gas
unitcount = 25
nominalcapacity = 500.000000
co2 = 0.900000
marginal-cost = 50.000000
market-bid-cost = 50.000000
```
