### PR TITLE
bugfix(matrix): correct the loading and saving of empty matrices as TSV files

### DIFF
--- a/antarest/matrixstore/repository.py
+++ b/antarest/matrixstore/repository.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
+import typing as t
 from pathlib import Path
-from typing import List, Optional, Union
 
 import numpy as np
 from filelock import FileLock
@@ -31,19 +31,19 @@ class MatrixDataSetRepository:
         logger.debug(f"Matrix dataset {matrix_user_metadata.id} for user {matrix_user_metadata.owner_id} saved")
         return matrix_user_metadata
 
-    def get(self, id: str) -> Optional[MatrixDataSet]:
+    def get(self, id: str) -> t.Optional[MatrixDataSet]:
         matrix: MatrixDataSet = db.session.query(MatrixDataSet).get(id)
         return matrix
 
-    def get_all_datasets(self) -> List[MatrixDataSet]:
-        matrix_datasets: List[MatrixDataSet] = db.session.query(MatrixDataSet).all()
+    def get_all_datasets(self) -> t.List[MatrixDataSet]:
+        matrix_datasets: t.List[MatrixDataSet] = db.session.query(MatrixDataSet).all()
         return matrix_datasets
 
     def query(
         self,
-        name: Optional[str],
-        owner: Optional[int] = None,
-    ) -> List[MatrixDataSet]:
+        name: t.Optional[str],
+        owner: t.Optional[int] = None,
+    ) -> t.List[MatrixDataSet]:
         """
         Query a list of MatrixUserMetadata by searching for each one separately if a set of filter match
 
@@ -59,7 +59,7 @@ class MatrixDataSetRepository:
             query = query.filter(MatrixDataSet.name.ilike(f"%{name}%"))  # type: ignore
         if owner is not None:
             query = query.filter(MatrixDataSet.owner_id == owner)
-        datasets: List[MatrixDataSet] = query.distinct().all()
+        datasets: t.List[MatrixDataSet] = query.distinct().all()
         return datasets
 
     def delete(self, dataset_id: str) -> None:
@@ -83,7 +83,7 @@ class MatrixRepository:
         logger.debug(f"Matrix {matrix.id} saved")
         return matrix
 
-    def get(self, matrix_hash: str) -> Optional[Matrix]:
+    def get(self, matrix_hash: str) -> t.Optional[Matrix]:
         matrix: Matrix = db.session.query(Matrix).get(matrix_hash)
         return matrix
 
@@ -130,6 +130,7 @@ class MatrixContentRepository:
 
         matrix_file = self.bucket_dir.joinpath(f"{matrix_hash}.tsv")
         matrix = np.loadtxt(matrix_file, delimiter="\t", dtype=np.float64, ndmin=2)
+        matrix = matrix.reshape((1, 0)) if matrix.size == 0 else matrix
         data = matrix.tolist()
         index = list(range(matrix.shape[0]))
         columns = list(range(matrix.shape[1]))
@@ -148,7 +149,7 @@ class MatrixContentRepository:
         matrix_file = self.bucket_dir.joinpath(f"{matrix_hash}.tsv")
         return matrix_file.exists()
 
-    def save(self, content: Union[List[List[MatrixData]], npt.NDArray[np.float64]]) -> str:
+    def save(self, content: t.Union[t.List[t.List[MatrixData]], npt.NDArray[np.float64]]) -> str:
         """
         Saves the content of a matrix as a TSV file in the bucket directory
         and returns its SHA256 hash.
@@ -188,8 +189,12 @@ class MatrixContentRepository:
             # Ensure exclusive access to the matrix file between multiple processes (or threads).
             lock_file = matrix_file.with_suffix(".tsv.lock")
             with FileLock(lock_file, timeout=15):
-                # noinspection PyTypeChecker
-                np.savetxt(matrix_file, matrix, delimiter="\t", fmt="%.18f")
+                if matrix.size == 0:
+                    # If the array or dataframe is empty, create an empty file instead of
+                    # traditional saving to avoid unwanted line breaks.
+                    open(matrix_file, mode="wb").close()
+                else:
+                    np.savetxt(matrix_file, matrix, delimiter="\t", fmt="%.18f")
 
             # IMPORTANT: Deleting the lock file under Linux can make locking unreliable.
             # See https://github.com/tox-dev/py-filelock/issues/31

--- a/antarest/matrixstore/service.py
+++ b/antarest/matrixstore/service.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import logging
 import tempfile
 from abc import ABC, abstractmethod
