### PR TITLE
fix(st-storage): fixing archived study configuration reading for short-term storages

### DIFF
--- a/antarest/core/utils/utils.py
+++ b/antarest/core/utils/utils.py
@@ -121,15 +121,15 @@ def retry(
     func: Callable[[], T], attempts: int = 10, interval: float = 0.5
 ) -> T:
     attempt = 0
-    catched_exception: Optional[Exception] = None
+    caught_exception: Optional[Exception] = None
     while attempt < attempts:
         try:
             attempt += 1
             return func()
         except Exception as e:
             time.sleep(interval)
-            catched_exception = e
-    raise catched_exception or ShouldNotHappenException()
+            caught_exception = e
+    raise caught_exception or ShouldNotHappenException()
 
 
 def assert_this(b: Any) -> None:
@@ -196,7 +196,7 @@ def extract_file_to_tmp_dir(
             exc_info=e,
         )
         tmp_dir.cleanup()
-        raise e
+        raise
     path = Path(tmp_dir.name) / inside_zip_path
     return path, tmp_dir
 

--- a/antarest/study/storage/rawstudy/model/filesystem/config/files.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/files.py
@@ -43,10 +43,6 @@ class FileType(Enum):
     MULTI_INI = "multi_ini"
 
 
-class FileTypeNotSupportedException(Exception):
-    pass
-
-
 def build(
     study_path: Path, study_id: str, output_path: Optional[Path] = None
 ) -> "FileStudyTreeConfig":
@@ -92,9 +88,13 @@ def _extract_data_from_file(
     file_type: FileType,
     multi_ini_keys: Optional[List[str]] = None,
 ) -> Any:
+    """
+    Extract and process data from various types of files.
+    """
+
     tmp_dir = None
     try:
-        if root.suffix == ".zip":
+        if root.suffix.lower() == ".zip":
             output_data_path, tmp_dir = extract_file_to_tmp_dir(
                 root, inside_root_path
             )
