### PR TITLE
ci: upgrade mypy to v1.4.1 and Black to v23.7.0 for improved typing and formatting

### DIFF
--- a/antarest/core/tasks/model.py
+++ b/antarest/core/tasks/model.py
@@ -148,7 +148,7 @@ class TaskJob(Base):  # type: ignore
             if self.completion_date
             else None,
             logs=sorted(
-                [log.to_dto() for log in self.logs], key=lambda l: l.id  # type: ignore
+                [log.to_dto() for log in self.logs], key=lambda l: l.id
             )
             if with_logs
             else None,

--- a/antarest/matrixstore/uri_resolver_service.py
+++ b/antarest/matrixstore/uri_resolver_service.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 
 import pandas as pd
 
-from antarest.core.model import JSON, SUB_JSON
+from antarest.core.model import SUB_JSON
 from antarest.matrixstore.service import ISimpleMatrixService
 
 
@@ -40,15 +40,18 @@ class UriResolverService:
     def _resolve_matrix(self, id: str, formatted: bool = True) -> SUB_JSON:
         data = self.matrix_service.get(id)
         if data:
-            formatted_data = {
-                "data": data.data,
-                "index": data.index,
-                "columns": data.columns,
-            }
             if formatted:
-                return formatted_data
+                return {
+                    "data": data.data,
+                    "index": data.index,
+                    "columns": data.columns,
+                }
             else:
