### PR TITLE
fix(api): correct API endpoints and CLI tools

### DIFF
--- a/antarest/gui.py
+++ b/antarest/gui.py
@@ -6,7 +6,13 @@ import webbrowser
 from multiprocessing import Process
 from pathlib import Path
 
-import requests
+try:
+    # `httpx` is a modern alternative to the `requests` library
+    import httpx as requests
+except ImportError:
+    # noinspection PyUnresolvedReferences, PyPackageRequirements
+    import requests
+
 import uvicorn  # type: ignore
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QAction, QApplication, QMenu, QSystemTrayIcon

--- a/antarest/login/ldap.py
+++ b/antarest/login/ldap.py
@@ -2,7 +2,12 @@ import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-import requests
+try:
+    # `httpx` is a modern alternative to the `requests` library
+    import httpx as requests
+except ImportError:
+    # noinspection PyUnresolvedReferences, PyPackageRequirements
+    import requests
 
 from antarest.core.config import Config
 from antarest.core.model import JSON

--- a/antarest/study/web/studies_blueprint.py
+++ b/antarest/study/web/studies_blueprint.py
@@ -79,9 +79,10 @@ def create_study_routes(study_service: StudyService, ftm: FileTransferManager, c
 
     @bp.put(
         "/studies/{uuid}/comments",
-        status_code=HTTPStatus.NO_CONTENT.value,
+        status_code=HTTPStatus.NO_CONTENT,
         tags=[APITag.study_raw_data],
         summary="Update comments",
+        response_model=None,
     )
     def edit_comments(
         uuid: str,

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -284,6 +284,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         tags=[APITag.study_data],
         summary="Remove layer",
         status_code=HTTPStatus.NO_CONTENT,
+        response_model=None,
     )
     def remove_layer(
         uuid: str,
@@ -1659,6 +1660,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         tags=[APITag.study_data],
         summary="Remove short-term storages from an area",
         status_code=HTTPStatus.NO_CONTENT,
+        response_model=None,
     )
     def delete_st_storages(
         uuid: str,

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -137,7 +137,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         "/studies/{uuid}/areas/{area_id}/ui",
         tags=[APITag.study_data],
         summary="Update area information",
-        response_model=AreaInfoDTO,
+        response_model=None,
     )
     def update_area_ui(
         uuid: str,

--- a/antarest/tools/lib.py
+++ b/antarest/tools/lib.py
@@ -8,8 +8,17 @@ from typing import List, Optional, Set, Union
 from zipfile import ZipFile
 
 import numpy as np
-import requests
-from requests import Session
+
+try:
+    # The HTTPX equivalent of `requests.Session` is `httpx.Client`.
+    import httpx as requests
+    from httpx import Client as Session
+except ImportError:
+    # noinspection PyUnresolvedReferences, PyPackageRequirements
+    import requests
+
+    # noinspection PyUnresolvedReferences,PyPackageRequirements
+    from requests import Session
 
 from antarest.core.cache.business.local_chache import LocalCache
 from antarest.core.config import CacheConfig
@@ -48,7 +57,7 @@ class RemoteVariantGenerator(IVariantGenerator):
         session: Optional[Session] = None,
     ):
         self.study_id = study_id
-        self.session = session or requests.session()
+        self.session = session or Session()
         # TODO fix this
         self.session.verify = False
         self.host = host

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,9 @@ ignore_missing_imports = True
 [mypy-pytest.*]
 ignore_missing_imports = True
 
+[mypy-httpx.*]
+ignore_missing_imports = True
+
 [mypy-jsonref.*]
 ignore_missing_imports = True
 

--- a/tests/core/test_utils_bp.py
+++ b/tests/core/test_utils_bp.py
@@ -39,5 +39,5 @@ def test_server_health() -> None:
     app = FastAPI(title=__name__)
     app.include_router(create_utils_routes(Config()))
     client = TestClient(app)
-    result = client.get("/health", stream=True)
+    result = client.get("/health")
     assert result.json() == {"status": "available"}

--- a/tests/integration/study_data_blueprint/test_st_storage.py
+++ b/tests/integration/study_data_blueprint/test_st_storage.py
@@ -239,7 +239,7 @@ class TestSTStorage:
             json=[siemens_battery_id],
         )
         assert res.status_code == 204, res.json()
-        assert res.text == "null"
+        assert res.text in {"", "null"}  # Old FastAPI versions return 'null'.
 
         # deletion of short-term storages with empty list
         res = client.delete(
@@ -248,7 +248,7 @@ class TestSTStorage:
             json=[],
         )
         assert res.status_code == 204, res.json()
-        assert res.text == "null"
+        assert res.text in {"", "null"}  # Old FastAPI versions return 'null'.
 
         # deletion of short-term storages with multiple IDs
         res = client.post(
@@ -275,7 +275,7 @@ class TestSTStorage:
             json=[siemens_battery_id1, siemens_battery_id2],
         )
         assert res.status_code == 204, res.json()
