### PR TITLE
fix(ui): update dynamic areaId segment URL path on area change

### DIFF
--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/AreasTab.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/AreasTab.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useMemo } from "react";
-import { useOutletContext } from "react-router-dom";
+import { useEffect, useMemo } from "react";
+import { useLocation, useNavigate, useOutletContext } from "react-router-dom";
 import { Paper } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { StudyMetadata } from "../../../../../../common/types";
@@ -17,6 +17,31 @@ function AreasTab(props: Props) {
   const { study } = useOutletContext<{ study: StudyMetadata }>();
   const areaId = useAppSelector(getCurrentAreaId);
   const [t] = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  /**
+   * Updates the URL path to include the current areaId.
+   *
+   * The effect splits the current path, replaces the segment immediately after 'area'
+   * with the new areaId, and navigates to this updated path. It ensures the rest of the
+   * path, especially in deeply nested URLs, remains unchanged.
+   */
+  useEffect(() => {
+    const currentPath = location.pathname;
+    const pathSegments = currentPath.split("/");
+
+    const areaIndex = pathSegments.findIndex((segment) => segment === "area");
+    if (areaIndex >= 0 && areaIndex + 1 < pathSegments.length) {
+      // replace only the segment after 'area' with the new areaId
+      pathSegments[areaIndex + 1] = areaId.toString();
+
+      const newPath = pathSegments.join("/");
+      if (newPath !== currentPath) {
+        navigate(newPath, { replace: true });
+      }
+    }
+  }, [areaId, navigate, location.pathname]);
 
   const tabList = useMemo(() => {
     const baseTabs = [


### PR DESCRIPTION
#### Summary

This PR addresses the issue where the `areaId` in the URL was not updating when the `areaId` in the Redux store changed, especially in nested routes. The fix ensures that the URL is correctly updated to reflect the new `areaId`, while the rest of the path remains unchanged.

(Also fixes an issue that prevent users to go back to the Map view)

#### Changes Made

- Utilized `useEffect` to listen for changes in `areaId`.
- Used `useNavigate` and `useLocation` from `react-router-dom` to dynamically update the URL.
- Added logic to only modify the `areaId` segment of the URL, preserving subsequent path segments.

#### How to Test

1. Checkout this branch and run the application.
2. Navigate to a page with a nested route that includes `areaId`.
3. Trigger an action that changes the `areaId` in the Redux store.
4. Verify that the URL updates to reflect the new `areaId` while keeping the rest of the path intact.

#### Additional Notes

This fix enhances the application's navigational consistency and user experience by ensuring that the URL stays synchronized with the application's state.

Fixes #1810 

---