-                df = pd.DataFrame(**formatted_data)
+                df = pd.DataFrame(
+                    data=data.data,
+                    index=data.index,
+                    columns=data.columns,
+                )
                 if not df.empty:
                     return (
                         df.to_csv(

--- a/antarest/matrixstore/uri_resolver_service.py
+++ b/antarest/matrixstore/uri_resolver_service.py
@@ -1,7 +1,7 @@
 import re
 from typing import Optional, Tuple
 
-import pandas as pd  # type: ignore
+import pandas as pd
 
 from antarest.core.model import JSON, SUB_JSON
 from antarest.matrixstore.service import ISimpleMatrixService

--- a/antarest/study/business/matrix_management.py
+++ b/antarest/study/business/matrix_management.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 import operator
-from typing import List, Tuple
+from typing import List, Tuple, cast
 
 import numpy as np
 import pandas as pd
@@ -71,10 +71,12 @@ def update_matrix_content_with_slices(
             matrix_slice.column_from : matrix_slice.column_to,
         ] = True
 
+    # noinspection PyTypeChecker
     new_matrix_data = matrix_data.where(mask).apply(operation.compute)
     new_matrix_data[new_matrix_data.isnull()] = matrix_data
 
-    return new_matrix_data.astype(matrix_data.dtypes)
+    # noinspection PyTypeChecker
+    return cast(pd.DataFrame, new_matrix_data.astype(matrix_data.dtypes))
 
 
 def update_matrix_content_with_coordinates(
@@ -89,7 +91,8 @@ def update_matrix_content_with_coordinates(
             )
         except IndexError as exc:
             raise MatrixIndexError(operation, (row, column), exc) from None
-    return df.astype(df.dtypes)
+    # noinspection PyTypeChecker
+    return df.astype(dict(df.dtypes))
 
 
 def group_by_slices(
@@ -254,7 +257,10 @@ class MatrixManager:
 
         try:
             logger.info(f"Loading matrix data from node '{path}'...")
-            matrix_df: pd.DataFrame = matrix_node.parse(return_dataframe=True)
+            matrix_df = cast(
+                pd.DataFrame,
+                matrix_node.parse(return_dataframe=True),
+            )
         except ValueError as exc:
             raise MatrixManagerError(f"Cannot parse matrix: {exc}") from exc
 

--- a/antarest/study/business/matrix_management.py
+++ b/antarest/study/business/matrix_management.py
@@ -4,7 +4,7 @@ import operator
 from typing import List, Tuple
 
 import numpy as np
-import pandas as pd  # type:ignore
+import pandas as pd
 from antarest.matrixstore.matrix_editor import (
     MatrixEditInstruction,
     MatrixSlice,

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/date_serializer.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/date_serializer.py
@@ -2,7 +2,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import List, Tuple
 
-import pandas as pd  # type: ignore
+import pandas as pd
 from pandas import DataFrame
 
 

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/date_serializer.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/date_serializer.py
@@ -8,7 +8,7 @@ from pandas import DataFrame
 
 class IDateMatrixSerializer(ABC):
     """
-    Abstract class to handle date index reading and writing for many time frequency.
+    Abstract class to handle date index reading and writing for many time frequencies.
     Used by OutputSeriesMatrix
     """
 
@@ -39,7 +39,6 @@ class IDateMatrixSerializer(ABC):
             df: raw matrix from file content
 
         Returns: (date index, other matrix part)
-
         """
         raise NotImplementedError()
 
@@ -50,8 +49,7 @@ class IDateMatrixSerializer(ABC):
         Args:
             index: date index
 
-        Returns: raw matrix date waith antares style ready to be save on disk
-
+        Returns: raw matrix date with antares style ready to be saved on disk
         """
         raise NotImplementedError()
 
@@ -94,10 +92,7 @@ class HourlyMatrixSerializer(IDateMatrixSerializer):
 
     def extract_date(self, df: pd.DataFrame) -> Tuple[pd.Index, pd.DataFrame]:
         # Extract left part with date
-        date = df.iloc[
-            :,
-            2:5,
-        ]
+        date = df.iloc[:, 2:5]
         date.columns = ["day", "month", "hour"]
         date["month"] = date["month"].map(IDateMatrixSerializer._MONTHS)
         date = (
@@ -110,10 +105,7 @@ class HourlyMatrixSerializer(IDateMatrixSerializer):
 
         # Extract right part with data
         to_remove = df.columns[0:5]
-        body = df.drop(
-            to_remove,
-            axis=1,
-        )
+        body = df.drop(to_remove, axis=1)
 
         return pd.Index(date), body
 

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -79,7 +79,7 @@ class InputSeriesMatrix(MatrixNode):
             if return_dataframe:
                 return matrix
 
-            data: JSON = matrix.to_dict(orient="split")
+            data = cast(JSON, matrix.to_dict(orient="split"))
             stopwatch.log_elapsed(
                 lambda x: logger.info(f"Matrix to dict in {x}s")
             )
@@ -89,7 +89,9 @@ class InputSeriesMatrix(MatrixNode):
             logger.warning(f"Empty file found when parsing {file_path}")
             matrix = pd.DataFrame(self.default_empty)
             return (
-                matrix if return_dataframe else matrix.to_dict(orient="split")
+                matrix
+                if return_dataframe
+                else cast(JSON, matrix.to_dict(orient="split"))
             )
 
     def check_errors(

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, List, Optional, Union, cast
 
 import numpy as np
-import pandas as pd  # type: ignore
+import pandas as pd
 from antarest.core.model import JSON
 from antarest.core.utils.utils import StopWatch
 from antarest.study.storage.rawstudy.model.filesystem.config.model import (
@@ -17,7 +17,7 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import (
     MatrixNode,
 )
 from numpy import typing as npt
-from pandas.errors import EmptyDataError  # type: ignore
+from pandas.errors import EmptyDataError
 
 logger = logging.getLogger(__name__)
 

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
@@ -4,7 +4,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, List, Optional, Union
 
-import pandas as pd  # type: ignore
+import pandas as pd
 
 from antarest.core.model import JSON
 from antarest.study.storage.rawstudy.model.filesystem.config.model import (

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
@@ -2,10 +2,9 @@ import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, cast
 
 import pandas as pd
-
 from antarest.core.model import JSON
 from antarest.study.storage.rawstudy.model.filesystem.config.model import (
     FileStudyTreeConfig,
@@ -71,7 +70,8 @@ class MatrixNode(LazyNode[Union[bytes, JSON], Union[bytes, JSON], JSON], ABC):
         matrix = self.parse()
 
         if "data" in matrix:
-            uuid = self.context.matrix.create(matrix["data"])
+            data = cast(List[List[float]], matrix["data"])
+            uuid = self.context.matrix.create(data)
             self.get_link_path().write_text(
                 self.context.resolver.build_matrix_uri(uuid)
             )
@@ -115,7 +115,7 @@ class MatrixNode(LazyNode[Union[bytes, JSON], Union[bytes, JSON], JSON], ABC):
                 tmp_dir.cleanup()
             return b""
 
-        return self.parse(file_path, tmp_dir)
+        return cast(JSON, self.parse(file_path, tmp_dir))
 
     @abstractmethod
     def parse(

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Any, List, Optional, Union, cast
 
-import pandas as pd  # type: ignore
+import pandas as pd
 from pandas import DataFrame
 
 from antarest.core.model import JSON

--- a/antarest/study/storage/study_upgrader/upgrader_820.py
+++ b/antarest/study/storage/study_upgrader/upgrader_820.py
@@ -2,7 +2,7 @@ import glob
 from pathlib import Path
 
 import numpy
-import pandas  # type: ignore
+import pandas
 
 
 def upgrade_820(study_path: Path) -> None:

--- a/antarest/study/storage/study_upgrader/upgrader_820.py
+++ b/antarest/study/storage/study_upgrader/upgrader_820.py
@@ -1,8 +1,10 @@
 import glob
 from pathlib import Path
+from typing import cast
 
-import numpy
+import numpy as np
 import pandas
+import numpy.typing as npt
 
 
 def upgrade_820(study_path: Path) -> None:
@@ -29,21 +31,24 @@ def upgrade_820(study_path: Path) -> None:
                     df_direct = df.iloc[:, 0]
                     df_indirect = df.iloc[:, 1]
                     name = Path(txt).stem
-                    numpy.savetxt(
+                    # noinspection PyTypeChecker
+                    np.savetxt(
                         folder_path / f"{name}_parameters.txt",
-                        df_parameters.values,
+                        cast(npt.NDArray[np.float64], df_parameters.values),
                         delimiter="\t",
                         fmt="%.6f",
                     )
-                    numpy.savetxt(
+                    # noinspection PyTypeChecker
+                    np.savetxt(
                         folder_path / "capacities" / f"{name}_direct.txt",
-                        df_direct.values,
+                        cast(npt.NDArray[np.float64], df_direct.values),
                         delimiter="\t",
                         fmt="%.6f",
                     )
-                    numpy.savetxt(
+                    # noinspection PyTypeChecker
+                    np.savetxt(
                         folder_path / "capacities" / f"{name}_indirect.txt",
-                        df_indirect.values,
+                        cast(npt.NDArray[np.float64], df_indirect.values),
                         delimiter="\t",
                         fmt="%.6f",
                     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,13 @@ black~=23.7.0
 mypy~=1.4.1
 pyinstaller~=4.8
 checksumdir~=1.2.0
+
+# Extra requirements installed by `mypy --install-types`.
+# IMPORTANT: Make sure the versions of these typing libraries match the versions
+# of the corresponding implementation libraries used in production (in `requirements.txt`).
+
+pandas-stubs~=1.4.0
+types-psycopg2~=2.9.4
+types-redis~=4.1.2
+types-requests~=2.27.1
+types-PyYAML~=5.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements-test.txt
 # Version of Black should match the versions set in `.github/workflows/main.yml`
-black~=23.1.0
+black~=23.7.0
 mypy~=0.931
 pyinstaller~=4.8
 checksumdir~=1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements-test.txt
 # Version of Black should match the versions set in `.github/workflows/main.yml`
 black~=23.7.0
-mypy~=0.931
+mypy~=1.4.1
 pyinstaller~=4.8
 checksumdir~=1.2.0


### PR DESCRIPTION
This pull request upgrades the mypy version to v1.4.1 and Black version to v23.7.0 in order to enhance type checking in the project. The upgrade required updating development dependencies to fix the versions of Python modules dedicated to typings. This was done to avoid conflicts with production libraries defined in the `requirements.txt` file.

Upgrade details:
- mypy: v1.4.1
  - Improved type inference and more accurate type-checking
  - Revealed and fixed minor type anomalies
  - Inaccurate typings addressed using appropriate `cast` statements
  - Enhanced support for the Pandas module's typing

- Black: v23.7.0
  - Codebase remained unaffected by the upgrade
  - Ensured consistent code formatting and style