-        assert res.text == "null"
+        assert res.text in {"", "null"}  # Old FastAPI versions return 'null'.
 
         # Check the removal
         res = client.get(

--- a/tests/integration/study_data_blueprint/test_st_storage.py
+++ b/tests/integration/study_data_blueprint/test_st_storage.py
@@ -233,7 +233,8 @@ class TestSTStorage:
         }
 
         # deletion of short-term storages
-        res = client.delete(
+        res = client.request(
+            "DELETE",
             f"/v1/studies/{study_id}/areas/{area_id}/storages",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[siemens_battery_id],
@@ -242,7 +243,8 @@ class TestSTStorage:
         assert res.text in {"", "null"}  # Old FastAPI versions return 'null'.
 
         # deletion of short-term storages with empty list
-        res = client.delete(
+        res = client.request(
+            "DELETE",
             f"/v1/studies/{study_id}/areas/{area_id}/storages",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[],
@@ -269,7 +271,8 @@ class TestSTStorage:
         assert res.status_code == 200, res.json()
         siemens_battery_id2 = res.json()["id"]
 
-        res = client.delete(
+        res = client.request(
+            "DELETE",
             f"/v1/studies/{study_id}/areas/{area_id}/storages",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[siemens_battery_id1, siemens_battery_id2],
@@ -292,7 +295,8 @@ class TestSTStorage:
 
         # Check delete with the wrong value of area_id
         bad_area_id = "bad_area"
-        res = client.delete(
+        res = client.request(
+            "DELETE",
             f"/v1/studies/{study_id}/areas/{bad_area_id}/storages",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[siemens_battery_id],
@@ -309,7 +313,8 @@ class TestSTStorage:
 
         # Check delete with the wrong value of study_id
         bad_study_id = "bad_study"
-        res = client.delete(
+        res = client.request(
+            "DELETE",
             f"/v1/studies/{bad_study_id}/areas/{area_id}/storages",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[siemens_battery_id],

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1452,7 +1452,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.AREA,
+            "table_type": TableTemplateType.AREA.value,
             "columns": ",".join(FIELDS_INFO_BY_TYPE[TableTemplateType.AREA]),
         },
     )
@@ -1488,7 +1488,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.AREA,
+            "table_type": TableTemplateType.AREA.value,
         },
         json={
             "area 1": {
@@ -1509,7 +1509,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.AREA,
+            "table_type": TableTemplateType.AREA.value,
             "columns": ",".join(list(FIELDS_INFO_BY_TYPE[TableTemplateType.AREA])),
         },
     )
@@ -1547,7 +1547,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.LINK,
+            "table_type": TableTemplateType.LINK.value,
             "columns": ",".join(FIELDS_INFO_BY_TYPE[TableTemplateType.LINK]),
         },
     )
@@ -1571,7 +1571,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.LINK,
+            "table_type": TableTemplateType.LINK.value,
         },
         json={
             "area 1 / area 2": {
@@ -1586,7 +1586,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.LINK,
+            "table_type": TableTemplateType.LINK.value,
             "columns": ",".join(FIELDS_INFO_BY_TYPE[TableTemplateType.LINK]),
         },
     )
@@ -1612,7 +1612,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.CLUSTER,
+            "table_type": TableTemplateType.CLUSTER.value,
             "columns": ",".join(FIELDS_INFO_BY_TYPE[TableTemplateType.CLUSTER]),
         },
     )
@@ -1668,7 +1668,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.CLUSTER,
+            "table_type": TableTemplateType.CLUSTER.value,
         },
         json={
             "area 1 / cluster 1": {
@@ -1687,7 +1687,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.CLUSTER,
+            "table_type": TableTemplateType.CLUSTER.value,
             "columns": ",".join(FIELDS_INFO_BY_TYPE[TableTemplateType.CLUSTER]),
         },
     )
@@ -1745,7 +1745,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.RENEWABLE,
+            "table_type": TableTemplateType.RENEWABLE.value,
             "columns": ",".join(FIELDS_INFO_BY_TYPE[TableTemplateType.RENEWABLE]),
         },
     )
@@ -1771,7 +1771,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.RENEWABLE,
+            "table_type": TableTemplateType.RENEWABLE.value,
         },
         json={
             "area 1 / cluster renewable 1": {
@@ -1788,7 +1788,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.RENEWABLE,
+            "table_type": TableTemplateType.RENEWABLE.value,
             "columns": ",".join(FIELDS_INFO_BY_TYPE[TableTemplateType.RENEWABLE]),
         },
     )
@@ -1816,7 +1816,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.BINDING_CONSTRAINT,
+            "table_type": TableTemplateType.BINDING_CONSTRAINT.value,
             "columns": ",".join(FIELDS_INFO_BY_TYPE[TableTemplateType.BINDING_CONSTRAINT]),
         },
     )
