### PR TITLE
fix(ui-api): resolve Area deletion & Layers/Districts UI modification issues

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -165,12 +165,18 @@ class ConstraintIdNotFoundError(HTTPException):
 
 class LayerNotFound(HTTPException):
     def __init__(self) -> None:
-        super().__init__(HTTPStatus.NOT_FOUND)
+        super().__init__(
+            HTTPStatus.NOT_FOUND,
+            "Layer not found",
+        )
 
 
 class LayerNotAllowedToBeDeleted(HTTPException):
-    def __init__(self) -> None:
-        super().__init__(HTTPStatus.EXPECTATION_FAILED)
+    def __init__(self, layer_name: str = "All") -> None:
+        super().__init__(
+            HTTPStatus.BAD_REQUEST,
+            f"You cannot delete the layer: '{layer_name}'",
+        )
 
 
 class StudyOutputNotFoundError(Exception):

--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -325,12 +325,30 @@ class AreaManager:
         return layer_id
 
     def remove_layer(self, study: RawStudy, layer_id: str) -> None:
-        file_study = self.storage_service.get_storage(study).get_raw(study)
+        """
+        Remove a layer from a study.
+
+        Args:
+            study (RawStudy): The study to remove the layer from.
+            layer_id (str): The ID of the layer to remove.
+
+        Raises:
+            LayerNotAllowedToBeDeleted: If the layer ID is "0".
+
+        Returns:
+            None
+        """
         if layer_id == "0":
             raise LayerNotAllowedToBeDeleted
+
+        file_study = self.storage_service.get_storage(study).get_raw(study)
         layers = file_study.tree.get(["layers", "layers", "layers"])
-        # remove all areas from the layer since this info is stored in area data...
-        self.update_layer_areas(study, layer_id, [])
+
+        # remove areas from layer if any
+        areas = list(file_study.config.areas)
+        if areas:
+            self.update_layer(study, layer_id, {"areas": []})
+
         command = UpdateConfig(
             target=f"layers/layers/layers",
             data={

--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -339,7 +339,7 @@ class AreaManager:
         layers = file_study.tree.get(["layers", "layers", "layers"])
 
         if layer_id not in layers:
-            raise LayerNotFound(layer_id)
+            raise LayerNotFound
 
         del layers[layer_id]
 

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -326,6 +326,7 @@ def create_study_data_routes(
         "/studies/{uuid}/layers/{layer_id}",
         tags=[APITag.study_data],
         summary="Remove layer",
+        status_code=HTTPStatus.NO_CONTENT,
     )
     def remove_layer(
         uuid: str,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 import time
 from pathlib import Path
 from unittest.mock import ANY
@@ -923,6 +924,73 @@ def test_area_management(app: FastAPI):
         LayerInfoDTO(id="0", name="All", areas=["area 1", "area 2"]).dict(),
         LayerInfoDTO(id="1", name="test2", areas=["area 2"]).dict(),
     ]
+
+    # Delete the layer '1' that has 1 area
+    res = client.delete(
+        f"/v1/studies/{study_id}/layers/1",
+        headers={
+            "Authorization": f'Bearer {admin_credentials["access_token"]}'
+        },
+    )
+    assert res.status_code == HTTPStatus.NO_CONTENT
+
+    # Ensure the layer is deleted
+    res = client.get(
+        f"/v1/studies/{study_id}/layers",
+        headers={
+            "Authorization": f'Bearer {admin_credentials["access_token"]}'
+        },
+    )
+    assert res.json() == [
+        LayerInfoDTO(id="0", name="All", areas=["area 1", "area 2"]).dict(),
+    ]
+
+    # Create the layer again without areas
+    res = client.post(
+        f"/v1/studies/{study_id}/layers?name=test2",
+        headers={
+            "Authorization": f'Bearer {admin_credentials["access_token"]}'
+        },
+    )
+    assert res.json() == "1"
+
+    # Delete the layer with no areas
+    res = client.delete(
+        f"/v1/studies/{study_id}/layers/1",
+        headers={
+            "Authorization": f'Bearer {admin_credentials["access_token"]}'
+        },
+    )
+    assert res.status_code == HTTPStatus.NO_CONTENT
+
+    # Ensure the layer is deleted
+    res = client.get(
+        f"/v1/studies/{study_id}/layers",
+        headers={
+            "Authorization": f'Bearer {admin_credentials["access_token"]}'
+        },
+    )
+    assert res.json() == [
+        LayerInfoDTO(id="0", name="All", areas=["area 1", "area 2"]).dict(),
+    ]
+
+    # Try to delete a non-existing layer
+    res = client.delete(
+        f"/v1/studies/{study_id}/layers/1",
+        headers={
+            "Authorization": f'Bearer {admin_credentials["access_token"]}'
+        },
+    )
+    assert res.status_code == HTTPStatus.NOT_FOUND
+
+    # Try to delete the layer 'All'
+    res = client.delete(
+        f"/v1/studies/{study_id}/layers/0",
+        headers={
+            "Authorization": f'Bearer {admin_credentials["access_token"]}'
+        },
+    )
+    assert res.status_code == HTTPStatus.BAD_REQUEST
 
     # -- `district` integration tests
 

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Districts/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Districts/index.tsx
@@ -45,7 +45,7 @@ function Districts() {
         return acc;
       }, {}),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [columns.length]
+    [columns.length, areas]
   );
 
   ////////////////////////////////////////////////////////////////

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Districts/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Districts/index.tsx
@@ -32,21 +32,18 @@ function Districts() {
     [districtsById]
   );
 
