### PR TITLE
fix(thematic-trimming): correct the name of the "Profit by plant" variable

### DIFF
--- a/antarest/study/business/thematic_trimming_management.py
+++ b/antarest/study/business/thematic_trimming_management.py
@@ -1,82 +1,92 @@
-from typing import Any, Dict, List, Optional, cast
+import typing as t
 
-from pydantic.types import StrictBool
-
-from antarest.study.business.utils import GENERAL_DATA_PATH, FieldInfo, FormFieldsBaseModel, execute_or_add_commands
+from antarest.study.business.utils import (
+    GENERAL_DATA_PATH,
+    AllOptionalMetaclass,
+    FieldInfo,
+    FormFieldsBaseModel,
+    execute_or_add_commands,
+)
 from antarest.study.model import Study
 from antarest.study.storage.storage_service import StudyStorageService
 from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 
 
-class ThematicTrimmingFormFields(FormFieldsBaseModel):
-    ov_cost: Optional[StrictBool]
-    op_cost: Optional[StrictBool]
-    mrg_price: Optional[StrictBool]
-    co2_emis: Optional[StrictBool]
-    dtg_by_plant: Optional[StrictBool]
-    balance: Optional[StrictBool]
-    row_bal: Optional[StrictBool]
-    psp: Optional[StrictBool]
-    misc_ndg: Optional[StrictBool]
-    load: Optional[StrictBool]
-    h_ror: Optional[StrictBool]
-    wind: Optional[StrictBool]
-    solar: Optional[StrictBool]
-    nuclear: Optional[StrictBool]
-    lignite: Optional[StrictBool]
-    coal: Optional[StrictBool]
-    gas: Optional[StrictBool]
-    oil: Optional[StrictBool]
-    mix_fuel: Optional[StrictBool]
-    misc_dtg: Optional[StrictBool]
-    h_stor: Optional[StrictBool]
-    h_pump: Optional[StrictBool]
-    h_lev: Optional[StrictBool]
-    h_infl: Optional[StrictBool]
-    h_ovfl: Optional[StrictBool]
-    h_val: Optional[StrictBool]
-    h_cost: Optional[StrictBool]
-    unsp_enrg: Optional[StrictBool]
-    spil_enrg: Optional[StrictBool]
-    lold: Optional[StrictBool]
-    lolp: Optional[StrictBool]
-    avl_dtg: Optional[StrictBool]
-    dtg_mrg: Optional[StrictBool]
-    max_mrg: Optional[StrictBool]
-    np_cost: Optional[StrictBool]
-    np_cost_by_plant: Optional[StrictBool]
-    nodu: Optional[StrictBool]
-    nodu_by_plant: Optional[StrictBool]
-    flow_lin: Optional[StrictBool]
-    ucap_lin: Optional[StrictBool]
-    loop_flow: Optional[StrictBool]
-    flow_quad: Optional[StrictBool]
-    cong_fee_alg: Optional[StrictBool]
-    cong_fee_abs: Optional[StrictBool]
-    marg_cost: Optional[StrictBool]
-    cong_prod_plus: Optional[StrictBool]
-    cong_prod_minus: Optional[StrictBool]
-    hurdle_cost: Optional[StrictBool]
+class ThematicTrimmingFormFields(FormFieldsBaseModel, metaclass=AllOptionalMetaclass):
+    """
+    This class manages the configuration of result filtering in a simulation.
+
+    This table allows the user to enable or disable specific variables before running a simulation.
+    """
+
+    ov_cost: bool
+    op_cost: bool
+    mrg_price: bool
+    co2_emis: bool
+    dtg_by_plant: bool
+    balance: bool
+    row_bal: bool
+    psp: bool
+    misc_ndg: bool
+    load: bool
+    h_ror: bool
+    wind: bool
+    solar: bool
+    nuclear: bool
+    lignite: bool
+    coal: bool
+    gas: bool
+    oil: bool
+    mix_fuel: bool
+    misc_dtg: bool
+    h_stor: bool
+    h_pump: bool
+    h_lev: bool
+    h_infl: bool
+    h_ovfl: bool
+    h_val: bool
+    h_cost: bool
+    unsp_enrg: bool
+    spil_enrg: bool
+    lold: bool
+    lolp: bool
+    avl_dtg: bool
+    dtg_mrg: bool
+    max_mrg: bool
+    np_cost: bool
+    np_cost_by_plant: bool
+    nodu: bool
+    nodu_by_plant: bool
+    flow_lin: bool
+    ucap_lin: bool
+    loop_flow: bool
+    flow_quad: bool
+    cong_fee_alg: bool
+    cong_fee_abs: bool
+    marg_cost: bool
+    cong_prod_plus: bool
+    cong_prod_minus: bool
+    hurdle_cost: bool
     # For study versions >= 810
