### PR TITLE
fix(variant): enhance `VariantCommandsExtractor` for Renewable Clusters and Short-Term Storage

### DIFF
--- a/antarest/study/storage/variantstudy/variant_command_extractor.py
+++ b/antarest/study/storage/variantstudy/variant_command_extractor.py
@@ -179,6 +179,7 @@ class VariantCommandsExtractor:
                 CommandName.REMOVE_LINK,
                 CommandName.REMOVE_THERMAL_CLUSTER,
                 CommandName.REMOVE_RENEWABLES_CLUSTER,
+                CommandName.REMOVE_ST_STORAGE,
             ]:
                 command_list = first_commands
                 priority = 1
@@ -193,6 +194,7 @@ class VariantCommandsExtractor:
                 command_list = last_commands
                 priority = 3
             elif command_obj.command_name in [
+                CommandName.CREATE_ST_STORAGE,
                 CommandName.CREATE_RENEWABLES_CLUSTER,
                 CommandName.CREATE_THERMAL_CLUSTER,
                 CommandName.CREATE_LINK,

--- a/antarest/study/storage/variantstudy/variant_command_extractor.py
+++ b/antarest/study/storage/variantstudy/variant_command_extractor.py
@@ -178,6 +178,7 @@ class VariantCommandsExtractor:
             elif command_obj.command_name in [
                 CommandName.REMOVE_LINK,
                 CommandName.REMOVE_THERMAL_CLUSTER,
+                CommandName.REMOVE_RENEWABLES_CLUSTER,
             ]:
                 command_list = first_commands
                 priority = 1
@@ -192,6 +193,7 @@ class VariantCommandsExtractor:
                 command_list = last_commands
                 priority = 3
             elif command_obj.command_name in [
+                CommandName.CREATE_RENEWABLES_CLUSTER,
                 CommandName.CREATE_THERMAL_CLUSTER,
                 CommandName.CREATE_LINK,
             ]:


### PR DESCRIPTION
The `VariantCommandsExtractor` should handle Renewable clusters and Short-Term Storage.

WARNING❗ This bugfix is only related to the `dev` (v2.15.0) branch. Another fix is done in the `hotfix/v2.14.5` branch.