-  const defaultValues = useMemo(
-    () =>
-      areas.reduce((acc: Record<string, Record<string, boolean>>, area) => {
-        acc[area.id] = Object.values(districtsById).reduce(
-          (acc2: Record<string, boolean>, district) => {
-            acc2[district.id] = !!district.areas.includes(area.id);
-            return acc2;
-          },
-          {}
-        );
-        return acc;
-      }, {}),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [columns.length, areas]
-  );
+  const defaultValues = useMemo(() => {
+    const districts = Object.values(districtsById);
+
+    return areas.reduce((acc, area) => {
+      acc[area.id] = districts.reduce((acc2, district) => {
+        acc2[district.id] = district.areas.includes(area.id);
+        return acc2;
+      }, {} as Record<string, boolean>);
+
+      return acc;
+    }, {} as Record<string, Record<string, boolean>>);
+  }, [areas, districtsById]);
 
   ////////////////////////////////////////////////////////////////
   // Event handlers

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Layers/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Layers/index.tsx
@@ -47,7 +47,7 @@ function Layers() {
         return acc;
       }, {}),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [columns.length]
+    [columns.length, areas]
   );
 
   ////////////////////////////////////////////////////////////////

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Layers/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Layers/index.tsx
@@ -34,21 +34,18 @@ function Layers() {
     );
   }, [layersById]);
 
-  const defaultValues = useMemo(
-    () =>
-      areas.reduce((acc: Record<string, Record<string, boolean>>, area) => {
-        acc[area.id] = Object.values(layersById).reduce(
-          (acc2: Record<string, boolean>, layer) => {
-            acc2[layer.id] = !!layer.areas.includes(area.id);
-            return acc2;
-          },
-          {}
-        );
-        return acc;
-      }, {}),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [columns.length, areas]
-  );
+  const defaultValues = useMemo(() => {
+    const layers = Object.values(layersById);
+
+    return areas.reduce((acc, area) => {
+      acc[area.id] = layers.reduce((acc2, layer) => {
+        acc2[layer.id] = layer.areas.includes(area.id);
+        return acc2;
+      }, {} as Record<string, boolean>);
+
+      return acc;
+    }, {} as Record<string, Record<string, boolean>>);
+  }, [areas, layersById]);
 
   ////////////////////////////////////////////////////////////////
   // Event handlers

--- a/webapp/src/components/common/FormTable/Table.tsx
+++ b/webapp/src/components/common/FormTable/Table.tsx
@@ -36,7 +36,7 @@ function Table(props: TableProps) {
                 ? longestHeaderLength
                 : headerLength;
             },
-            3 // To force minimum size
+            20 // To force minimum size
           ) * 8,
     [data, rowHeaders]
   );

--- a/webapp/src/components/common/FormTable/Table.tsx
+++ b/webapp/src/components/common/FormTable/Table.tsx
@@ -36,7 +36,7 @@ function Table(props: TableProps) {
                 ? longestHeaderLength
                 : headerLength;
             },
-            20 // To force minimum size
+            10 // To force minimum size
           ) * 8,
     [data, rowHeaders]
   );

