### PR TITLE
feat(ui-search): enhance search fields with clear button for value reset on click

### DIFF
--- a/webapp/src/components/common/fieldEditors/SearchFE.tsx
+++ b/webapp/src/components/common/fieldEditors/SearchFE.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { InputAdornment } from "@mui/material";
 import ClearIcon from "@mui/icons-material/Clear";
 import IconButton from "@mui/material/IconButton";
@@ -7,7 +8,7 @@ import clsx from "clsx";
 import StringFE, { StringFEProps } from "./StringFE";
 
 export interface SearchFE extends Omit<StringFEProps, "placeholder" | "label"> {
-  InputProps?: Omit<StringFEProps["InputProps"], "startAdornment" | "endAdornment">;
+  InputProps?: Omit<StringFEProps["InputProps"], "startAdornment" | "endAdornment" | "value">;
   onSearchValueChange?: (value: string) => void;
   useLabel?: boolean;
 }
@@ -25,6 +26,7 @@ function SearchFE(props: SearchFE) {
   const placeholderOrLabel = {
     [useLabel ? "label" : "placeholder"]: t("global.search"),
   };
+  const [value, setValue] = useState("");
 
   return (
     <StringFE
@@ -44,6 +46,7 @@ function SearchFE(props: SearchFE) {
               aria-label="Clear"
               size="small"
               onClick={() => {
+                setValue("");
                 onSearchValueChange?.("");
               }}
             >
@@ -52,8 +55,10 @@ function SearchFE(props: SearchFE) {
           </InputAdornment>
         ),
       }}
+      value={value}
       onChange={(event) => {
         onChange?.(event);
+        setValue(event.target.value);
         onSearchValueChange?.(event.target.value);
       }}
     />

--- a/webapp/src/components/common/fieldEditors/SearchFE.tsx
+++ b/webapp/src/components/common/fieldEditors/SearchFE.tsx
@@ -1,11 +1,13 @@
 import { InputAdornment } from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
+import IconButton from "@mui/material/IconButton";
 import SearchIcon from "@mui/icons-material/Search";
 import { useTranslation } from "react-i18next";
 import clsx from "clsx";
 import StringFE, { StringFEProps } from "./StringFE";
 
 export interface SearchFE extends Omit<StringFEProps, "placeholder" | "label"> {
-  InputProps?: Omit<StringFEProps["InputProps"], "startAdornment">;
+  InputProps?: Omit<StringFEProps["InputProps"], "startAdornment" | "endAdornment">;
   onSearchValueChange?: (value: string) => void;
   useLabel?: boolean;
 }
@@ -34,6 +36,19 @@ function SearchFE(props: SearchFE) {
         startAdornment: (
           <InputAdornment position="start">
             <SearchIcon />
+          </InputAdornment>
+        ),
+        endAdornment: (
+          <InputAdornment position="end">
+            <IconButton
+              aria-label="Clear"
+              size="small"
+              onClick={() => {
+                onSearchValueChange?.("");
+              }}
+            >
+              <ClearIcon />
+            </IconButton>
           </InputAdornment>
         ),
       }}


### PR DESCRIPTION
## Description

This pull request enhances the `SearchFE` component by adding a clear button to reset the search field's value when
clicked.

## Changes Made

- Added a clear button to the search field: `InputAdornment` + `IconButton`
- Implemented functionality to reset the field value on button click: `onClick` and `onChange`

## Screenshots

![improve-search-fields](https://github.com/AntaresSimulatorTeam/AntaREST/assets/43534797/12227f60-c10f-4994-8b39-24bde36f071c)


## Testing

- When the user enter a value in the search field, the clear button should be visible.
  And the list of studies should be filtered by the entered value.
- When the user clicks the clear button, the search field should be cleared and the list of studies should be reset.

## Related Issues

Closes #1729
