### PR TITLE
fix(ui-common): prevent null values for string cells in HandsonTable component

### DIFF
--- a/webapp/src/components/common/Handsontable.tsx
+++ b/webapp/src/components/common/Handsontable.tsx
@@ -2,6 +2,7 @@ import HotTable, { HotTableProps } from "@handsontable/react";
 import { styled } from "@mui/material";
 import { registerAllModules } from "handsontable/registry";
 import { forwardRef } from "react";
+import * as RA from "ramda-adjunct";
 import { SECONDARY_MAIN_COLOR } from "../../theme";
 
 // Register Handsontable's modules
@@ -31,10 +32,32 @@ const StyledHotTable = styled(HotTable)(() => ({
 export type HandsontableProps = Omit<HotTableProps, "licenseKey">;
 
 const Handsontable = forwardRef<HotTable, HandsontableProps>((props, ref) => {
+  ////////////////////////////////////////////////////////////////
+  // Event Handlers
+  ////////////////////////////////////////////////////////////////
+
+  const handleBeforeChange: HotTableProps["beforeChange"] =
+    function beforeChange(this: unknown, changes, ...rest): void {
+      changes.filter(Boolean).forEach((cell) => {
+        const [, , oldValue, newValue] = cell;
+        // Prevent null values for string cells
+        if (RA.isString(oldValue) && newValue === null) {
+          // eslint-disable-next-line no-param-reassign
+          cell[3] = "";
+        }
+      });
+      props.beforeChange?.call(this, changes, ...rest);
+    };
+
+  ////////////////////////////////////////////////////////////////
+  // JSX
+  ////////////////////////////////////////////////////////////////
+
   return (
     <StyledHotTable
       licenseKey="non-commercial-and-evaluation"
       {...props}
+      beforeChange={handleBeforeChange}
       ref={ref}
     />
   );


### PR DESCRIPTION
fix #1663  

-This Pull Request addresses an issue in the TableMode, when you press the delete button, the default behavior is to set the cell value to `null`. This behavior is now modified so that the cell's value is set to an empty string (`""`) instead.

Note: only **string** inputs are concerned
