### PR TITLE
feat(api-raw): add the `create_missing` flag to allow creating missing files when uploading a file

### DIFF
--- a/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
@@ -118,13 +118,23 @@ class TestFetchRawData:
             "exception": "ChildNotFoundError",
         }
 
-        # To create or update a resource, you can use PUT method and the `create_missing` flag.
+        # To create a resource, you can use PUT method and the `create_missing` flag.
         # The expected status code should be 204 No Content.
         res = client.put(
             f"/v1/studies/{study_id}/raw",
             params={"path": "user/somewhere/something.txt", "create_missing": True},
             headers=headers,
             files={"file": io.BytesIO(b"Goodbye Cruel World!")},
+        )
+        assert res.status_code == 204, res.json()
+
+        # To update a resource, you can use PUT method, with or without the `create_missing` flag.
+        # The expected status code should be 204 No Content.
+        res = client.put(
+            f"/v1/studies/{study_id}/raw",
+            params={"path": "user/somewhere/something.txt", "create_missing": True},
+            headers=headers,
+            files={"file": io.BytesIO(b"This is the end!")},
         )
         assert res.status_code == 204, res.json()
 
@@ -135,7 +145,7 @@ class TestFetchRawData:
             headers=headers,
         )
         assert res.status_code == 200, res.json()
-        assert res.content == b"Goodbye Cruel World!"
+        assert res.content == b"This is the end!"
 
         # If we ask for properties, we should have a JSON content
         rel_path = "/input/links/de/properties/fr"

--- a/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
@@ -186,7 +186,7 @@ class TestFetchRawData:
         first_row = [float(x) for x in actual_lines[0].split("\t")]
         assert first_row == [100000, 100000, 0.01, 0.01, 0, 0, 0, 0]
 
-        # If wa ask for and empty matrix, we should have an empty binary content
+        # If ask for an empty matrix, we should have an empty binary content
         res = client.get(
             f"/v1/studies/{study_id}/raw",
             params={"path": "input/thermal/prepro/de/01_solar/data", "formatted": False},


### PR DESCRIPTION
This PR modifies the `/v1/studies/{uuid}/raw` endpoint to add a `create_missing` flag authorizing creation of the directories and file targeted by the `path` if they don't exist.

This creation of files and folders is only possible for the `user` directory, to guard against possible data corruption. The `user/expansion` directory is also excluded to prevent modification of the Xpansion configuration.

Note that if the file targeted by the `path` does exist, there is no restriction and the user can modify it.
Note: setting up a control here could be very complicated.

Before this modification, if the `path` didn't exist, we'd get a 404 error.

Remember that the aim is to enable the user to store Microsoft Office documents, in particular Excel sheets, in the "user" directory.

The documentation of RAW Study endpoints is also improved.

Fix #1573 