### PR TITLE
fix(api-raw): correct the `/studies/{uuid}/raw` endpoint to return "text/plain" content for matrices

### DIFF
--- a/tests/storage/web/test_studies_bp.py
+++ b/tests/storage/web/test_studies_bp.py
@@ -72,7 +72,9 @@ def test_server() -> None:
     client = TestClient(app)
     client.get("/v1/studies/study1/raw?path=settings/general/params")
 
-    mock_service.get.assert_called_once_with("study1", "settings/general/params", 3, True, PARAMS)
+    mock_service.get.assert_called_once_with(
+        "study1", "settings/general/params", depth=3, formatted=True, params=PARAMS
+    )
 
 
 @pytest.mark.unit_test
@@ -121,7 +123,7 @@ def test_server_with_parameters() -> None:
     parameters = RequestParameters(user=ADMIN)
 
     assert result.status_code == HTTPStatus.OK
-    mock_storage_service.get.assert_called_once_with("study1", "/", 4, True, parameters)
+    mock_storage_service.get.assert_called_once_with("study1", "/", depth=4, formatted=True, params=parameters)
 
     result = client.get("/v1/studies/study2/raw?depth=WRONG_TYPE")
     assert result.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
@@ -130,7 +132,7 @@ def test_server_with_parameters() -> None:
     assert result.status_code == HTTPStatus.OK
 
     excepted_parameters = RequestParameters(user=ADMIN)
-    mock_storage_service.get.assert_called_with("study2", "/", 3, True, excepted_parameters)
+    mock_storage_service.get.assert_called_with("study2", "/", depth=3, formatted=True, params=excepted_parameters)
 
 
 @pytest.mark.unit_test


### PR DESCRIPTION
Correct the `/studies/{uuid}/raw` to return "text/plain" content for matrices