--- a/webapp/src/redux/ducks/studyMaps.ts
+++ b/webapp/src/redux/ducks/studyMaps.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import {
   createAction,
   createAsyncThunk,
@@ -96,6 +95,23 @@ const initialState = studyMapsAdapter.getInitialState({
   layers: {},
   districts: {},
 }) as StudyMapsState;
+
+////////////////////////////////////////////////////////////////
+// Utils
+////////////////////////////////////////////////////////////////
+
+function filterAreasFromEntity<T extends StudyLayer | StudyMapDistrict>(
+  entities: Record<string, T>,
+  nodeId: StudyMapNode["id"]
+): Record<string, T> {
+  return R.map(
+    (entity) => ({
+      ...entity,
+      areas: entity.areas.filter((areaId) => areaId !== nodeId),
+    }),
+    entities
+  );
+}
 
 const n = makeActionName("studyMaps");
 
@@ -627,14 +643,14 @@ export default createReducer(initialState, (builder) => {
     })
     .addCase(deleteStudyMapNode.fulfilled, (draftState, action) => {
       const { nodeId } = action.payload;
-      const { layers, districts } = draftState;
-
-      Object.values(layers).forEach((layer) => {
-        layer.areas = layer.areas.filter((areaId) => areaId !== nodeId);
-      });
-      Object.values(districts).forEach((district) => {
-        district.areas = district.areas.filter((areaId) => areaId !== nodeId);
-      });
+      draftState.layers = filterAreasFromEntity<StudyLayer>(
+        draftState.layers,
+        nodeId
+      );
+      draftState.districts = filterAreasFromEntity<StudyMapDistrict>(
+        draftState.districts,
+        nodeId
+      );
     })
     .addCase(createStudyMapLinkTemp, (draftState, action) => {
       const { studyId, link } = action.payload;

--- a/webapp/src/redux/ducks/studyMaps.ts
+++ b/webapp/src/redux/ducks/studyMaps.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import {
   createAction,
   createAsyncThunk,
@@ -288,7 +289,10 @@ export const updateStudyMapNode = createAsyncThunk<
 });
 
 export const deleteStudyMapNode = createAsyncThunk<
-  void, // WebSocket will update it
+  {
+    studyId: StudyMetadata["id"];
+    nodeId: StudyMapNode["id"];
+  },
   {
     studyId: StudyMetadata["id"];
     nodeId: StudyMapNode["id"];
@@ -300,16 +304,15 @@ export const deleteStudyMapNode = createAsyncThunk<
     const { studyId, nodeId } = data;
     const state = getState();
     const node = getStudyMap(state, studyId)?.nodes[nodeId];
-
-    if (node) {
-      dispatch(deleteStudyMapNodeTemp({ studyId, nodeId }));
-
-      try {
-        await studyDataApi.deleteArea(studyId, nodeId);
-      } catch (error) {
+    dispatch(deleteStudyMapNodeTemp({ studyId, nodeId }));
+    try {
+      await studyDataApi.deleteArea(studyId, nodeId);
+      return { studyId, nodeId };
+    } catch (error) {
+      if (node) {
         dispatch(createStudyMapNodeTemp({ studyId, node }));
-        return rejectWithValue(error);
       }
+      return rejectWithValue(error);
     }
   }
 );
@@ -361,7 +364,6 @@ export const createStudyMapLink = createAsyncThunk<
   } catch (err) {
     dispatch(deleteStudyLink({ studyId, area1, area2 }));
     dispatch(deleteStudyMapLinkTemp({ studyId, linkId }));
-
     return rejectWithValue(err);
   }
 });
@@ -460,30 +462,27 @@ export const fetchStudyMapDistricts = createAsyncThunk<
   Record<StudyMapDistrict["id"], StudyMapDistrict>,
   StudyMap["studyId"],
   AppAsyncThunkConfig
