### PR TITLE
fix(tasks): resolve incorrect UTC timezone usage for task completion dates in list view

### DIFF
--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -412,5 +412,6 @@ class TaskJobService(ITaskService):
         task.result_status = result
         task.result = command_result
         if status.is_final():
-            task.completion_date = datetime.datetime.now(datetime.timezone.utc)
+            # Do not use the `timezone.utc` timezone to preserve a naive datetime.
+            task.completion_date = datetime.datetime.utcnow()
         self.repo.save(task)

--- a/antarest/launcher/service.py
+++ b/antarest/launcher/service.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import shutil
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from http import HTTPStatus
 from pathlib import Path
 from typing import Dict, List, Optional, cast
@@ -166,7 +166,8 @@ class LauncherService:
                 job_result.output_id = output_id
                 final_status = status in [JobStatus.SUCCESS, JobStatus.FAILED]
                 if final_status:
-                    job_result.completion_date = datetime.now(timezone.utc)
+                    # Do not use the `timezone.utc` timezone to preserve a naive datetime.
+                    job_result.completion_date = datetime.utcnow()
                 self.job_result_repository.save(job_result)
                 self.event_bus.push(
                     Event(

--- a/antarest/matrixstore/service.py
+++ b/antarest/matrixstore/service.py
@@ -5,7 +5,7 @@ import logging
 import tempfile
 import zipfile
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Sequence, Tuple, Union
 
@@ -154,11 +154,13 @@ class MatrixService(ISimpleMatrixService):
         matrix_id = self.matrix_content_repository.save(data)
         shape = data.shape if isinstance(data, np.ndarray) else (len(data), len(data[0]) if data else 0)
         with db():
+            # Do not use the `timezone.utc` timezone to preserve a naive datetime.
+            created_at = datetime.utcnow()
             matrix = Matrix(
                 id=matrix_id,
                 width=shape[1],
                 height=shape[0],
-                created_at=datetime.now(timezone.utc),
+                created_at=created_at,
             )
             self.repo.save(matrix)
         return matrix_id

--- a/tests/core/tasks/test_task_job_service.py
+++ b/tests/core/tasks/test_task_job_service.py
@@ -1,0 +1,29 @@
+import datetime
+
+from sqlalchemy.orm import Session  # type: ignore
+
+from antarest.core.tasks.model import TaskJob
+
+
+def test_database_date_utc(db_session: Session) -> None:
+    now = datetime.datetime.utcnow()
+    later = now + datetime.timedelta(seconds=1)
+
+    with db_session:
+        task_job = TaskJob(name="foo")
+        db_session.add(task_job)
+        db_session.commit()
+
+    with db_session:
+        task_job = db_session.query(TaskJob).filter(TaskJob.name == "foo").one()
+        assert now <= task_job.creation_date <= later
+        assert task_job.completion_date is None
+
+    with db_session:
+        task_job = db_session.query(TaskJob).filter(TaskJob.name == "foo").one()
+        task_job.completion_date = datetime.datetime.utcnow()
+        db_session.commit()
+
+    with db_session:
+        task_job = db_session.query(TaskJob).filter(TaskJob.name == "foo").one()
+        assert now <= task_job.creation_date <= task_job.completion_date <= later


### PR DESCRIPTION
This PR correct the way `completion_date` is updated at the end of task processing.

![wrong-completion-date-in-task-view](https://github.com/AntaresSimulatorTeam/AntaREST/assets/43534797/7ae54827-a06e-4e8f-a9d2-ecdc71677be5)

The task list in the study main view is also fixed:

![study_view-completion_date-corrected](https://github.com/AntaresSimulatorTeam/AntaREST/assets/43534797/55aa0f52-4432-469c-adf0-dd991d505c49)