@@ -184,7 +185,9 @@ class MatrixService(ISimpleMatrixService):
             A SHA256 hash that identifies the imported matrix.
         """
         if is_json:
-            return self.create(MatrixContent.parse_raw(file).data)
+            obj = json.loads(file)
+            content = MatrixContent(**obj)
+            return self.create(content.data)
         # noinspection PyTypeChecker
         matrix = np.loadtxt(BytesIO(file), delimiter="\t", dtype=np.float64, ndmin=2)
         matrix = matrix.reshape((1, 0)) if matrix.size == 0 else matrix

--- a/antarest/matrixstore/uri_resolver_service.py
+++ b/antarest/matrixstore/uri_resolver_service.py
@@ -11,7 +11,7 @@ class UriResolverService:
     def __init__(self, matrix_service: ISimpleMatrixService):
         self.matrix_service = matrix_service
 
-    def resolve(self, uri: str, formatted: bool = True) -> Optional[SUB_JSON]:
+    def resolve(self, uri: str, formatted: bool = True) -> SUB_JSON:
         res = UriResolverService._extract_uri_components(uri)
         if res:
             protocol, uuid = res
@@ -52,19 +52,17 @@ class UriResolverService:
                     index=data.index,
                     columns=data.columns,
                 )
-                if not df.empty:
-                    return (
-                        df.to_csv(
-                            None,
-                            sep="\t",
-                            header=False,
-                            index=False,
-                            float_format="%.6f",
-                        )
-                        or ""
-                    )
-                else:
+                if df.empty:
                     return ""
+                else:
+                    csv = df.to_csv(
+                        None,
+                        sep="\t",
+                        header=False,
+                        index=False,
+                        float_format="%.6f",
+                    )
+                    return csv or ""
         raise ValueError(f"id matrix {id} not found")
 
     def build_matrix_uri(self, id: str) -> str:

--- a/antarest/matrixstore/web.py
+++ b/antarest/matrixstore/web.py
@@ -55,7 +55,7 @@ def create_matrix_api(service: MatrixService, ftm: FileTransferManager, config: 
     ) -> Any:
         logger.info("Importing new matrix dataset", extra={"user": current_user.id})
         if current_user.id is not None:
-            return service.create_by_importation(file, json)
+            return service.create_by_importation(file, is_json=json)
         raise UserHasNotPermissionError()
 
     @bp.get("/matrix/{id}", tags=[APITag.matrix], response_model=MatrixDTO)

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -1378,6 +1378,7 @@ class StudyService:
             if isinstance(data, bytes):
                 # noinspection PyTypeChecker
                 matrix = np.loadtxt(io.BytesIO(data), delimiter="\t", dtype=np.float64, ndmin=2)
+                matrix = matrix.reshape((1, 0)) if matrix.size == 0 else matrix
                 return ReplaceMatrix(
                     target=url,
                     matrix=matrix.tolist(),

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
@@ -98,15 +98,16 @@ class OutputSeriesMatrix(LazyNode[Union[bytes, JSON], Union[bytes, JSON], JSON])
         matrix = pd.concat([time, matrix], axis=1)
 
         head = self.head_writer.build(var=df.columns.size, end=df.index.size)
-        self.config.path.write_text(head)
-
-        matrix.to_csv(
-            open(self.config.path, "a", newline="\n"),
-            sep="\t",
-            index=False,
-            header=False,
-            line_terminator="\n",
-        )
+        with self.config.path.open(mode="w", newline="\n") as fd:
+            fd.write(head)
+            if not matrix.empty:
+                matrix.to_csv(
+                    fd,
+                    sep="\t",
+                    header=False,
+                    index=False,
+                    float_format="%.6f",
+                )
 
     def check_errors(
         self,

--- a/antarest/tools/lib.py
+++ b/antarest/tools/lib.py
@@ -77,6 +77,7 @@ class RemoteVariantGenerator(IVariantGenerator):
         matrix_dataset: List[str] = []
         for matrix_file in matrices_dir.iterdir():
             matrix = np.loadtxt(matrix_file, delimiter="\t", dtype=np.float64, ndmin=2)
+            matrix = matrix.reshape((1, 0)) if matrix.size == 0 else matrix
             matrix_data = matrix.tolist()
             res = self.session.post(self.build_url("/v1/matrix"), json=matrix_data)
             res.raise_for_status()

--- a/tests/matrixstore/test_service.py
+++ b/tests/matrixstore/test_service.py
@@ -3,8 +3,8 @@ import io
 import json
 import time
 import typing as t
-from unittest.mock import ANY, Mock
 import zipfile
+from unittest.mock import ANY, Mock
 
 import numpy as np
 import pytest
@@ -186,7 +186,7 @@ class TestMatrixService:
     ) -> None:
         """
         Create a new matrix by importing a file.