@@ -1838,7 +1838,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.BINDING_CONSTRAINT,
+            "table_type": TableTemplateType.BINDING_CONSTRAINT.value,
         },
         json={
             "binding constraint 1": {
@@ -1855,7 +1855,7 @@ def test_area_management(app: FastAPI):
         table_mode_url,
         headers={"Authorization": f'Bearer {admin_credentials["access_token"]}'},
         params={
-            "table_type": TableTemplateType.BINDING_CONSTRAINT,
+            "table_type": TableTemplateType.BINDING_CONSTRAINT.value,
             "columns": ",".join(FIELDS_INFO_BY_TYPE[TableTemplateType.BINDING_CONSTRAINT]),
         },
     )

--- a/tests/integration/test_integration_xpansion.py
+++ b/tests/integration/test_integration_xpansion.py
@@ -76,7 +76,8 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
     )
     assert res.status_code == 200
 
-    assert (tmp_path / "internal_workspace" / study_id / "user" / "expansion").exists()
+    expansion_path = tmp_path / "internal_workspace" / study_id / "user" / "expansion"
+    assert expansion_path.exists()
 
     res = client.get(
         f"{xpansion_base_url}/settings",
@@ -145,7 +146,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
     files = {
         "file": (
             filename_constraints1,
-            io.StringIO(content_constraints1),
+            io.BytesIO(content_constraints1.encode("utf-8")),
             "image/jpeg",
         )
     }
@@ -155,14 +156,13 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
         files=files,
     )
     assert res.status_code == 200
-    assert (
-        tmp_path / "internal_workspace" / study_id / "user" / "expansion" / "constraints" / filename_constraints1
-    ).open().read() == content_constraints1
+    actual_path = expansion_path / "constraints" / filename_constraints1
+    assert actual_path.read_text() == content_constraints1
 
     files = {
         "file": (
             filename_constraints1,
-            io.StringIO(content_constraints1),
+            io.BytesIO(content_constraints1.encode("utf-8")),
             "image/jpeg",
         ),
     }
@@ -177,7 +177,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
     files = {
         "file": (
             filename_constraints2,
-            io.StringIO(content_constraints2),
+            io.BytesIO(content_constraints2.encode("utf-8")),
             "image/jpeg",
         ),
     }
@@ -191,7 +191,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
     files = {
         "file": (
             filename_constraints3,
-            io.StringIO(content_constraints3),
+            io.BytesIO(content_constraints3.encode("utf-8")),
             "image/jpeg",
         ),
     }
@@ -280,7 +280,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
     files = {
         "file": (
             filename_capa1,
-            io.StringIO(content_capa1),
+            io.BytesIO(content_capa1.encode("utf-8")),
             "txt/csv",
         )
     }
@@ -290,9 +290,8 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
         files=files,
     )
     assert res.status_code == 200
-    assert (
-        tmp_path / "internal_workspace" / study_id / "user" / "expansion" / "capa" / filename_capa1
-    ).open().read() == content_capa1
+    actual_path = expansion_path / "capa" / filename_capa1
+    assert actual_path.read_text() == content_capa1
 
     res = client.post(
         f"{xpansion_base_url}/resources/capacities",
@@ -304,7 +303,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
     files = {
         "file": (
             filename_capa2,
-            io.StringIO(content_capa2),
+            io.BytesIO(content_capa2.encode("utf-8")),
             "txt/csv",
         )
     }
@@ -318,7 +317,7 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
     files = {
         "file": (
             filename_capa3,
-            io.StringIO(content_capa3),
+            io.BytesIO(content_capa3.encode("utf-8")),
             "txt/csv",
         )
     }
@@ -406,4 +405,4 @@ def test_integration_xpansion(app: FastAPI, tmp_path: Path):
     )
     assert res.status_code == 200
 
-    assert not (tmp_path / "internal_workspace" / study_id / "user" / "expansion").exists()
+    assert not expansion_path.exists()

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -27,7 +27,8 @@ def wait_task_completion(
     end_time = time.time() + timeout
     while time.time() < end_time:
         time.sleep(0.1)
-        res = client.get(
+        res = client.request(
+            "GET",
             f"/v1/tasks/{task_id}",
             headers={"Authorization": f"Bearer {access_token}"},
             json={"wait_for_completion": True},


### PR DESCRIPTION
This PR includes updates to the API endpoints and CLI tools as per the provided change log.

## Summary

- Updated the construction of `UploadFile` objects in unit tests to accommodate changes in Starlette's API (>= 0.24).
- Updated stream file download tests for compatibility with both Requests and Httpx.
- Prepared for migration from `Requests` to `httpx` by adjusting imports and usage in LDAP, command line tools, and GUI code.
- Corrected and updated integration tests for Starlette >= 0.21, which introduced changes to the `TestClient` implementation.
- Corrected unit tests for Xpansion-related endpoints to use `io.BytesIO` for file uploads instead of `io.StringIO`.
- Corrected the response model for the `update_area_ui` endpoint to return `None`.
- Corrected JSON payloads for endpoints related to "table mode" to properly convert enumerated values into strings.
- Corrected the endpoint for `HTTPStatus.NO_CONTENT (204)` and updated the response model to `None`.

## Related Issues

Fixes #1724
