### PR TITLE
chore: fix typo in the documentation of shell scripts

### DIFF
--- a/scripts/create_db_migration.sh
+++ b/scripts/create_db_migration.sh
@@ -4,7 +4,7 @@
 # usage:
 #
 # export ANTAREST_CONF=/path/to/application.yaml
-# bash ./scripts/scripts/create_db_migration.sh <name_of_your_migration>
+# bash ./scripts/create_db_migration.sh <name_of_your_migration>
 
 set -e
 

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -4,7 +4,7 @@
 # usage:
 #
 # export ANTAREST_CONF=/path/to/application.yaml
-# bash ./scripts/scripts/rollback.sh
+# bash ./scripts/rollback.sh
 
 set -e
 


### PR DESCRIPTION
This PR is only to remove the redundant "scripts/" word in the shell comments.