-    res_generation_by_plant: Optional[StrictBool]
-    misc_dtg_2: Optional[StrictBool]
-    misc_dtg_3: Optional[StrictBool]
-    misc_dtg_4: Optional[StrictBool]
-    wind_offshore: Optional[StrictBool]
-    wind_onshore: Optional[StrictBool]
-    solar_concrt: Optional[StrictBool]
-    solar_pv: Optional[StrictBool]
-    solar_rooft: Optional[StrictBool]
-    renw_1: Optional[StrictBool]
-    renw_2: Optional[StrictBool]
-    renw_3: Optional[StrictBool]
-    renw_4: Optional[StrictBool]
+    res_generation_by_plant: bool
+    misc_dtg_2: bool
+    misc_dtg_3: bool
+    misc_dtg_4: bool
+    wind_offshore: bool
+    wind_onshore: bool
+    solar_concrt: bool
+    solar_pv: bool
+    solar_rooft: bool
+    renw_1: bool
+    renw_2: bool
+    renw_3: bool
+    renw_4: bool
     # For study versions >= 830
-    dens: Optional[StrictBool]
-    profit: Optional[StrictBool]
+    dens: bool
+    profit_by_plant: bool
 
 
-FIELDS_INFO: Dict[str, FieldInfo] = {
+FIELDS_INFO: t.Dict[str, FieldInfo] = {
     "ov_cost": {"path": "OV. COST", "default_value": True},
     "op_cost": {"path": "OP. COST", "default_value": True},
     "mrg_price": {"path": "MRG. PRICE", "default_value": True},
@@ -125,58 +135,26 @@ FIELDS_INFO: Dict[str, FieldInfo] = {
     "cong_prod_plus": {"path": "CONG. PROD +", "default_value": True},
     "cong_prod_minus": {"path": "CONG. PROD -", "default_value": True},
     "hurdle_cost": {"path": "HURDLE COST", "default_value": True},
-    "res_generation_by_plant": {
-        "path": "RES generation by plant",
-        "default_value": True,
-        "start_version": 810,
-    },
-    "misc_dtg_2": {
-        "path": "MISC. DTG 2",
-        "default_value": True,
-        "start_version": 810,
-    },
-    "misc_dtg_3": {
-        "path": "MISC. DTG 3",
-        "default_value": True,
-        "start_version": 810,
-    },
-    "misc_dtg_4": {
-        "path": "MISC. DTG 4",
-        "default_value": True,
-        "start_version": 810,
-    },
-    "wind_offshore": {
-        "path": "WIND OFFSHORE",
-        "default_value": True,
-        "start_version": 810,
-    },
-    "wind_onshore": {
-        "path": "WIND ONSHORE",
-        "default_value": True,
-        "start_version": 810,
-    },
-    "solar_concrt": {
-        "path": "SOLAR CONCRT.",
-        "default_value": True,
-        "start_version": 810,
-    },
-    "solar_pv": {
-        "path": "SOLAR PV",
-        "default_value": True,
-        "start_version": 810,
-    },
-    "solar_rooft": {
-        "path": "SOLAR ROOFT",
-        "default_value": True,
-        "start_version": 810,
-    },
+    "res_generation_by_plant": {"path": "RES generation by plant", "default_value": True, "start_version": 810},
+    "misc_dtg_2": {"path": "MISC. DTG 2", "default_value": True, "start_version": 810},
+    "misc_dtg_3": {"path": "MISC. DTG 3", "default_value": True, "start_version": 810},
+    "misc_dtg_4": {"path": "MISC. DTG 4", "default_value": True, "start_version": 810},
+    "wind_offshore": {"path": "WIND OFFSHORE", "default_value": True, "start_version": 810},
+    "wind_onshore": {"path": "WIND ONSHORE", "default_value": True, "start_version": 810},
+    "solar_concrt": {"path": "SOLAR CONCRT.", "default_value": True, "start_version": 810},
+    "solar_pv": {"path": "SOLAR PV", "default_value": True, "start_version": 810},
+    "solar_rooft": {"path": "SOLAR ROOFT", "default_value": True, "start_version": 810},
     "renw_1": {"path": "RENW. 1", "default_value": True, "start_version": 810},
     "renw_2": {"path": "RENW. 2", "default_value": True, "start_version": 810},
     "renw_3": {"path": "RENW. 3", "default_value": True, "start_version": 810},
     "renw_4": {"path": "RENW. 4", "default_value": True, "start_version": 810},
     "dens": {"path": "DENS", "default_value": True, "start_version": 830},
-    "profit": {"path": "Profit", "default_value": True, "start_version": 830},
+    "profit_by_plant": {"path": "Profit by plant", "default_value": True, "start_version": 830},
 }
+
+
+def get_fields_info(study_version: int) -> t.Mapping[str, FieldInfo]:
+    return {key: info for key, info in FIELDS_INFO.items() if (info.get("start_version") or -1) <= study_version}
 
 
 class ThematicTrimmingManager:
@@ -188,44 +166,35 @@ class ThematicTrimmingManager:
         Get Thematic Trimming field values for the webapp form
         """
         file_study = self.storage_service.get_storage(study).get_raw(study)
-        study_ver = file_study.config.version
         config = file_study.tree.get(GENERAL_DATA_PATH.split("/"))
-        trimming_config = config.get("variables selection", None)
-        selected_vars_reset = trimming_config.get("selected_vars_reset", True) if trimming_config else None
+        trimming_config = config.get("variables selection") or {}
+        exclude_vars = trimming_config.get("select_var -") or []
+        include_vars = trimming_config.get("select_var +") or []
+        selected_vars_reset = trimming_config.get("selected_vars_reset", True)
 
-        def get_value(field_info: FieldInfo) -> Any:
-            if study_ver < field_info.get("start_version", -1):  # type: ignore
-                return None
-
+        def get_value(field_info: FieldInfo) -> t.Any:
             if selected_vars_reset is None:
                 return field_info["default_value"]
-
             var_name = field_info["path"]
+            return var_name not in exclude_vars if selected_vars_reset else var_name in include_vars
 
-            return (
-                var_name not in trimming_config.get("select_var -", [])
-                if selected_vars_reset
-                else var_name in trimming_config.get("select_var +", [])
-            )
-
-        return ThematicTrimmingFormFields.construct(**{name: get_value(info) for name, info in FIELDS_INFO.items()})
+        fields_info = get_fields_info(int(study.version))
+        fields_values = {name: get_value(info) for name, info in fields_info.items()}
+        return ThematicTrimmingFormFields(**fields_values)
 
     def set_field_values(self, study: Study, field_values: ThematicTrimmingFormFields) -> None:
         """
         Set Thematic Trimming config from the webapp form
         """
         file_study = self.storage_service.get_storage(study).get_raw(study)
-        study_ver = file_study.config.version
         field_values_dict = field_values.dict()
 
-        keys_by_bool: Dict[bool, List[Any]] = {True: [], False: []}
-        for name, info in FIELDS_INFO.items():
-            start_ver = cast(int, info.get("start_version", 0))
+        keys_by_bool: t.Dict[bool, t.List[t.Any]] = {True: [], False: []}
+        fields_info = get_fields_info(int(study.version))
+        for name, info in fields_info.items():
+            keys_by_bool[field_values_dict[name]].append(info["path"])
 
-            if start_ver <= study_ver:
-                keys_by_bool[field_values_dict[name]].append(info["path"])
-
-        config_data: Dict[str, Any]
+        config_data: t.Dict[str, t.Any]
         if len(keys_by_bool[True]) > len(keys_by_bool[False]):
             config_data = {
                 "selected_vars_reset": True,

--- a/antarest/study/business/utils.py
+++ b/antarest/study/business/utils.py
@@ -66,6 +66,8 @@ class FormFieldsBaseModel(BaseModel):
     class Config:
         alias_generator = to_camel_case
         extra = Extra.forbid
+        validate_assignment = True
+        allow_population_by_field_name = True
 
 
 class FieldInfo(TypedDict, total=False):
@@ -108,7 +110,7 @@ class AllOptionalMetaclass(pydantic.main.ModelMetaclass):
     ) -> Any:
         annotations = namespaces.get("__annotations__", {})
         for base in bases:
-            annotations.update(base.__annotations__)
+            annotations.update(getattr(base, "__annotations__", {}))
         for field, field_type in annotations.items():
             if not field.startswith("__"):
                 # Optional fields are correctly handled

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -9,6 +9,9 @@ from antarest.core.model import PublicMode
 from antarest.core.tasks.model import TaskDTO, TaskStatus
 from antarest.study.business.adequacy_patch_management import PriceTakingOrder
 from antarest.study.business.area_management import AreaType, LayerInfoDTO
+from antarest.study.business.areas.properties_management import AdequacyPatchMode
+from antarest.study.business.areas.renewable_management import TimeSeriesInterpretation
+from antarest.study.business.areas.thermal_management import LawOption, TimeSeriesGenerationOption
 from antarest.study.business.general_management import Mode
 from antarest.study.business.optimization_management import (
     SimplexOptimizationRange,
@@ -17,14 +20,10 @@ from antarest.study.business.optimization_management import (
 )
 from antarest.study.business.table_mode_management import (
     FIELDS_INFO_BY_TYPE,
-    AdequacyPatchMode,
     AssetType,
     BindingConstraintOperator,
     BindingConstraintType,
-    LawOption,
     TableTemplateType,
-    TimeSeriesGenerationOption,
-    TimeSeriesInterpretation,
     TransmissionCapacity,
 )
 from antarest.study.model import MatrixIndex, StudyDownloadLevelDTO
@@ -33,7 +32,7 @@ from tests.integration.assets import ASSETS_DIR
 from tests.integration.utils import wait_for
 
 
-def test_main(client: TestClient, admin_access_token: str, study_id: str):
+def test_main(client: TestClient, admin_access_token: str, study_id: str) -> None:
     admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
 
     # create some new users
@@ -366,7 +365,7 @@ def test_main(client: TestClient, admin_access_token: str, study_id: str):
     assert new_meta.json()["horizon"] == "2035"
 
 
-def test_matrix(client: TestClient, admin_access_token: str, study_id: str):
+def test_matrix(client: TestClient, admin_access_token: str, study_id: str) -> None:
     admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
 
     matrix = [[1, 2], [3, 4]]
@@ -419,7 +418,7 @@ def test_matrix(client: TestClient, admin_access_token: str, study_id: str):
     assert res.status_code == 200
 
 
-def test_area_management(client: TestClient, admin_access_token: str, study_id: str):
+def test_area_management(client: TestClient, admin_access_token: str, study_id: str) -> None:
     admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
 
     created = client.post("/v1/studies?name=foo", headers=admin_headers)
@@ -965,7 +964,7 @@ def test_area_management(client: TestClient, admin_access_token: str, study_id: 
         "renw3": True,
         "renw4": True,
         "dens": True,
-        "profit": True,
+        "profitByPlant": True,
     }
 
     client.put(
@@ -1034,7 +1033,7 @@ def test_area_management(client: TestClient, admin_access_token: str, study_id: 
             "renw3": True,
             "renw4": True,
             "dens": True,
-            "profit": True,
+            "profitByPlant": True,
         },
     )
     res_thematic_trimming_config = client.get(
@@ -1104,7 +1103,7 @@ def test_area_management(client: TestClient, admin_access_token: str, study_id: 
         "renw3": True,
         "renw4": True,
         "dens": True,
-        "profit": True,
+        "profitByPlant": True,
     }
 
     # Properties form
@@ -1939,7 +1938,7 @@ def test_area_management(client: TestClient, admin_access_token: str, study_id: 
     ]
 
 
-def test_archive(client: TestClient, admin_access_token: str, study_id: str, tmp_path: Path):
+def test_archive(client: TestClient, admin_access_token: str, study_id: str, tmp_path: Path) -> None:
     admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
 
     study_res = client.post("/v1/studies?name=foo", headers=admin_headers)
@@ -1976,7 +1975,7 @@ def test_archive(client: TestClient, admin_access_token: str, study_id: str, tmp
     assert not (tmp_path / "archive_dir" / f"{study_id}.zip").exists()
 
 
-def test_variant_manager(client: TestClient, admin_access_token: str, study_id: str):
+def test_variant_manager(client: TestClient, admin_access_token: str, study_id: str) -> None:
     admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
 
     base_study_res = client.post("/v1/studies?name=foo", headers=admin_headers)
@@ -2131,7 +2130,7 @@ def test_variant_manager(client: TestClient, admin_access_token: str, study_id: 
     assert res.status_code == 200
     task_result = TaskDTO.parse_obj(res.json())
     assert task_result.status == TaskStatus.COMPLETED
-    assert task_result.result.success
+    assert task_result.result.success  # type: ignore
 
     res = client.get(f"/v1/studies/{variant_id}", headers=admin_headers)
     assert res.status_code == 200
@@ -2158,7 +2157,7 @@ def test_variant_manager(client: TestClient, admin_access_token: str, study_id: 
     assert res.status_code == 404
 
 
-def test_maintenance(client: TestClient, admin_access_token: str, study_id: str):
+def test_maintenance(client: TestClient, admin_access_token: str, study_id: str) -> None:
     admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
 
     # Create non admin user
@@ -2213,7 +2212,7 @@ def test_maintenance(client: TestClient, admin_access_token: str, study_id: str)
     assert res.json() == message
 
 
-def test_binding_constraint_manager(client: TestClient, admin_access_token: str, study_id: str):
+def test_binding_constraint_manager(client: TestClient, admin_access_token: str, study_id: str) -> None:
     admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
 
     created = client.post("/v1/studies?name=foo", headers=admin_headers)

--- a/tests/storage/business/test_config_manager.py
+++ b/tests/storage/business/test_config_manager.py
@@ -28,7 +28,7 @@ def test_thematic_trimming_config() -> None:
         storage_service=StudyStorageService(raw_study_service, variant_study_service),
     )
 
-    study = VariantStudy(version="820")
+    study = VariantStudy()
     config = FileStudyTreeConfig(
         study_path=Path("somepath"),
         path=Path("somepath"),
@@ -52,36 +52,37 @@ def test_thematic_trimming_config() -> None:
         {"variables selection": {"selected_vars_reset": False, "select_var +": ["CONG. FEE (ALG.)"]}},
     ]
 
+    study.version = config.version = 700
     actual = thematic_trimming_manager.get_field_values(study)
-    fields_info = get_fields_info(config.version)
+    fields_info = get_fields_info(study.version)
     expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
     assert actual == expected
 
-    config.version = 800
+    study.version = config.version = 800
     actual = thematic_trimming_manager.get_field_values(study)
-    fields_info = get_fields_info(config.version)
-    expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
-    expected.avl_dtg = False
-    assert actual == expected
-
-    config.version = 820
-    actual = thematic_trimming_manager.get_field_values(study)
-    fields_info = get_fields_info(config.version)
+    fields_info = get_fields_info(study.version)
     expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
     expected.avl_dtg = False
     assert actual == expected
 
-    config.version = 830
+    study.version = config.version = 820
     actual = thematic_trimming_manager.get_field_values(study)
-    fields_info = get_fields_info(config.version)
+    fields_info = get_fields_info(study.version)
+    expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
+    expected.avl_dtg = False
+    assert actual == expected
+
+    study.version = config.version = 830
+    actual = thematic_trimming_manager.get_field_values(study)
+    fields_info = get_fields_info(study.version)
     expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
     expected.dens = False
     expected.profit_by_plant = False
     assert actual == expected
 
-    config.version = 840
+    study.version = config.version = 840
     actual = thematic_trimming_manager.get_field_values(study)
-    fields_info = get_fields_info(config.version)
+    fields_info = get_fields_info(study.version)
     expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, False))
     expected.cong_fee_alg = True
     assert actual == expected

--- a/tests/storage/business/test_config_manager.py
+++ b/tests/storage/business/test_config_manager.py
@@ -5,6 +5,7 @@ from antarest.study.business.thematic_trimming_management import (
     FIELDS_INFO,
     ThematicTrimmingFormFields,
     ThematicTrimmingManager,
+    get_fields_info,
 )
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
@@ -17,7 +18,7 @@ from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 
 
-def test_thematic_trimming_config():
+def test_thematic_trimming_config() -> None:
     command_context = CommandContext.construct()
     command_factory_mock = Mock()
     command_factory_mock.command_context = command_context
@@ -39,44 +40,54 @@ def test_thematic_trimming_config():
     file_tree_mock = Mock(spec=FileStudyTree, context=Mock(), config=config)
     variant_study_service.get_raw.return_value = FileStudy(config=config, tree=file_tree_mock)
     file_tree_mock.get.side_effect = [
+        # For study version < 800:
         {},
+        # For study version >= 800:
         {"variables selection": {"select_var -": ["AVL DTG"]}},
+        # For study version >= 820:
         {"variables selection": {"select_var -": ["AVL DTG"]}},
-        {
-            "variables selection": {
-                "selected_vars_reset": False,
-                "select_var +": ["CONG. FEE (ALG.)"],
-            }
-        },
+        # For study version >= 830:
+        {"variables selection": {"selected_vars_reset": True, "select_var -": ["DENS", "Profit by plant"]}},
+        # For study version >= 840:
+        {"variables selection": {"selected_vars_reset": False, "select_var +": ["CONG. FEE (ALG.)"]}},
     ]
 
-    def get_expected(value=True) -> ThematicTrimmingFormFields:
-        return ThematicTrimmingFormFields.construct(
-            **{
-                field_name: value
-                for field_name in [
-                    name
-                    for name, info in FIELDS_INFO.items()
-                    if info.get("start_version", -1) <= config.version  # type: ignore
-                ]
-            }
-        )
-
-    assert thematic_trimming_manager.get_field_values(study) == get_expected()
+    actual = thematic_trimming_manager.get_field_values(study)
+    fields_info = get_fields_info(config.version)
+    expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
+    assert actual == expected
 
     config.version = 800
-    expected = get_expected().copy(update={"avl_dtg": False})
-    assert thematic_trimming_manager.get_field_values(study) == expected
+    actual = thematic_trimming_manager.get_field_values(study)
+    fields_info = get_fields_info(config.version)
+    expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
+    expected.avl_dtg = False
+    assert actual == expected
 
     config.version = 820
-    expected = get_expected().copy(update={"avl_dtg": False})
-    assert thematic_trimming_manager.get_field_values(study) == expected
+    actual = thematic_trimming_manager.get_field_values(study)
+    fields_info = get_fields_info(config.version)
+    expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
+    expected.avl_dtg = False
+    assert actual == expected
+
+    config.version = 830
+    actual = thematic_trimming_manager.get_field_values(study)
+    fields_info = get_fields_info(config.version)
+    expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
+    expected.dens = False
+    expected.profit_by_plant = False
+    assert actual == expected
 
     config.version = 840
-    expected = get_expected(False).copy(update={"cong_fee_alg": True})
-    assert thematic_trimming_manager.get_field_values(study) == expected
+    actual = thematic_trimming_manager.get_field_values(study)
+    fields_info = get_fields_info(config.version)
+    expected = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, False))
+    expected.cong_fee_alg = True
+    assert actual == expected
 
-    new_config = get_expected().copy(update={"coal": False})
+    new_config = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, True))
+    new_config.coal = False
     thematic_trimming_manager.set_field_values(study, new_config)
     assert variant_study_service.append_commands.called_with(
         UpdateConfig(
@@ -86,7 +97,8 @@ def test_thematic_trimming_config():
         )
     )
 
-    new_config = get_expected(False).copy(update={"renw_1": True})
+    new_config = ThematicTrimmingFormFields(**dict.fromkeys(fields_info, False))
+    new_config.renw_1 = True
     thematic_trimming_manager.set_field_values(study, new_config)
     assert variant_study_service.append_commands.called_with(
         UpdateConfig(

--- a/webapp/src/components/App/Singlestudy/explore/Configuration/General/dialogs/ThematicTrimmingDialog/utils.ts
+++ b/webapp/src/components/App/Singlestudy/explore/Configuration/General/dialogs/ThematicTrimmingDialog/utils.ts
@@ -67,7 +67,7 @@ export interface ThematicTrimmingFormFields {
   renw4?: boolean;
   // For study versions >= 830
   dens?: boolean;
-  profit?: boolean;
+  profitByPlant?: boolean;
 }
 
 const keysMap: Record<keyof ThematicTrimmingFormFields, string> = {
@@ -135,7 +135,7 @@ const keysMap: Record<keyof ThematicTrimmingFormFields, string> = {
   renw4: "RENW. 4",
   // Study version >= 830
   dens: "DENS",
-  profit: "Profit",
+  profitByPlant: "Profit by plant",
 };
 
 // Allow to support all study versions by using directly the server config


### PR DESCRIPTION
This modification addresses the variable name used to enable or disable the calculation of power plant profits. It replaces the name "Profit" with "Profit by plant." On the back-office implementation side, changes have been made to simplify maintenance, and tests have been added to ensure proper handling of this variable. On the front end, the variable has been renamed to `profitByPlant` to align with TypeScript/ReactJS naming conventions.

![image](https://github.com/AntaresSimulatorTeam/AntaREST/assets/43534797/06a4abeb-b767-44ab-8239-ad15dace27d2)