->(
-  n("FETCH_STUDY_MAP_DISTRICTS"),
-  async (studyId, { dispatch, rejectWithValue }) => {
-    try {
-      const districts = await studyApi.getStudyDistricts(studyId);
-      const studyMapDistricts = districts.reduce(
-        (acc, { id, name, output, comments, areas }) => {
-          acc[id] = {
-            id,
-            name,
-            output,
-            comments,
-            areas,
-          };
-          return acc;
-        },
-        {} as StudyMapsState["districts"]
-      );
-      return studyMapDistricts;
-    } catch (err) {
-      return rejectWithValue(err);
-    }
+>(n("FETCH_STUDY_MAP_DISTRICTS"), async (studyId, { rejectWithValue }) => {
+  try {
+    const districts = await studyApi.getStudyDistricts(studyId);
+    const studyMapDistricts = districts.reduce(
+      (acc, { id, name, output, comments, areas }) => {
+        acc[id] = {
+          id,
+          name,
+          output,
+          comments,
+          areas,
+        };
+        return acc;
+      },
+      {} as StudyMapsState["districts"]
+    );
+    return studyMapDistricts;
+  } catch (err) {
+    return rejectWithValue(err);
   }
-);
+});
 
 export const createStudyMapDistrict = createAsyncThunk<
   StudyMapDistrict,
@@ -622,7 +621,23 @@ export default createReducer(initialState, (builder) => {
     })
     .addCase(deleteStudyMapNodeTemp, (draftState, action) => {
       const { studyId, nodeId } = action.payload;
-      delete draftState.entities[studyId]?.nodes[nodeId];
+      const entity = draftState.entities[studyId];
+      if (entity) {
+        delete entity.nodes[nodeId];
+      }
+    })
+    .addCase(deleteStudyMapNode.fulfilled, (draftState, action) => {
+      const { studyId, nodeId } = action.payload;
+      const entity = draftState.entities[studyId];
+      if (entity) {
+        const { layers, districts } = draftState;
+        Object.values(layers).forEach((layer) => {
+          layer.areas = layer.areas.filter((areaId) => areaId !== nodeId);
+        });
+        Object.values(districts).forEach((district) => {
+          district.areas = district.areas.filter((areaId) => areaId !== nodeId);
+        });
+      }
     })
     .addCase(createStudyMapLinkTemp, (draftState, action) => {
       const { studyId, link } = action.payload;

--- a/webapp/src/redux/ducks/studyMaps.ts
+++ b/webapp/src/redux/ducks/studyMaps.ts
@@ -290,7 +290,6 @@ export const updateStudyMapNode = createAsyncThunk<
 
 export const deleteStudyMapNode = createAsyncThunk<
   {
-    studyId: StudyMetadata["id"];
     nodeId: StudyMapNode["id"];
   },
   {
@@ -307,7 +306,7 @@ export const deleteStudyMapNode = createAsyncThunk<
     dispatch(deleteStudyMapNodeTemp({ studyId, nodeId }));
     try {
       await studyDataApi.deleteArea(studyId, nodeId);
-      return { studyId, nodeId };
+      return { nodeId };
     } catch (error) {
       if (node) {
         dispatch(createStudyMapNodeTemp({ studyId, node }));
@@ -627,17 +626,15 @@ export default createReducer(initialState, (builder) => {
       }
     })
     .addCase(deleteStudyMapNode.fulfilled, (draftState, action) => {
-      const { studyId, nodeId } = action.payload;
-      const entity = draftState.entities[studyId];
-      if (entity) {
-        const { layers, districts } = draftState;
-        Object.values(layers).forEach((layer) => {
-          layer.areas = layer.areas.filter((areaId) => areaId !== nodeId);
-        });
-        Object.values(districts).forEach((district) => {
-          district.areas = district.areas.filter((areaId) => areaId !== nodeId);
-        });
-      }
+      const { nodeId } = action.payload;
+      const { layers, districts } = draftState;
+
+      Object.values(layers).forEach((layer) => {
+        layer.areas = layer.areas.filter((areaId) => areaId !== nodeId);
+      });
+      Object.values(districts).forEach((district) => {
+        district.areas = district.areas.filter((areaId) => areaId !== nodeId);
+      });
     })
     .addCase(createStudyMapLinkTemp, (draftState, action) => {
       const { studyId, link } = action.payload;


### PR DESCRIPTION
fix #1565 

#### This PR addresses several interrelated issues concerning areas and layers/districts.

- Deletions of areas were not being reflected properly in the layers + districts configuration panel. With this fix, any changes made to areas (including deletions) will be accurately mirrored in the UI.

- Inability to delete layers once all areas were removed has been addressed. 

- Finally, we've rectified the issue where old area data (old area IDs) were being sent to the backend after all areas were deleted and new ones were created. The system will now correctly send the updated area data to the backend, preventing data inconsistency errors.

- Additionally, we have made UI improvements to the layers/districts tables. The first column width has been increased to ensure that long area names are fully visible, enhancing readability and usability for our users.