### PR TITLE
feat(ui): reduce studies header height

### DIFF
--- a/webapp/src/components/App/Singlestudy/NavHeader/Actions.tsx
+++ b/webapp/src/components/App/Singlestudy/NavHeader/Actions.tsx
@@ -2,7 +2,9 @@ import { Box, Tooltip, Typography, Chip, Button, Divider } from "@mui/material";
 import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { StudyMetadata, StudyType } from "../../../../common/types";
 import { toggleFavorite } from "../../../../redux/ducks/studies";
 import StarToggle from "../../../common/StarToggle";
@@ -31,9 +33,26 @@ function Actions({
 }: Props) {
   const [t] = useTranslation();
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const isStudyFavorite = useAppSelector(isCurrentStudyFavorite);
   const isManaged = study?.managed;
   const isArchived = study?.archived;
+
+  ////////////////////////////////////////////////////////////////
+  // Event handlers
+  ////////////////////////////////////////////////////////////////
+
+  const handleClickBack = () => {
+    if (isExplorer) {
+      navigate(`/studies/${study?.id}`);
+    } else {
+      navigate("/studies");
+    }
+  };
+
+  ////////////////////////////////////////////////////////////////
+  // JSX
+  ////////////////////////////////////////////////////////////////
 
   if (!study) {
     return null;
@@ -51,12 +70,36 @@ function Actions({
         gap: 2,
       }}
     >
+      <Box>
+        <Button
+          variant="text"
+          color="secondary"
+          onClick={handleClickBack}
+          sx={{ pl: 0 }}
+        >
+          <ArrowBackIcon
+            color="secondary"
+            onClick={handleClickBack}
+            sx={{ cursor: "pointer", mr: 1 }}
+          />
+          <Tooltip
+            title={isExplorer ? study?.name : t("global.studies")}
+            followCursor
+          >
+            <Typography variant="button">
+              {isExplorer ? t("button.back") : t("global.studies")}
+            </Typography>
+          </Tooltip>
+        </Button>
+      </Box>
+      <Divider flexItem orientation="vertical" />
       <Tooltip title={study.folder} placement="bottom-start">
         <Typography
           variant="h6"
           noWrap
           sx={{
             flex: 1,
+            ml: 1,
           }}
         >
           {study.name}

--- a/webapp/src/components/App/Singlestudy/NavHeader/index.tsx
+++ b/webapp/src/components/App/Singlestudy/NavHeader/index.tsx
@@ -3,8 +3,7 @@ import debug from "debug";
 import { useSnackbar } from "notistack";
 import { useNavigate } from "react-router-dom";
 import { AxiosError } from "axios";
-import { Box, Button, Tooltip, Typography } from "@mui/material";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { Box, Typography } from "@mui/material";
 import UpgradeIcon from "@mui/icons-material/Upgrade";
 import UnarchiveOutlinedIcon from "@mui/icons-material/UnarchiveOutlined";
 import DownloadOutlinedIcon from "@mui/icons-material/DownloadOutlined";
@@ -76,14 +75,6 @@ function NavHeader({
 
   const handleClose = () => {
     setAnchorEl(null);
-  };
-
-  const handleClickBack = () => {
-    if (isExplorer) {
-      navigate(`/studies/${study?.id}`);
-    } else {
-      navigate("/studies");
-    }
   };
 
   const handleLaunch = () => {
@@ -209,31 +200,6 @@ function NavHeader({
         overflow: "hidden",
       }}
     >
-      <Box
-        sx={{
-          width: 1,
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "flex-start",
-          alignItems: "center",
-        }}
-      >
-        <ArrowBackIcon
-          color="secondary"
-          onClick={handleClickBack}
-          sx={{ cursor: "pointer" }}
-        />
-        <Button variant="text" color="secondary" onClick={handleClickBack}>
-          <Tooltip
-            title={isExplorer ? study?.name : t("global.studies")}
-            followCursor
-          >
-            <Typography variant="button">
-              {isExplorer ? t("button.back") : t("global.studies")}
-            </Typography>
-          </Tooltip>
-        </Button>
-      </Box>
       <Box
         sx={{
           width: 1,

--- a/webapp/src/theme.ts
+++ b/webapp/src/theme.ts
@@ -3,7 +3,7 @@ import { createTheme } from "@mui/material/styles";
 
 export const DRAWER_WIDTH = 60;
 export const DRAWER_WIDTH_EXTENDED = 240;
-export const STUDIES_HEIGHT_HEADER = 130;
+export const STUDIES_HEIGHT_HEADER = 100;
 export const STUDIES_SIDE_NAV_WIDTH = 300;
 export const STUDIES_LIST_HEADER_HEIGHT = 100;
 export const STUDIES_FILTER_WIDTH = 300;


### PR DESCRIPTION
### Optimizing UI: Reduced Header Height and Integrated Return Button

In this update, we've reduced the overall header height. This enhancement was achieved by strategically repositioning the return button into the same container as the study title. 

#### Key Changes:

Return Button Integration: The return button is now seamlessly incorporated with the study title, ensuring a cleaner and more consolidated header area.
Reduced Header Height: Minor adjustments to the header height in the MUI theme have been implemented, contributing to a more efficient use of screen space and a less cluttered appearance.

### Before:
![header2](https://github.com/AntaresSimulatorTeam/AntaREST/assets/33469289/ea451a18-19f8-4195-a93b-a03da9d3060e)


### After:
![header1](https://github.com/AntaresSimulatorTeam/AntaREST/assets/33469289/bffa1218-b22f-46aa-9f22-11b418839f55)