@@ -102,20 +102,20 @@ def _extract_data_from_file(
             output_data_path = root / inside_root_path
 
         if file_type == FileType.TXT:
-            output_data: Any = output_data_path.read_text().split("\n")
+            text = output_data_path.read_text(encoding="utf-8")
+            return text.splitlines(keepends=False)
         elif file_type == FileType.MULTI_INI:
-            output_data = MultipleSameKeysIniReader(multi_ini_keys).read(
-                output_data_path
-            )
+            reader = MultipleSameKeysIniReader(multi_ini_keys)
+            return reader.read(output_data_path)
         elif file_type == FileType.SIMPLE_INI:
-            output_data = IniReader().read(output_data_path)
-        else:
-            raise FileTypeNotSupportedException()
+            reader = IniReader()
+            return reader.read(output_data_path)
+        else:  # pragma: no cover
+            raise NotImplementedError(file_type)
+
     finally:
         if tmp_dir:
             tmp_dir.cleanup()
-
-    return output_data
 
 
 def _parse_version(path: Path) -> int:

--- a/antarest/study/storage/rawstudy/model/filesystem/config/files.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/files.py
@@ -105,11 +105,11 @@ def _extract_data_from_file(
             text = output_data_path.read_text(encoding="utf-8")
             return text.splitlines(keepends=False)
         elif file_type == FileType.MULTI_INI:
-            reader = MultipleSameKeysIniReader(multi_ini_keys)
-            return reader.read(output_data_path)
+            multi_reader = MultipleSameKeysIniReader(multi_ini_keys)
+            return multi_reader.read(output_data_path)
         elif file_type == FileType.SIMPLE_INI:
-            reader = IniReader()
-            return reader.read(output_data_path)
+            ini_reader = IniReader()
+            return ini_reader.read(output_data_path)
         else:  # pragma: no cover
             raise NotImplementedError(file_type)
 

--- a/antarest/study/storage/rawstudy/model/filesystem/config/files.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/files.py
@@ -388,6 +388,11 @@ def _parse_st_storage(root: Path, area: str) -> List[STStorageConfig]:
     """
     Parse the short-term storage INI file, return an empty list if missing.
     """
+
+    # st_storage feature exists only since 8.6 version
+    if _parse_version(root) < 860:
+        return []
+
     config_dict: Dict[str, Any] = _extract_data_from_file(
         root=root,
         inside_root_path=Path(f"input/st-storage/clusters/{area}/list.ini"),

--- a/tests/storage/repository/filesystem/config/test_config_files.py
+++ b/tests/storage/repository/filesystem/config/test_config_files.py
@@ -312,6 +312,9 @@ initialleveloptim = False
 
 def test_parse_st_storage(tmp_path: Path) -> None:
     study_path = build_empty_files(tmp_path)
+    study_path.joinpath("study.antares").write_text(
+        "[antares] \n version = 860"
+    )
     config_dir = study_path.joinpath("input", "st-storage", "clusters", "fr")
     config_dir.mkdir(parents=True)
     config_dir.joinpath("list.ini").write_text(ST_STORAGE_LIST_INI)
@@ -340,6 +343,12 @@ def test_parse_st_storage(tmp_path: Path) -> None:
             initial_level_optim=False,
         ),
     ]
+
+    # With a study version anterior to 860, it should always return an empty list
+    study_path.joinpath("study.antares").write_text(
+        "[antares] \n version = 850"
+    )
+    assert _parse_st_storage(study_path, "fr") == []
 
 
 def test_parse_st_storage_with_no_file(tmp_path: Path) -> None:

--- a/tests/storage/repository/filesystem/config/test_config_files.py
+++ b/tests/storage/repository/filesystem/config/test_config_files.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Dict, Any
 from zipfile import ZipFile
 
 import pytest
@@ -46,7 +47,7 @@ def build_empty_files(tmp: Path) -> Path:
     return study_path
 
 
-def test_parse_output_parmeters(tmp_path) -> None:
+def test_parse_output_parameters(tmp_path: Path) -> None:
     study = build_empty_files(tmp_path)
     content = """
     [output]
@@ -201,7 +202,7 @@ def test_parse_outputs(tmp_path: Path) -> None:
     ],
 )
 def test_parse_outputs__nominal(
-    tmp_path: Path, assets_name: str, expected: dict
+    tmp_path: Path, assets_name: str, expected: Dict[str, Any]
 ) -> None:
     """
     This test decompresses a zipped study (stored in the `assets` directory)


### PR DESCRIPTION
Cette Pull Request (PR) corrige un problème lié à la lecture des propriétés d'une étude lorsque celle-ci est archivée.

Plus précisément, l'erreur concerne la fonction de lecture de la configuration des stockages court terme, qui n'existe que pour les études dont la version est supérieure ou égale à 8.6. Lorsqu'on tentait de lire la configuration pour une étude archivée en version plus ancienne, on recevait le message d'erreur : "There is no item named 'input/st-storage/clusters/00_xp_batt_in/list.ini' in the archive".

Cette PR corrige la fonction `_parse_st_storage` pour qu'elle retourne une liste de stockages court terme vide lorsque l'étude est ancienne.

Une amélioration technique a également été apportée à la fonction d'extraction des fichiers compressés afin de mieux gérer les exceptions.

Les critères d'acceptation sont les suivants :

- Si l'étude n'est pas archivée, on doit voir la liste des stockages court terme (éventuellement vide si la version est inférieure à 8.6).
- Si l'étude est archivée et en version inférieure à 8.6, on doit obtenir une liste de stockage court terme vide.
- Si l'étude est archivée et en version supérieure ou égale à 8.6, on doit obtenir la liste des stockages court terme de l'étude (s'il y en a effectivement).

Actuellement, pour visualiser la liste des stockages court terme, il faudra utiliser la vue "Debug", car la vue "Stockages Court Terme" dédiée est encore en cours de développement.