### PR TITLE
fix(launcher): fixing launcher versions display and API endpoint for solver versions

### DIFF
--- a/antarest/core/config.py
+++ b/antarest/core/config.py
@@ -2,10 +2,9 @@ import logging
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional
 
 import yaml
-
 from antarest.core.model import JSON
 from antarest.core.roles import RoleType
 
@@ -162,7 +161,7 @@ class StorageConfig:
 
 @dataclass(frozen=True)
 class LocalConfig:
-    binaries: Dict[str, Path] = field(default_factory=lambda: {})
+    binaries: Dict[str, Path] = field(default_factory=dict)
 
     @staticmethod
     def from_dict(data: JSON) -> Optional["LocalConfig"]:
@@ -186,9 +185,7 @@ class SlurmConfig:
     default_json_db_name: str = ""
     slurm_script_path: str = ""
     max_cores: int = 64
-    antares_versions_on_remote_server: List[str] = field(
-        default_factory=lambda: []
-    )
+    antares_versions_on_remote_server: List[str] = field(default_factory=list)
 
     @staticmethod
     def from_dict(data: JSON) -> "SlurmConfig":

--- a/antarest/launcher/service.py
+++ b/antarest/launcher/service.py
@@ -748,7 +748,7 @@ class LauncherService:
             This list is empty if the configuration is not available.
 
         Raises:
-            ValueError: if the configuration is not "default", "slurm" or "local".
+            KeyError: if the configuration is not "default", "slurm" or "local".
         """
         local_config = self.config.launcher.local
         slurm_config = self.config.launcher.slurm
@@ -760,12 +760,7 @@ class LauncherService:
             else [],
         }
         versions_map["default"] = versions_map[default_config]
-        try:
-            return versions_map[solver]
-        except KeyError:
-            raise ValueError(
-                f"Unknown solver configuration: '{solver}'"
-            ) from None
+        return versions_map[solver]
 
     def get_launch_progress(
         self, job_id: str, params: RequestParameters

--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -203,14 +203,11 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
     @bp.get(
         "/launcher/_versions",
         tags=[APITag.launcher],
-        summary="Get list of supported study version for all configured launchers",
-        response_model=Dict[str, List[str]],
+        summary="Get list of supported solver versions for all configured launchers",
+        response_model=Dict[str, Dict[str, List[str]]],
     )
-    def get_versions(
-        current_user: JWTUser = Depends(auth.get_current_user),
-    ) -> Any:
-        params = RequestParameters(user=current_user)
-        logger.info(f"Fetching version list")
-        return service.get_versions(params=params)
+    def get_solver_versions() -> Dict[str, Dict[str, List[str]]]:
+        logger.info("Fetching versions list")
+        return service.get_versions()
 
     return bp

--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -222,12 +222,12 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
         response_model=List[str],
     )
     def get_solver_versions(
-        solver: Optional[str] = Query(
-            None,
+        solver: str = Query(
+            "local",
             examples={
-                "default solver": {
+                "Default solver": {
                     "description": "Get the solver versions of the default configuration",
-                    "value": "",
+                    "value": "default",
                 },
                 "SLURM solver": {
                     "description": "Get the solver versions of the SLURM server if available",
@@ -246,7 +246,6 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
         Args:
         - `solver`: name of the configuration to read: "default", "slurm" or "local".
         """
-        solver = solver or "local"
         logger.info(
             f"Fetching the list of solver versions for the '{solver}' configuration"
         )

--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -1,8 +1,8 @@
 import logging
-from typing import Any, Optional, List, Dict
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from antarest.core.config import Config
 from antarest.core.filetransfer.model import FileDownloadTaskDTO
@@ -203,11 +203,38 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
     @bp.get(
         "/launcher/_versions",
         tags=[APITag.launcher],
-        summary="Get list of supported solver versions for all configured launchers",
-        response_model=Dict[str, Dict[str, List[str]]],
+        summary="Get list of supported solver versions",
+        response_model=List[str],
     )
-    def get_solver_versions() -> Dict[str, Dict[str, List[str]]]:
-        logger.info("Fetching versions list")
-        return service.get_versions()
+    def get_solver_versions(
+        solver: Optional[str] = Query(
+            None,
+            examples={
+                "default solver": {
+                    "description": "Get the solver versions of the default configuration",
+                    "value": "",
+                },
+                "SLURM solver": {
+                    "description": "Get the solver versions of the SLURM server if available",
+                    "value": "slurm",
+                },
+                "Local solver": {
+                    "description": "Get the solver versions of the Local server if available",
+                    "value": "local",
+                },
+            },
+        )
+    ) -> List[str]:
+        """
+        Get list of supported solver versions defined in the configuration.
+
+        Args:
+        - `solver`: name of the configuration to read: "default", "slurm" or "local".
+        """
+        solver = solver or "local"
+        logger.info(
+            f"Fetching the list of solver versions for the '{solver}' configuration"
+        )
+        return service.get_solver_versions(solver)
 
     return bp

