### PR TITLE
feat(simulation-ui): use API to get launcher number of cores

### DIFF
--- a/webapp/public/locales/en/main.json
+++ b/webapp/public/locales/en/main.json
@@ -506,6 +506,7 @@
   "study.error.exportOutput": "Failed to export the output",
   "study.error.listOutputs": "Failed to retrieve output list",
   "study.error.launcherVersions": "Failed to retrieve launcher versions",
+  "study.error.launcherCores": "Failed to retrieve launcher number of cores",
   "study.error.fetchComments": "Failed to fetch comments",
   "study.error.commentsNotSaved": "Comments not saved",
   "study.error.studyIdCopy": "Failed to copy study ID",

--- a/webapp/public/locales/fr/main.json
+++ b/webapp/public/locales/fr/main.json
@@ -506,6 +506,7 @@
   "study.error.exportOutput": "Échec lors de l'export de la sortie",
   "study.error.listOutputs": "Échec de la récupération des sorties",
   "study.error.launcherVersions": "Échec lors de la récupération des versions du launcher",
+  "study.error.launcherCores": "Échec lors de la récupération du nombre de cœurs du launcher",
   "study.error.fetchComments": "Échec lors de la récupération des commentaires",
   "study.error.commentsNotSaved": "Erreur lors de l'enregistrement des commentaires",
   "study.error.studyIdCopy": "Erreur lors de la copie de l'identifiant de l'étude",

--- a/webapp/src/components/App/Studies/LauncherDialog.tsx
+++ b/webapp/src/components/App/Studies/LauncherDialog.tsx
@@ -12,6 +12,7 @@ import {
   FormGroup,
   List,
   ListItem,
+  Skeleton,
   Slider,
   Stack,
   Switch,
@@ -46,6 +47,7 @@ import LinearProgressWithLabel from "../../common/LinearProgressWithLabel";
 import SelectSingle from "../../common/SelectSingle";
 import CheckBoxFE from "../../common/fieldEditors/CheckBoxFE";
 import { convertVersions } from "../../../services/utils";
+import UsePromiseCond from "../../common/utils/UsePromiseCond";
 
 const LAUNCH_DURATION_MAX_HOURS = 240;
 const LAUNCH_LOAD_DEFAULT = 22;
@@ -79,12 +81,9 @@ function LauncherDialog(props: Props) {
     deps: [open],
   });
 
-  const { data: cores } = usePromiseWithSnackbarError(
-    () => getLauncherCores(),
-    {
-      errorMessage: t("study.error.launcherCores"),
-    },
-  );
+  const cores = usePromiseWithSnackbarError(() => getLauncherCores(), {
+    errorMessage: t("study.error.launcherCores"),
+  });
 
   const { data: outputList } = usePromiseWithSnackbarError(
     () => Promise.all(studyIds.map((sid) => getStudyOutputs(sid))),
@@ -344,21 +343,26 @@ function LauncherDialog(props: Props) {
               />
             )}
           </Box>
-          {cores && (
-            <Slider
-              sx={{
-                width: "95%",
-                mx: 1,
-              }}
-              defaultValue={cores.defaultValue}
-              step={1}
-              min={cores.min}
-              max={cores.max}
-              valueLabelDisplay="auto"
-              color="secondary"
-              onChange={(event, val) => handleChange("nb_cpu", val as number)}
-            />
-          )}
+          <UsePromiseCond
+            response={cores}
+            ifResolved={(cores) => (
+              <Slider
+                sx={{
+                  width: "95%",
+                  mx: 1,
+                }}
+                defaultValue={cores.defaultValue}
+                step={1}
+                min={cores.min}
+                max={cores.max}
+                valueLabelDisplay="auto"
+                color="secondary"
+                onChange={(event, val) => handleChange("nb_cpu", val as number)}
+              />
+            )}
+            ifPending={() => <Skeleton />}
+            ifRejected={() => <Slider disabled />}
+          />
         </FormControl>
         <Typography sx={{ mt: 1 }}>Xpansion</Typography>
         <FormGroup

--- a/webapp/src/components/App/Studies/LauncherDialog.tsx
+++ b/webapp/src/components/App/Studies/LauncherDialog.tsx
@@ -31,6 +31,7 @@ import {
   LaunchOptions,
 } from "../../../common/types";
 import {
+  getLauncherCores,
   getLauncherLoad,
   getLauncherVersions,
   getStudyOutputs,
@@ -48,7 +49,6 @@ import { convertVersions } from "../../../services/utils";
 
 const LAUNCH_DURATION_MAX_HOURS = 240;
 const LAUNCH_LOAD_DEFAULT = 22;
-const LAUNCH_LOAD_SLIDER = { step: 1, min: 1, max: 24 };
 
 interface Props {
   open: boolean;
@@ -78,6 +78,13 @@ function LauncherDialog(props: Props) {
     errorMessage: t("study.error.launchLoad"),
     deps: [open],
   });
+
+  const { data: cores } = usePromiseWithSnackbarError(
+    () => getLauncherCores(),
+    {
+      errorMessage: t("study.error.launcherCores"),
+    },
+  );
 
   const { data: outputList } = usePromiseWithSnackbarError(
     () => Promise.all(studyIds.map((sid) => getStudyOutputs(sid))),
@@ -337,19 +344,21 @@ function LauncherDialog(props: Props) {
               />
             )}
           </Box>
-          <Slider
-            sx={{
-              width: "95%",
-              mx: 1,
-            }}
-            defaultValue={LAUNCH_LOAD_DEFAULT}
-            step={LAUNCH_LOAD_SLIDER.step}
-            min={LAUNCH_LOAD_SLIDER.min}
-            color="secondary"
-            max={LAUNCH_LOAD_SLIDER.max}
-            valueLabelDisplay="auto"
-            onChange={(event, val) => handleChange("nb_cpu", val as number)}
-          />
+          {cores && (
+            <Slider
+              sx={{
+                width: "95%",
+                mx: 1,
+              }}
+              defaultValue={cores.defaultValue}
+              step={1}
+              min={cores.min}
+              max={cores.max}
+              valueLabelDisplay="auto"
+              color="secondary"
+              onChange={(event, val) => handleChange("nb_cpu", val as number)}
+            />
+          )}
         </FormControl>
         <Typography sx={{ mt: 1 }}>Xpansion</Typography>
         <FormGroup

--- a/webapp/src/services/api/study.ts
+++ b/webapp/src/services/api/study.ts
@@ -301,6 +301,11 @@ export const getLauncherVersions = async (): Promise<Array<string>> => {
   return res.data;
 };
 
+export const getLauncherCores = async (): Promise<Record<string, number>> => {
+  const res = await client.get("/v1/launcher/nbcores");
+  return res.data;
+};
+
 export const getLauncherLoad = async (): Promise<LauncherLoadDTO> => {
   const res = await client.get("/v1/launcher/load");
   return res.data;


### PR DESCRIPTION
fix #1706 