### PR TITLE
feat(permission): update permission types, replaced DELETE with WRITE for improved study control

### DIFF
--- a/antarest/core/model.py
+++ b/antarest/core/model.py
@@ -28,7 +28,6 @@ class StudyPermissionType(str, enum.Enum):
     READ = "READ"
     RUN = "RUN"
     WRITE = "WRITE"
-    DELETE = "DELETE"
     MANAGE_PERMISSIONS = "MANAGE_PERMISSIONS"
 
 

--- a/antarest/core/permissions.py
+++ b/antarest/core/permissions.py
@@ -30,10 +30,6 @@ permission_matrix = {
         "roles": [RoleType.ADMIN, RoleType.WRITER],
         "public_modes": [PublicMode.FULL, PublicMode.EDIT],
     },
-    StudyPermissionType.DELETE: {
-        "roles": [RoleType.ADMIN],
-        "public_modes": [PublicMode.FULL],
-    },
     StudyPermissionType.MANAGE_PERMISSIONS: {
         "roles": [RoleType.ADMIN],
         "public_modes": [],

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -1041,7 +1041,7 @@ class StudyService:
 
         """
         study = self.get_study(uuid)
-        assert_permission(params.user, study, StudyPermissionType.DELETE)
+        assert_permission(params.user, study, StudyPermissionType.WRITE)
 
         study_info = study.to_json_summary()
 
@@ -1791,7 +1791,7 @@ class StudyService:
     def archive(self, uuid: str, params: RequestParameters) -> str:
         logger.info(f"Archiving study {uuid}")
         study = self.get_study(uuid)
-        assert_permission(params.user, study, StudyPermissionType.DELETE)
+        assert_permission(params.user, study, StudyPermissionType.WRITE)
 
         self._assert_study_unarchived(study)
 
@@ -1849,7 +1849,7 @@ class StudyService:
         ):
             raise TaskAlreadyRunning()
 
-        assert_permission(params.user, study, StudyPermissionType.DELETE)
+        assert_permission(params.user, study, StudyPermissionType.WRITE)
 
         if not isinstance(study, RawStudy):
             raise StudyTypeUnsupported(study.id, study.type)

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -296,7 +296,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
             extra={"user": current_user.id},
         )
         params = RequestParameters(user=current_user)
-        study = study_service.check_study_access(uuid, StudyPermissionType.DELETE, params)
+        study = study_service.check_study_access(uuid, StudyPermissionType.READ, params)
         study_service.areas.remove_layer(study, layer_id)
 
     @bp.get(
@@ -1691,7 +1691,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
             extra={"user": current_user.id},
         )
         params = RequestParameters(user=current_user)
-        study = study_service.check_study_access(uuid, StudyPermissionType.DELETE, params)
+        study = study_service.check_study_access(uuid, StudyPermissionType.WRITE, params)
         study_service.st_storage_manager.delete_storages(study, area_id, storage_ids)
 
     return bp

--- a/tests/integration/test_integration_token_end_to_end.py
+++ b/tests/integration/test_integration_token_end_to_end.py
@@ -208,7 +208,7 @@ def test_nominal_case_of_an_api_user(client: TestClient, admin_access_token: str
         status_ = res_.json()["status"]
         return bool(status_ != "failed")
 
-    wait_for(callback, timeout=5, sleep_time=0.2)
+    wait_for(callback)
 
     res = client.delete(f"/v1/studies/{variant_id}", headers=bot_headers)
     assert res.status_code == 200

--- a/tests/storage/test_service.py
+++ b/tests/storage/test_service.py
@@ -862,7 +862,6 @@ def test_assert_permission() -> None:
     # when study found in workspace without group
     study = Study(id=uuid, public_mode=PublicMode.FULL)
     assert not assert_permission(jwt, study, StudyPermissionType.MANAGE_PERMISSIONS, raising=False)
-    assert assert_permission(jwt, study, StudyPermissionType.DELETE)
     assert assert_permission(jwt, study, StudyPermissionType.READ)
     assert assert_permission(jwt, study, StudyPermissionType.WRITE)
     assert assert_permission(jwt, study, StudyPermissionType.RUN)


### PR DESCRIPTION
In the Antares Web application, we removed the DELETE permission type and replaced it with WRITE. This change was made because a user with WRITE rights on a study should be able to delete study parameters, such as a thermal cluster. The relevant permissions now include "READ," "RUN," "WRITE," and "MANAGE_PERMISSIONS."