--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -1,8 +1,10 @@
+import http
 import logging
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
+from fastapi.exceptions import HTTPException
 
 from antarest.core.config import Config
 from antarest.core.filetransfer.model import FileDownloadTaskDTO
@@ -235,6 +237,12 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
         logger.info(
             f"Fetching the list of solver versions for the '{solver}' configuration"
         )
-        return service.get_solver_versions(solver)
+        try:
+            return service.get_solver_versions(solver)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=http.HTTPStatus.UNPROCESSABLE_ENTITY,
+                detail=str(e),
+            )
 
     return bp

--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -216,7 +216,7 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
         return service.get_load(from_cluster)
 
     @bp.get(
-        "/launcher/_versions",
+        "/launcher/versions",
         tags=[APITag.launcher],
         summary="Get list of supported solver versions",
         response_model=List[str],

--- a/antarest/study/web/studies_blueprint.py
+++ b/antarest/study/web/studies_blueprint.py
@@ -439,8 +439,9 @@ def create_study_routes(
         "/studies/_versions",
         tags=[APITag.study_management],
         summary="Show available study versions",
+        response_model=List[str],
     )
-    def get_studies_version(
+    def get_study_versions(
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> Any:
         params = RequestParameters(user=current_user)

--- a/tests/launcher/test_service.py
+++ b/tests/launcher/test_service.py
@@ -337,21 +337,28 @@ def test_service_get_jobs_from_database():
 @pytest.mark.parametrize(
     "config_local,config_slurm,expected_output",
     [
-        (None, None, {}),
+        (
+            None,
+            None,
+            {"default": {"local": []}, "others": {"slurm": []}},
+        ),
         (
             None,
             SlurmConfig(antares_versions_on_remote_server=["42", "43"]),
-            {"slurm": ["42", "43"]},
+            {"default": {"local": []}, "others": {"slurm": ["42", "43"]}},
         ),
         (
             LocalConfig(binaries={"24": Path(), "34": Path()}),
             None,
-            {"local": ["24", "34"]},
+            {"default": {"local": ["24", "34"]}, "others": {"slurm": []}},
         ),
         (
             LocalConfig(binaries={"24": Path(), "34": Path()}),
             SlurmConfig(antares_versions_on_remote_server=["42", "43"]),
-            {"local": ["24", "34"], "slurm": ["42", "43"]},
+            {
+                "default": {"local": ["24", "34"]},
+                "others": {"slurm": ["42", "43"]},
+            },
         ),
     ],
 )
@@ -370,7 +377,7 @@ def test_service_get_versions(config_local, config_slurm, expected_output):
         cache=Mock(),
     )
 
-    assert expected_output == launcher_service.get_versions(params=Mock())
+    assert expected_output == launcher_service.get_versions()
 
 
 @pytest.mark.unit_test

--- a/tests/launcher/test_service.py
+++ b/tests/launcher/test_service.py
@@ -376,7 +376,7 @@ def test_service_get_jobs_from_database():
             id="local-config-unknown",
             marks=pytest.mark.xfail(
                 reason="Unknown solver configuration: 'unknown'",
-                raises=ValueError,
+                raises=KeyError,
                 strict=True,
             ),
         ),
@@ -408,7 +408,7 @@ def test_service_get_jobs_from_database():
             id="slurm-config-unknown",
             marks=pytest.mark.xfail(
                 reason="Unknown solver configuration: 'unknown'",
-                raises=ValueError,
+                raises=KeyError,
                 strict=True,
             ),
         ),

--- a/tests/launcher/test_service.py
+++ b/tests/launcher/test_service.py
@@ -3,6 +3,7 @@ import os
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Dict, Union, List, Literal
 from unittest.mock import Mock, patch, call
 from uuid import uuid4
 from zipfile import ZipFile, ZIP_DEFLATED
