### PR TITLE
feat(ui-modelization): add dynamic area selection on Areas tab click

### DIFF
--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/index.tsx
@@ -65,7 +65,7 @@ function Hydro() {
   return (
     <Root>
       <DocLink to={`${ACTIVE_WINDOWS_DOC_PATH}#hydro`} isAbsolute />
-      <TabWrapper study={study} tabStyle="normal" tabList={tabList} />
+      <TabWrapper study={study} tabList={tabList} isScrollable />
     </Root>
   );
 }

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/style.ts
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/style.ts
@@ -4,6 +4,7 @@ export const Root = styled(Box)(({ theme }) => ({
   width: "100%",
   height: "100%",
   padding: theme.spacing(2),
+  paddingTop: 0,
   display: "flex",
   overflow: "auto",
 }));

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/index.tsx
@@ -1,57 +1,73 @@
 import { useMemo } from "react";
-import { useOutletContext } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
 import { Box } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { StudyMetadata } from "../../../../../common/types";
 import TabWrapper from "../TabWrapper";
 import useAppSelector from "../../../../../redux/hooks/useAppSelector";
-import { getCurrentAreaId } from "../../../../../redux/selectors";
+import { getAreas, getCurrentAreaId } from "../../../../../redux/selectors";
+import useAppDispatch from "../../../../../redux/hooks/useAppDispatch";
+import { setCurrentArea } from "../../../../../redux/ducks/studySyntheses";
 
 function Modelization() {
   const { study } = useOutletContext<{ study: StudyMetadata }>();
-  const areaId = useAppSelector(getCurrentAreaId);
   const [t] = useTranslation();
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+  const areas = useAppSelector((state) => getAreas(state, study.id));
+  const areaId = useAppSelector(getCurrentAreaId);
 
-  const tabList = useMemo(
-    () => [
+  const tabList = useMemo(() => {
+    const basePath = `/studies/${study.id}/explore/modelization`;
+
+    const handleAreasClick = () => {
+      if (areaId.length === 0 && areas.length > 0) {
+        const firstAreaId = areas[0].id ?? null;
+
+        if (firstAreaId) {
+          dispatch(setCurrentArea(firstAreaId));
+          navigate(`${basePath}/area/${firstAreaId}`, { replace: true });
+        }
+      }
+    };
+
+    return [
       {
         label: t("study.modelization.map"),
-        path: `/studies/${study?.id}/explore/modelization/map`,
+        path: `${basePath}/map`,
       },
       {
         label: t("study.areas"),
-        path: `/studies/${study?.id}/explore/modelization/area/${areaId}`,
+        path: `${basePath}/area/${areaId}`,
+        onClick: handleAreasClick,
       },
       {
         label: t("study.links"),
-        path: `/studies/${study?.id}/explore/modelization/links`,
+        path: `${basePath}/links`,
       },
       {
         label: t("study.bindingconstraints"),
-        path: `/studies/${study?.id}/explore/modelization/bindingcontraint`,
+        path: `${basePath}/bindingcontraint`,
       },
       {
         label: t("study.debug"),
-        path: `/studies/${study?.id}/explore/modelization/debug`,
+        path: `${basePath}/debug`,
       },
       {
         label: t("study.modelization.tableMode"),
-        path: `/studies/${study?.id}/explore/modelization/tablemode`,
+        path: `${basePath}/tablemode`,
       },
-    ],
-    [areaId, study?.id, t],
-  );
+    ];
+  }, [areaId, areas, dispatch, navigate, study?.id, t]);
 
   return (
     <Box
-      width="100%"
-      flexGrow={1}
-      display="flex"
-      flexDirection="column"
-      justifyContent="center"
-      alignItems="center"
-      boxSizing="border-box"
-      overflow="hidden"
+      sx={{
+        display: "flex",
+        flex: 1,
+        width: 1,
+        overflow: "hidden",
+      }}
     >
       <TabWrapper study={study} tabStyle="withoutBorder" tabList={tabList} />
     </Box>

--- a/webapp/src/components/App/Singlestudy/explore/TabWrapper.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/TabWrapper.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import * as React from "react";
 import { styled, SxProps, Theme } from "@mui/material";
 import Tabs from "@mui/material/Tabs";
@@ -28,19 +28,32 @@ export const StyledTab = styled(Tabs, {
   }),
 );
 
+interface TabItem {
+  label: string;
+  path: string;
+  onClick?: () => void;
+}
+
 interface Props {
   study: StudyMetadata | undefined;
-  tabList: Array<{ label: string; path: string }>;
+  tabList: TabItem[];
   border?: boolean;
   tabStyle?: "normal" | "withoutBorder";
   sx?: SxProps<Theme>;
+  isScrollable?: boolean;
 }
 
-function TabWrapper(props: Props) {
-  const { study, tabList, border, tabStyle, sx } = props;
+function TabWrapper({
+  study,
+  tabList,
+  border,
+  tabStyle,
+  sx,
+  isScrollable = false,
+}: Props) {
   const location = useLocation();
   const navigate = useNavigate();
-  const [selectedTab, setSelectedTab] = React.useState(0);
+  const [selectedTab, setSelectedTab] = useState(0);
 
   useEffect(() => {
     const getTabIndex = (): number => {
@@ -66,6 +79,11 @@ function TabWrapper(props: Props) {
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setSelectedTab(newValue);
     navigate(tabList[newValue].path);
+
+    const onTabClick = tabList[newValue].onClick;
+    if (onTabClick) {
+      onTabClick();
+    }
   };
 
   ////////////////////////////////////////////////////////////////
@@ -87,16 +105,15 @@ function TabWrapper(props: Props) {
       )}
     >
       <StyledTab
-        border={border === true}
+        border={border}
         tabStyle={tabStyle}
         value={selectedTab}
         onChange={handleChange}
-        variant="scrollable"
+        variant={isScrollable ? "scrollable" : "standard"}
         sx={{
           width: "98%",
-          ...(border === true
-            ? { borderBottom: 1, borderColor: "divider" }
-            : {}),
+          borderBottom: border ? 1 : 0,
+          borderColor: border ? "divider" : "inherit",
         }}
       >
         {tabList.map((tab) => (
@@ -107,10 +124,5 @@ function TabWrapper(props: Props) {
     </Box>
   );
 }
-
-TabWrapper.defaultProps = {
-  border: undefined,
-  tabStyle: "normal",
-};
 
 export default TabWrapper;

--- a/webapp/src/redux/ducks/studySyntheses.ts
+++ b/webapp/src/redux/ducks/studySyntheses.ts
@@ -87,14 +87,7 @@ const initDefaultAreaLinkSelection = (
   studyData?: FileStudyTreeConfigDTO,
 ): void => {
   if (studyData) {
-    // Set current area
-    const areas = Object.keys(studyData.areas);
-    if (areas.length > 0) {
-      dispatch(setCurrentArea(areas[0]));
-    } else {
-      dispatch(setCurrentArea(""));
-    }
-
+    dispatch(setCurrentArea(""));
     dispatch(setCurrentLink(""));
   } else {
     dispatch(setCurrentArea(""));


### PR DESCRIPTION
## Dynamic Handling of Area Selection in `Modelization` Component

### Description:

This PR introduces a significant change in the way areas are handled within the `Modelization`. 
The current system has a default area selection mechanism when navigating to the map view. However, this approach has led to a couple of issues:

- Inability to Access the Areas View without an Active Selection:
Previously, if a user navigated to the map view and deselected the currently active area, they found themselves unable to navigate back to the areas view unless they selected an area again. This behavior was unintuitive and potentially frustrating for users who might want to browse different areas or had no specific area to focus on initially.

- Errors When Creating New Layers with a Preselected Area:
The existing system also posed a problem when creating new layers while an area was selected. If the selected area was not present in the newly created layer, the application attempted to retrieve UI information for the non-existent area in the context of that layer, leading to errors. 

### Solution:

To address these issues, we have implemented a dynamic area handling mechanism. Now, the area is determined dynamically when the "Areas" tab is clicked. The key changes include:

- No Default Area on Initial Render:
No area is preselected. 

- Dynamic Area Selection on Tab Click:
The `"Areas"` tab click now triggers a dynamic process to determine and set the current area. If no area is currently selected (i.e., `areaId` is empty), the first area from the list of available areas is automatically selected and dispatched to the Redux store. This selection is then reflected in the navigation, taking the user to the view for the selected area.