### PR TITLE
fix(st-storage): update "group" parameter values for Short-Term Storage

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/config/st_storage.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/st_storage.py
@@ -22,7 +22,11 @@ class STStorageGroup(EnumIgnoreCase):
     PSP_CLOSED = "PSP_closed"
     PONDAGE = "Pondage"
     BATTERY = "Battery"
-    OTHER = "Other"
+    OTHER1 = "Other1"
+    OTHER2 = "Other2"
+    OTHER3 = "Other3"
+    OTHER4 = "Other4"
+    OTHER5 = "Other5"
 
 
 # noinspection SpellCheckingInspection
@@ -48,7 +52,7 @@ class STStorageConfig(BaseModel):
         regex=r"[a-zA-Z0-9_(),& -]+",
     )
     group: STStorageGroup = Field(
-        ...,
+        STStorageGroup.OTHER1,
         description="Energy storage system group (mandatory)",
     )
     injection_nominal_capacity: float = Field(

--- a/antarest/study/storage/rawstudy/model/filesystem/config/st_storage.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/st_storage.py
@@ -15,7 +15,7 @@ class STStorageGroup(EnumIgnoreCase):
         - PSP_CLOSED: Represents a closed pumped storage plant.
         - PONDAGE: Represents a pondage storage system (reservoir storage system).
         - BATTERY: Represents a battery storage system.
-        - OTHER: Represents other energy storage systems.
+        - OTHER1...OTHER5: Represents other energy storage systems.
     """
 
     PSP_OPEN = "PSP_open"
@@ -53,7 +53,7 @@ class STStorageConfig(BaseModel):
     )
     group: STStorageGroup = Field(
         STStorageGroup.OTHER1,
-        description="Energy storage system group (mandatory)",
+        description="Energy storage system group",
     )
     injection_nominal_capacity: float = Field(
         0,

--- a/tests/variantstudy/model/command/test_create_st_storage.py
+++ b/tests/variantstudy/model/command/test_create_st_storage.py
@@ -1,3 +1,4 @@
+import copy
 import re
 
 import numpy as np
@@ -327,7 +328,7 @@ class TestCreateSTStorage:
         create_area.apply(recent_study)
 
         # Remove the group from the nominal case parameters
-        parameters_whithout_groups = PARAMETERS
+        parameters_whithout_groups = copy.deepcopy(PARAMETERS)
         del parameters_whithout_groups["group"]
 
         # Then, apply the config for a new ST Storage


### PR DESCRIPTION
This pull request addresses several issues related to the "group" parameter for short-term storage. The PR includes the following changes:

1. Removed the "Other" enumerated value from the list of possible values for the "group" parameter.
2. Added new enumerated values: "Other1", "Other2", "Other3", "Other4", and "Other5" to the "group" parameter.

Additionally, this PR modifies the behavior of the "group" parameter. It is no longer mandatory but has become optional. The default value, as per Anatres Solver specifications, is set to "Group1".