@@ -335,37 +336,113 @@ def test_service_get_jobs_from_database():
 
 @pytest.mark.unit_test
 @pytest.mark.parametrize(
-    "config_local,config_slurm,expected_output",
+    "config, solver, expected",
     [
-        (
-            None,
-            None,
-            {"default": {"local": []}, "others": {"slurm": []}},
-        ),
-        (
-            None,
-            SlurmConfig(antares_versions_on_remote_server=["42", "43"]),
-            {"default": {"local": []}, "others": {"slurm": ["42", "43"]}},
-        ),
-        (
-            LocalConfig(binaries={"24": Path(), "34": Path()}),
-            None,
-            {"default": {"local": ["24", "34"]}, "others": {"slurm": []}},
-        ),
-        (
-            LocalConfig(binaries={"24": Path(), "34": Path()}),
-            SlurmConfig(antares_versions_on_remote_server=["42", "43"]),
+        pytest.param(
             {
-                "default": {"local": ["24", "34"]},
-                "others": {"slurm": ["42", "43"]},
+                "default": "local",
+                "local": [],
+                "slurm": [],
             },
+            "default",
+            [],
+            id="empty-config",
+        ),
+        pytest.param(
+            {
+                "default": "local",
+                "local": ["456", "123", "798"],
+            },
+            "default",
+            ["123", "456", "798"],
+            id="local-config-default",
+        ),
+        pytest.param(
+            {
+                "default": "local",
+                "local": ["456", "123", "798"],
+            },
+            "slurm",
+            [],
+            id="local-config-slurm",
+        ),
+        pytest.param(
+            {
+                "default": "local",
+                "local": ["456", "123", "798"],
+            },
+            "unknown",
+            [],
+            id="local-config-unknown",
+            marks=pytest.mark.xfail(
+                reason="Unknown solver configuration: 'unknown'",
+                raises=ValueError,
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            {
+                "default": "slurm",
+                "slurm": ["258", "147", "369"],
+            },
+            "default",
+            ["147", "258", "369"],
+            id="slurm-config-default",
+        ),
+        pytest.param(
+            {
+                "default": "slurm",
+                "slurm": ["258", "147", "369"],
+            },
+            "local",
+            [],
+            id="slurm-config-local",
+        ),
+        pytest.param(
+            {
+                "default": "slurm",
+                "slurm": ["258", "147", "369"],
+            },
+            "unknown",
+            [],
+            id="slurm-config-unknown",
+            marks=pytest.mark.xfail(
+                reason="Unknown solver configuration: 'unknown'",
+                raises=ValueError,
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            {
+                "default": "slurm",
+                "local": ["456", "123", "798"],
+                "slurm": ["258", "147", "369"],
+            },
+            "local",
+            ["123", "456", "798"],
+            id="local+slurm-config-local",
         ),
     ],
 )
-def test_service_get_versions(config_local, config_slurm, expected_output):
-    config = Config(
-        launcher=LauncherConfig(local=config_local, slurm=config_slurm)
+def test_service_get_solver_versions(
+    config: Dict[str, Union[str, List[str]]],
+    solver: Literal["default", "local", "slurm", "unknown"],
+    expected: List[str],
+) -> None:
+    # Prepare the configuration
+    default = config.get("default", "local")
+    local = LocalConfig(
+        binaries={k: Path(f"solver-{k}.exe") for k in config.get("local", [])}
     )
+    slurm = SlurmConfig(
+        antares_versions_on_remote_server=config.get("slurm", [])
+    )
+    launcher_config = LauncherConfig(
+        default=default,
+        local=local if local else None,
+        slurm=slurm if slurm else None,
+    )
+    config = Config(launcher=launcher_config)
     launcher_service = LauncherService(
         config=config,
         study_service=Mock(),
@@ -377,7 +454,11 @@ def test_service_get_versions(config_local, config_slurm, expected_output):
         cache=Mock(),
     )
 
-    assert expected_output == launcher_service.get_versions()
+    # Fetch the solver versions
+    actual = launcher_service.get_solver_versions(solver)
+
+    # Check the result
+    assert actual == expected
 
 
 @pytest.mark.unit_test

--- a/tests/launcher/test_web.py
+++ b/tests/launcher/test_web.py
@@ -131,7 +131,7 @@ def test_get_solver_versions():
 
     app = create_app(service)
     client = TestClient(app)
-    res = client.get("/v1/launcher/_versions")
+    res = client.get("/v1/launcher/versions")
     res.raise_for_status()
     assert res.json() == output
 
@@ -144,7 +144,7 @@ def test_get_solver_versions__failed():
 
     app = create_app(service)
     client = TestClient(app)
-    res = client.get("/v1/launcher/_versions?solver=remote")
+    res = client.get("/v1/launcher/versions?solver=remote")
     assert res.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
     assert res.json() == {"detail": "Unknown solver configuration: 'remote'"}
 

--- a/tests/launcher/test_web.py
+++ b/tests/launcher/test_web.py
@@ -139,14 +139,14 @@ def test_get_solver_versions():
 @pytest.mark.unit_test
 def test_get_solver_versions__failed():
     service = Mock()
-    error = ValueError("bad solver")
+    error = KeyError("bad solver")
     service.get_solver_versions.side_effect = error
 
     app = create_app(service)
     client = TestClient(app)
     res = client.get("/v1/launcher/_versions?solver=remote")
     assert res.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
-    assert res.json() == {"detail": str(error)}
+    assert res.json() == {"detail": "Unknown solver configuration: 'remote'"}
 
 
 @pytest.mark.unit_test

--- a/tests/launcher/test_web.py
+++ b/tests/launcher/test_web.py
@@ -123,12 +123,9 @@ def test_jobs() -> None:
 
 
 @pytest.mark.unit_test
-def test_version():
+def get_solver_versions():
     service = Mock()
-    output = {
-        "default": {"local": ["1", "2"]},
-        "others": {"slurm": ["3", "4"]},
-    }
+    output = ["1", "2", "3"]
     service.get_versions.return_value = output
 
     app = create_app(service)

--- a/tests/launcher/test_web.py
+++ b/tests/launcher/test_web.py
@@ -1,3 +1,4 @@
+import http
 from unittest.mock import Mock, call
 from uuid import uuid4
 
@@ -123,16 +124,29 @@ def test_jobs() -> None:
 
 
 @pytest.mark.unit_test
-def get_solver_versions():
+def test_get_solver_versions():
     service = Mock()
     output = ["1", "2", "3"]
-    service.get_versions.return_value = output
+    service.get_solver_versions.return_value = output
 
     app = create_app(service)
     client = TestClient(app)
     res = client.get("/v1/launcher/_versions")
     res.raise_for_status()
     assert res.json() == output
+
+
+@pytest.mark.unit_test
+def test_get_solver_versions__failed():
+    service = Mock()
+    error = ValueError("bad solver")
+    service.get_solver_versions.side_effect = error
+
+    app = create_app(service)
+    client = TestClient(app)
+    res = client.get("/v1/launcher/_versions?solver=remote")
+    assert res.status_code == http.HTTPStatus.UNPROCESSABLE_ENTITY
+    assert res.json() == {"detail": str(error)}
 
 
 @pytest.mark.unit_test

--- a/tests/launcher/test_web.py
+++ b/tests/launcher/test_web.py
@@ -125,13 +125,16 @@ def test_jobs() -> None:
 @pytest.mark.unit_test
 def test_version():
     service = Mock()
-    output = {"local": ["1", "2"], "slurm": ["3", "4"]}
+    output = {
+        "default": {"local": ["1", "2"]},
+        "others": {"slurm": ["3", "4"]},
+    }
     service.get_versions.return_value = output
 
     app = create_app(service)
     client = TestClient(app)
-    res = client.get(f"/v1/launcher/_versions")
-    assert res.status_code == 200
+    res = client.get("/v1/launcher/_versions")
+    res.raise_for_status()
     assert res.json() == output
 
 

--- a/webapp/public/locales/en/main.json
+++ b/webapp/public/locales/en/main.json
@@ -505,6 +505,7 @@
   "study.question.killJob": "Are you sure you want to cancel the simulation job?",
   "study.error.exportOutput": "Failed to export the output",
   "study.error.listOutputs": "Failed to retrieve output list",
+  "study.error.launcherVersions": "Failed to retrieve launcher versions",
   "study.error.fetchComments": "Failed to fetch comments",
   "study.error.commentsNotSaved": "Comments not saved",
   "study.error.studyIdCopy": "Failed to copy study ID",

--- a/webapp/public/locales/fr/main.json
+++ b/webapp/public/locales/fr/main.json
@@ -505,6 +505,7 @@
   "study.question.killJob": "Êtes-vous sûr de vouloir annuler la simulation ?",
   "study.error.exportOutput": "Échec lors de l'export de la sortie",
   "study.error.listOutputs": "Échec de la récupération des sorties",
+  "study.error.launcherVersions": "Échec lors de la récupération des versions du launcher",
   "study.error.fetchComments": "Échec lors de la récupération des commentaires",
   "study.error.commentsNotSaved": "Erreur lors de l'enregistrement des commentaires",
   "study.error.studyIdCopy": "Erreur lors de la copie de l'identifiant de l'étude",

--- a/webapp/src/components/App/Studies/LauncherDialog.tsx
+++ b/webapp/src/components/App/Studies/LauncherDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Accordion,
   AccordionDetails,
@@ -32,19 +32,19 @@ import {
 } from "../../../common/types";
 import {
   getLauncherLoad,
+  getLauncherVersions,
   getStudyOutputs,
   launchStudy,
 } from "../../../services/api/study";
 import useEnqueueErrorSnackbar from "../../../hooks/useEnqueueErrorSnackbar";
 import BasicDialog from "../../common/dialogs/BasicDialog";
 import useAppSelector from "../../../redux/hooks/useAppSelector";
-import { getStudy, getStudyVersionsFormatted } from "../../../redux/selectors";
+import { getStudy } from "../../../redux/selectors";
 import usePromiseWithSnackbarError from "../../../hooks/usePromiseWithSnackbarError";
 import LinearProgressWithLabel from "../../common/LinearProgressWithLabel";
 import SelectSingle from "../../common/SelectSingle";
-import { fetchStudyVersions } from "../../../redux/ducks/studies";
-import useAppDispatch from "../../../redux/hooks/useAppDispatch";
 import CheckBoxFE from "../../common/fieldEditors/CheckBoxFE";
+import { convertVersions } from "../../../services/utils";
 
 const LAUNCH_DURATION_MAX_HOURS = 240;
 const LAUNCH_LOAD_DEFAULT = 12;
@@ -73,8 +73,6 @@ function LauncherDialog(props: Props) {
     (state) => studyIds.map((sid) => getStudy(state, sid)?.name),
     shallowEqual
   );
-  const dispatch = useAppDispatch();
-  const versionList = useAppSelector(getStudyVersionsFormatted);
 
   const { data: load } = usePromiseWithSnackbarError(() => getLauncherLoad(), {
     errorMessage: t("study.error.launchLoad"),
@@ -86,13 +84,10 @@ function LauncherDialog(props: Props) {
     { errorMessage: t("study.error.listOutputs"), deps: [studyIds] }
   );
 
-  useEffect(() => {
-    (async () => {
-      if (!versionList || versionList.length === 0) {
-        dispatch(fetchStudyVersions());
-      }
-    })();
-  }, [versionList, dispatch]);
+  const { data: launcherVersions = [] } = usePromiseWithSnackbarError(
+    async () => convertVersions(await getLauncherVersions()),
+    { errorMessage: t("study.error.launcherVersions") }
+  );
 
   ////////////////////////////////////////////////////////////////
   // Event Handlers
@@ -508,7 +503,7 @@ function LauncherDialog(props: Props) {
             </FormControl>
             <SelectSingle
               name={t("global.version")}
-              list={versionList}
+              list={launcherVersions}
               data={solverVersion}
               setValue={setSolverVersion}
               sx={{ width: 1, mt: 2 }}

--- a/webapp/src/services/api/study.ts
+++ b/webapp/src/services/api/study.ts
@@ -287,6 +287,11 @@ interface LauncherLoadDTO {
   local: number;
 }
 
+export const getLauncherVersions = async (): Promise<Array<string>> => {
+  const res = await client.get("/v1/launcher/versions");
+  return res.data;
+};
+
 export const getLauncherLoad = async (): Promise<LauncherLoadDTO> => {
   const res = await client.get("/v1/launcher/load");
   return res.data;


### PR DESCRIPTION
Description:
This pull request addresses the issue with the display of Launcher versions by examining the available versions in the application's configuration.

Currently, when launching a simulation study, the list of default Solver versions is displayed correctly.

![image](https://github.com/AntaresSimulatorTeam/AntaREST/assets/43534797/351bdb3f-272d-45d0-b3c6-535e1215aabf)

Regarding the API, the `/v1/launcher/versions` endpoint is used to retrieve the default versions in the form of a JSON list, for example: `["800", "810", "820"]`. The response status will be 200 OK.

The endpoint includes an optional parameter named `solver`, which allows specifying the desired Solver for obtaining versions. The valid values for this parameter are as follows: "default" (default Solver based on the application's configuration), "slurm" (Solver installed on the computation server), or "local" (Solver installed locally). If an unknown Solver name is provided, the API will return a 422 error with a JSON-formatted error message, for example: `{"detail": "Unknown solver configuration: 'remote'"}`.

![image](https://github.com/AntaresSimulatorTeam/AntaREST/assets/43534797/8616a342-ed0f-4350-b076-81bc540a3588)

Changes proposed in this pull request:
- Correct the display of Launcher versions when launching a simulation study.
- Implement the `/v1/launcher/versions` endpoint to retrieve default Solver versions.
- Introduce the `solver` parameter in the endpoint to specify desired Solver versions.
- Handle the case of an unknown Solver name and return an appropriate error response.

These changes aim to improve the overall functionality and user experience of the application's Launcher and Solver version management.