-        The file is either a JSON file or a CSV file.
+        The file is either a JSON file or a TSV file.
         """
         # Prepare the matrix data to import
         matrix = np.array(data, dtype=np.float64)
@@ -199,7 +199,7 @@ class TestMatrixService:
             filename = "matrix.json"
             json_format = True
         else:
-            # CSV format of the array (without header)
+            # TSV format of the array (without header)
             buffer = io.BytesIO()
             np.savetxt(buffer, matrix, delimiter="\t")
             buffer.seek(0)
@@ -210,7 +210,7 @@ class TestMatrixService:
         upload_file = _create_upload_file(filename=filename, file=buffer, content_type=content_type)
 
         # when a matrix is created (inserted) in the service
-        info_list: t.Sequence[MatrixInfoDTO] = matrix_service.create_by_importation(upload_file, json=json_format)
+        info_list: t.Sequence[MatrixInfoDTO] = matrix_service.create_by_importation(upload_file, is_json=json_format)
 
         # Then, check the list of created matrices
         assert len(info_list) == 1
@@ -237,7 +237,7 @@ class TestMatrixService:
     @pytest.mark.parametrize("content_type", ["application/json", "text/plain"])
     def test_create_by_importation__zip_file(self, matrix_service: MatrixService, content_type: str) -> None:
         """
-        Create a ZIP file with several matrices, using either a JSON format or a CSV format.
+        Create a ZIP file with several matrices, using either a JSON format or a TSV format.
         All matrices of the ZIP file use the same format.
         Check that the matrices are correctly imported.
         """
@@ -259,7 +259,7 @@ class TestMatrixService:
             ]
             json_format = True
         else:
-            # CSV format of the array (without header)
+            # TSV format of the array (without header)
             content_list = []
             for matrix in matrix_list:
                 buffer = io.BytesIO()
@@ -278,7 +278,7 @@ class TestMatrixService:
         upload_file = _create_upload_file(filename="matrices.zip", file=buffer, content_type="application/zip")
 
         # When matrices are created (inserted) in the service
-        info_list: t.Sequence[MatrixInfoDTO] = matrix_service.create_by_importation(upload_file, json=json_format)
+        info_list: t.Sequence[MatrixInfoDTO] = matrix_service.create_by_importation(upload_file, is_json=json_format)
 
         # Then, check the list of created matrices
         assert len(info_list) == len(data_list)

--- a/tests/storage/repository/filesystem/matrix/output_series_matrix_test.py
+++ b/tests/storage/repository/filesystem/matrix/output_series_matrix_test.py
@@ -9,7 +9,7 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import Matri
 from antarest.study.storage.rawstudy.model.filesystem.matrix.output_series_matrix import OutputSeriesMatrix
 
 MATRIX_DAILY_DATA = """\
-DE	area	va	hourly
+DE\tarea\tva\thourly
 \tVARIABLES\tBEGIN\tEND
 \t2\t1\t2
 
@@ -21,7 +21,7 @@ DE\thourly\t\t\t\t01_solar\t02_wind_on
 """
 
 
-def test_get(tmp_path: Path):
+def test_get(tmp_path: Path) -> None:
     file = tmp_path / "matrix-daily.txt"
     file.write_text("\n\n\n\nmock\tfile\ndummy\tdummy\ndummy\tdummy\ndummy\tdummy")
     config = FileStudyTreeConfig(study_path=file, path=file, study_id="id", version=-1)
@@ -55,7 +55,7 @@ def test_get(tmp_path: Path):
     assert node.load() == matrix.to_dict(orient="split")
 
 
-def test_save(tmp_path: Path):
+def test_save(tmp_path: Path) -> None:
     file = tmp_path / "matrix-daily.txt"
     config = FileStudyTreeConfig(study_path=file, path=file, study_id="id", version=-1)
 


### PR DESCRIPTION
## Description

The purpose of this pull request is to address an issue encountered when generating empty matrices. In certain cases, empty matrices are saved in TSV format with a newline character instead of being saved as completely empty files.

The proposed solution involves modifying the code to save an empty file when the matrix is empty.

Additionally, when loading an empty file, it will be treated as a 2D empty matrix.

## Technical Details

A 2D-NumPy array is considered empty if its `size` attribute is zero or if its `shape` is `(1, 0)`. This corresponds to the Python array `[[]]`.

## Changes Made

- Modified the code to save an empty file when an empty matrix is encountered during the saving process.
- Updated the loading logic to correctly interpret empty files as 2D empty matrices.
- Improved unit tests to ensure proper reading and writing of empty matrices in TSV format.

## Testing

Unit tests have been enhanced to thoroughly validate the functionality of reading and writing empty matrices to disk in TSV format.

## Related Issue

close #1731

## Checklist
- [x] Code has been tested and is functioning as expected.
- [x] Unit tests have been added or updated to cover the changes.
- [x] Documentation has been updated to reflect these changes, if necessary.
