### PR TITLE
fix(st-storage): allow DELETE endpoint to accept multiple IDs as parameters

### DIFF
--- a/antarest/study/business/st_storage_manager.py
+++ b/antarest/study/business/st_storage_manager.py
@@ -45,6 +45,16 @@ class FormBaseModel(FormFieldsBaseModel):
         allow_population_by_field_name = True
 
 
+class InputPayload(FormBaseModel):
+    """
+    Model representing the form used to delete  new short-term storages entry
+    """
+
+    storges_id: List[str] = Field(
+        description="storage id of a short storage", alias="storgesId"
+    )
+
+
 class StorageCreation(FormBaseModel):
     """
     Model representing the form used to create a new short-term storage entry.
@@ -445,29 +455,30 @@ class STStorageManager:
         values = new_config.dict(by_alias=False)
         return StorageOutput(**values)
 
-    def delete_storage(
+    def delete_storages(
         self,
         study: Study,
         area_id: str,
-        storage_id: str,
+        form: List[str],
     ) -> None:
         """
-        Delete a short-term storage configuration form the given study and area_id.
+        Delete  short-term storages configuration form the given study and area_id.
 
         Args:
             study: The study object.
             area_id: The area ID of the short-term storage.
-            storage_id: The ID of the short-term storage to remove.
+            form: list ID of  short-term storages to remove.
         """
-        command = RemoveSTStorage(
-            area_id=area_id,
-            storage_id=storage_id,
-            command_context=self.storage_service.variant_study_service.command_factory.command_context,
-        )
-        file_study = self.storage_service.get_storage(study).get_raw(study)
-        execute_or_add_commands(
-            study, file_study, [command], self.storage_service
-        )
+        for storage_id in form:
+            command = RemoveSTStorage(
+                area_id=area_id,
+                storage_id=storage_id,
+                command_context=self.storage_service.variant_study_service.command_factory.command_context,
+            )
+            file_study = self.storage_service.get_storage(study).get_raw(study)
+            execute_or_add_commands(
+                study, file_study, [command], self.storage_service
+            )
 
     def get_matrix(
         self,

--- a/antarest/study/business/st_storage_manager.py
+++ b/antarest/study/business/st_storage_manager.py
@@ -449,21 +449,24 @@ class STStorageManager:
         self,
         study: Study,
         area_id: str,
-        form: List[str],
+        storage_ids: Sequence[str],
     ) -> None:
         """
-        Delete  short-term storages configuration form the given study and area_id.
+        Delete short-term storage configuration form the given study and area_id.
 
         Args:
             study: The study object.
             area_id: The area ID of the short-term storage.
