### PR TITLE
fix(xpansion): correct field names and types in Xpansion settings

### DIFF
--- a/antarest/study/business/xpansion_management.py
+++ b/antarest/study/business/xpansion_management.py
@@ -116,7 +116,7 @@ class XpansionSettingsDTO(BaseModel):
         None, alias="ampl.solve_bounds_frequency"
     )
     relative_gap: Optional[float] = Field(default=None, ge=0)
-    batch_size: Optional[int] = Field(default=0, alias="batch-size", ge=0)
+    batch_size: Optional[int] = Field(default=0, ge=0)
     solver: Optional[Solver] = None
     timelimit: Optional[int] = 1000000000000  # 1e12
     log_level: Optional[int] = 0
@@ -289,7 +289,7 @@ class XpansionManager:
             else:
                 xpansion_settings["relative_gap"] = 1e-12
                 xpansion_settings["solver"] = Solver.CBC.value
-                xpansion_settings["batch-size"] = 0
+                xpansion_settings["batch_size"] = 0
 
             xpansion_configuration_data = {
                 "user": {

--- a/antarest/study/storage/rawstudy/model/filesystem/root/user/expansion/settings.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/user/expansion/settings.py
@@ -15,54 +15,61 @@ from antarest.study.storage.rawstudy.model.filesystem.ini_file_node import (
 )
 
 
+# noinspection SpellCheckingInspection
 class ExpansionSettings(IniFileNode):
-    # /!\ The name of all the parameters is correct. Especially the differences of "_" and "-" in parameter names.
+    # /!\ The name of all the parameters is correct.
+    # Especially the differences of "_" and "-" in parameter names.
     """
     Common:
-        optimality_gap:float = 1
-        max_iteration:int = +Inf
-        uc_type:str = "expansion_fast" or "expansion_accurate". default="expansion_fast"
-        master:str = "integer" or "relaxed". default="integer"
-        yearly-weights:str = filename. default = None
-        additional-constraints:str = filename. default = None
+        - optimality_gap: float = 1
+        - max_iteration: int = +Inf
+        - uc_type: str = "expansion_fast" or "expansion_accurate". default="expansion_fast"
+        - master: str = "integer" or "relaxed". default="integer"
+        - yearly-weights: str = filename. default = None
+        - additional-constraints: str = filename. default = None
+
     version < 800 only:
-        relaxed-optimality-gap:float = 1e6
-        cut-type:str = "average", "yearly" or "weekly". default="yearly"
-        ampl.solver:str = "cbc"
-        ampl.presolve:int = 0
-        ampl.solve_bounds_frequency:int = 1000000
-    version > 800 only:
-        relative_gap:float = 1e-12
-        solver:str = "Cbc" or "Coin". default="Cbc"
-        batch-size:int = 0
+        - relaxed-optimality-gap: float = 1e6
+        - cut-type: str = "average", "yearly" or "weekly". default="yearly"
+        - ampl.solver: str = "cbc"
+        - ampl.presolve: int = 0
+        - ampl.solve_bounds_frequency: int = 1000000
+
+    version >= 800 only:
+        - relative_gap: float = 1e-12
+        - solver: str = "Cbc" or "Coin". default="Cbc"
+        - batch_size: int = 0
     """
 
     def __init__(self, context: ContextServer, config: FileStudyTreeConfig):
-        super().__init__(
-            context,
-            config,
-            reader=SimpleKeyValueReader(),
-            writer=SimpleKeyValueWriter(),
-        )
-        types = {
+        common_types = {
             "optimality_gap": float,
             "max_iteration": int,
             "uc_type": str,
             "master": str,
             "yearly-weights": str,
-            "relaxed-optimality-gap": float,
-            "cut-type": str,
             "additional_constraints": str,
-            "ampl.solver": str,
-            "ampl.presolve": int,
-            "ampl.solve_bounds_frequency": int,
         }
-        if self.config.version > 800:
-            types["relative-gap"] = float
-            types["solver"] = str
-            types["batch-size"] = int
-            del types["relaxed-optimality-gap"]
-            del types["cut-type"]
-            del types["ampl.solver"]
-            del types["ampl.presolve"]
-            del types["ampl.solve_bounds_frequency"]
+        if config.version < 800:
+            types = {
+                "relaxed-optimality-gap": float,
+                "cut-type": str,
+                "ampl.solver": str,
+                "ampl.presolve": int,
+                "ampl.solve_bounds_frequency": int,
+                **common_types,
+            }
+        else:
+            types = {
+                "relative-gap": float,
+                "solver": str,
+                "batch_size": int,
+                **common_types,
+            }
+        super().__init__(
+            context,
+            config,
+            types=types,
+            reader=SimpleKeyValueReader(),
+            writer=SimpleKeyValueWriter(),
+        )

--- a/tests/integration/test_integration_xpansion.py
+++ b/tests/integration/test_integration_xpansion.py
@@ -1,4 +1,4 @@
-from io import StringIO
+import io
 from pathlib import Path
 
 from antarest.study.business.area_management import AreaType
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 
-def test_integration_xpansion(app: FastAPI, tmp_path: str):
+def test_integration_xpansion(app: FastAPI, tmp_path: Path):
     client = TestClient(app, raise_server_exceptions=False)
     res = client.post(
         "/v1/login", json={"username": "admin", "password": "admin"}
@@ -78,7 +78,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
     assert res.status_code == 200
 
     assert (
-        Path(tmp_path) / "internal_workspace" / study_id / "user" / "expansion"
+        tmp_path / "internal_workspace" / study_id / "user" / "expansion"
     ).exists()
 
     res = client.get(
@@ -98,7 +98,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
         "relative_gap": 1e-12,
         "relaxed-optimality-gap": None,
         "solver": "Cbc",
-        "batch-size": 0,
+        "batch_size": 0,
         "uc_type": "expansion_fast",
         "yearly-weights": None,
         "timelimit": 1e12,
@@ -124,7 +124,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
         "relative_gap": None,
         "relaxed-optimality-gap": None,
         "solver": None,
-        "batch-size": 0,
+        "batch_size": 0,
         "uc_type": "expansion_fast",
         "yearly-weights": None,
         "timelimit": 1e12,
@@ -148,7 +148,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
     files = {
         "file": (
             filename_constraints1,
-            StringIO(content_constraints1),
+            io.StringIO(content_constraints1),
             "image/jpeg",
         )
     }
@@ -171,7 +171,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
     files = {
         "file": (
             filename_constraints1,
-            StringIO(content_constraints1),
+            io.StringIO(content_constraints1),
             "image/jpeg",
         ),
     }
@@ -186,7 +186,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
     files = {
         "file": (
             filename_constraints2,
-            StringIO(content_constraints2),
+            io.StringIO(content_constraints2),
             "image/jpeg",
         ),
     }
@@ -195,11 +195,12 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
         headers=headers,
         files=files,
     )
+    res.raise_for_status()
 
     files = {
         "file": (
             filename_constraints3,
-            StringIO(content_constraints3),
+            io.StringIO(content_constraints3),
             "image/jpeg",
         ),
     }
@@ -208,7 +209,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
         headers=headers,
         files=files,
     )
-    assert res.status_code == 200
+    res.raise_for_status()
 
     res = client.get(
         f"{xpansion_base_url}/resources/constraints/{filename_constraints1}",
@@ -294,7 +295,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
     files = {
         "file": (
             filename_capa1,
-            StringIO(content_capa1),
+            io.StringIO(content_capa1),
             "txt/csv",
         )
     }
@@ -324,7 +325,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
     files = {
         "file": (
             filename_capa2,
-            StringIO(content_capa2),
+            io.StringIO(content_capa2),
             "txt/csv",
         )
     }
@@ -338,7 +339,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
     files = {
         "file": (
             filename_capa3,
-            StringIO(content_capa3),
+            io.StringIO(content_capa3),
             "txt/csv",
         )
     }
@@ -431,5 +432,5 @@ def test_integration_xpansion(app: FastAPI, tmp_path: str):
     assert res.status_code == 200
 
     assert not (
-        Path(tmp_path) / "internal_workspace" / study_id / "user" / "expansion"
+        tmp_path / "internal_workspace" / study_id / "user" / "expansion"
     ).exists()

--- a/tests/storage/business/test_xpansion_manager.py
+++ b/tests/storage/business/test_xpansion_manager.py
@@ -134,7 +134,7 @@ def make_link_and_areas(empty_study):
                     "master": "integer",
                     "relative_gap": 1e-12,
                     "solver": "Cbc",
-                    "batch-size": 0,
+                    "batch_size": 0,
                 },
                 "sensitivity": {"sensitivity_in": {}},
                 "candidates": {},
@@ -231,7 +231,7 @@ def test_delete_xpansion_configuration(tmp_path: Path):
                     "ampl.solve_bounds_frequency": None,
                     "relative_gap": 1e-12,
                     "solver": "Cbc",
-                    "batch-size": 0,
+                    "batch_size": 0,
                 }
             ),
         ),
@@ -318,7 +318,7 @@ def test_update_xpansion_settings(tmp_path: Path):
             "ampl.solve_bounds_frequency": None,
             "relative_gap": 1e-12,
             "solver": "Cbc",
-            "batch-size": 4,
+            "batch_size": 4,
         }
     )
 


### PR DESCRIPTION
We made a mistake by naming this parameter with a `-` because Xpansion expects an `_`. 

It's preventing Thomas from performing his tests so it's quite urgent