-            form: list ID of  short-term storages to remove.
+            storage_ids: IDs list of short-term storages to remove.
         """
-        for storage_id in form:
+        command_context = (
+            self.storage_service.variant_study_service.command_factory.command_context
+        )
+        for storage_id in storage_ids:
             command = RemoveSTStorage(
                 area_id=area_id,
                 storage_id=storage_id,
-                command_context=self.storage_service.variant_study_service.command_factory.command_context,
+                command_context=command_context,
             )
             file_study = self.storage_service.get_storage(study).get_raw(study)
             execute_or_add_commands(

--- a/antarest/study/business/st_storage_manager.py
+++ b/antarest/study/business/st_storage_manager.py
@@ -45,16 +45,6 @@ class FormBaseModel(FormFieldsBaseModel):
         allow_population_by_field_name = True
 
 
-class InputPayload(FormBaseModel):
-    """
-    Model representing the form used to delete  new short-term storages entry
-    """
-
-    storges_id: List[str] = Field(
-        description="storage id of a short storage", alias="storgesId"
-    )
-
-
 class StorageCreation(FormBaseModel):
     """
     Model representing the form used to create a new short-term storage entry.

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -62,6 +62,7 @@ from antarest.study.business.st_storage_manager import (
     StorageOutput,
     STStorageMatrix,
     STStorageTimeSeries,
+    InputPayload,
 )
 from antarest.study.business.table_mode_management import (
     ColumnsModelTypes,
@@ -77,6 +78,7 @@ from fastapi import APIRouter, Body, Depends
 from fastapi.params import Body, Query
 
 logger = logging.getLogger(__name__)
+_default_value = InputPayload(storges_id=["toto"])
 
 
 def create_study_data_routes(
@@ -1889,38 +1891,37 @@ def create_study_data_routes(
         )
 
     @bp.delete(
-        path="/studies/{uuid}/areas/{area_id}/storages/{storage_id}",
+        path="/studies/{uuid}/areas/{area_id}/storages",
         tags=[APITag.study_data],
-        summary="Remove a short-term storage from an area",
+        summary="Remove  short-term storages from an area",
         status_code=HTTPStatus.NO_CONTENT,
     )
-    def delete_st_storage(
+    def delete_st_storages(
         uuid: str,
         area_id: str,
-        storage_id: str,
+        form: List[str],
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> None:
         """
-        Delete a short-term storage from an area.
+        Delete  short-term storages from an area.
 
         Args:
         - `uuid`: The UUID of the study.
         - `area_id`: The area ID.
-        - `storage_id`: The storage id of the study that we want to delete.
+        - `form`:   List of storages id of the study that we want to delete.
 
         Permissions:
         - User must have DELETED permission on the study.
         """
-        logger.info(
-            f"Delete short-term storage {storage_id} from {area_id} for study {uuid}",
-            extra={"user": current_user.id},
-        )
+        for storage_id in form:
+            logger.info(
+                f"Delete short-term storage {storage_id} from {area_id} for study {uuid}",
+                extra={"user": current_user.id},
+            )
         params = RequestParameters(user=current_user)
         study = study_service.check_study_access(
             uuid, StudyPermissionType.DELETE, params
         )
-        study_service.st_storage_manager.delete_storage(
-            study, area_id, storage_id
-        )
+        study_service.st_storage_manager.delete_storages(study, area_id, form)
 
     return bp

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -1891,35 +1891,36 @@ def create_study_data_routes(
     @bp.delete(
         path="/studies/{uuid}/areas/{area_id}/storages",
         tags=[APITag.study_data],
-        summary="Remove  short-term storages from an area",
+        summary="Remove short-term storages from an area",
         status_code=HTTPStatus.NO_CONTENT,
     )
     def delete_st_storages(
         uuid: str,
         area_id: str,
-        form: List[str],
+        storage_ids: Sequence[str],
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> None:
         """
-        Delete  short-term storages from an area.
+        Delete short-term storages from an area.
 
         Args:
         - `uuid`: The UUID of the study.
         - `area_id`: The area ID.
-        - `form`:   List of storages id of the study that we want to delete.
+        - `storage_ids`: List of IDs of the storages to remove from the area.
 
         Permissions:
         - User must have DELETED permission on the study.
         """
-        for storage_id in form:
-            logger.info(
-                f"Delete short-term storage {storage_id} from {area_id} for study {uuid}",
-                extra={"user": current_user.id},
-            )
+        logger.info(
+            f"Delete short-term storage ID's {storage_ids} from {area_id} for study {uuid}",
+            extra={"user": current_user.id},
+        )
         params = RequestParameters(user=current_user)
         study = study_service.check_study_access(
             uuid, StudyPermissionType.DELETE, params
         )
-        study_service.st_storage_manager.delete_storages(study, area_id, form)
+        study_service.st_storage_manager.delete_storages(
+            study, area_id, storage_ids
+        )
 
     return bp

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -62,7 +62,6 @@ from antarest.study.business.st_storage_manager import (
     StorageOutput,
     STStorageMatrix,
     STStorageTimeSeries,
-    InputPayload,
 )
 from antarest.study.business.table_mode_management import (
     ColumnsModelTypes,
@@ -78,7 +77,6 @@ from fastapi import APIRouter, Body, Depends
 from fastapi.params import Body, Query
 
 logger = logging.getLogger(__name__)
-_default_value = InputPayload(storges_id=["toto"])
 
 
 def create_study_data_routes(

--- a/tests/integration/study_data_blueprint/test_st_storage.py
+++ b/tests/integration/study_data_blueprint/test_st_storage.py
@@ -236,8 +236,45 @@ class TestSTStorage:
 
         # deletion of short-term storages
         res = client.delete(
-            f"/v1/studies/{study_id}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{study_id}/areas/{area_id}/storages",
             headers={"Authorization": f"Bearer {user_access_token}"},
+            json=[siemens_battery_id],
+        )
+        assert res.status_code == 204, res.json()
+        assert res.text == "null"
+
+        # deletion of short-term storages with empty list
+        res = client.delete(
+            f"/v1/studies/{study_id}/areas/{area_id}/storages",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            json=[],
+        )
+        assert res.status_code == 204, res.json()
+        assert res.text == "null"
+
+        # deletion of short-term storages with multiple IDs
+        res = client.post(
+            f"/v1/studies/{study_id}/areas/{area_id}/storages",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            json={"name": siemens_battery, "group": "Battery"},
+        )
+        assert res.status_code == 200, res.json()
+        siemens_battery_id1 = res.json()["id"]
+
+        siemens_battery_del = siemens_battery + "del"
+
+        res = client.post(
+            f"/v1/studies/{study_id}/areas/{area_id}/storages",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            json={"name": siemens_battery_del, "group": "Battery"},
+        )
+        assert res.status_code == 200, res.json()
+        siemens_battery_id2 = res.json()["id"]
+
+        res = client.delete(
+            f"/v1/studies/{study_id}/areas/{area_id}/storages",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            json=[siemens_battery_id1, siemens_battery_id2],
         )
         assert res.status_code == 204, res.json()
         assert res.text == "null"
@@ -260,8 +297,9 @@ class TestSTStorage:
         # Check delete with the wrong value of area_id
         bad_area_id = "bad_area"
         res = client.delete(
-            f"/v1/studies/{study_id}/areas/{bad_area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{study_id}/areas/{bad_area_id}/storages",
             headers={"Authorization": f"Bearer {user_access_token}"},
+            json=[siemens_battery_id],
         )
         assert res.status_code == 500, res.json()
         obj = res.json()
@@ -276,8 +314,9 @@ class TestSTStorage:
         # Check delete with the wrong value of study_id
         bad_study_id = "bad_study"
         res = client.delete(
-            f"/v1/studies/{bad_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{bad_study_id}/areas/{area_id}/storages",
             headers={"Authorization": f"Bearer {user_access_token}"},
+            json=[siemens_battery_id],
         )
         obj = res.json()
         description = obj["description"]

--- a/tests/integration/study_data_blueprint/test_st_storage.py
+++ b/tests/integration/study_data_blueprint/test_st_storage.py
@@ -261,7 +261,7 @@ class TestSTStorage:
         assert res.status_code == 200, res.json()
         siemens_battery_id1 = res.json()["id"]
 
-        siemens_battery_del = siemens_battery + "del"
+        siemens_battery_del = f"{siemens_battery}del"
 
         res = client.post(
             f"/v1/studies/{study_id}/areas/{area_id}/storages",


### PR DESCRIPTION
When the user wants to delete a short-term storage from the user interface, he or she checks one or more of the items in the list view.

When validating the delete form, the front end calls the DELETE /v1/studies/{uuid}/areas/{area_id}/storages/{storage_id} endpoint by passing a list of short term storage IDs.

Currently the DELETE endpoint only accepts a single ID, although multiple IDs may be required.