### PR TITLE
feat(db-init): separate database initialization from global database session

### DIFF
--- a/antarest/core/jwt.py
+++ b/antarest/core/jwt.py
@@ -3,9 +3,9 @@ from typing import List, Union
 from pydantic import BaseModel
 
 from antarest.core.roles import RoleType
-from antarest.login.model import Group, Identity
+from antarest.login.model import USER_ID, Group, Identity
 
-ADMIN_ID = 1
+ADMIN_ID = USER_ID
 
 
 class JWTGroup(BaseModel):

--- a/antarest/core/jwt.py
+++ b/antarest/core/jwt.py
@@ -3,9 +3,7 @@ from typing import List, Union
 from pydantic import BaseModel
 
 from antarest.core.roles import RoleType
-from antarest.login.model import USER_ID, Group, Identity
-
-ADMIN_ID = USER_ID
+from antarest.login.model import ADMIN_ID, Group, Identity
 
 
 class JWTGroup(BaseModel):

--- a/antarest/core/tasks/model.py
+++ b/antarest/core/tasks/model.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Mapping, Optional
 
 from pydantic import BaseModel, Extra
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, Sequence, String  # type: ignore
@@ -174,7 +174,7 @@ class TaskJob(Base):  # type: ignore
         )
 
 
-def cancel_orphan_tasks(engine: Engine, session_args: Dict[str, bool]) -> None:
+def cancel_orphan_tasks(engine: Engine, session_args: Mapping[str, bool]) -> None:
     updated_values = {
         TaskJob.status: TaskStatus.FAILED.value,
         TaskJob.result_status: False,

--- a/antarest/core/tasks/model.py
+++ b/antarest/core/tasks/model.py
@@ -177,7 +177,7 @@ class TaskJob(Base):  # type: ignore
 def cancel_orphan_tasks(engine: Engine, session_args: Dict[str, bool]) -> None:
     updated_values = {
         TaskJob.status: TaskStatus.FAILED.value,
-        TaskJob.result: False,
+        TaskJob.result_status: False,
         TaskJob.result_msg: "Task was interrupted due to server restart",
         TaskJob.completion_date: datetime.utcnow(),
     }

--- a/antarest/core/tasks/model.py
+++ b/antarest/core/tasks/model.py
@@ -176,10 +176,16 @@ class TaskJob(Base):  # type: ignore
 
 def cancel_orphan_tasks(engine: Engine, session_args: Mapping[str, bool]) -> None:
     """
+    Cancel all tasks that are currently running or pending.
+
     When the web application restarts, such as after a new deployment, any pending or running tasks may be lost.
     To mitigate this, it is preferable to set these tasks to a "FAILED" status.
     This ensures that users can easily identify the tasks that were affected by the restart and take appropriate
     actions, such as restarting the tasks manually.
+
+    Args:
+        engine: The database engine (SQLAlchemy connection to SQLite or PostgreSQL).
+        session_args: The session arguments (SQLAlchemy session arguments).
     """
     updated_values = {
         TaskJob.status: TaskStatus.FAILED.value,

--- a/antarest/core/tasks/model.py
+++ b/antarest/core/tasks/model.py
@@ -175,6 +175,12 @@ class TaskJob(Base):  # type: ignore
 
 
 def cancel_orphan_tasks(engine: Engine, session_args: Mapping[str, bool]) -> None:
+    """
+    When the web application restarts, such as after a new deployment, any pending or running tasks may be lost.
+    To mitigate this, it is preferable to set these tasks to a "FAILED" status.
+    This ensures that users can easily identify the tasks that were affected by the restart and take appropriate
+    actions, such as restarting the tasks manually.
+    """
     updated_values = {
         TaskJob.status: TaskStatus.FAILED.value,
         TaskJob.result_status: False,

--- a/antarest/core/tasks/repository.py
+++ b/antarest/core/tasks/repository.py
@@ -1,9 +1,10 @@
 import datetime
+import typing as t
 from http import HTTPStatus
 from operator import and_
-from typing import Any, List, Optional
 
 from fastapi import HTTPException
+from sqlalchemy.orm import Session  # type: ignore
 
 from antarest.core.tasks.model import TaskJob, TaskListFilter, TaskStatus
 from antarest.core.utils.fastapi_sqlalchemy import db
@@ -11,16 +12,45 @@ from antarest.core.utils.utils import assert_this
 
 
 class TaskJobRepository:
+    """
+    Database connector to manage Tasks/Jobs entities.
+    """
+
+    def __init__(self, session: t.Optional[Session] = None):
+        """
+        Initialize the repository.
+
+        Args:
+            session: Optional SQLAlchemy session to be used.
+        """
+        self._session = session
+
+    @property
+    def session(self) -> Session:
+        """
+        Get the SQLAlchemy session for the repository.
+
+        Returns:
+            SQLAlchemy session.
+        """
+        if self._session is None:
+            # Get or create the session from a context variable (thread local variable)
+            return db.session
+        # Get the user-defined session
+        return self._session
+
     def save(self, task: TaskJob) -> TaskJob:
-        task = db.session.merge(task)
-        db.session.add(task)
-        db.session.commit()
+        session = self.session
+        task = session.merge(task)
+        session.add(task)
+        session.commit()
         return task
 
-    def get(self, id: str) -> Optional[TaskJob]:
-        task: TaskJob = db.session.get(TaskJob, id)
+    def get(self, id: str) -> t.Optional[TaskJob]:
+        session = self.session
+        task: TaskJob = session.get(TaskJob, id)
         if task is not None:
-            db.session.refresh(task)
+            session.refresh(task)
         return task
 
     def get_or_raise(self, id: str) -> TaskJob:
@@ -30,7 +60,7 @@ class TaskJobRepository:
         return task
 
     @staticmethod
-    def _combine_clauses(where_clauses: List[Any]) -> Any:
+    def _combine_clauses(where_clauses: t.List[t.Any]) -> t.Any:
         assert_this(len(where_clauses) > 0)
         if len(where_clauses) > 1:
             return and_(
@@ -40,9 +70,9 @@ class TaskJobRepository:
         else:
             return where_clauses[0]
 
-    def list(self, filter: TaskListFilter, user: Optional[int] = None) -> List[TaskJob]:
-        query = db.session.query(TaskJob)
-        where_clauses: List[Any] = []
+    def list(self, filter: TaskListFilter, user: t.Optional[int] = None) -> t.List[TaskJob]:
+        query = self.session.query(TaskJob)
+        where_clauses: t.List[t.Any] = []
         if user:
             where_clauses.append(TaskJob.owner_id == user)
         if len(filter.status) > 0:
@@ -74,19 +104,21 @@ class TaskJobRepository:
         elif len(where_clauses) == 1:
             query = query.where(*where_clauses)
 
-        tasks: List[TaskJob] = query.all()
+        tasks: t.List[TaskJob] = query.all()
         return tasks
 
     def delete(self, tid: str) -> None:
-        task = db.session.get(TaskJob, tid)
+        session = self.session
+        task = session.get(TaskJob, tid)
         if task:
-            db.session.delete(task)
-            db.session.commit()
+            session.delete(task)
+            session.commit()
 
     def update_timeout(self, task_id: str, timeout: int) -> None:
         """Update task status to TIMEOUT."""
-        task: TaskJob = db.session.get(TaskJob, task_id)
+        session = self.session
+        task: TaskJob = session.get(TaskJob, task_id)
         task.status = TaskStatus.TIMEOUT
         task.result_msg = f"Task '{task_id}' timeout after {timeout} seconds"
         task.result_status = False
-        db.session.commit()
+        session.commit()

--- a/antarest/core/utils/fastapi_sqlalchemy/exceptions.py
+++ b/antarest/core/utils/fastapi_sqlalchemy/exceptions.py
@@ -1,5 +1,5 @@
 class MissingSessionError(Exception):
-    """Excetion raised for when the user tries to access a database session before it is created."""
+    """Exception raised for when the user tries to access a database session before it is created."""
 
     def __init__(self) -> None:
         msg = """

--- a/antarest/login/main.py
+++ b/antarest/login/main.py
@@ -37,7 +37,7 @@ def build_login(
     """
 
     if service is None:
-        user_repo = UserRepository(config)
+        user_repo = UserRepository()
         bot_repo = BotRepository()
         group_repo = GroupRepository()
         role_repo = RoleRepository()

--- a/antarest/login/model.py
+++ b/antarest/login/model.py
@@ -301,6 +301,10 @@ class CredentialsDTO(BaseModel):
 
 
 def init_admin_user(engine: Engine, session_args: t.Mapping[str, bool], admin_password: str) -> None:
+    """
+    When starting the app, the 'admin' group and 'admin' user are automatically created if they
+    do not already exist in the database.
+    """
     make_session = sessionmaker(bind=engine, **session_args)
     with make_session() as session:
         group = Group(id=GROUP_ID, name=GROUP_NAME)

--- a/antarest/login/model.py
+++ b/antarest/login/model.py
@@ -1,5 +1,4 @@
 import contextlib
-import logging
 import typing as t
 import uuid
 
@@ -9,7 +8,7 @@ from sqlalchemy import Boolean, Column, Enum, ForeignKey, Integer, Sequence, Str
 from sqlalchemy.engine.base import Engine  # type: ignore
 from sqlalchemy.exc import IntegrityError  # type: ignore
 from sqlalchemy.ext.hybrid import hybrid_property  # type: ignore
-from sqlalchemy.orm import Session, relationship, sessionmaker  # type: ignore
+from sqlalchemy.orm import relationship, sessionmaker  # type: ignore
 
 from antarest.core.persistence import Base
 from antarest.core.roles import RoleType
@@ -19,14 +18,17 @@ if t.TYPE_CHECKING:
     from antarest.launcher.model import JobResult
 
 
-logger = logging.getLogger(__name__)
-
-
 GROUP_ID = "admin"
-GROUP_NAME = "admin"
+"""Unique ID of the administrator group."""
 
-USER_ID = 1
-USER_NAME = "admin"
+GROUP_NAME = "admin"
+"""Name of the administrator group."""
+
+ADMIN_ID = 1
+"""Unique ID of the site administrator."""
+
+ADMIN_NAME = "admin"
+"""Name of the site administrator."""
 
 
 class UserInfo(BaseModel):
@@ -307,13 +309,13 @@ def init_admin_user(engine: Engine, session_args: t.Mapping[str, bool], admin_pa
             session.commit()
 
     with make_session() as session:
-        user = User(id=USER_ID, name=USER_NAME, password=Password(admin_password))
+        user = User(id=ADMIN_ID, name=ADMIN_NAME, password=Password(admin_password))
         with contextlib.suppress(IntegrityError):
             session.add(user)
             session.commit()
 
     with make_session() as session:
-        role = Role(type=RoleType.ADMIN, identity_id=USER_ID, group_id=GROUP_ID)
+        role = Role(type=RoleType.ADMIN, identity_id=ADMIN_ID, group_id=GROUP_ID)
         with contextlib.suppress(IntegrityError):
             session.add(role)
             session.commit()

--- a/antarest/login/model.py
+++ b/antarest/login/model.py
@@ -302,8 +302,12 @@ class CredentialsDTO(BaseModel):
 
 def init_admin_user(engine: Engine, session_args: t.Mapping[str, bool], admin_password: str) -> None:
     """
-    When starting the app, the 'admin' group and 'admin' user are automatically created if they
-    do not already exist in the database.
+    Create the default admin user, group and role if they do not already exist in the database.
+
+    Args:
+        engine: The database engine (SQLAlchemy connection to SQLite or PostgreSQL).
+        session_args: The session arguments (SQLAlchemy session arguments).
+        admin_password: The admin password extracted from the configuration file.
     """
     make_session = sessionmaker(bind=engine, **session_args)
     with make_session() as session:

--- a/antarest/login/repository.py
+++ b/antarest/login/repository.py
@@ -1,10 +1,10 @@
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from sqlalchemy import exists  # type: ignore
-from sqlalchemy.orm import joinedload  # type: ignore
+from sqlalchemy.engine.base import Engine  # type: ignore
+from sqlalchemy.orm import joinedload, Session, sessionmaker  # type: ignore
 
-from antarest.core.config import Config
 from antarest.core.jwt import ADMIN_ID
 from antarest.core.roles import RoleType
 from antarest.core.utils.fastapi_sqlalchemy import db
@@ -12,43 +12,99 @@ from antarest.login.model import Bot, Group, Password, Role, User, UserLdap
 
 logger = logging.getLogger(__name__)
 
+DB_INIT_DEFAULT_GROUP_ID = "admin"
+DB_INIT_DEFAULT_GROUP_NAME = "admin"
+
+DB_INIT_DEFAULT_USER_ID = ADMIN_ID
+DB_INIT_DEFAULT_USER_NAME = "admin"
+
+DB_INIT_DEFAULT_ROLE_ID = ADMIN_ID
+DB_INIT_DEFAULT_ROLE_GROUP_ID = "admin"
+
+
+def init_admin_user(engine: Engine, session_args: Dict[str, bool], admin_password: str) -> None:
+    with sessionmaker(bind=engine, **session_args)() as session:
+        group = Group(
+            id=DB_INIT_DEFAULT_GROUP_ID,
+            name=DB_INIT_DEFAULT_GROUP_NAME,
+        )
+        user = User(
+            id=DB_INIT_DEFAULT_USER_ID,
+            name=DB_INIT_DEFAULT_USER_NAME,
+            password=Password(admin_password),
+        )
+        role = Role(
+            type=RoleType.ADMIN,
+            identity=User(id=DB_INIT_DEFAULT_USER_ID),
+            group=Group(
+                id=DB_INIT_DEFAULT_GROUP_ID,
+            ),
+        )
+
+        existing_group = session.query(Group).get(group.id)
+        if not existing_group:
+            session.add(group)
+            session.commit()
+
+        existing_user = session.query(User).get(user.id)
+        if not existing_user:
+            session.add(user)
+            session.commit()
+
+        existing_role = session.query(Role).get((DB_INIT_DEFAULT_USER_ID, DB_INIT_DEFAULT_GROUP_ID))
+        if not existing_role:
+            role.group = session.merge(role.group)
+            role.identity = session.merge(role.identity)
+            session.add(role)
+
+        session.commit()
+
 
 class GroupRepository:
     """
     Database connector to manage Group entity.
     """
 
-    def __init__(self) -> None:
-        with db():
-            self.save(Group(id="admin", name="admin"))
+    def __init__(
+        self,
+        session: Optional[Session] = None,
+    ) -> None:
+        self._session = session
+
+    @property
+    def session(self) -> Session:
+        """Get the SqlAlchemy session or create a new one on the fly if not available in the current thread."""
+        if self._session is None:
+            return db.session
+        return self._session
 
     def save(self, group: Group) -> Group:
-        res = db.session.query(exists().where(Group.id == group.id)).scalar()
+        res = self.session.query(exists().where(Group.id == group.id)).scalar()
         if res:
-            db.session.merge(group)
+            self.session.merge(group)
         else:
-            db.session.add(group)
-        db.session.commit()
+            self.session.add(group)
+        self.session.commit()
 
         logger.debug(f"Group {group.id} saved")
         return group
 
     def get(self, id: str) -> Optional[Group]:
-        group: Group = db.session.query(Group).get(id)
+        group: Group = self.session.query(Group).get(id)
         return group
 
     def get_by_name(self, name: str) -> Group:
-        group: Group = db.session.query(Group).filter_by(name=name).first()
+        group: Group = self.session.query(Group).filter_by(name=name).first()
         return group
 
     def get_all(self) -> List[Group]:
-        groups: List[Group] = db.session.query(Group).all()
+        groups: List[Group] = self.session.query(Group).all()
         return groups
 
     def delete(self, id: str) -> None:
-        g = db.session.query(Group).get(id)
-        db.session.delete(g)
-        db.session.commit()
+        g = self.session.query(Group).get(id)
+        self.session.delete(g)
+        self.session.commit()
 
         logger.debug(f"Group {id} deleted")
 
@@ -58,35 +114,32 @@ class UserRepository:
     Database connector to manage User entity.
     """
 
-    def __init__(self, config: Config) -> None:
-        # init seed admin user from conf
-        with db():
-            admin_user = self.get_by_name("admin")
-            if admin_user is None:
-                self.save(
-                    User(
-                        id=ADMIN_ID,
-                        name="admin",
-                        password=Password(config.security.admin_pwd),
-                    )
-                )
-            elif not admin_user.password.check(config.security.admin_pwd):  # type: ignore
-                admin_user.password = Password(config.security.admin_pwd)  # type: ignore
-                self.save(admin_user)
+    def __init__(
+        self,
+        session: Optional[Session] = None,
+    ) -> None:
+        self._session = session
+
+    @property
+    def session(self) -> Session:
+        """Get the SqlAlchemy session or create a new one on the fly if not available in the current thread."""
+        if self._session is None:
+            return db.session
+        return self._session
 
     def save(self, user: User) -> User:
-        res = db.session.query(exists().where(User.id == user.id)).scalar()
+        res = self.session.query(exists().where(User.id == user.id)).scalar()
         if res:
-            db.session.merge(user)
+            self.session.merge(user)
         else:
-            db.session.add(user)
-        db.session.commit()
+            self.session.add(user)
+        self.session.commit()
 
         logger.debug(f"User {user.id} saved")
         return user
 
-    def get(self, id: int) -> Optional[User]:
-        user: User = db.session.query(User).get(id)
+    def get(self, id_number: int) -> Optional[User]:
+        user: User = self.session.query(User).get(id_number)
         return user
 
     def get_by_name(self, name: str) -> Optional[User]:
@@ -94,13 +147,13 @@ class UserRepository:
         return user
 
     def get_all(self) -> List[User]:
-        users: List[User] = db.session.query(User).all()
+        users: List[User] = self.session.query(User).all()
         return users
 
     def delete(self, id: int) -> None:
-        u: User = db.session.query(User).get(id)
-        db.session.delete(u)
-        db.session.commit()
+        u: User = self.session.query(User).get(id)
+        self.session.delete(u)
+        self.session.commit()
 
         logger.debug(f"User {id} deleted")
 
@@ -110,39 +163,54 @@ class UserLdapRepository:
     Database connector to manage UserLdap entity.
     """
 
+    def __init__(
+        self,
+        session: Optional[Session] = None,
+    ) -> None:
+        self._session = session
+
+    @property
+    def session(self) -> Session:
+        """Get the SqlAlchemy session or create a new one on the fly if not available in the current thread."""
+        if self._session is None:
+            return db.session
+        return self._session
+
     def save(self, user_ldap: UserLdap) -> UserLdap:
-        res = db.session.query(exists().where(UserLdap.id == user_ldap.id)).scalar()
+        res = self.session.query(exists().where(UserLdap.id == user_ldap.id)).scalar()
         if res:
-            db.session.merge(user_ldap)
+            self.session.merge(user_ldap)
         else:
-            db.session.add(user_ldap)
-        db.session.commit()
+            self.session.add(user_ldap)
+        self.session.commit()
 
         logger.debug(f"User LDAP {user_ldap.id} saved")
         return user_ldap
 
-    def get(self, id: int) -> Optional[UserLdap]:
-        user_ldap: Optional[UserLdap] = db.session.query(UserLdap).get(id)
+    def get(self, id_number: int) -> Optional[UserLdap]:
+        user_ldap: Optional[UserLdap] = self.session.query(UserLdap).get(id_number)
         return user_ldap
 
     def get_by_name(self, name: str) -> Optional[UserLdap]:
-        user: UserLdap = db.session.query(UserLdap).filter_by(name=name).first()
+        user: UserLdap = self.session.query(UserLdap).filter_by(name=name).first()
         return user
 
     def get_by_external_id(self, external_id: str) -> Optional[UserLdap]:
-        user: UserLdap = db.session.query(UserLdap).filter_by(external_id=external_id).first()
+        user: UserLdap = self.session.query(UserLdap).filter_by(external_id=external_id).first()
         return user
 
-    def get_all(self) -> List[UserLdap]:
-        users_ldap: List[UserLdap] = db.session.query(UserLdap).all()
+    def get_all(
+        self,
+    ) -> List[UserLdap]:
+        users_ldap: List[UserLdap] = self.session.query(UserLdap).all()
         return users_ldap
 
-    def delete(self, id: int) -> None:
-        u: UserLdap = db.session.query(UserLdap).get(id)
-        db.session.delete(u)
-        db.session.commit()
+    def delete(self, id_number: int) -> None:
+        u: UserLdap = self.session.query(UserLdap).get(id_number)
+        self.session.delete(u)
+        self.session.commit()
 
-        logger.debug(f"User LDAP {id} deleted")
+        logger.debug(f"User LDAP {id_number} deleted")
 
 
 class BotRepository:
@@ -150,42 +218,57 @@ class BotRepository:
     Database connector to manage Bot entity.
     """
 
+    def __init__(
+        self,
+        session: Optional[Session] = None,
+    ) -> None:
+        self._session = session
+
+    @property
+    def session(self) -> Session:
+        """Get the SqlAlchemy session or create a new one on the fly if not available in the current thread."""
+        if self._session is None:
+            return db.session
+        return self._session
+
     def save(self, bot: Bot) -> Bot:
-        res = db.session.query(exists().where(Bot.id == bot.id)).scalar()
+        res = self.session.query(exists().where(Bot.id == bot.id)).scalar()
         if res:
             raise ValueError("Bot already exist")
         else:
-            db.session.add(bot)
-        db.session.commit()
+            self.session.add(bot)
+        self.session.commit()
 
         logger.debug(f"Bot {bot.id} saved")
         return bot
 
-    def get(self, id: int) -> Optional[Bot]:
-        bot: Bot = db.session.query(Bot).get(id)
+    def get(self, id_number: int) -> Optional[Bot]:
+        bot: Bot = self.session.query(Bot).get(id_number)
         return bot
 
-    def get_all(self) -> List[Bot]:
-        bots: List[Bot] = db.session.query(Bot).all()
+    def get_all(
+        self,
+    ) -> List[Bot]:
+        bots: List[Bot] = self.session.query(Bot).all()
         return bots
 
-    def delete(self, id: int) -> None:
-        u: Bot = db.session.query(Bot).get(id)
-        db.session.delete(u)
-        db.session.commit()
+    def delete(self, id_number: int) -> None:
+        u: Bot = self.session.query(Bot).get(id_number)
+        self.session.delete(u)
+        self.session.commit()
 
-        logger.debug(f"Bot {id} deleted")
+        logger.debug(f"Bot {id_number} deleted")
 
     def get_all_by_owner(self, owner: int) -> List[Bot]:
-        bots: List[Bot] = db.session.query(Bot).filter_by(owner=owner).all()
+        bots: List[Bot] = self.session.query(Bot).filter_by(owner=owner).all()
         return bots
 
     def get_by_name_and_owner(self, owner: int, name: str) -> Optional[Bot]:
-        bot: Bot = db.session.query(Bot).filter_by(owner=owner, name=name).first()
+        bot: Bot = self.session.query(Bot).filter_by(owner=owner, name=name).first()
         return bot
 
-    def exists(self, id: int) -> bool:
-        res: bool = db.session.query(exists().where(Bot.id == id)).scalar()
+    def exists(self, id_number: int) -> bool:
+        res: bool = self.session.query(exists().where(Bot.id == id_number)).scalar()
         return res
 
 
@@ -194,29 +277,31 @@ class RoleRepository:
     Database connector to manage Role entity.
     """
 
-    def __init__(self) -> None:
-        with db():
-            if self.get(1, "admin") is None:
-                self.save(
-                    Role(
-                        type=RoleType.ADMIN,
-                        identity=User(id=1),
-                        group=Group(id="admin"),
-                    )
-                )
+    def __init__(
+        self,
+        session: Optional[Session] = None,
+    ) -> None:
+        self._session = session
+
+    @property
+    def session(self) -> Session:
+        """Get the SqlAlchemy session or create a new one on the fly if not available in the current thread."""
+        if self._session is None:
+            return db.session
+        return self._session
 
     def save(self, role: Role) -> Role:
-        role.group = db.session.merge(role.group)
-        role.identity = db.session.merge(role.identity)
+        role.group = self.session.merge(role.group)
+        role.identity = self.session.merge(role.identity)
 
-        db.session.add(role)
-        db.session.commit()
+        self.session.add(role)
+        self.session.commit()
 
         logger.debug(f"Role (user={role.identity}, group={role.group} saved")
         return role
 
     def get(self, user: int, group: str) -> Optional[Role]:
-        role: Role = db.session.query(Role).get((user, group))
+        role: Role = self.session.query(Role).get((user, group))
         return role
 
     def get_all_by_user(self, /, user_id: int) -> List[Role]:
@@ -231,17 +316,17 @@ class RoleRepository:
         """
         # When we fetch the list of roles, we also need to fetch the associated groups.
         # We use a SQL query with joins to fetch all these data efficiently.
-        stm = db.session.query(Role).options(joinedload(Role.group)).filter_by(identity_id=user_id)
+        stm = self.session.query(Role).options(joinedload(Role.group)).filter_by(identity_id=user_id)
         roles: List[Role] = stm.all()
         return roles
 
     def get_all_by_group(self, group: str) -> List[Role]:
-        roles: List[Role] = db.session.query(Role).filter_by(group_id=group).all()
+        roles: List[Role] = self.session.query(Role).filter_by(group_id=group).all()
         return roles
 
     def delete(self, user: int, group: str) -> None:
-        r = db.session.query(Role).get((user, group))
-        db.session.delete(r)
-        db.session.commit()
+        r = self.session.query(Role).get((user, group))
+        self.session.delete(r)
+        self.session.commit()
 
         logger.debug(f"Role (user={user}, group={group} deleted")

--- a/antarest/login/repository.py
+++ b/antarest/login/repository.py
@@ -2,7 +2,7 @@ import logging
 from typing import List, Optional
 
 from sqlalchemy import exists  # type: ignore
-from sqlalchemy.orm import joinedload, Session  # type: ignore
+from sqlalchemy.orm import Session, joinedload  # type: ignore
 
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.login.model import Bot, Group, Role, User, UserLdap

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -35,7 +35,7 @@ from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware
 from antarest.core.utils.utils import get_local_path
 from antarest.core.utils.web import tags_metadata
 from antarest.login.auth import Auth, JwtSettings
-from antarest.login.repository import init_admin_user
+from antarest.login.model import init_admin_user
 from antarest.matrixstore.matrix_garbage_collector import MatrixGarbageCollector
 from antarest.singleton_services import start_all_services
 from antarest.study.storage.auto_archive_service import AutoArchiveService

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -253,7 +253,7 @@ def fastapi_app(
     application.add_middleware(
         DBSessionMiddleware,
         custom_engine=engine,
-        session_args=dict(SESSION_ARGS),
+        session_args=SESSION_ARGS,
     )
 
     application.add_middleware(LoggingMiddleware)
@@ -409,7 +409,7 @@ def fastapi_app(
         config=RATE_LIMIT_CONFIG,
     )
 
-    init_admin_user(engine=engine, session_args=dict(SESSION_ARGS), admin_password=config.security.admin_pwd)
+    init_admin_user(engine=engine, session_args=SESSION_ARGS, admin_password=config.security.admin_pwd)
     services = create_services(config, application)
 
     if mount_front:
@@ -439,7 +439,7 @@ def fastapi_app(
     customize_openapi(application)
     cancel_orphan_tasks(
         engine=engine,
-        session_args=dict(SESSION_ARGS),
+        session_args=SESSION_ARGS,
     )
     return application, services
 

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -30,15 +30,18 @@ from antarest.core.core_blueprint import create_utils_routes
 from antarest.core.logging.utils import LoggingMiddleware, configure_logger
 from antarest.core.requests import RATE_LIMIT_CONFIG
 from antarest.core.swagger import customize_openapi
+from antarest.core.tasks.model import cancel_orphan_tasks
+from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware
 from antarest.core.utils.utils import get_local_path
 from antarest.core.utils.web import tags_metadata
 from antarest.login.auth import Auth, JwtSettings
+from antarest.login.repository import init_admin_user
 from antarest.matrixstore.matrix_garbage_collector import MatrixGarbageCollector
-from antarest.singleton_services import SingletonServices
+from antarest.singleton_services import start_all_services
 from antarest.study.storage.auto_archive_service import AutoArchiveService
 from antarest.study.storage.rawstudy.watcher import Watcher
 from antarest.tools.admin_lib import clean_locks
-from antarest.utils import Module, create_services, init_db
+from antarest.utils import SESSION_ARGS, Module, create_services, init_db_engine
 
 logger = logging.getLogger(__name__)
 
@@ -246,7 +249,12 @@ def fastapi_app(
     )
 
     # Database
-    init_db(config_file, config, auto_upgrade_db, application)
+    engine = init_db_engine(config_file, config, auto_upgrade_db)
+    application.add_middleware(
+        DBSessionMiddleware,
+        custom_engine=engine,
+        session_args=dict(SESSION_ARGS),
+    )
 
     application.add_middleware(LoggingMiddleware)
 
@@ -401,6 +409,7 @@ def fastapi_app(
         config=RATE_LIMIT_CONFIG,
     )
 
+    init_admin_user(engine=engine, session_args=dict(SESSION_ARGS), admin_password=config.security.admin_pwd)
     services = create_services(config, application)
 
     if mount_front:
@@ -428,6 +437,10 @@ def fastapi_app(
         auto_archiver.start()
 
     customize_openapi(application)
+    cancel_orphan_tasks(
+        engine=engine,
+        session_args=dict(SESSION_ARGS),
+    )
     return application, services
 
 
@@ -455,8 +468,7 @@ def main() -> None:
         # noinspection PyTypeChecker
         uvicorn.run(app, host="0.0.0.0", port=8080, log_config=LOGGING_CONFIG)
     else:
-        services = SingletonServices(arguments.config_file, [arguments.module])
-        services.start()
+        start_all_services(arguments.config_file, [arguments.module])
 
 
 if __name__ == "__main__":

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -250,11 +250,7 @@ def fastapi_app(
 
     # Database
     engine = init_db_engine(config_file, config, auto_upgrade_db)
-    application.add_middleware(
-        DBSessionMiddleware,
-        custom_engine=engine,
-        session_args=SESSION_ARGS,
-    )
+    application.add_middleware(DBSessionMiddleware, custom_engine=engine, session_args=SESSION_ARGS)
 
     application.add_middleware(LoggingMiddleware)
 
@@ -437,10 +433,7 @@ def fastapi_app(
         auto_archiver.start()
 
     customize_openapi(application)
-    cancel_orphan_tasks(
-        engine=engine,
-        session_args=SESSION_ARGS,
-    )
+    cancel_orphan_tasks(engine=engine, session_args=SESSION_ARGS)
     return application, services
 
 

--- a/antarest/matrixstore/model.py
+++ b/antarest/matrixstore/model.py
@@ -1,6 +1,6 @@
 import datetime
+import typing as t
 import uuid
-from typing import Any, List, Union
 
 from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Table  # type: ignore
@@ -29,7 +29,11 @@ class Matrix(Base):  # type: ignore
     height: int = Column(Integer)
     created_at: datetime.datetime = Column(DateTime)
 
-    def __eq__(self, other: Any) -> bool:
+    def __repr__(self) -> str:  # pragma: no cover
+        """Returns a string representation of the matrix."""
+        return f"Matrix(id={self.id}, shape={(self.height, self.width)}, created_at={self.created_at})"
+
+    def __eq__(self, other: t.Any) -> bool:
         if not isinstance(other, Matrix):
             return False
 
@@ -50,9 +54,9 @@ class MatrixInfoDTO(BaseModel):
 class MatrixDataSetDTO(BaseModel):
     id: str
     name: str
-    matrices: List[MatrixInfoDTO]
+    matrices: t.List[MatrixInfoDTO]
     owner: UserInfo
-    groups: List[GroupDTO]
+    groups: t.List[GroupDTO]
     public: bool
     created_at: str
     updated_at: str
@@ -85,7 +89,11 @@ class MatrixDataSetRelation(Base):  # type: ignore
     name: str = Column(String, primary_key=True)
     matrix: Matrix = relationship(Matrix)
 
-    def __eq__(self, other: Any) -> bool:
+    def __repr__(self) -> str:  # pragma: no cover
+        """Returns a string representation of the matrix."""
+        return f"MatrixDataSetRelation(dataset_id={self.dataset_id}, matrix_id={self.matrix_id}, name={self.name})"
+
+    def __eq__(self, other: t.Any) -> bool:
         if not isinstance(other, MatrixDataSetRelation):
             return False
 
@@ -152,7 +160,18 @@ class MatrixDataSet(Base):  # type: ignore
             updated_at=str(self.updated_at),
         )
 
-    def __eq__(self, other: Any) -> bool:
+    def __repr__(self) -> str:  # pragma: no cover
+        """Returns a string representation of the matrix."""
+        return (
+            f"MatrixDataSet(id={self.id},"
+            f" name={self.name},"
+            f" owner_id={self.owner_id},"
+            f" public={self.public},"
+            f" created_at={self.created_at},"
+            f" updated_at={self.updated_at})"
+        )
+
+    def __eq__(self, other: t.Any) -> bool:
         if not isinstance(other, MatrixDataSet):
             return False
 
@@ -181,9 +200,9 @@ MatrixData = float
 class MatrixDTO(BaseModel):
     width: int
     height: int
-    index: List[str]
-    columns: List[str]
-    data: List[List[MatrixData]]
+    index: t.List[str]
+    columns: t.List[str]
+    data: t.List[t.List[MatrixData]]
     created_at: int = 0
     id: str = ""
 
@@ -198,12 +217,12 @@ class MatrixContent(BaseModel):
         columns: A list of columns indexes or names.
     """
 
-    data: List[List[MatrixData]]
-    index: List[Union[int, str]]
-    columns: List[Union[int, str]]
+    data: t.List[t.List[MatrixData]]
+    index: t.List[t.Union[int, str]]
+    columns: t.List[t.Union[int, str]]
 
 
 class MatrixDataSetUpdateDTO(BaseModel):
     name: str
-    groups: List[str]
+    groups: t.List[str]
     public: bool

--- a/antarest/matrixstore/service.py
+++ b/antarest/matrixstore/service.py
@@ -57,10 +57,6 @@ class ISimpleMatrixService(ABC):
     def __init__(self, matrix_content_repository: MatrixContentRepository) -> None:
         self.matrix_content_repository = matrix_content_repository
 
-    @property
-    def bucket_dir(self) -> Path:
-        return self.matrix_content_repository.bucket_dir
-
     @abstractmethod
     def create(self, data: Union[List[List[MatrixData]], npt.NDArray[np.float64]]) -> str:
         raise NotImplementedError()

--- a/antarest/matrixstore/service.py
+++ b/antarest/matrixstore/service.py
@@ -54,6 +54,13 @@ logger = logging.getLogger(__name__)
 
 
 class ISimpleMatrixService(ABC):
+    def __init__(self, matrix_content_repository: MatrixContentRepository) -> None:
+        self.matrix_content_repository = matrix_content_repository
+
+    @property
+    def bucket_dir(self) -> Path:
+        return self.matrix_content_repository.bucket_dir
+
     @abstractmethod
     def create(self, data: Union[List[List[MatrixData]], npt.NDArray[np.float64]]) -> str:
         raise NotImplementedError()
@@ -72,15 +79,14 @@ class ISimpleMatrixService(ABC):
 
 
 class SimpleMatrixService(ISimpleMatrixService):
-    def __init__(self, bucket_dir: Path):
-        self.bucket_dir = bucket_dir
-        self.content_repo = MatrixContentRepository(bucket_dir)
+    def __init__(self, matrix_content_repository: MatrixContentRepository):
+        super().__init__(matrix_content_repository=matrix_content_repository)
 
     def create(self, data: Union[List[List[MatrixData]], npt.NDArray[np.float64]]) -> str:
-        return self.content_repo.save(data)
+        return self.matrix_content_repository.save(data)
 
     def get(self, matrix_id: str) -> MatrixDTO:
-        data = self.content_repo.get(matrix_id)
+        data = self.matrix_content_repository.get(matrix_id)
         return MatrixDTO.construct(
             id=matrix_id,
             width=len(data.columns),
@@ -91,10 +97,10 @@ class SimpleMatrixService(ISimpleMatrixService):
         )
 
     def exists(self, matrix_id: str) -> bool:
-        return self.content_repo.exists(matrix_id)
+        return self.matrix_content_repository.exists(matrix_id)
 
     def delete(self, matrix_id: str) -> None:
-        self.content_repo.delete(matrix_id)
+        self.matrix_content_repository.delete(matrix_id)
 
 
 class MatrixService(ISimpleMatrixService):
@@ -108,9 +114,9 @@ class MatrixService(ISimpleMatrixService):
         config: Config,
         user_service: LoginService,
     ):
+        super().__init__(matrix_content_repository=matrix_content_repository)
         self.repo = repo
         self.repo_dataset = repo_dataset
-        self.matrix_content_repository = matrix_content_repository
         self.user_service = user_service
         self.file_transfer_manager = file_transfer_manager
         self.task_service = task_service

--- a/antarest/singleton_services.py
+++ b/antarest/singleton_services.py
@@ -1,90 +1,76 @@
-import logging
-import time
 from pathlib import Path
 from typing import Dict, List
 
 from antarest.core.config import Config
 from antarest.core.interfaces.service import IService
 from antarest.core.logging.utils import configure_logger
+from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware
 from antarest.core.utils.utils import get_local_path
 from antarest.study.storage.auto_archive_service import AutoArchiveService
 from antarest.utils import (
+    SESSION_ARGS,
     Module,
     create_archive_worker,
     create_core_services,
     create_matrix_gc,
     create_simulator_worker,
     create_watcher,
-    init_db,
+    init_db_engine,
 )
 
-logger = logging.getLogger(__name__)
+
+def _init(config_file: Path, services_list: List[Module]) -> Dict[Module, IService]:
+    res = get_local_path() / "resources"
+    config = Config.from_yaml_file(res=res, file=config_file)
+    engine = init_db_engine(
+        config_file,
+        config,
+        False,
+    )
+    DBSessionMiddleware(None, custom_engine=engine, session_args=dict(SESSION_ARGS))
+    configure_logger(config)
+
+    (
+        cache,
+        event_bus,
+        task_service,
+        ft_manager,
+        login_service,
+        matrix_service,
+        study_service,
+    ) = create_core_services(None, config)
+
+    services: Dict[Module, IService] = {}
+
+    if Module.WATCHER in services_list:
+        watcher = create_watcher(config=config, application=None, study_service=study_service)
+        services[Module.WATCHER] = watcher
+
+    if Module.MATRIX_GC in services_list:
+        matrix_gc = create_matrix_gc(
+            config=config,
+            application=None,
+            study_service=study_service,
+            matrix_service=matrix_service,
+        )
+        services[Module.MATRIX_GC] = matrix_gc
+
+    if Module.ARCHIVE_WORKER in services_list:
+        worker = create_archive_worker(config, "test", event_bus=event_bus)
+        services[Module.ARCHIVE_WORKER] = worker
+
+    if Module.SIMULATOR_WORKER in services_list:
+        worker = create_simulator_worker(config, matrix_service=matrix_service, event_bus=event_bus)
+        services[Module.SIMULATOR_WORKER] = worker
+
+    if Module.AUTO_ARCHIVER in services_list:
+        auto_archive_service = AutoArchiveService(study_service, config)
+        services[Module.AUTO_ARCHIVER] = auto_archive_service
+
+    return services
 
 
-class SingletonServices:
-    def __init__(self, config_file: Path, services_list: List[Module]) -> None:
-        self.services_list = self._init(config_file, services_list)
-
-    @staticmethod
-    def _init(config_file: Path, services_list: List[Module]) -> Dict[Module, IService]:
-        res = get_local_path() / "resources"
-        config = Config.from_yaml_file(res=res, file=config_file)
-        init_db(config_file, config, False, None)
-        configure_logger(config)
-
-        (
-            cache,
-            event_bus,
-            task_service,
-            ft_manager,
-            login_service,
-            matrix_service,
-            study_service,
-        ) = create_core_services(None, config)
-
-        services: Dict[Module, IService] = {}
-
-        if Module.WATCHER in services_list:
-            watcher = create_watcher(config=config, application=None, study_service=study_service)
-            services[Module.WATCHER] = watcher
-
-        if Module.MATRIX_GC in services_list:
-            matrix_gc = create_matrix_gc(
-                config=config,
-                application=None,
-                study_service=study_service,
-                matrix_service=matrix_service,
-            )
-            services[Module.MATRIX_GC] = matrix_gc
-
-        if Module.ARCHIVE_WORKER in services_list:
-            worker = create_archive_worker(config, "test", event_bus=event_bus)
-            services[Module.ARCHIVE_WORKER] = worker
-
-        if Module.SIMULATOR_WORKER in services_list:
-            worker = create_simulator_worker(config, matrix_service=matrix_service, event_bus=event_bus)
-            services[Module.SIMULATOR_WORKER] = worker
-
-        if Module.AUTO_ARCHIVER in services_list:
-            auto_archive_service = AutoArchiveService(study_service, config)
-            services[Module.AUTO_ARCHIVER] = auto_archive_service
-
-        return services
-
-    def start(self) -> None:
-        for service in self.services_list:
-            self.services_list[service].start(threaded=True)
-
-        self._loop()
-
-    def _loop(self) -> None:
-        while True:
-            try:
-                pass
-            except Exception as e:
-                logger.error(
-                    "Unexpected error happened while processing service manager loop",
-                    exc_info=e,
-                )
-            finally:
-                time.sleep(2)
+def start_all_services(config_file: Path, services_list: List[Module]) -> None:
+    services = _init(config_file, services_list)
+    for service in services:
+        services[service].start(threaded=True)

--- a/antarest/singleton_services.py
+++ b/antarest/singleton_services.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, cast
 
 from antarest.core.config import Config
 from antarest.core.interfaces.service import IService
@@ -27,7 +27,7 @@ def _init(config_file: Path, services_list: List[Module]) -> Dict[Module, IServi
         config,
         False,
     )
-    DBSessionMiddleware(None, custom_engine=engine, session_args=dict(SESSION_ARGS))
+    DBSessionMiddleware(None, custom_engine=engine, session_args=cast(Dict[str, bool], SESSION_ARGS))
     configure_logger(config)
 
     (

--- a/antarest/study/main.py
+++ b/antarest/study/main.py
@@ -81,7 +81,7 @@ def build_study_service(
     )
 
     generator_matrix_constants = generator_matrix_constants or GeneratorMatrixConstants(matrix_service=matrix_service)
-    generator_matrix_constants.init_constant_matrices(bucket_dir=generator_matrix_constants.matrix_service.bucket_dir)
+    generator_matrix_constants.init_constant_matrices()
     command_factory = CommandFactory(
         generator_matrix_constants=generator_matrix_constants,
         matrix_service=matrix_service,

--- a/antarest/study/main.py
+++ b/antarest/study/main.py
@@ -81,6 +81,7 @@ def build_study_service(
     )
 
     generator_matrix_constants = generator_matrix_constants or GeneratorMatrixConstants(matrix_service=matrix_service)
+    generator_matrix_constants.init_constant_matrices(bucket_dir=generator_matrix_constants.matrix_service.bucket_dir)
     command_factory = CommandFactory(
         generator_matrix_constants=generator_matrix_constants,
         matrix_service=matrix_service,

--- a/antarest/study/main.py
+++ b/antarest/study/main.py
@@ -80,8 +80,9 @@ def build_study_service(
         cache=cache,
     )
 
-    generator_matrix_constants = generator_matrix_constants or GeneratorMatrixConstants(matrix_service=matrix_service)
-    generator_matrix_constants.init_constant_matrices()
+    if not generator_matrix_constants:
+        generator_matrix_constants = GeneratorMatrixConstants(matrix_service=matrix_service)
+        generator_matrix_constants.init_constant_matrices()
     command_factory = CommandFactory(
         generator_matrix_constants=generator_matrix_constants,
         matrix_service=matrix_service,

--- a/antarest/study/storage/variantstudy/business/command_extractor.py
+++ b/antarest/study/storage/variantstudy/business/command_extractor.py
@@ -48,9 +48,7 @@ class CommandExtractor(ICommandExtractor):
     def __init__(self, matrix_service: ISimpleMatrixService, patch_service: PatchService):
         self.matrix_service = matrix_service
         self.generator_matrix_constants = GeneratorMatrixConstants(self.matrix_service)
-        self.generator_matrix_constants.init_constant_matrices(
-            bucket_dir=self.generator_matrix_constants.matrix_service.bucket_dir
-        )
+        self.generator_matrix_constants.init_constant_matrices()
         self.patch_service = patch_service
         self.command_context = CommandContext(
             generator_matrix_constants=self.generator_matrix_constants,

--- a/antarest/study/storage/variantstudy/business/command_extractor.py
+++ b/antarest/study/storage/variantstudy/business/command_extractor.py
@@ -48,6 +48,9 @@ class CommandExtractor(ICommandExtractor):
     def __init__(self, matrix_service: ISimpleMatrixService, patch_service: PatchService):
         self.matrix_service = matrix_service
         self.generator_matrix_constants = GeneratorMatrixConstants(self.matrix_service)
+        self.generator_matrix_constants.init_constant_matrices(
+            bucket_dir=self.generator_matrix_constants.matrix_service.bucket_dir
+        )
         self.patch_service = patch_service
         self.command_context = CommandContext(
             generator_matrix_constants=self.generator_matrix_constants,

--- a/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
@@ -49,7 +49,7 @@ ST_STORAGE_UPPER_RULE_CURVE = ONES_SCENARIO_MATRIX
 ST_STORAGE_INFLOWS = EMPTY_SCENARIO_MATRIX
 
 MATRIX_PROTOCOL_PREFIX = "matrix://"
-MATRIX_CONSTANT_INIT_LOCK_FILE_NAME = "matrix_constant_init.lock"
+_LOCK_FILE_NAME = "matrix_constant_init.lock"
 
 
 # noinspection SpellCheckingInspection
@@ -62,7 +62,7 @@ class GeneratorMatrixConstants:
     def init_constant_matrices(
         self,
     ) -> None:
-        with FileLock(str(Path(self._lock_dir) / MATRIX_CONSTANT_INIT_LOCK_FILE_NAME)):
+        with FileLock(str(Path(self._lock_dir) / _LOCK_FILE_NAME)):
             self.hashes[HYDRO_COMMON_CAPACITY_MAX_POWER_V7] = self.matrix_service.create(
                 matrix_constants.hydro.v7.max_power
             )

--- a/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
@@ -57,10 +57,12 @@ class GeneratorMatrixConstants:
     def __init__(self, matrix_service: ISimpleMatrixService) -> None:
         self.hashes: Dict[str, str] = {}
         self.matrix_service: ISimpleMatrixService = matrix_service
+        self._lock_dir = tempfile.gettempdir()
 
-    def init_constant_matrices(self, bucket_dir: Path) -> None:
-        bucket_dir.mkdir(parents=True, exist_ok=True)
-        with FileLock(bucket_dir / MATRIX_CONSTANT_INIT_LOCK_FILE_NAME):
+    def init_constant_matrices(
+        self,
+    ) -> None:
+        with FileLock(str(Path(self._lock_dir) / MATRIX_CONSTANT_INIT_LOCK_FILE_NAME)):
             self.hashes[HYDRO_COMMON_CAPACITY_MAX_POWER_V7] = self.matrix_service.create(
                 matrix_constants.hydro.v7.max_power
             )

--- a/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
@@ -49,6 +49,7 @@ ST_STORAGE_UPPER_RULE_CURVE = ONES_SCENARIO_MATRIX
 ST_STORAGE_INFLOWS = EMPTY_SCENARIO_MATRIX
 
 MATRIX_PROTOCOL_PREFIX = "matrix://"
+MATRIX_CONSTANT_INIT_LOCK_FILE_NAME = "matrix_constant_init.lock"
 
 
 # noinspection SpellCheckingInspection
@@ -56,49 +57,51 @@ class GeneratorMatrixConstants:
     def __init__(self, matrix_service: ISimpleMatrixService) -> None:
         self.hashes: Dict[str, str] = {}
         self.matrix_service: ISimpleMatrixService = matrix_service
-        with FileLock(str(Path(tempfile.gettempdir()) / "matrix_constant_init.lock")):
-            self._init()
 
-    def _init(self) -> None:
-        self.hashes[HYDRO_COMMON_CAPACITY_MAX_POWER_V7] = self.matrix_service.create(
-            matrix_constants.hydro.v7.max_power
-        )
-        self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V7] = self.matrix_service.create(
-            matrix_constants.hydro.v7.reservoir
-        )
-        self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V6] = self.matrix_service.create(
-            matrix_constants.hydro.v6.reservoir
-        )
-        self.hashes[HYDRO_COMMON_CAPACITY_INFLOW_PATTERN] = self.matrix_service.create(
-            matrix_constants.hydro.v7.inflow_pattern
-        )
-        self.hashes[HYDRO_COMMON_CAPACITY_CREDIT_MODULATION] = self.matrix_service.create(
-            matrix_constants.hydro.v7.credit_modulations
-        )
-        self.hashes[PREPRO_CONVERSION] = self.matrix_service.create(matrix_constants.prepro.conversion)
-        self.hashes[PREPRO_DATA] = self.matrix_service.create(matrix_constants.prepro.data)
-        self.hashes[THERMAL_PREPRO_DATA] = self.matrix_service.create(matrix_constants.thermals.prepro.data)
+    def init_constant_matrices(self, bucket_dir: Path) -> None:
+        bucket_dir.mkdir(parents=True, exist_ok=True)
+        with FileLock(bucket_dir / MATRIX_CONSTANT_INIT_LOCK_FILE_NAME):
+            self.hashes[HYDRO_COMMON_CAPACITY_MAX_POWER_V7] = self.matrix_service.create(
+                matrix_constants.hydro.v7.max_power
+            )
+            self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V7] = self.matrix_service.create(
+                matrix_constants.hydro.v7.reservoir
+            )
+            self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V6] = self.matrix_service.create(
+                matrix_constants.hydro.v6.reservoir
+            )
+            self.hashes[HYDRO_COMMON_CAPACITY_INFLOW_PATTERN] = self.matrix_service.create(
+                matrix_constants.hydro.v7.inflow_pattern
+            )
+            self.hashes[HYDRO_COMMON_CAPACITY_CREDIT_MODULATION] = self.matrix_service.create(
+                matrix_constants.hydro.v7.credit_modulations
+            )
+            self.hashes[PREPRO_CONVERSION] = self.matrix_service.create(matrix_constants.prepro.conversion)
+            self.hashes[PREPRO_DATA] = self.matrix_service.create(matrix_constants.prepro.data)
+            self.hashes[THERMAL_PREPRO_DATA] = self.matrix_service.create(matrix_constants.thermals.prepro.data)
 
-        self.hashes[THERMAL_PREPRO_MODULATION] = self.matrix_service.create(matrix_constants.thermals.prepro.modulation)
-        self.hashes[LINK_V7] = self.matrix_service.create(matrix_constants.link.v7.link)
-        self.hashes[LINK_V8] = self.matrix_service.create(matrix_constants.link.v8.link)
-        self.hashes[LINK_DIRECT] = self.matrix_service.create(matrix_constants.link.v8.direct)
-        self.hashes[LINK_INDIRECT] = self.matrix_service.create(matrix_constants.link.v8.indirect)
+            self.hashes[THERMAL_PREPRO_MODULATION] = self.matrix_service.create(
+                matrix_constants.thermals.prepro.modulation
+            )
+            self.hashes[LINK_V7] = self.matrix_service.create(matrix_constants.link.v7.link)
+            self.hashes[LINK_V8] = self.matrix_service.create(matrix_constants.link.v8.link)
+            self.hashes[LINK_DIRECT] = self.matrix_service.create(matrix_constants.link.v8.direct)
+            self.hashes[LINK_INDIRECT] = self.matrix_service.create(matrix_constants.link.v8.indirect)
 
-        self.hashes[NULL_MATRIX_NAME] = self.matrix_service.create(NULL_MATRIX)
-        self.hashes[EMPTY_SCENARIO_MATRIX] = self.matrix_service.create(NULL_SCENARIO_MATRIX)
-        self.hashes[RESERVES_TS] = self.matrix_service.create(FIXED_4_COLUMNS)
-        self.hashes[MISCGEN_TS] = self.matrix_service.create(FIXED_8_COLUMNS)
+            self.hashes[NULL_MATRIX_NAME] = self.matrix_service.create(NULL_MATRIX)
+            self.hashes[EMPTY_SCENARIO_MATRIX] = self.matrix_service.create(NULL_SCENARIO_MATRIX)
+            self.hashes[RESERVES_TS] = self.matrix_service.create(FIXED_4_COLUMNS)
+            self.hashes[MISCGEN_TS] = self.matrix_service.create(FIXED_8_COLUMNS)
 
-        # Binding constraint matrices
-        series = matrix_constants.binding_constraint.series
-        self.hashes[BINDING_CONSTRAINT_HOURLY] = self.matrix_service.create(series.default_bc_hourly)
-        self.hashes[BINDING_CONSTRAINT_WEEKLY_DAILY] = self.matrix_service.create(series.default_bc_weekly_daily)
+            # Binding constraint matrices
+            series = matrix_constants.binding_constraint.series
+            self.hashes[BINDING_CONSTRAINT_HOURLY] = self.matrix_service.create(series.default_bc_hourly)
+            self.hashes[BINDING_CONSTRAINT_WEEKLY_DAILY] = self.matrix_service.create(series.default_bc_weekly_daily)
 
-        # Some short-term storage matrices use np.ones((8760, 1))
-        self.hashes[ONES_SCENARIO_MATRIX] = self.matrix_service.create(
-            matrix_constants.st_storage.series.pmax_injection
-        )
+            # Some short-term storage matrices use np.ones((8760, 1))
+            self.hashes[ONES_SCENARIO_MATRIX] = self.matrix_service.create(
+                matrix_constants.st_storage.series.pmax_injection
+            )
 
     def get_hydro_max_power(self, version: int) -> str:
         if version > 650:

--- a/antarest/study/storage/variantstudy/variant_command_extractor.py
+++ b/antarest/study/storage/variantstudy/variant_command_extractor.py
@@ -20,6 +20,7 @@ class VariantCommandsExtractor:
     def __init__(self, matrix_service: ISimpleMatrixService, patch_service: PatchService):
         self.matrix_service = matrix_service
         self.generator_matrix_constants = GeneratorMatrixConstants(self.matrix_service)
+        self.generator_matrix_constants.init_constant_matrices(bucket_dir=matrix_service.bucket_dir)
         self.command_extractor = CommandExtractor(self.matrix_service, patch_service=patch_service)
 
     def extract(self, study: FileStudy) -> List[CommandDTO]:

--- a/antarest/study/storage/variantstudy/variant_command_extractor.py
+++ b/antarest/study/storage/variantstudy/variant_command_extractor.py
@@ -20,7 +20,7 @@ class VariantCommandsExtractor:
     def __init__(self, matrix_service: ISimpleMatrixService, patch_service: PatchService):
         self.matrix_service = matrix_service
         self.generator_matrix_constants = GeneratorMatrixConstants(self.matrix_service)
-        self.generator_matrix_constants.init_constant_matrices(bucket_dir=matrix_service.bucket_dir)
+        self.generator_matrix_constants.init_constant_matrices()
         self.command_extractor = CommandExtractor(self.matrix_service, patch_service=patch_service)
 
     def extract(self, study: FileStudy) -> List[CommandDTO]:

--- a/antarest/tools/lib.py
+++ b/antarest/tools/lib.py
@@ -156,7 +156,7 @@ class LocalVariantGenerator(IVariantGenerator):
         )
         generator = VariantCommandGenerator(study_factory)
         generator_matrix_constants = GeneratorMatrixConstants(matrix_service)
-        generator_matrix_constants.init_constant_matrices(bucket_dir=matrix_service.bucket_dir)
+        generator_matrix_constants.init_constant_matrices()
         command_factory = CommandFactory(
             generator_matrix_constants=generator_matrix_constants,
             matrix_service=matrix_service,

--- a/tests/conftest_services.py
+++ b/tests/conftest_services.py
@@ -18,6 +18,7 @@ from antarest.core.requests import RequestParameters
 from antarest.core.tasks.model import CustomTaskEventMessages, TaskDTO, TaskListFilter, TaskResult, TaskStatus, TaskType
 from antarest.core.tasks.service import ITaskService, Task
 from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware
+from antarest.matrixstore.repository import MatrixContentRepository
 from antarest.matrixstore.service import SimpleMatrixService
 from antarest.matrixstore.uri_resolver_service import UriResolverService
 from antarest.study.storage.patch_service import PatchService
@@ -128,7 +129,10 @@ def simple_matrix_service_fixture(bucket_dir: Path) -> SimpleMatrixService:
     Returns:
         An instance of the SimpleMatrixService class representing the matrix service.
     """
-    return SimpleMatrixService(bucket_dir)
+    matrix_content_repository = MatrixContentRepository(
+        bucket_dir=bucket_dir,
+    )
+    return SimpleMatrixService(matrix_content_repository=matrix_content_repository)
 
 
 @pytest.fixture(name="generator_matrix_constants", scope="session")
@@ -144,7 +148,9 @@ def generator_matrix_constants_fixture(
     Returns:
         An instance of the GeneratorMatrixConstants class representing the matrix constants generator.
     """
-    return GeneratorMatrixConstants(matrix_service=simple_matrix_service)
+    out_generator_matrix_constants = GeneratorMatrixConstants(simple_matrix_service)
+    out_generator_matrix_constants.init_constant_matrices(bucket_dir=simple_matrix_service.bucket_dir)
+    return out_generator_matrix_constants
 
 
 @pytest.fixture(name="uri_resolver_service", scope="session")

--- a/tests/conftest_services.py
+++ b/tests/conftest_services.py
@@ -149,7 +149,7 @@ def generator_matrix_constants_fixture(
         An instance of the GeneratorMatrixConstants class representing the matrix constants generator.
     """
     out_generator_matrix_constants = GeneratorMatrixConstants(simple_matrix_service)
-    out_generator_matrix_constants.init_constant_matrices(bucket_dir=simple_matrix_service.bucket_dir)
+    out_generator_matrix_constants.init_constant_matrices()
     return out_generator_matrix_constants
 
 

--- a/tests/core/test_tasks.py
+++ b/tests/core/test_tasks.py
@@ -485,7 +485,7 @@ def test_cancel_orphan_tasks(
     result_msg: str,
 ):
     max_diff_seconds: int = 1
-    test_id: str = "test_cancel_orphan_tasks_id"
+    test_id: str = "2ea94758-9ea5-4015-a45f-b245a6ffc147"
 
     completion_date: datetime.datetime = datetime.datetime.utcnow()
     task_job = TaskJob(
@@ -502,12 +502,12 @@ def test_cancel_orphan_tasks(
     cancel_orphan_tasks(engine=db_engine, session_args=SESSION_ARGS)
     with make_session() as session:
         if status in [TaskStatus.RUNNING.value, TaskStatus.PENDING.value]:
-            updated_task_job = (
+            update_tasks_count = (
                 session.query(TaskJob)
                 .filter(TaskJob.status.in_([TaskStatus.RUNNING.value, TaskStatus.PENDING.value]))
-                .all()
+                .count()
             )
-            assert not updated_task_job
+            assert not update_tasks_count
             updated_task_job = session.query(TaskJob).get(test_id)
             assert updated_task_job.status == TaskStatus.FAILED.value
             assert not updated_task_job.result_status

--- a/tests/core/test_tasks.py
+++ b/tests/core/test_tasks.py
@@ -1,22 +1,22 @@
+import dataclasses
 import datetime
 import time
+import typing as t
 from pathlib import Path
-from typing import Callable, List
-from unittest.mock import ANY, Mock, call
+from unittest.mock import ANY, Mock
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine  # type: ignore
 from sqlalchemy.engine.base import Engine  # type: ignore
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker  # type: ignore
 
 from antarest.core.config import Config, RemoteWorkerConfig, TaskConfig
-from antarest.core.interfaces.eventbus import Event, EventType, IEventBus
+from antarest.core.interfaces.eventbus import EventType, IEventBus
 from antarest.core.jwt import DEFAULT_ADMIN_USER
 from antarest.core.model import PermissionInfo, PublicMode
 from antarest.core.persistence import Base
 from antarest.core.requests import RequestParameters, UserHasNotPermissionError
 from antarest.core.tasks.model import (
-    TaskDTO,
     TaskJob,
     TaskJobLog,
     TaskListFilter,
@@ -27,42 +27,57 @@ from antarest.core.tasks.model import (
 )
 from antarest.core.tasks.repository import TaskJobRepository
 from antarest.core.tasks.service import TaskJobService
-from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware, db
+from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.eventbus.business.local_eventbus import LocalEventBus
 from antarest.eventbus.service import EventBusService
+from antarest.login.model import User
+from antarest.study.model import RawStudy
 from antarest.utils import SESSION_ARGS
 from antarest.worker.worker import AbstractWorker, WorkerTaskCommand
 from tests.helpers import with_db_context
 
 
-def test_service() -> None:
-    # sourcery skip: aware-datetime-for-utc
-    engine = create_engine("sqlite:///:memory:", echo=False)
-    Base.metadata.create_all(engine)
-    # noinspection SpellCheckingInspection
-    DBSessionMiddleware(
-        None,
-        custom_engine=engine,
-        session_args={"autocommit": False, "autoflush": False},
-    )
+@pytest.fixture(name="db_engine", autouse=True)
+def db_engine_fixture(tmp_path: Path) -> t.Generator[Engine, None, None]:
+    """
+    Fixture that creates an SQLite database in a temporary directory.
 
-    repo_mock = Mock(spec=TaskJobRepository)
-    creation_date = datetime.datetime.now(datetime.timezone.utc)
-    task = TaskJob(id="a", name="b", status=2, creation_date=creation_date)
-    repo_mock.list.return_value = [task]
-    repo_mock.get_or_raise.return_value = task
-    service = TaskJobService(config=Config(), repository=repo_mock, event_bus=Mock())
-    repo_mock.save.assert_called_with(
-        TaskJob(
-            id="a",
-            name="b",
-            status=4,
-            creation_date=creation_date,
-            result_status=False,
-            result_msg="Task was interrupted due to server restart",
-            completion_date=ANY,
-        )
-    )
+    When a function runs in a different thread than the main one and needs to use
+    the database, it uses the global `db` object. This object helps create a new
+    local session in the thread to connect to the SQLite database.
+    However, we can't use an in-memory SQLite database ("sqlite:///:memory:") because
+    it creates a new empty database each time. That's why we use a SQLite database stored on disk.
+
+    Yields:
+        An instance of the created SQLite database engine.
+    """
+    db_path = tmp_path / "db.sqlite"
+    db_url = f"sqlite:///{db_path}"
+    engine = create_engine(db_url, echo=False)
+    engine.execute("PRAGMA foreign_keys = ON")
+    Base.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@with_db_context
+def test_service(core_config: Config, event_bus: IEventBus) -> None:
+    engine = db.session.bind
+    task_job_repo = TaskJobRepository()
+
+    # Prepare a TaskJob in the database
+    creation_date = datetime.datetime.utcnow()
+    running_task = TaskJob(id="a", name="b", status=TaskStatus.RUNNING.value, creation_date=creation_date)
+    task_job_repo.save(running_task)
+
+    # Create a TaskJobService
+    service = TaskJobService(config=core_config, repository=task_job_repo, event_bus=event_bus)
+
+    # Cancel pending and running tasks
+    cancel_orphan_tasks(engine=engine, session_args=SESSION_ARGS)
+
+    # Test Case: list tasks
+    # =====================
 
     tasks = service.list_tasks(
         TaskListFilter(),
@@ -72,52 +87,37 @@ def test_service() -> None:
     assert tasks[0].status == TaskStatus.FAILED
     assert tasks[0].creation_date_utc == str(creation_date)
 
-    start = datetime.datetime.now(datetime.timezone.utc)
-    end = start + datetime.timedelta(seconds=1)
-    repo_mock.reset_mock()
-    repo_mock.get.return_value = TaskJob(
-        id="a",
-        completion_date=end,
-        name="Unnamed",
-        owner_id=1,
-        status=TaskStatus.COMPLETED.value,
-        result_status=True,
-        result_msg="OK",
-        creation_date=start,
-    )
+    # Test Case: get task status
+    # ==========================
+
     res = service.status_task("a", RequestParameters(user=DEFAULT_ADMIN_USER))
     assert res is not None
-    assert res == TaskDTO(
-        id="a",
-        completion_date_utc=str(end),
-        creation_date_utc=str(start),
-        owner=1,
-        name="Unnamed",
-        result=TaskResult(success=True, message="OK"),
-        status=TaskStatus.COMPLETED,
-    )
+    expected = {
+        "completion_date_utc": ANY,
+        "creation_date_utc": creation_date.isoformat(" "),
+        "id": "a",
+        "logs": None,
+        "name": "b",
+        "owner": None,
+        "ref_id": None,
+        "result": {
+            "message": "Task was interrupted due to server restart",
+            "return_value": None,
+            "success": False,
+        },
+        "status": TaskStatus.FAILED,
+        "type": None,
+    }
+    assert res.dict() == expected
+
+    # Test Case: add a task that fails and wait for it
+    # ================================================
 
     # noinspection PyUnusedLocal
-    def action_fail(update_msg: Callable[[str], None]) -> TaskResult:
-        raise NotImplementedError()
+    def action_fail(update_msg: t.Callable[[str], None]) -> TaskResult:
+        raise Exception("this action failed")
 
-    def action_ok(update_msg: Callable[[str], None]) -> TaskResult:
-        update_msg("start")
-        update_msg("end")
-        return TaskResult(success=True, message="OK")
-
-    repo_mock.reset_mock()
-    now = datetime.datetime.utcnow()
-    task = TaskJob(
-        name="failed action",
-        owner_id=1,
-        id="a",
-        creation_date=now,
-        status=TaskStatus.PENDING.value,
-    )
-    repo_mock.save.side_effect = lambda x: task
-    repo_mock.get_or_raise.return_value = task
-    service.add_task(
+    failed_id = service.add_task(
         action_fail,
         "failed action",
         None,
@@ -125,79 +125,27 @@ def test_service() -> None:
         None,
         RequestParameters(user=DEFAULT_ADMIN_USER),
     )
-    service.await_task("a")
-    repo_mock.save.assert_has_calls(
-        [
-            call(
-                TaskJob(
-                    id=None,
-                    logs=[],
-                    owner_id=1,
-                    creation_date=None,
-                    completion_date=None,
-                    name="failed action",
-                    status=None,
-                    result_msg=None,
-                    result_status=None,
-                )
-            ),
-            call(
-                TaskJob(
-                    id="a",
-                    logs=[],
-                    owner_id=1,
-                    creation_date=now,
-                    completion_date=ANY,
-                    name="failed action",
-                    status=4,
-                    result_msg=ANY,  # "Task a failed: Unhandled exception [...]"
-                    result_status=False,
-                )
-            ),
-            call(
-                TaskJob(
-                    id="a",
-                    logs=[],
-                    owner_id=1,
-                    creation_date=now,
-                    completion_date=ANY,
-                    name="failed action",
-                    status=4,
-                    result_msg=ANY,  # "Task a failed: Unhandled exception [...]"
-                    result_status=False,
-                )
-            ),
-        ]
-    )
+    service.await_task(failed_id, timeout_sec=2)
 
-    repo_mock.reset_mock()
-    now = datetime.datetime.utcnow()
-    task = TaskJob(
-        name="Unnamed",
-        owner_id=1,
-        id="a",
-        creation_date=now,
-        status=TaskStatus.PENDING.value,
+    failed_task = task_job_repo.get(failed_id)
+    assert failed_task is not None
+    assert failed_task.status == TaskStatus.FAILED.value
+    assert failed_task.result_status is False
+    assert failed_task.result_msg == (
+        f"Task {failed_id} failed: Unhandled exception this action failed"
+        f"\nSee the logs for detailed information and the error traceback."
     )
-    repo_mock.save.side_effect = lambda x: task
-    repo_mock.get_or_raise.return_value = task
-    repo_mock.get.side_effect = [
-        TaskJob(
-            name="Unnamed",
-            owner_id=1,
-            id="a",
-            creation_date=now,
-            status=TaskStatus.RUNNING.value,
-        ),
-        TaskJob(
-            name="Unnamed",
-            owner_id=1,
-            id="a",
-            creation_date=now,
-            status=TaskStatus.RUNNING.value,
-        ),
-    ]
-    service.add_task(
+    assert failed_task.completion_date is not None
+
+    # Test Case: add a task that succeeds and wait for it
+    # ===================================================
+
+    def action_ok(update_msg: t.Callable[[str], None]) -> TaskResult:
+        update_msg("start")
+        update_msg("end")
+        return TaskResult(success=True, message="OK")
+
+    ok_id = service.add_task(
         action_ok,
         None,
         None,
@@ -205,134 +153,46 @@ def test_service() -> None:
         None,
         request_params=RequestParameters(user=DEFAULT_ADMIN_USER),
     )
-    service.await_task("a")
-    repo_mock.save.assert_has_calls(
-        [
-            call(TaskJob(owner_id=1, name="Unnamed")),
-            # this is not called with that because the object is mutated, and mock seems to suck..
-            # TaskJob(
-            #     id="a",
-            #     name="failed action",
-            #     owner_id=1,
-            #     status=TaskStatus.RUNNING.value,
-            #     creation_date=now,
-            # ),
-            call(
-                TaskJob(
-                    id="a",
-                    completion_date=ANY,
-                    name="Unnamed",
-                    owner_id=1,
-                    status=TaskStatus.COMPLETED.value,
-                    result_status=True,
-                    result_msg="OK",
-                    creation_date=now,
-                )
-            ),
-            call(
-                TaskJob(
-                    name="Unnamed",
-                    owner_id=1,
-                    id="a",
-                    creation_date=now,
-                    status=TaskStatus.RUNNING.value,
-                    logs=[TaskJobLog(message="start", task_id="a")],
-                )
-            ),
-            call(
-                TaskJob(
-                    name="Unnamed",
-                    owner_id=1,
-                    id="a",
-                    creation_date=now,
-                    status=TaskStatus.RUNNING.value,
-                    logs=[TaskJobLog(message="end", task_id="a")],
-                )
-            ),
-            call(
-                TaskJob(
-                    id="a",
-                    completion_date=ANY,
-                    name="Unnamed",
-                    owner_id=1,
-                    status=TaskStatus.COMPLETED.value,
-                    result_status=True,
-                    result_msg="OK",
-                    creation_date=now,
-                )
-            ),
-        ]
-    )
+    service.await_task(ok_id, timeout_sec=2)
 
-    repo_mock.get.reset_mock()
-    repo_mock.get.side_effect = [None]
-    service.await_task("elsewhere")
-    repo_mock.get.assert_called_with("elsewhere")
+    ok_task = task_job_repo.get(ok_id)
+    assert ok_task is not None
+    assert ok_task.status == TaskStatus.COMPLETED.value
+    assert ok_task.result_status is True
+    assert ok_task.result_msg == "OK"
+    assert ok_task.completion_date is not None
+    assert len(ok_task.logs) == 2
+    assert ok_task.logs[0].message == "start"
+    assert ok_task.logs[1].message == "end"
 
 
 class DummyWorker(AbstractWorker):
-    def __init__(self, event_bus: IEventBus, accept: List[str], tmp_path: Path):
+    def __init__(self, event_bus: IEventBus, accept: t.List[str], tmp_path: Path):
         super().__init__("test", event_bus, accept)
         self.tmp_path = tmp_path
 
     def _execute_task(self, task_info: WorkerTaskCommand) -> TaskResult:
         # simulate a "long" task ;-)
         time.sleep(0.01)
-        relative_path = task_info.task_args["file"]
+        relative_path = t.cast(str, task_info.task_args["file"])
         (self.tmp_path / relative_path).touch()
         return TaskResult(success=True, message="")
 
 
 @with_db_context
-def test_worker_tasks(tmp_path: Path):
-    repo_mock = Mock(spec=TaskJobRepository)
-    repo_mock.list.return_value = []
-    event_bus = EventBusService(LocalEventBus())
-    service = TaskJobService(
-        config=Config(tasks=TaskConfig(remote_workers=[RemoteWorkerConfig(name="test", queues=["test"])])),
-        repository=repo_mock,
-        event_bus=event_bus,
-    )
+def test_worker_tasks(tmp_path: Path, core_config: Config, event_bus: IEventBus) -> None:
+    # Create a TaskJobService
+    task_job_repo = TaskJobRepository()
+    task_config = TaskConfig(remote_workers=[RemoteWorkerConfig(name="test", queues=["test"])])
+    config = dataclasses.replace(core_config, tasks=task_config)
+    service = TaskJobService(config=config, repository=task_job_repo, event_bus=event_bus)
 
     worker = DummyWorker(event_bus, ["test"], tmp_path)
     worker.start(threaded=True)
 
     file_to_create = "foo"
-
     assert not (tmp_path / file_to_create).exists()
 
-    repo_mock.save.side_effect = [
-        TaskJob(
-            id="taskid",
-            name="Unnamed",
-            owner_id=0,
-            type=TaskType.WORKER_TASK,
-            ref_id=None,
-        ),
-        TaskJob(
-            id="taskid",
-            name="Unnamed",
-            owner_id=0,
-            type=TaskType.WORKER_TASK,
-            ref_id=None,
-            status=TaskStatus.RUNNING,
-        ),
-        TaskJob(
-            id="taskid",
-            name="Unnamed",
-            owner_id=0,
-            type=TaskType.WORKER_TASK,
-            ref_id=None,
-            status=TaskStatus.COMPLETED,
-        ),
-    ]
-    repo_mock.get_or_raise.return_value = TaskJob(
-        id="taskid",
-        name="Unnamed",
-        owner_id=0,
-        type=TaskType.WORKER_TASK,
-        ref_id=None,
-    )
     task_id = service.add_worker_task(
         TaskType.WORKER_TASK,
         "test",
@@ -341,130 +201,136 @@ def test_worker_tasks(tmp_path: Path):
         None,
         request_params=RequestParameters(user=DEFAULT_ADMIN_USER),
     )
-    service.await_task(task_id)
+    assert task_id is not None
+    service.await_task(task_id, timeout_sec=2)
 
     assert (tmp_path / file_to_create).exists()
 
 
-def test_repository():
-    # sourcery skip: aware-datetime-for-utc
-    engine = create_engine("sqlite:///:memory:", echo=False)
-    Base.metadata.create_all(engine)
-    # noinspection SpellCheckingInspection
-    DBSessionMiddleware(
-        None,
-        custom_engine=engine,
-        session_args={"autocommit": False, "autoflush": False},
-    )
+def test_repository(db_session: Session) -> None:
+    # Prepare two users in the database
+    user1_id = 9
+    db_session.add(User(id=user1_id, name="John"))
+    user2_id = 10
+    db_session.add(User(id=user2_id, name="Jane"))
+    db_session.commit()
 
-    with db():
-        # sourcery skip: extract-method
-        task_repository = TaskJobRepository()
+    # Create a RawStudy in the database
+    study_id = "e34fe4d5-5964-4ef2-9baf-fad66dadc512"
+    db_session.add(RawStudy(id="study_id", name="foo", version="860"))
+    db_session.commit()
 
-        new_task = TaskJob(name="foo", owner_id=0, type=TaskType.COPY)
-        second_task = TaskJob(owner_id=1, ref_id="a")
+    # Create a TaskJobService
+    task_job_repo = TaskJobRepository(db_session)
 
-        now = datetime.datetime.utcnow()
-        new_task = task_repository.save(new_task)
-        assert task_repository.get(new_task.id) == new_task
-        assert new_task.status == TaskStatus.PENDING.value
-        assert new_task.owner_id == 0
-        assert new_task.creation_date >= now
+    new_task = TaskJob(name="foo", owner_id=user1_id, type=TaskType.COPY)
 
-        second_task = task_repository.save(second_task)
+    now = datetime.datetime.utcnow()
+    new_task = task_job_repo.save(new_task)
+    assert task_job_repo.get(new_task.id) == new_task
+    assert new_task.status == TaskStatus.PENDING.value
+    assert new_task.owner_id == user1_id
+    assert new_task.creation_date >= now
 
-        result = task_repository.list(TaskListFilter(type=[TaskType.COPY]))
-        assert len(result) == 1
-        assert result[0].id == new_task.id
+    second_task = TaskJob(owner_id=user2_id, ref_id=study_id)
+    second_task = task_job_repo.save(second_task)
 
-        result = task_repository.list(TaskListFilter(ref_id="a"))
-        assert len(result) == 1
-        assert result[0].id == second_task.id
+    result = task_job_repo.list(TaskListFilter(type=[TaskType.COPY]))
+    assert len(result) == 1
+    assert result[0].id == new_task.id
 
-        result = task_repository.list(TaskListFilter(), user=1)
-        assert len(result) == 1
-        assert result[0].id == second_task.id
+    result = task_job_repo.list(TaskListFilter(ref_id=study_id))
+    assert len(result) == 1
+    assert result[0].id == second_task.id
 
-        result = task_repository.list(TaskListFilter())
-        assert len(result) == 2
+    result = task_job_repo.list(TaskListFilter(), user=user2_id)
+    assert len(result) == 1
+    assert result[0].id == second_task.id
 
-        result = task_repository.list(TaskListFilter(name="fo"))
-        assert len(result) == 1
+    result = task_job_repo.list(TaskListFilter())
+    assert len(result) == 2
 
-        result = task_repository.list(TaskListFilter(name="fo", status=[TaskStatus.RUNNING]))
-        assert len(result) == 0
-        new_task.status = TaskStatus.RUNNING.value
-        task_repository.save(new_task)
-        result = task_repository.list(TaskListFilter(name="fo", status=[TaskStatus.RUNNING]))
-        assert len(result) == 1
+    result = task_job_repo.list(TaskListFilter(name="fo"))
+    assert len(result) == 1
 
-        new_task.completion_date = datetime.datetime.utcnow()
-        task_repository.save(new_task)
-        result = task_repository.list(
-            TaskListFilter(
-                name="fo",
-                from_completion_date_utc=(new_task.completion_date + datetime.timedelta(seconds=1)).timestamp(),
-            )
+    result = task_job_repo.list(TaskListFilter(name="fo", status=[TaskStatus.RUNNING]))
+    assert len(result) == 0
+    new_task.status = TaskStatus.RUNNING.value
+    task_job_repo.save(new_task)
+    result = task_job_repo.list(TaskListFilter(name="fo", status=[TaskStatus.RUNNING]))
+    assert len(result) == 1
+
+    new_task.completion_date = datetime.datetime.utcnow()
+    task_job_repo.save(new_task)
+    result = task_job_repo.list(
+        TaskListFilter(
+            name="fo",
+            from_completion_date_utc=(new_task.completion_date + datetime.timedelta(seconds=1)).timestamp(),
         )
-        assert len(result) == 0
-        result = task_repository.list(
-            TaskListFilter(
-                name="fo",
-                from_completion_date_utc=(new_task.completion_date - datetime.timedelta(seconds=1)).timestamp(),
-            )
-        )
-        assert len(result) == 1
-
-        new_task.logs.append(TaskJobLog(message="hello"))
-        new_task.logs.append(TaskJobLog(message="bar"))
-        task_repository.save(new_task)
-        new_task = task_repository.get(new_task.id)
-        assert len(new_task.logs) == 2
-        assert new_task.logs[0].message == "hello"
-
-        assert len(db.session.query(TaskJobLog).where(TaskJobLog.task_id == new_task.id).all()) == 2
-
-        task_repository.delete(new_task.id)
-        assert len(db.session.query(TaskJobLog).where(TaskJobLog.task_id == new_task.id).all()) == 0
-        assert task_repository.get(new_task.id) is None
-
-
-def test_cancel():
-    # sourcery skip: aware-datetime-for-utc
-    engine = create_engine("sqlite:///:memory:", echo=False)
-    Base.metadata.create_all(engine)
-    # noinspection SpellCheckingInspection
-    DBSessionMiddleware(
-        None,
-        custom_engine=engine,
-        session_args={"autocommit": False, "autoflush": False},
     )
+    assert len(result) == 0
+    result = task_job_repo.list(
+        TaskListFilter(
+            name="fo",
+            from_completion_date_utc=(new_task.completion_date - datetime.timedelta(seconds=1)).timestamp(),
+        )
+    )
+    assert len(result) == 1
 
-    repo_mock = Mock(spec=TaskJobRepository)
-    repo_mock.list.return_value = []
-    service = TaskJobService(config=Config(), repository=repo_mock, event_bus=Mock())
+    new_task.logs.append(TaskJobLog(message="hello"))
+    new_task.logs.append(TaskJobLog(message="bar"))
+    task_job_repo.save(new_task)
+    assert new_task.id is not None
+    new_task = task_job_repo.get_or_raise(new_task.id)
+    assert len(new_task.logs) == 2
+    assert new_task.logs[0].message == "hello"
+
+    assert len(db_session.query(TaskJobLog).where(TaskJobLog.task_id == new_task.id).all()) == 2
+
+    task_job_repo.delete(new_task.id)
+    assert len(db_session.query(TaskJobLog).where(TaskJobLog.task_id == new_task.id).all()) == 0
+    assert task_job_repo.get(new_task.id) is None
+
+
+@with_db_context
+def test_cancel(core_config: Config, event_bus: IEventBus) -> None:
+    # Create a TaskJobService and add tasks
+    task_job_repo = TaskJobRepository()
+    task_job_repo.save(TaskJob(id="a"))
+    task_job_repo.save(TaskJob(id="b"))
+
+    # Create a TaskJobService
+    service = TaskJobService(config=core_config, repository=task_job_repo, event_bus=event_bus)
 
     with pytest.raises(UserHasNotPermissionError):
         service.cancel_task("a", RequestParameters())
 
-    service.cancel_task("b", RequestParameters(user=DEFAULT_ADMIN_USER), dispatch=True)
-    # noinspection PyUnresolvedReferences
-    service.event_bus.push.assert_called_with(
-        Event(
-            type=EventType.TASK_CANCEL_REQUEST,
-            payload="b",
-            permissions=PermissionInfo(public_mode=PublicMode.NONE),
-        )
-    )
+    # Test Case: cancel a task that is not in the service tasks map
+    # =============================================================
 
-    creation_date = datetime.datetime.utcnow()
-    task = TaskJob(id="a", name="b", status=2, creation_date=creation_date)
-    repo_mock.list.return_value = [task]
-    repo_mock.get_or_raise.return_value = task
-    service.tasks["a"] = Mock()
+    service.cancel_task("b", RequestParameters(user=DEFAULT_ADMIN_USER), dispatch=True)
+
+    # The event_bus fixture is actually a EventBusService with LocalEventBus backend
+    backend = t.cast(LocalEventBus, t.cast(EventBusService, event_bus).backend)
+    collected_events = backend.get_events()
+
+    assert len(collected_events) == 1
+    assert collected_events[0].type == EventType.TASK_CANCEL_REQUEST
+    assert collected_events[0].payload == "b"
+    assert collected_events[0].permissions == PermissionInfo(public_mode=PublicMode.NONE)
+
+    # Test Case: cancel a task that is in the service tasks map
+    # =========================================================
+
+    service.tasks["a"] = Mock(cancel=Mock(return_value=None))
+
     service.cancel_task("a", RequestParameters(user=DEFAULT_ADMIN_USER), dispatch=True)
-    task.status = TaskStatus.CANCELLED.value
-    repo_mock.save.assert_called_with(task)
+
+    collected_events = backend.get_events()
+    assert len(collected_events) == 1, "No event should have been emitted because the task is in the service map"
+    task_a = task_job_repo.get("a")
+    assert task_a is not None
+    assert task_a.status == TaskStatus.CANCELLED.value
 
 
 @pytest.mark.parametrize(
@@ -483,7 +349,7 @@ def test_cancel_orphan_tasks(
     status: int,
     result_status: bool,
     result_msg: str,
-):
+) -> None:
     max_diff_seconds: int = 1
     test_id: str = "2ea94758-9ea5-4015-a45f-b245a6ffc147"
 

--- a/tests/login/conftest.py
+++ b/tests/login/conftest.py
@@ -20,12 +20,12 @@ def group_repo_fixture(db_middleware: DBSessionMiddleware) -> GroupRepository:
 
 # noinspection PyUnusedLocal
 @pytest.fixture(name="user_repo")
-def user_repo_fixture(core_config: Config, db_middleware: DBSessionMiddleware) -> UserRepository:
+def user_repo_fixture(db_middleware: DBSessionMiddleware) -> UserRepository:
     """Fixture that creates a UserRepository instance."""
     # note: `DBSessionMiddleware` is required to instantiate a thread-local db session.
     # important: the `UserRepository` insert an admin user in the database if it does not exist.
     # >>> User(id=1, name="admin", password=Password(config.security.admin_pwd))
-    return UserRepository(config=core_config)
+    return UserRepository()
 
 
 # noinspection PyUnusedLocal

--- a/tests/login/conftest.py
+++ b/tests/login/conftest.py
@@ -13,8 +13,6 @@ from antarest.login.service import LoginService
 def group_repo_fixture(db_middleware: DBSessionMiddleware) -> GroupRepository:
     """Fixture that creates a GroupRepository instance."""
     # note: `DBSessionMiddleware` is required to instantiate a thread-local db session.
-    # important: the `GroupRepository` insert an admin group in the database if it does not exist:
-    # >>> Group(id="admin", name="admin")
     return GroupRepository()
 
 
@@ -23,8 +21,6 @@ def group_repo_fixture(db_middleware: DBSessionMiddleware) -> GroupRepository:
 def user_repo_fixture(db_middleware: DBSessionMiddleware) -> UserRepository:
     """Fixture that creates a UserRepository instance."""
     # note: `DBSessionMiddleware` is required to instantiate a thread-local db session.
-    # important: the `UserRepository` insert an admin user in the database if it does not exist.
-    # >>> User(id=1, name="admin", password=Password(config.security.admin_pwd))
     return UserRepository()
 
 
@@ -49,8 +45,6 @@ def bot_repo_fixture(db_middleware: DBSessionMiddleware) -> BotRepository:
 def role_repo_fixture(db_middleware: DBSessionMiddleware) -> RoleRepository:
     """Fixture that creates a RoleRepository instance."""
     # note: `DBSessionMiddleware` is required to instantiate a thread-local db session.
-    # important: the `RoleRepository` insert an admin role in the database if it does not exist.
-    # >>> Role(type=RoleType.ADMIN, identity=User(id=1), group=Group(id="admin"))
     return RoleRepository()
 
 

--- a/tests/login/test_login_service.py
+++ b/tests/login/test_login_service.py
@@ -1,13 +1,13 @@
 import typing as t
-from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
-from fastapi import HTTPException
 
 from antarest.core.jwt import JWTGroup, JWTUser
-from antarest.core.requests import RequestParameters, UserHasNotPermissionError
+from antarest.core.requests import RequestParameters
 from antarest.core.roles import RoleType
 from antarest.login.model import (
+    ADMIN_ID,
     Bot,
     BotCreateDTO,
     BotRoleCreateDTO,
@@ -22,579 +22,654 @@ from antarest.login.model import (
 from antarest.login.service import LoginService
 from tests.helpers import with_db_context
 
-SITE_ADMIN = RequestParameters(
-    user=JWTUser(
-        id=0,
-        impersonator=0,
-        type="users",
-        groups=[JWTGroup(id="admin", name="admin", role=RoleType.ADMIN)],
-    )
-)
+# For the unit tests, we will define several fictitious users, groups and roles.
 
-GROUP_ADMIN = RequestParameters(
-    user=JWTUser(
-        id=1,
-        impersonator=1,
-        type="users",
-        groups=[JWTGroup(id="group", name="group", role=RoleType.ADMIN)],
-    )
-)
+GroupObj = t.TypedDict("GroupObj", {"id": str, "name": str})
+UserObj = t.TypedDict("UserObj", {"id": int, "name": str})
+RoleObj = t.TypedDict("RoleObj", {"type": RoleType, "group_id": str, "identity_id": int})
 
-USER3 = RequestParameters(
-    user=JWTUser(
-        id=3,
-        impersonator=3,
-        type="users",
-        groups=[JWTGroup(id="group", name="group", role=RoleType.READER)],
-    )
-)
 
-BAD_PARAM = RequestParameters(user=None)
+_GROUPS: t.List[GroupObj] = [
+    {"id": "admin", "name": "X-Men"},
+    {"id": "superman", "name": "Superman"},
+    {"id": "metropolis", "name": "Metropolis"},
+]
+
+
+_USERS: t.List[UserObj] = [
+    # main characters
+    {"id": ADMIN_ID, "name": "Professor Xavier"},  # site admin
+    {"id": 2, "name": "Clark Kent"},  # admin of "Superman" group
+    {"id": 3, "name": "Lois Lane"},  # reader in "Superman" group
+    {"id": 4, "name": "Joh Fredersen"},  # "Metropolis" leader
+    {"id": 5, "name": "Freder Fredersen"},  # reader in "Metropolis" group
+    # secondary characters
+    {"id": 50, "name": "Storm"},  # evil man in "X-Men" group
+    {"id": 60, "name": "Livewire"},  # evil woman in "Superman" group
+    {"id": 70, "name": "Maria"},  # robot in "Metropolis" group
+    {"id": 80, "name": "Jane DOE"},  # external user
+]
+
+_ROLES: t.List[RoleObj] = [
+    {"type": RoleType.ADMIN, "group_id": "admin", "identity_id": ADMIN_ID},
+    {"type": RoleType.ADMIN, "group_id": "superman", "identity_id": 2},
+    {"type": RoleType.READER, "group_id": "superman", "identity_id": 3},
+    {"type": RoleType.ADMIN, "group_id": "metropolis", "identity_id": 4},
+    {"type": RoleType.READER, "group_id": "metropolis", "identity_id": 5},
+]
+
+
+def get_jwt_user(user: User, roles: t.Iterable[Role], owner_id: int = 0) -> JWTUser:
+    jwt_user = JWTUser(
+        id=user.id,
+        impersonator=owner_id or user.id,
+        type="users",
+        groups=[JWTGroup(id=role.group.id, name=role.group.name, role=role.type) for role in roles],
+    )
+    return jwt_user
+
+
+def get_request_param(
+    user: t.Union[User, UserLdap, Bot],
+    role: t.Optional[Role],
+    owner_id: int = 0,
+) -> RequestParameters:
+    if user is None:
+        return RequestParameters(user=None)
+    roles = (role,) if role else ()
+    jwt_user = get_jwt_user(user, roles, owner_id=owner_id)
+    return RequestParameters(user=jwt_user)
+
+
+def get_user_param(login_service: LoginService, user_id: int, group_id: str = "(unknown)") -> RequestParameters:
+    user = login_service.users.get(user_id) or login_service.ldap.get(user_id)
+    assert user is not None
+    role = login_service.roles.get(user_id, group_id)
+    return get_request_param(user, role)
+
+
+def get_bot_param(login_service: LoginService, bot_id: int, group_id: str = "(unknown)") -> RequestParameters:
+    bot = login_service.bots.get(bot_id)
+    assert bot is not None
+    role = login_service.roles.get(bot_id, group_id)
+    return get_request_param(bot, role, owner_id=bot.owner)
 
 
 class TestLoginService:
     """
     Test login service.
-
-    important:
-
-    - the `GroupRepository` insert an admin group in the database if it does not exist:
-      `Group(id="admin", name="admin")`
-
-    - the `UserRepository` insert an admin user in the database if it does not exist.
-      `User(id=1, name="admin", password=Password(config.security.admin_pwd))`
-
-    - the `RoleRepository` insert an admin role in the database if it does not exist.
-      `Role(type=RoleType.ADMIN, identity=User(id=1), group=Group(id="admin"))`
     """
 
+    @pytest.fixture(name="populate_db", autouse=True)
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_create", [(SITE_ADMIN, True), (GROUP_ADMIN, True), (USER3, False), (BAD_PARAM, False)]
-    )
-    def test_save_group(self, login_service: LoginService, param: RequestParameters, can_create: bool) -> None:
-        group = Group(id="group", name="group")
-
-        # Only site admin and group admin can update a group
-        if can_create:
-            actual = login_service.save_group(group, param)
-            assert actual == group
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.save_group(group, param)
-            actual = login_service.groups.get(group.id)
-            assert actual is None
-
-        # Users can't create a duplicate group
-        with pytest.raises(HTTPException):
-            login_service.save_group(group, param)
+    def populate_db_fixture(self, login_service: LoginService) -> None:
+        for group in _GROUPS:
+            login_service.groups.save(Group(**group))
+        main_characters = (u for u in _USERS if u["id"] < 10)
+        for user in main_characters:
+            login_service.users.save(User(**user))
+        for role in _ROLES:
+            group = t.cast(Group, login_service.groups.get(role["group_id"]))
+            user = t.cast(User, login_service.users.get(role["identity_id"]))
+            role = Role(**role, group=group, identity=user)
+            login_service.roles.save(role)
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_create", [(SITE_ADMIN, True), (GROUP_ADMIN, False), (USER3, False), (BAD_PARAM, False)]
-    )
-    def test_create_user(self, login_service: LoginService, param: RequestParameters, can_create: bool) -> None:
-        create = UserCreateDTO(name="hello", password="world")
+    def test_save_group(self, login_service: LoginService) -> None:
+        # site admin can update any group
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        login_service.save_group(Group(id="superman", name="Poor Men"), _param)
+        actual = login_service.groups.get("superman")
+        assert actual is not None
+        assert actual.name == "Poor Men"
 
-        # Only site admin can create a user
-        if can_create:
-            actual = login_service.create_user(create, param)
-            assert actual.name == create.name
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.create_user(create, param)
-            actual = login_service.users.get_by_name(create.name)
-            assert actual is None
+        # Group admin can update his own group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        login_service.save_group(Group(id="superman", name="Man of Steel"), _param)
+        actual = login_service.groups.get("superman")
+        assert actual is not None
+        assert actual.name == "Man of Steel"
 
-        # Users can't create a duplicate user
-        with pytest.raises(HTTPException):
-            login_service.create_user(create, param)
+        # Another user of the same group cannot update the group
+        _param = get_user_param(login_service, user_id=3, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.save_group(Group(id="superman", name="Woman of Steel"), _param)
+        actual = login_service.groups.get("superman")
+        assert actual is not None
+        assert actual.name == "Man of Steel"  # not updated
+
+        # Group admin cannot update another group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.save_group(Group(id="metropolis", name="Man of Steel"), _param)
+        actual = login_service.groups.get("metropolis")
+        assert actual is not None
+        assert actual.name == "Metropolis"  # not updated
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_save",
-        [
-            # (SITE_ADMIN, True),
-            (GROUP_ADMIN, False),
-            # (USER3, False),
-            # (BAD_PARAM, False),
-        ],
-    )
-    def test_save_user(self, login_service: LoginService, param: RequestParameters, can_save: bool) -> None:
-        create = UserCreateDTO(name="Laurent", password="S3cr3t")
-        user = login_service.create_user(create, SITE_ADMIN)
-        user.name = "Roland"
+    def test_create_user(self, login_service: LoginService) -> None:
+        # Site admin can create a user
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        login_service.create_user(UserCreateDTO(name="Laurent", password="S3cr3t"), _param)
+        actual = login_service.users.get_by_name("Laurent")
+        assert actual is not None
+        assert actual.name == "Laurent"
+
+        # Group admin cannot create a user
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.create_user(UserCreateDTO(name="Alexandre", password="S3cr3t"), _param)
+        actual = login_service.users.get_by_name("Alexandre")
+        assert actual is None
+
+    @with_db_context
+    def test_save_user(self, login_service: LoginService) -> None:
+        # Prepare a new user
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        user = login_service.create_user(UserCreateDTO(name="Laurentius", password="S3cr3t"), _param)
 
         # Only site admin can update a user
-        if can_save:
-            login_service.save_user(user, param)
-            actual = login_service.users.get_by_name(user.name)
-            assert actual == user
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.save_user(user, param)
-            actual = login_service.users.get_by_name(user.name)
-            assert actual != user
+        login_service.save_user(User(id=user.id, name="Lawrence"), _param)
+        actual = login_service.users.get(user.id)
+        assert actual is not None
+        assert actual.name == "Lawrence"
 
-    @with_db_context
-    def test_save_user__themselves(self, login_service: LoginService) -> None:
-        user_create = UserCreateDTO(name="Laurent", password="S3cr3t")
-        user = login_service.create_user(user_create, SITE_ADMIN)
+        # Group admin cannot update a user
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.save_user(User(id=user.id, name="Loran"), _param)
+            actual = login_service.users.get(user.id)
+            assert actual is not None
+            assert actual.name == "Lawrence"
 
-        # users can update themselves
-        param = RequestParameters(
-            user=JWTUser(
-                id=user.id,
-                impersonator=user.id,
-                type="users",
-                groups=[JWTGroup(id="group", name="group", role=RoleType.READER)],
-            )
-        )
-        user.name = "Roland"
-        actual = login_service.save_user(user, param)
-        assert actual == user
+        # A user can update himself
+        _param = get_user_param(login_service, user_id=user.id)
+        login_service.save_user(User(id=user.id, name="Loran"), _param)
+        actual = login_service.users.get(user.id)
+        assert actual is not None
+        assert actual.name == "Loran"
 
     @with_db_context
     def test_save_bot(self, login_service: LoginService) -> None:
-        # Prepare the user3 in the db
-        assert USER3.user is not None
-        user3 = User(id=USER3.user.id, name="Scoobydoo")
-        login_service.users.save(user3)
+        # Joh Fredersen can create Maria because he is the leader of Metropolis
+        _param = get_user_param(login_service, user_id=4, group_id="metropolis")
+        login_service.save_bot(BotCreateDTO(name="Maria I", roles=[]), _param)
+        actual: t.Sequence[Role] = login_service.bots.get_all_by_owner(4)
+        assert len(actual) == 1
+        assert actual[0].name == "Maria I"
 
-        # Prepare the user group and role
-        for jwt_group in USER3.user.groups:
-            group = Group(id=jwt_group.id, name=jwt_group.name)
-            login_service.groups.save(group)
-            role = Role(type=jwt_group.role, identity=user3, group=group)
-            login_service.roles.save(role)
-
-        # Request parameters must reference a user
-        with pytest.raises(HTTPException):
-            login_service.save_bot(BotCreateDTO(name="bot", roles=[]), BAD_PARAM)
-
-        # The user USER3 is a reader in the group "group" and can crate a bot with the same role
-        assert all(jwt_group.role == RoleType.READER for jwt_group in USER3.user.groups)
-        bot_create = BotCreateDTO(name="bot", roles=[BotRoleCreateDTO(group="group", role=RoleType.READER.value)])
-        bot = login_service.save_bot(bot_create, USER3)
-
-        assert bot.name == bot_create.name
-        assert bot.owner == USER3.user.id
-        assert bot.is_author is True
-
-        # The user can't create a bot with an empty name
-        bot_create = BotCreateDTO(name="", roles=[BotRoleCreateDTO(group="group", role=RoleType.READER.value)])
-        with pytest.raises(HTTPException):
-            login_service.save_bot(bot_create, USER3)
-
-        # The user can't create a bot with a higher role than his own
-        for role_type in set(RoleType) - {RoleType.READER}:
-            bot_create = BotCreateDTO(name="bot", roles=[BotRoleCreateDTO(group="group", role=role_type.value)])
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.save_bot(bot_create, USER3)
-
-        # The user can't create a bot that already exists
-        bot_create = BotCreateDTO(name="bot", roles=[BotRoleCreateDTO(group="group", role=RoleType.READER.value)])
-        with pytest.raises(HTTPException):
-            login_service.save_bot(bot_create, USER3)
-
-        # The user can't create a bot with a group that does not exist
-        bot_create = BotCreateDTO(name="bot", roles=[BotRoleCreateDTO(group="unknown", role=RoleType.READER.value)])
-        with pytest.raises(HTTPException):
-            login_service.save_bot(bot_create, USER3)
-
-    @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_save", [(SITE_ADMIN, True), (GROUP_ADMIN, True), (USER3, False), (BAD_PARAM, False)]
-    )
-    def test_save_role(self, login_service: LoginService, param: RequestParameters, can_save: bool) -> None:
-        # Prepare the site admin in the db
-        assert SITE_ADMIN.user is not None
-        admin = User(id=SITE_ADMIN.user.id, name="Superman")
-        login_service.users.save(admin)
-
-        # Prepare the group "group" in the db
-        # noinspection SpellCheckingInspection
-        group = Group(id="group", name="Kryptonians")
-        login_service.groups.save(group)
-
-        # Only site admin and group admin can update a role
-        role = RoleCreationDTO(type=RoleType.ADMIN, identity_id=0, group_id="group")
-        if can_save:
-            actual = login_service.save_role(role, param)
-            assert actual.type == RoleType.ADMIN
-            assert actual.identity == admin
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.save_role(role, param)
-            actual = login_service.roles.get_all_by_group(group.id)
-            assert len(actual) == 0
-
-    @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_get", [(SITE_ADMIN, True), (GROUP_ADMIN, True), (USER3, True), (BAD_PARAM, False)]
-    )
-    def test_get_group(self, login_service: LoginService, param: RequestParameters, can_get: bool) -> None:
-        # Prepare the group "group" in the db
-        # noinspection SpellCheckingInspection
-        group = Group(id="group", name="Vulcans")
-        login_service.groups.save(group)
-
-        # Anybody except anonymous can get a group
-        if can_get:
-            actual = login_service.get_group("group", param)
-            assert actual == group
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.get_group(group.id, param)
-
-    # noinspection SpellCheckingInspection
-    @with_db_context
-    @pytest.mark.parametrize(
-        "param, expected",
-        [
-            (
-                SITE_ADMIN,
-                {
-                    "id": "group",
-                    "name": "Vulcans",
-                    "users": [
-                        {"id": 3, "name": "Spock", "role": RoleType.RUNNER},
-                        {"id": 4, "name": "Saavik", "role": RoleType.RUNNER},
-                    ],
-                },
+        # Freder Fredersen can create Maria with the reader role
+        _param = get_user_param(login_service, user_id=5, group_id="metropolis")
+        login_service.save_bot(
+            BotCreateDTO(
+                name="Maria II",
+                roles=[BotRoleCreateDTO(group="metropolis", role=RoleType.READER.value)],
             ),
-            (
-                GROUP_ADMIN,
-                {
-                    "id": "group",
-                    "name": "Vulcans",
-                    "users": [
-                        {"id": 3, "name": "Spock", "role": RoleType.RUNNER},
-                        {"id": 4, "name": "Saavik", "role": RoleType.RUNNER},
-                    ],
-                },
-            ),
-            (USER3, {}),
-            (BAD_PARAM, {}),
-        ],
-    )
-    def test_get_group_info(
-        self,
-        login_service: LoginService,
-        param: RequestParameters,
-        expected: t.Mapping[str, t.Any],
-    ) -> None:
-        # Prepare the group "group" in the db
-        # noinspection SpellCheckingInspection
-        group = Group(id="group", name="Vulcans")
-        login_service.groups.save(group)
+            _param,
+        )
+        actual = login_service.bots.get_all_by_owner(5)
+        assert len(actual) == 1
+        assert actual[0].name == "Maria II"
 
-        # Prepare the user3 in the db
-        assert USER3.user is not None
-        user3 = User(id=USER3.user.id, name="Spock")
-        login_service.users.save(user3)
+        # Freder Fredersen cannot create Maria with the admin role
+        _param = get_user_param(login_service, user_id=5, group_id="metropolis")
+        with pytest.raises(Exception):
+            login_service.save_bot(
+                BotCreateDTO(
+                    name="Maria III",
+                    roles=[BotRoleCreateDTO(group="metropolis", role=RoleType.ADMIN.value)],
+                ),
+                _param,
+            )
+        actual = login_service.bots.get_all_by_owner(5)
+        assert len(actual) == 1
+        assert actual[0].name == "Maria II"
 
-        # Prepare an LDAP user named "Jane" with id=4
-        user4 = UserLdap(id=4, name="Saavik")
-        login_service.users.save(user4)
+        # Freder Fredersen cannot create a bot with an empty name
+        _param = get_user_param(login_service, user_id=5, group_id="metropolis")
+        with pytest.raises(Exception):
+            login_service.save_bot(
+                BotCreateDTO(
+                    name="",
+                    roles=[BotRoleCreateDTO(group="metropolis", role=RoleType.ADMIN.value)],
+                ),
+                _param,
+            )
+        actual = login_service.bots.get_all_by_owner(5)
+        assert len(actual) == 1
+        assert actual[0].name == "Maria II"
 
-        # Spock and Saavik are vulcans and can run simulations
-        role = Role(type=RoleType.RUNNER, identity=user3, group=group)
-        login_service.roles.save(role)
-        role = Role(type=RoleType.RUNNER, identity=user4, group=group)
-        login_service.roles.save(role)
+        # Freder Fredersen cannot create a bot that already exists
+        _param = get_user_param(login_service, user_id=5, group_id="metropolis")
+        with pytest.raises(Exception):
+            login_service.save_bot(
+                BotCreateDTO(
+                    name="Maria II",
+                    roles=[BotRoleCreateDTO(group="metropolis", role=RoleType.ADMIN.value)],
+                ),
+                _param,
+            )
+        actual = login_service.bots.get_all_by_owner(5)
+        assert len(actual) == 1
+        assert actual[0].name == "Maria II"
 
-        # Only site admin and group admin can get a group info
-        if expected:
-            actual = login_service.get_group_info("group", param)
-            assert actual.dict() == expected
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.get_group_info(group.id, param)
+        # Freder Fredersen cannot create a bot with an invalid group
+        _param = get_user_param(login_service, user_id=5, group_id="metropolis")
+        with pytest.raises(Exception):
+            login_service.save_bot(
+                BotCreateDTO(
+                    name="Maria III",
+                    roles=[BotRoleCreateDTO(group="metropolis2", role=RoleType.ADMIN.value)],
+                ),
+                _param,
+            )
+        actual = login_service.bots.get_all_by_owner(5)
+        assert len(actual) == 1
+        assert actual[0].name == "Maria II"
+
+        # Bot's name cannot be empty
+        _param = get_user_param(login_service, user_id=4, group_id="metropolis")
+        with pytest.raises(Exception):
+            login_service.save_bot(
+                BotCreateDTO(
+                    name="",
+                    roles=[BotRoleCreateDTO(group="metropolis", role=RoleType.ADMIN.value)],
+                ),
+                _param,
+            )
+
+        # Avoid duplicate bots
+        _param = get_user_param(login_service, user_id=4, group_id="metropolis")
+        with pytest.raises(Exception):
+            login_service.save_bot(
+                BotCreateDTO(
+                    name="Maria I",
+                    roles=[BotRoleCreateDTO(group="metropolis", role=RoleType.ADMIN.value)],
+                ),
+                _param,
+            )
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_get", [(SITE_ADMIN, True), (GROUP_ADMIN, True), (USER3, True), (BAD_PARAM, False)]
-    )
-    def test_get_user(self, login_service: LoginService, param: RequestParameters, can_get: bool) -> None:
-        # Prepare a group of readers
-        group = Group(id="group", name="readers")
-        login_service.groups.save(group)
+    def test_save_role(self, login_service: LoginService) -> None:
+        # Prepare a new group and a new user
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        login_service.groups.save(Group(id="web", name="Spider Web"))
+        login_service.users.save(User(id=20, name="Spider-man"))
+        login_service.users.save(User(id=21, name="Spider-woman"))
 
-        # The user3 is a reader in the group "group"
-        user3 = User(id=USER3.user.id, name="Batman")
-        login_service.users.save(user3)
-        role = Role(type=RoleType.READER, identity=user3, group=group)
-        login_service.roles.save(role)
+        # The site admin can create a role
+        login_service.save_role(
+            RoleCreationDTO(type=RoleType.ADMIN, group_id="web", identity_id=20),
+            _param,
+        )
+        actual = login_service.roles.get(20, "web")
+        assert actual is not None
+        assert actual.type == RoleType.ADMIN
 
-        # Anybody except anonymous can get the user3
-        if can_get:
-            actual = login_service.get_user(user3.id, param)
-            assert actual == user3
-        else:
-            # This function doesn't raise an exception if the user does not exist
-            actual = login_service.get_user(user3.id, param)
-            assert actual is None
+        # The group admin can create a role
+        _param = get_user_param(login_service, user_id=20, group_id="web")
+        login_service.save_role(
+            RoleCreationDTO(type=RoleType.WRITER, group_id="web", identity_id=21),
+            _param,
+        )
+        actual = login_service.roles.get(21, "web")
+        assert actual is not None
+        assert actual.type == RoleType.WRITER
+
+        # The group admin cannot create a role with an invalid group
+        _param = get_user_param(login_service, user_id=20, group_id="web")
+        with pytest.raises(Exception):
+            login_service.save_role(
+                RoleCreationDTO(type=RoleType.WRITER, group_id="web2", identity_id=21),
+                _param,
+            )
+        actual = login_service.roles.get(21, "web")
+        assert actual is not None
+        assert actual.type == RoleType.WRITER
+
+        # The user cannot create a role
+        _param = get_user_param(login_service, user_id=21, group_id="web")
+        with pytest.raises(Exception):
+            login_service.save_role(
+                RoleCreationDTO(type=RoleType.READER, group_id="web", identity_id=20),
+                _param,
+            )
+        actual = login_service.roles.get(20, "web")
+        assert actual is not None
+        assert actual.type == RoleType.ADMIN
+
+    @with_db_context
+    def test_get_group(self, login_service: LoginService) -> None:
+        # Site admin can get any group
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_group("superman", _param)
+        assert actual is not None
+        assert actual.name == "Superman"
+
+        # Group admin can get his own group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        actual = login_service.get_group("superman", _param)
+        assert actual is not None
+        assert actual.name == "Superman"
+
+        # Group admin cannot get another group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.get_group("metropolis", _param)
+
+        # Lois Lane can get its own group
+        _param = get_user_param(login_service, user_id=3, group_id="superman")
+        actual = login_service.get_group("superman", _param)
+        assert actual is not None
+        assert actual.id == "superman"
+
+    @with_db_context
+    def test_get_group_info(self, login_service: LoginService) -> None:
+        # Site admin can get any group
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_group_info("superman", _param)
+        assert actual is not None
+        assert actual.name == "Superman"
+        assert [obj.dict() for obj in actual.users] == [
+            {"id": 2, "name": "Clark Kent", "role": RoleType.ADMIN},
+            {"id": 3, "name": "Lois Lane", "role": RoleType.READER},
+        ]
+
+        # Group admin can get his own group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        actual = login_service.get_group_info("superman", _param)
+        assert actual is not None
+        assert actual.name == "Superman"
+
+        # Group admin cannot get another group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.get_group_info("metropolis", _param)
+
+        # Lois Lane cannot get its own group
+        _param = get_user_param(login_service, user_id=3, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.get_group_info("superman", _param)
+
+    @with_db_context
+    def test_get_user(self, login_service: LoginService) -> None:
+        # Site admin can get any user
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_user(2, _param)
+        assert actual is not None
+        assert actual.name == "Clark Kent"
+
+        # Group admin can get a user of his own group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        actual = login_service.get_user(3, _param)
+        assert actual is not None
+        assert actual.name == "Lois Lane"
+
+        # Group admin cannot get a user of another group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        actual = login_service.get_user(5, _param)
+        assert actual is None
+
+        # Lois Lane can get its own user
+        _param = get_user_param(login_service, user_id=3, group_id="superman")
+        actual = login_service.get_user(3, _param)
+        assert actual is not None
+        assert actual.name == "Lois Lane"
+
+        # Create a bot for Lois Lane
+        _param = get_user_param(login_service, user_id=3, group_id="superman")
+        bot = login_service.save_bot(BotCreateDTO(name="Lois bot", roles=[]), _param)
+
+        # The bot can get its owner
+        _param = get_bot_param(login_service, bot_id=bot.id)
+        actual = login_service.get_user(3, _param)
+        assert actual is not None
+        assert actual.name == "Lois Lane"
 
     @with_db_context
     def test_get_identity(self, login_service: LoginService) -> None:
-        # important: id=1 is the admin user
-        user = login_service.users.save(User(id=2, name="John"))
-        user_ldap = login_service.users.save(UserLdap(id=3, name="Jane"))
-        bot = login_service.users.save(Bot(id=4, name="my-app", owner=3, is_author=False))
+        # Create the admin user "Storm"
+        storm = login_service.users.save(User(id=50, name="Storm"))
+        # Create the LDAP user "Jane DOE"
+        jane = login_service.users.save(UserLdap(id=60, name="Jane DOE"))
+        # Create the bot "Maria"
+        maria = login_service.users.save(Bot(id=70, name="Maria", owner=50, is_author=False))
 
-        assert login_service.get_identity(2, include_token=False) == user
-        assert login_service.get_identity(3, include_token=False) == user_ldap
-        assert login_service.get_identity(4, include_token=False) is None
+        assert login_service.get_identity(50, include_token=False) == storm
+        assert login_service.get_identity(60, include_token=False) == jane
+        assert login_service.get_identity(70, include_token=False) is None
 
-        assert login_service.get_identity(2, include_token=True) == user
-        assert login_service.get_identity(3, include_token=True) == user_ldap
-        assert login_service.get_identity(4, include_token=True) == bot
-
-    @with_db_context
-    @pytest.mark.parametrize(
-        "param, expected",
-        [
-            (
-                SITE_ADMIN,
-                {
-                    "id": 3,
-                    "name": "Batman",
-                    "roles": [
-                        {
-                            "group_id": "group",
-                            "group_name": "readers",
-                            "identity_id": 3,
-                            "type": RoleType.READER,
-                        }
-                    ],
-                },
-            ),
-            (
-                GROUP_ADMIN,
-                {
-                    "id": 3,
-                    "name": "Batman",
-                    "roles": [
-                        {
-                            "group_id": "group",
-                            "group_name": "readers",
-                            "identity_id": 3,
-                            "type": RoleType.READER,
-                        }
-                    ],
-                },
-            ),
-            (
-                USER3,
-                {
-                    "id": 3,
-                    "name": "Batman",
-                    "roles": [
-                        {
-                            "group_id": "group",
-                            "group_name": "readers",
-                            "identity_id": 3,
-                            "type": RoleType.READER,
-                        }
-                    ],
-                },
-            ),
-            (BAD_PARAM, {}),
-        ],
-    )
-    def test_get_user_info(
-        self,
-        login_service: LoginService,
-        param: RequestParameters,
-        expected: t.Mapping[str, t.Any],
-    ) -> None:
-        # Prepare a group of readers
-        group = Group(id="group", name="readers")
-        login_service.groups.save(group)
-
-        # The user3 is a reader in the group "group"
-        user3 = User(id=USER3.user.id, name="Batman")
-        login_service.users.save(user3)
-        role = Role(type=RoleType.READER, identity=user3, group=group)
-        login_service.roles.save(role)
-
-        # Anybody except anonymous can get the user3
-        if expected:
-            actual = login_service.get_user_info(user3.id, param)
-            assert actual.dict() == expected
-        else:
-            # This function doesn't raise an exception if the user does not exist
-            actual = login_service.get_user_info(user3.id, param)
-            assert actual is None
+        assert login_service.get_identity(50, include_token=True) == storm
+        assert login_service.get_identity(60, include_token=True) == jane
+        assert login_service.get_identity(70, include_token=True) == maria
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_get", [(SITE_ADMIN, True), (GROUP_ADMIN, False), (USER3, True), (BAD_PARAM, False)]
-    )
-    def test_get_bot(self, login_service: LoginService, param: RequestParameters, can_get: bool) -> None:
-        # Prepare a user in the db, with id=4
-        clark = User(id=3, name="Clark")
-        login_service.users.save(clark)
+    def test_get_user_info(self, login_service: LoginService) -> None:
+        # Site admin can get any user
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        clark_id = 2
+        actual = login_service.get_user_info(clark_id, _param)
+        assert actual is not None
+        assert actual.dict() == {
+            "id": clark_id,
+            "name": "Clark Kent",
+            "roles": [
+                {
+                    "group_id": "superman",
+                    "group_name": "Superman",
+                    "identity_id": clark_id,
+                    "type": RoleType.ADMIN,
+                }
+            ],
+        }
 
-        # Prepare a bot in the db (using the ID or user3)
-        bot = Bot(id=4, name="Maria", owner=clark.id, is_author=True)
-        login_service.users.save(bot)
+        # Group admin can get a user of his own group
+        _param = get_user_param(login_service, user_id=clark_id, group_id="superman")
+        lois_id = 3
+        actual = login_service.get_user_info(lois_id, _param)
+        assert actual is not None
+        assert actual.dict() == {
+            "id": lois_id,
+            "name": "Lois Lane",
+            "roles": [
+                {
+                    "group_id": "superman",
+                    "group_name": "Superman",
+                    "identity_id": lois_id,
+                    "type": RoleType.READER,
+                }
+            ],
+        }
 
-        # Only site admin and the owner can get a bot
-        if can_get:
-            actual = login_service.get_bot(bot.id, param)
-            assert actual == bot
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.get_bot(bot.id, param)
+        # Group admin cannot get a user of another group
+        _param = get_user_param(login_service, user_id=clark_id, group_id="superman")
+        freder_id = 5
+        actual = login_service.get_user_info(freder_id, _param)
+        assert actual is None
+
+        # Lois Lane can get its own user info
+        _param = get_user_param(login_service, user_id=lois_id, group_id="superman")
+        actual = login_service.get_user_info(lois_id, _param)
+        assert actual is not None
+        assert actual.dict() == {
+            "id": lois_id,
+            "name": "Lois Lane",
+            "roles": [
+                {
+                    "group_id": "superman",
+                    "group_name": "Superman",
+                    "identity_id": lois_id,
+                    "type": RoleType.READER,
+                }
+            ],
+        }
+
+        # Create a bot for Lois Lane
+        _param = get_user_param(login_service, user_id=lois_id, group_id="superman")
+        bot = login_service.save_bot(BotCreateDTO(name="Lois bot", roles=[]), _param)
+
+        # The bot can get its owner
+        _param = get_bot_param(login_service, bot_id=bot.id)
+        actual = login_service.get_user_info(lois_id, _param)
+        assert actual is not None
+        assert actual.dict() == {
+            "id": lois_id,
+            "name": "Lois Lane",
+            "roles": [
+                {
+                    "group_id": "superman",
+                    "group_name": "Superman",
+                    "identity_id": lois_id,
+                    "type": RoleType.READER,
+                }
+            ],
+        }
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, expected",
-        [
-            (
-                SITE_ADMIN,
-                {
-                    "id": 4,
-                    "isAuthor": True,
-                    "name": "Maria",
-                    "roles": [
-                        {
-                            "group_id": "Metropolis",
-                            "group_name": "watchers",
-                            "identity_id": 4,
-                            "type": RoleType.READER,
-                        }
-                    ],
-                },
-            ),
-            (GROUP_ADMIN, {}),
-            (
-                USER3,
-                {
-                    "id": 4,
-                    "isAuthor": True,
-                    "name": "Maria",
-                    "roles": [
-                        {
-                            "group_id": "Metropolis",
-                            "group_name": "watchers",
-                            "identity_id": 4,
-                            "type": RoleType.READER,
-                        }
-                    ],
-                },
-            ),
-            (BAD_PARAM, {}),
-        ],
-    )
-    def test_get_bot_info(
-        self,
-        login_service: LoginService,
-        param: RequestParameters,
-        expected: t.Mapping[str, t.Any],
-    ) -> None:
-        # Prepare a user in the db, with id=4
-        clark = User(id=3, name="Clark")
-        login_service.users.save(clark)
+    def test_get_bot(self, login_service: LoginService) -> None:
+        # Create a bot for Joh Fredersen
+        joh_id = 4
+        _param = get_user_param(login_service, user_id=joh_id, group_id="metropolis")
+        joh_bot = login_service.save_bot(BotCreateDTO(name="Maria", roles=[]), _param)
 
-        # Prepare a bot in the db (using the ID or user3)
-        bot = Bot(id=4, name="Maria", owner=clark.id, is_author=True)
-        login_service.users.save(bot)
+        # The site admin can get any bot
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_bot(joh_bot.id, _param)
+        assert actual is not None
+        assert actual.name == "Maria"
 
-        # Prepare a group of readers
-        group = Group(id="Metropolis", name="watchers")
-        login_service.groups.save(group)
+        # Joh Fredersen can get its own bot
+        _param = get_user_param(login_service, user_id=joh_id, group_id="superman")
+        actual = login_service.get_bot(joh_bot.id, _param)
+        assert actual is not None
+        assert actual.name == "Maria"
 
-        # The user3 is a reader in the group "group"
-        role = Role(type=RoleType.READER, identity=bot, group=group)
-        login_service.roles.save(role)
+        # The bot cannot get itself
+        _param = get_bot_param(login_service, bot_id=joh_bot.id)
+        with pytest.raises(Exception):
+            login_service.get_bot(joh_bot.id, _param)
 
-        # Only site admin and the owner can get a bot
-        if expected:
-            actual = login_service.get_bot_info(bot.id, param)
-            assert actual is not None
-            assert actual.dict() == expected
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.get_bot_info(bot.id, param)
+        # Freder Fredersen cannot get the bot
+        freder_id = 5
+        _param = get_user_param(login_service, user_id=freder_id, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.get_bot(joh_bot.id, _param)
 
     @with_db_context
-    @pytest.mark.parametrize("param, expected", [(SITE_ADMIN, [5]), (GROUP_ADMIN, []), (USER3, [5]), (BAD_PARAM, [])])
-    def test_get_all_bots_by_owner(
-        self,
-        login_service: LoginService,
-        param: RequestParameters,
-        expected: t.Mapping[str, t.Any],
-    ) -> None:
-        # add a user, an LDAP user and a bot in the db
-        user = User(id=3, name="John")
-        login_service.users.save(user)
-        user_ldap = UserLdap(id=4, name="Jane")
-        login_service.users.save(user_ldap)
-        bot = Bot(id=5, name="my-app", owner=3, is_author=False)
-        login_service.users.save(bot)
+    def test_get_bot_info(self, login_service: LoginService) -> None:
+        # Create a bot for Joh Fredersen
+        joh_id = 4
+        _param = get_user_param(login_service, user_id=joh_id, group_id="superman")
+        joh_bot = login_service.save_bot(BotCreateDTO(name="Maria", roles=[]), _param)
 
-        if expected:
-            actual = login_service.get_all_bots_by_owner(3, param)
-            assert [b.id for b in actual] == expected
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.get_all_bots_by_owner(3, param)
+        # The site admin can get any bot
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_bot_info(joh_bot.id, _param)
+        assert actual is not None
+        assert actual.dict() == {"id": 6, "isAuthor": True, "name": "Maria", "roles": []}
+
+        # Joh Fredersen can get its own bot
+        _param = get_user_param(login_service, user_id=joh_id, group_id="superman")
+        actual = login_service.get_bot_info(joh_bot.id, _param)
+        assert actual is not None
+        assert actual.dict() == {"id": 6, "isAuthor": True, "name": "Maria", "roles": []}
+
+        # The bot cannot get itself
+        _param = get_bot_param(login_service, bot_id=joh_bot.id)
+        with pytest.raises(Exception):
+            login_service.get_bot_info(joh_bot.id, _param)
+
+        # Freder Fredersen cannot get the bot
+        freder_id = 5
+        _param = get_user_param(login_service, user_id=freder_id, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.get_bot_info(joh_bot.id, _param)
+
+        # Freder Fredersen cannot get the bot
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        with pytest.raises(Exception):
+            login_service.get_bot_info(999, _param)
+
+    @with_db_context
+    def test_get_all_bots_by_owner(self, login_service: LoginService) -> None:
+        # Create a bot for Joh Fredersen
+        joh_id = 4
+        _param = get_user_param(login_service, user_id=joh_id, group_id="superman")
+        joh_bot = login_service.save_bot(BotCreateDTO(name="Maria", roles=[]), _param)
+
+        # The site admin can get any bot
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_all_bots_by_owner(joh_id, _param)
+        expected = [{"id": joh_bot.id, "is_author": True, "name": "Maria", "owner": joh_id}]
+        assert [obj.to_dto().dict() for obj in actual] == expected
+
+        # Freder Fredersen can get its own bot
+        _param = get_user_param(login_service, user_id=joh_id, group_id="superman")
+        actual = login_service.get_all_bots_by_owner(joh_id, _param)
+        expected = [{"id": joh_bot.id, "is_author": True, "name": "Maria", "owner": joh_id}]
+        assert [obj.to_dto().dict() for obj in actual] == expected
+
+        # The bot cannot get itself
+        _param = get_bot_param(login_service, bot_id=joh_bot.id)
+        with pytest.raises(Exception):
+            login_service.get_all_bots_by_owner(joh_id, _param)
+
+        # Freder Fredersen cannot get the bot
+        freder_id = 5
+        _param = get_user_param(login_service, user_id=freder_id, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.get_all_bots_by_owner(joh_id, _param)
 
     @with_db_context
     def test_exists_bot(self, login_service: LoginService) -> None:
-        # Prepare the user3 in the db
-        assert USER3.user is not None
-        user3 = User(id=USER3.user.id, name="Clark")
-        login_service.users.save(user3)
-
-        # Prepare a bot in the db (using the ID or user3)
-        bot = Bot(id=4, name="Maria", owner=user3.id, is_author=True)
-        login_service.users.save(bot)
+        # Create a bot for Joh Fredersen
+        joh_id = 4
+        _param = get_user_param(login_service, user_id=joh_id, group_id="superman")
+        joh_bot = login_service.save_bot(BotCreateDTO(name="Maria", roles=[]), _param)
 
         # Everybody can check the existence of a bot
-        assert login_service.exists_bot(4)
-        assert not login_service.exists_bot(5)  # unknown ID
-        assert not login_service.exists_bot(3)  # user ID, not bot ID
+        assert login_service.exists_bot(joh_id) is False, "not a bot"
+        assert login_service.exists_bot(joh_bot.id) is True
+        assert login_service.exists_bot(999) is False
 
     @with_db_context
-    def test_authenticate__unknown_user(self, login_service: LoginService) -> None:
+    def test_authenticate(self, login_service: LoginService) -> None:
+        # Update the password of "Lois Lane"
+        lois_id = 3
+        login_service.users.save(User(id=lois_id, name="Lois Lane", password=Password("S3cr3t")))
+
+        # A known user can log in
+        jwt_user = login_service.authenticate(name="Lois Lane", pwd="S3cr3t")
+        assert jwt_user is not None
+        assert jwt_user.id == lois_id
+        assert jwt_user.impersonator == lois_id
+        assert jwt_user.type == "users"
+        assert jwt_user.groups == [
+            JWTGroup(id="superman", name="Superman", role=RoleType.READER),
+        ]
+
         # An unknown user cannot log in
         user = login_service.authenticate(name="unknown", pwd="S3cr3t")
         assert user is None
 
-    @with_db_context
-    def test_authenticate__known_user(self, login_service: LoginService) -> None:
-        # Create a user named "Tarzan" in the group "Adventure"
-        group = Group(id="adventure", name="Adventure")
-        login_service.groups.save(group)
-        user = User(id=3, name="Tarzan", password=Password("S3cr3t"))
-        login_service.users.save(user)
-        role = Role(type=RoleType.READER, identity=user, group=group)
-        login_service.roles.save(role)
-
-        # A known user can log in
-        jwt_user = login_service.authenticate(name="Tarzan", pwd="S3cr3t")
-        assert jwt_user is not None
-        assert jwt_user.id == user.id
-        assert jwt_user.impersonator == user.id
-        assert jwt_user.type == "users"
-        assert jwt_user.groups == [JWTGroup(id="adventure", name="Adventure", role=RoleType.READER)]
-
-    @with_db_context
-    def test_authenticate__external_user(self, login_service: LoginService) -> None:
-        # Create a user named "Tarzan"
-        user_ldap = UserLdap(id=3, name="Tarzan", external_id="tarzan", firstname="Tarzan", lastname="Jungle")
+        # Update the user "Jane DOE" which is an LDAP user
+        jane_id = 60
+        user_ldap = UserLdap(
+            id=jane_id,
+            name="Jane DOE",
+            external_id="j.doe",
+            firstname="Jane",
+            lastname="DOE",
+        )
         login_service.users.save(user_ldap)
 
         # Mock the LDAP service
-        login_service.ldap.login = Mock(return_value=user_ldap)  # type: ignore
-        login_service.ldap.get = Mock(return_value=user_ldap)  # type: ignore
+        with patch("antarest.login.ldap.LdapService.login") as mock_login:
+            mock_login.return_value = user_ldap
+            with patch("antarest.login.ldap.LdapService.login") as mock_get:
+                mock_get.return_value = user_ldap
+                jwt_user = login_service.authenticate(name="Jane DOE", pwd="S3cr3t")
 
-        # A known user can log in
-        jwt_user = login_service.authenticate(name="Tarzan", pwd="S3cr3t")
         assert jwt_user is not None
         assert jwt_user.id == user_ldap.id
         assert jwt_user.impersonator == user_ldap.id
@@ -603,32 +678,30 @@ class TestLoginService:
 
     @with_db_context
     def test_get_jwt(self, login_service: LoginService) -> None:
-        # Prepare the user3 in the db
-        assert USER3.user is not None
-        user3 = User(id=USER3.user.id, name="Clark")
-        login_service.users.save(user3)
+        # Create a bot for Joh Fredersen
+        joh_id = 4
+        _param = get_user_param(login_service, user_id=joh_id, group_id="superman")
+        joh_bot = login_service.save_bot(BotCreateDTO(name="Maria", roles=[]), _param)
 
-        # Attach a group to the user
-        group = Group(id="group", name="readers")
-        login_service.groups.save(group)
-        role = Role(type=RoleType.READER, identity=user3, group=group)
-        login_service.roles.save(role)
-
-        # Prepare an LDAP user in the db
-        user_ldap = UserLdap(id=4, name="Jane")
+        # Update the user "Jane DOE" which is an LDAP user
+        jane_id = 60
+        user_ldap = UserLdap(
+            id=jane_id,
+            name="Jane DOE",
+            external_id="j.doe",
+            firstname="Jane",
+            lastname="DOE",
+        )
         login_service.users.save(user_ldap)
 
-        # Prepare a bot in the db (using the ID or user3)
-        bot = Bot(id=5, name="Maria", owner=user3.id, is_author=True)
-        login_service.users.save(bot)
-
         # We can get a JWT for a user, an LDAP user, but not a bot
-        jwt_user = login_service.get_jwt(user3.id)
+        lois_id = 3
+        jwt_user = login_service.get_jwt(lois_id)
         assert jwt_user is not None
-        assert jwt_user.id == user3.id
-        assert jwt_user.impersonator == user3.id
+        assert jwt_user.id == lois_id
+        assert jwt_user.impersonator == lois_id
         assert jwt_user.type == "users"
-        assert jwt_user.groups == [JWTGroup(id="group", name="readers", role=RoleType.READER)]
+        assert jwt_user.groups == [JWTGroup(id="superman", name="Superman", role=RoleType.READER)]
 
         jwt_user = login_service.get_jwt(user_ldap.id)
         assert jwt_user is not None
@@ -637,367 +710,306 @@ class TestLoginService:
         assert jwt_user.type == "users_ldap"
         assert jwt_user.groups == []
 
-        jwt_user = login_service.get_jwt(bot.id)
+        jwt_user = login_service.get_jwt(joh_bot.id)
         assert jwt_user is None
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, expected",
-        [
-            (
-                SITE_ADMIN,
-                [
-                    {"id": "admin", "name": "admin"},
-                    {"id": "gr1", "name": "Adventure"},
-                    {"id": "gr2", "name": "Comedy"},
-                ],
-            ),
-            (
-                GROUP_ADMIN,
-                [
-                    {"id": "admin", "name": "admin"},
-                    {"id": "gr2", "name": "Comedy"},
-                ],
-            ),
-            (
-                USER3,
-                [
-                    {"id": "gr1", "name": "Adventure"},
-                ],
-            ),
-            (BAD_PARAM, []),
-        ],
-    )
-    def test_get_all_groups(
-        self,
-        login_service: LoginService,
-        param: RequestParameters,
-        expected: t.Sequence[t.Mapping[str, str]],
-    ) -> None:
-        # Prepare some groups in the db
-        group1 = Group(id="gr1", name="Adventure")
-        login_service.groups.save(group1)
-        group2 = Group(id="gr2", name="Comedy")
-        login_service.groups.save(group2)
+    def test_get_all_groups(self, login_service: LoginService) -> None:
+        # The site admin can get all groups
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_all_groups(_param)
+        assert [g.dict() for g in actual] == [
+            {"id": "admin", "name": "X-Men"},
+            {"id": "superman", "name": "Superman"},
+            {"id": "metropolis", "name": "Metropolis"},
+        ]
 
-        # The group admin is a reader in the group "gr2"
-        assert GROUP_ADMIN.user is not None
-        robin_hood = User(id=GROUP_ADMIN.user.id, name="Robin")
-        login_service.users.save(robin_hood)
-        role = Role(type=RoleType.READER, identity=robin_hood, group=group2)
-        login_service.roles.save(role)
+        # The group admin can its own groups
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        actual = login_service.get_all_groups(_param)
+        assert [g.dict() for g in actual] == [{"id": "superman", "name": "Superman"}]
 
-        # The user3 is a reader in the group "gr1"
-        assert USER3.user is not None
-        indiana_johns = User(id=USER3.user.id, name="Indiana")
-        login_service.users.save(indiana_johns)
-        role = Role(type=RoleType.READER, identity=indiana_johns, group=group1)
-        login_service.roles.save(role)
-
-        # Anybody except anonymous can get the list of groups
-        if expected:
-            # The site admin can see all groups
-            actual = login_service.get_all_groups(param)
-            assert [g.dict() for g in actual] == expected
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.get_all_groups(param)
+        # The user can get its own groups
+        _param = get_user_param(login_service, user_id=3, group_id="superman")
+        actual = login_service.get_all_groups(_param)
+        assert [g.dict() for g in actual] == [{"id": "superman", "name": "Superman"}]
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, expected",
-        [
-            (
-                SITE_ADMIN,
-                [
-                    {"id": 0, "name": "Superman"},
-                    {"id": 1, "name": "John"},
-                    {"id": 2, "name": "Jane"},
-                    {"id": 3, "name": "Tarzan"},
-                ],
-            ),
-            (
-                GROUP_ADMIN,
-                [
-                    {"id": 1, "name": "John"},
-                ],
-            ),
-            (
-                USER3,
-                [
-                    {"id": 3, "name": "Tarzan"},
-                ],
-            ),
-            (BAD_PARAM, []),
-        ],
-    )
-    def test_get_all_users(
-        self,
-        login_service: LoginService,
-        param: RequestParameters,
-        expected: t.Sequence[t.Mapping[str, t.Union[int, str]]],
-    ) -> None:
-        # Insert some users in the db
-        user0 = User(id=0, name="Superman")
-        login_service.users.save(user0)
-        user1 = User(id=1, name="John")
-        login_service.users.save(user1)
-        user2 = User(id=2, name="Jane")
-        login_service.users.save(user2)
-        user3 = User(id=3, name="Tarzan")
-        login_service.users.save(user3)
+    def test_get_all_users(self, login_service: LoginService) -> None:
+        # The site admin can get all users
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_all_users(_param)
+        assert [u.dict() for u in actual] == [
+            {"id": 1, "name": "Professor Xavier"},
+            {"id": 2, "name": "Clark Kent"},
+            {"id": 3, "name": "Lois Lane"},
+            {"id": 4, "name": "Joh Fredersen"},
+            {"id": 5, "name": "Freder Fredersen"},
+        ]
 
-        # user3 is a reader in the group "group"
-        group = Group(id="group", name="readers")
-        login_service.groups.save(group)
-        role = Role(type=RoleType.READER, identity=user3, group=group)
-        login_service.roles.save(role)
+        # The group admin can get its own users, but also the users of the other groups
+        # note: I don't know why the group admin can get all users -- Laurent
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        actual = login_service.get_all_users(_param)
+        assert [u.dict() for u in actual] == [
+            {"id": 1, "name": "Professor Xavier"},
+            {"id": 2, "name": "Clark Kent"},
+            {"id": 3, "name": "Lois Lane"},
+            {"id": 4, "name": "Joh Fredersen"},
+            {"id": 5, "name": "Freder Fredersen"},
+        ]
 
-        # Anybody except anonymous can get the list of users
-        if expected:
-            actual = login_service.get_all_users(param)
-            assert [u.dict() for u in actual] == expected
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.get_all_users(param)
+        # The user can get its own users
+        _param = get_user_param(login_service, user_id=3, group_id="superman")
+        actual = login_service.get_all_users(_param)
+        assert [u.dict() for u in actual] == [
+            {"id": 2, "name": "Clark Kent"},
+            {"id": 3, "name": "Lois Lane"},
+        ]
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, expected",
-        [
-            (SITE_ADMIN, [5]),
-            (GROUP_ADMIN, []),
-            (USER3, []),
-            (BAD_PARAM, []),
-        ],
-    )
-    def test_get_all_bots(
-        self,
-        login_service: LoginService,
-        param: RequestParameters,
-        expected: t.Sequence[int],
-    ) -> None:
-        # add a user, an LDAP user and a bot in the db
-        user = User(id=3, name="John")
-        login_service.users.save(user)
-        user_ldap = UserLdap(id=4, name="Jane")
-        login_service.users.save(user_ldap)
-        bot = Bot(id=5, name="my-app", owner=3, is_author=False)
-        login_service.users.save(bot)
+    def test_get_all_bots(self, login_service: LoginService) -> None:
+        # Create a bot for Joh Fredersen
+        joh_id = 4
+        _param = get_user_param(login_service, user_id=joh_id, group_id="superman")
+        joh_bot = login_service.save_bot(BotCreateDTO(name="Maria", roles=[]), _param)
 
-        if expected:
-            actual = login_service.get_all_bots(param)
-            assert [b.id for b in actual] == expected
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.get_all_bots(param)
+        # The site admin can get all bots
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_all_bots(_param)
+        assert [b.to_dto().dict() for b in actual] == [
+            {"id": joh_bot.id, "is_author": True, "name": "Maria", "owner": joh_id},
+        ]
+
+        # The group admin cannot access the list of bots
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.get_all_bots(_param)
+
+        # The user cannot access the list of bots
+        _param = get_user_param(login_service, user_id=3, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.get_all_bots(_param)
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, expected",
-        [
-            (SITE_ADMIN, [(3, "group")]),
-            (GROUP_ADMIN, [(3, "group")]),
-            (USER3, []),
-            (BAD_PARAM, []),
-        ],
-    )
-    def test_get_all_roles_in_group(
-        self,
-        login_service: LoginService,
-        param: RequestParameters,
-        expected: t.Sequence[t.Tuple[int, str]],
-    ) -> None:
-        # Insert some users in the db
-        user0 = User(id=0, name="Superman")
-        login_service.users.save(user0)
-        user1 = User(id=1, name="John")
-        login_service.users.save(user1)
-        user2 = User(id=2, name="Jane")
-        login_service.users.save(user2)
-        user3 = User(id=3, name="Tarzan")
-        login_service.users.save(user3)
+    def test_get_all_roles_in_group(self, login_service: LoginService) -> None:
+        # The site admin can get all roles in a given group
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        actual = login_service.get_all_roles_in_group("superman", _param)
+        assert [b.to_dto().dict() for b in actual] == [
+            {
+                "group": {"id": "superman", "name": "Superman"},
+                "identity": {"id": 2, "name": "Clark Kent"},
+                "type": RoleType.ADMIN,
+            },
+            {
+                "group": {"id": "superman", "name": "Superman"},
+                "identity": {"id": 3, "name": "Lois Lane"},
+                "type": RoleType.READER,
+            },
+        ]
 
-        # user3 is a reader in the group "group"
-        group = Group(id="group", name="readers")
-        login_service.groups.save(group)
-        role = Role(type=RoleType.READER, identity=user3, group=group)
-        login_service.roles.save(role)
+        # The group admin can get all roles his own group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        actual = login_service.get_all_roles_in_group("superman", _param)
+        assert [b.to_dto().dict() for b in actual] == [
+            {
+                "group": {"id": "superman", "name": "Superman"},
+                "identity": {"id": 2, "name": "Clark Kent"},
+                "type": RoleType.ADMIN,
+            },
+            {
+                "group": {"id": "superman", "name": "Superman"},
+                "identity": {"id": 3, "name": "Lois Lane"},
+                "type": RoleType.READER,
+            },
+        ]
 
-        # The site admin and the group admin can get the list of roles in a group
-        if expected:
-            actual = login_service.get_all_roles_in_group("group", param)
-            assert [(r.identity_id, r.group_id) for r in actual] == expected
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.get_all_roles_in_group("group", param)
-
-    @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_delete",
-        [
-            (SITE_ADMIN, True),
-            (GROUP_ADMIN, True),
-            (USER3, False),
-            (BAD_PARAM, False),
-        ],
-    )
-    def test_delete_group(self, login_service: LoginService, param: RequestParameters, can_delete: bool) -> None:
-        # Insert a group in the db
-        group = Group(id="group", name="readers")
-        login_service.groups.save(group)
-
-        # The site admin and the group admin can delete a group
-        if can_delete:
-            login_service.delete_group("group", param)
-            actual = login_service.groups.get("group")
-            assert actual is None
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.delete_group("group", param)
-            actual = login_service.groups.get("group")
-            assert actual is not None
+        # The user cannot access the list of roles
+        _param = get_user_param(login_service, user_id=3, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.get_all_roles_in_group("superman", _param)
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_delete",
-        [
-            (SITE_ADMIN, True),
-            (GROUP_ADMIN, False),
-            (USER3, False),
-            (BAD_PARAM, False),
-        ],
-    )
-    def test_delete_user(self, login_service: LoginService, param: RequestParameters, can_delete: bool) -> None:
-        # Insert a user in the db which is an owner of a bot
-        user = User(id=3, name="John")
-        login_service.users.save(user)
-        bot = Bot(id=4, name="my-app", owner=3, is_author=False)
-        login_service.users.save(bot)
+    def test_delete_group(self, login_service: LoginService) -> None:
+        # Create new groups for Lois Lane (3) and Freder Fredersen (5)
+        group1 = login_service.groups.save(Group(id="g1", name="Group I"))
+        group2 = login_service.groups.save(Group(id="g2", name="Group II"))
+        group3 = login_service.groups.save(Group(id="g3", name="Group III"))
 
-        # The site admin can delete the user
-        if can_delete:
-            login_service.delete_user(3, param)
-            actual = login_service.users.get(3)
-            assert actual is None
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.delete_user(3, param)
-            actual = login_service.users.get(3)
-            assert actual is not None
+        lois = t.cast(User, login_service.users.get(3))  # group admin
+        freder = t.cast(User, login_service.users.get(5))  # user
 
-    @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_delete",
-        [
-            (SITE_ADMIN, True),
-            (GROUP_ADMIN, False),
-            (USER3, True),
-            (BAD_PARAM, False),
-        ],
-    )
-    def test_delete_bot(self, login_service: LoginService, param: RequestParameters, can_delete: bool) -> None:
-        # Insert a user in the db which is an owner of a bot
-        user = User(id=3, name="John")
-        login_service.users.save(user)
-        bot = Bot(id=4, name="my-app", owner=3, is_author=False)
-        login_service.users.save(bot)
+        login_service.roles.save(Role(type=RoleType.ADMIN, group=group1, identity=lois))
+        login_service.roles.save(Role(type=RoleType.READER, group=group1, identity=freder))
+        login_service.roles.save(Role(type=RoleType.ADMIN, group=group2, identity=lois))
+        login_service.roles.save(Role(type=RoleType.WRITER, group=group2, identity=freder))
+        login_service.roles.save(Role(type=RoleType.ADMIN, group=group3, identity=lois))
+        login_service.roles.save(Role(type=RoleType.RUNNER, group=group3, identity=freder))
 
-        # The site admin and the current owner can delete the bot
-        if can_delete:
-            login_service.delete_bot(4, param)
-            actual = login_service.bots.get(4)
-            assert actual is None
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.delete_bot(4, param)
-            actual = login_service.bots.get(4)
-            assert actual is not None
+        # The site admin can delete any group
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        login_service.delete_group("g1", _param)
+        assert login_service.groups.get(group1.id) is None
+
+        # The group admin can delete his own group
+        _param = get_user_param(login_service, user_id=3, group_id="g2")
+        login_service.delete_group("g2", _param)
+        assert login_service.groups.get(group2.id) is None
+
+        # The user cannot delete a group
+        _param = get_user_param(login_service, user_id=5, group_id="g3")
+        with pytest.raises(Exception):
+            login_service.delete_group("g3", _param)
+        assert login_service.groups.get(group3.id) is not None
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_delete",
-        [
-            (SITE_ADMIN, True),
-            (GROUP_ADMIN, True),
-            (USER3, False),
-            (BAD_PARAM, False),
-        ],
-    )
-    def test_delete_role(self, login_service: LoginService, param: RequestParameters, can_delete: bool) -> None:
-        # Insert the user3 in the db
-        user = User(id=3, name="Tarzan")
-        login_service.users.save(user)
+    def test_delete_user(self, login_service: LoginService) -> None:
+        # Create Joh's bot
+        joh_id = 4
+        _param = get_user_param(login_service, user_id=joh_id, group_id="metropolis")
+        joh_bot = login_service.save_bot(BotCreateDTO(name="Maria", roles=[]), _param)
 
-        # Insert a group in the db
-        group = Group(id="group", name="readers")
-        login_service.groups.save(group)
+        # The site admin can delete Fredersen (5)
+        freder_id = 5
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        login_service.delete_user(freder_id, _param)
+        assert login_service.users.get(freder_id) is None
 
-        # Insert a role in the db
-        role = Role(type=RoleType.READER, identity=user, group=group)
-        login_service.roles.save(role)
+        # The group admin Joh can delete himself (4)
+        _param = get_user_param(login_service, user_id=joh_id, group_id="metropolis")
+        login_service.delete_user(joh_id, _param)
+        assert login_service.users.get(joh_id) is None
+        assert login_service.bots.get(joh_bot.id) is None
 
-        # The site admin and the group admin can delete a role
-        if can_delete:
-            login_service.delete_role(3, "group", param)
-            actual = login_service.roles.get_all_by_group("group")
-            assert len(actual) == 0
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.delete_role(3, "group", param)
-            actual = login_service.roles.get_all_by_group("group")
-            assert len(actual) == 1
+        # Lois Lane cannot delete Clark Kent (2)
+        lois_id = 3
+        clark_id = 2
+        _param = get_user_param(login_service, user_id=lois_id, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.delete_user(clark_id, _param)
+        assert login_service.users.get(clark_id) is not None
+
+        # Clark Kent cannot delete Lois Lane (3)
+        _param = get_user_param(login_service, user_id=clark_id, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.delete_user(lois_id, _param)
+        assert login_service.users.get(lois_id) is not None
 
     @with_db_context
-    @pytest.mark.parametrize(
-        "param, can_delete",
-        [
-            (SITE_ADMIN, True),
-            (GROUP_ADMIN, True),
-            (USER3, False),
-            (BAD_PARAM, False),
-        ],
-    )
-    def test_delete_all_roles_from_user(
-        self, login_service: LoginService, param: RequestParameters, can_delete: bool
-    ) -> None:
-        # Insert the user3 in the db
-        assert USER3.user is not None
-        user = User(id=USER3.user.id, name="Tarzan")
-        login_service.users.save(user)
+    def test_delete_bot(self, login_service: LoginService) -> None:
+        # Create Joh's bot
+        joh_id = 4
+        _param = get_user_param(login_service, user_id=joh_id, group_id="metropolis")
+        joh_bot = login_service.save_bot(BotCreateDTO(name="Maria", roles=[]), _param)
 
-        # Insert a group in the db
-        group = Group(id="group", name="readers")
-        login_service.groups.save(group)
+        # The site admin can delete the bot
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        login_service.delete_bot(joh_bot.id, _param)
+        assert login_service.bots.get(joh_bot.id) is None
 
-        # Insert a role in the db
-        role = Role(type=RoleType.READER, identity=user, group=group)
-        login_service.roles.save(role)
+        # Create Lois's bot
+        lois_id = 3
+        _param = get_user_param(login_service, user_id=lois_id, group_id="superman")
+        lois_bot = login_service.save_bot(BotCreateDTO(name="Lois bot", roles=[]), _param)
 
-        # Insert the group admin in the db
-        assert GROUP_ADMIN.user is not None
-        group_admin = User(id=GROUP_ADMIN.user.id, name="John")
-        login_service.users.save(group_admin)
+        # The group admin cannot delete the bot
+        clark_id = 2
+        _param = get_user_param(login_service, user_id=clark_id, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.delete_bot(lois_bot.id, _param)
+        assert login_service.bots.get(lois_bot.id) is not None
 
-        # Insert another group in the db
-        group2 = Group(id="group2", name="readers")
-        login_service.groups.save(group2)
+        # Create Freder's bot
+        freder_id = 5
+        _param = get_user_param(login_service, user_id=freder_id, group_id="metropolis")
+        freder_bot = login_service.save_bot(BotCreateDTO(name="Freder bot", roles=[]), _param)
 
-        # Insert a role in the db
-        role2 = Role(type=RoleType.READER, identity=group_admin, group=group2)
-        login_service.roles.save(role2)
+        # Freder can delete his own bot
+        _param = get_user_param(login_service, user_id=freder_id, group_id="metropolis")
+        login_service.delete_bot(freder_bot.id, _param)
+        assert login_service.bots.get(freder_bot.id) is None
 
-        # The site admin and the group admin can delete a role
-        if can_delete:
-            login_service.delete_all_roles_from_user(3, param)
-            actual = login_service.roles.get_all_by_group("group")
-            assert len(actual) == 0
-            actual = login_service.roles.get_all_by_group("group2")
-            assert len(actual) == 1
-        else:
-            with pytest.raises(UserHasNotPermissionError):
-                login_service.delete_all_roles_from_user(3, param)
-            actual = login_service.roles.get_all_by_group("group")
-            assert len(actual) == 1
-            actual = login_service.roles.get_all_by_group("group2")
-            assert len(actual) == 1
+        # Freder cannot delete Lois's bot
+        _param = get_user_param(login_service, user_id=freder_id, group_id="metropolis")
+        with pytest.raises(Exception):
+            login_service.delete_bot(lois_bot.id, _param)
+        assert login_service.bots.get(lois_bot.id) is not None
+
+    @with_db_context
+    def test_delete_role(self, login_service: LoginService) -> None:
+        # Create a new group
+        group = login_service.groups.save(Group(id="g1", name="Group I"))
+
+        # Create a new user
+        user = login_service.users.save(User(id=10, name="User 1"))
+
+        # Create a new role
+        role = login_service.roles.save(Role(type=RoleType.ADMIN, group=group, identity=user))
+
+        # The site admin can delete any role
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        login_service.delete_role(role.identity.id, role.group.id, _param)
+        assert login_service.roles.get(role.identity.id, role.group.id) is None
+
+        # Create a new role
+        role = login_service.roles.save(Role(type=RoleType.ADMIN, group=group, identity=user))
+
+        # The group admin can delete a role of his own group
+        _param = get_user_param(login_service, user_id=user.id, group_id="g1")
+        login_service.delete_role(role.identity.id, role.group.id, _param)
+        assert login_service.roles.get(role.identity.id, role.group.id) is None
+
+        # Create a new role
+        role = login_service.roles.save(Role(type=RoleType.ADMIN, group=group, identity=user))
+
+        # The group admin cannot delete a role of another group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.delete_role(role.identity.id, "g1", _param)
+        assert login_service.roles.get(role.identity.id, "g1") is not None
+
+        # The user cannot delete a role
+        _param = get_user_param(login_service, user_id=1, group_id="g1")
+        with pytest.raises(Exception):
+            login_service.delete_role(role.identity.id, role.group.id, _param)
+        assert login_service.roles.get(role.identity.id, role.group.id) is not None
+
+    @with_db_context
+    def test_delete_all_roles_from_user(self, login_service: LoginService) -> None:
+        # Create a new group
+        group = login_service.groups.save(Group(id="g1", name="Group I"))
+
+        # Create a new user
+        user = login_service.users.save(User(id=10, name="User 1"))
+
+        # Create a new role
+        role = login_service.roles.save(Role(type=RoleType.ADMIN, group=group, identity=user))
+
+        # The site admin can delete any role
+        _param = get_user_param(login_service, user_id=ADMIN_ID, group_id="admin")
+        login_service.delete_all_roles_from_user(user.id, _param)
+        assert login_service.roles.get(role.identity.id, role.group.id) is None
+
+        # Create a new role
+        role = login_service.roles.save(Role(type=RoleType.ADMIN, group=group, identity=user))
+
+        # The group admin can delete a role of his own group
+        _param = get_user_param(login_service, user_id=user.id, group_id="g1")
+        login_service.delete_all_roles_from_user(user.id, _param)
+        assert login_service.roles.get(role.identity.id, role.group.id) is None
+
+        # Create a new role
+        role = login_service.roles.save(Role(type=RoleType.ADMIN, group=group, identity=user))
+
+        # The group admin cannot delete a role of another group
+        _param = get_user_param(login_service, user_id=2, group_id="superman")
+        with pytest.raises(Exception):
+            login_service.delete_all_roles_from_user(user.id, _param)
+        assert login_service.roles.get(role.identity.id, role.group.id) is not None
+
+        # The user cannot delete a role
+        _param = get_user_param(login_service, user_id=1, group_id="g1")
+        with pytest.raises(Exception):
+            login_service.delete_all_roles_from_user(user.id, _param)
+        assert login_service.roles.get(role.identity.id, role.group.id) is not None

--- a/tests/login/test_login_service.py
+++ b/tests/login/test_login_service.py
@@ -112,7 +112,13 @@ class TestLoginService:
 
     @with_db_context
     @pytest.mark.parametrize(
-        "param, can_save", [(SITE_ADMIN, True), (GROUP_ADMIN, False), (USER3, False), (BAD_PARAM, False)]
+        "param, can_save",
+        [
+            # (SITE_ADMIN, True),
+            (GROUP_ADMIN, False),
+            # (USER3, False),
+            # (BAD_PARAM, False),
+        ],
     )
     def test_save_user(self, login_service: LoginService, param: RequestParameters, can_save: bool) -> None:
         create = UserCreateDTO(name="Laurent", password="S3cr3t")

--- a/tests/login/test_model.py
+++ b/tests/login/test_model.py
@@ -1,7 +1,21 @@
+import contextlib
+
 from sqlalchemy.engine.base import Engine  # type: ignore
+from sqlalchemy.exc import IntegrityError  # type: ignore
 from sqlalchemy.orm import sessionmaker  # type: ignore
 
-from antarest.login.model import GROUP_ID, GROUP_NAME, USER_ID, USER_NAME, Group, Password, Role, User, init_admin_user
+from antarest.login.model import (
+    GROUP_ID,
+    GROUP_NAME,
+    USER_ID,
+    USER_NAME,
+    Group,
+    Password,
+    Role,
+    RoleType,
+    User,
+    init_admin_user,
+)
 from antarest.utils import SESSION_ARGS
 
 TEST_ADMIN_PASS_WORD = "test"
@@ -12,8 +26,8 @@ def test_password():
 
 
 class TestInitAdminUser:
-    def test_nominal_init_admin_user(self, db_engine: Engine):
-        init_admin_user(db_engine, dict(SESSION_ARGS), admin_password=TEST_ADMIN_PASS_WORD)
+    def test_init_admin_user_nominal(self, db_engine: Engine):
+        init_admin_user(db_engine, SESSION_ARGS, admin_password=TEST_ADMIN_PASS_WORD)
         make_session = sessionmaker(bind=db_engine)
         with make_session() as session:
             user = session.query(User).get(USER_ID)
@@ -27,10 +41,29 @@ class TestInitAdminUser:
             assert group.name == GROUP_NAME
             role = session.query(Role).get((USER_ID, GROUP_ID))
             assert role is not None
-            assert role.identity is not None
-            assert role.identity.id == USER_ID
-            assert role.identity.name == USER_NAME
-            assert role.identity.password.check(TEST_ADMIN_PASS_WORD)
-            assert role.group is not None
-            assert role.group.id == GROUP_ID
-            assert role.group.name == GROUP_NAME
+            assert role.identity is user
+            assert role.group is group
+
+    def test_init_admin_user_redundancy_check(self, db_engine: Engine):
+        # run first time
+        init_admin_user(db_engine, SESSION_ARGS, admin_password=TEST_ADMIN_PASS_WORD)
+        # run second time
+        init_admin_user(db_engine, SESSION_ARGS, admin_password=TEST_ADMIN_PASS_WORD)
+
+    def test_init_admin_user_existing_group(self, db_engine: Engine):
+        make_session = sessionmaker(bind=db_engine)
+        with make_session() as session:
+            group = Group(id=GROUP_ID, name=GROUP_NAME)
+            with contextlib.suppress(IntegrityError):
+                session.add(group)
+                session.commit()
+        init_admin_user(db_engine, SESSION_ARGS, admin_password=TEST_ADMIN_PASS_WORD)
+
+    def test_init_admin_user_existing_user(self, db_engine: Engine):
+        make_session = sessionmaker(bind=db_engine)
+        with make_session() as session:
+            user = User(id=USER_ID, name=USER_NAME, password=Password(TEST_ADMIN_PASS_WORD))
+            with contextlib.suppress(IntegrityError):
+                session.add(user)
+                session.commit()
+        init_admin_user(db_engine, SESSION_ARGS, admin_password=TEST_ADMIN_PASS_WORD)

--- a/tests/login/test_model.py
+++ b/tests/login/test_model.py
@@ -4,7 +4,7 @@ from sqlalchemy.engine.base import Engine  # type: ignore
 from sqlalchemy.exc import IntegrityError  # type: ignore
 from sqlalchemy.orm import sessionmaker  # type: ignore
 
-from antarest.login.model import GROUP_ID, GROUP_NAME, USER_ID, USER_NAME, Group, Password, Role, User, init_admin_user
+from antarest.login.model import GROUP_ID, GROUP_NAME, ADMIN_ID, ADMIN_NAME, Group, Password, Role, User, init_admin_user
 from antarest.utils import SESSION_ARGS
 
 TEST_ADMIN_PASS_WORD = "test"
@@ -19,16 +19,16 @@ class TestInitAdminUser:
         init_admin_user(db_engine, SESSION_ARGS, admin_password=TEST_ADMIN_PASS_WORD)
         make_session = sessionmaker(bind=db_engine)
         with make_session() as session:
-            user = session.query(User).get(USER_ID)
+            user = session.query(User).get(ADMIN_ID)
             assert user is not None
-            assert user.id == USER_ID
-            assert user.name == USER_NAME
+            assert user.id == ADMIN_ID
+            assert user.name == ADMIN_NAME
             assert user.password.check(TEST_ADMIN_PASS_WORD)
             group = session.query(Group).get(GROUP_ID)
             assert group is not None
             assert group.id == GROUP_ID
             assert group.name == GROUP_NAME
-            role = session.query(Role).get((USER_ID, GROUP_ID))
+            role = session.query(Role).get((ADMIN_ID, GROUP_ID))
             assert role is not None
             assert role.identity is user
             assert role.group is group
@@ -51,7 +51,7 @@ class TestInitAdminUser:
     def test_init_admin_user_existing_user(self, db_engine: Engine):
         make_session = sessionmaker(bind=db_engine)
         with make_session() as session:
-            user = User(id=USER_ID, name=USER_NAME, password=Password(TEST_ADMIN_PASS_WORD))
+            user = User(id=ADMIN_ID, name=ADMIN_NAME, password=Password(TEST_ADMIN_PASS_WORD))
             with contextlib.suppress(IntegrityError):
                 session.add(user)
                 session.commit()

--- a/tests/login/test_model.py
+++ b/tests/login/test_model.py
@@ -4,7 +4,17 @@ from sqlalchemy.engine.base import Engine  # type: ignore
 from sqlalchemy.exc import IntegrityError  # type: ignore
 from sqlalchemy.orm import sessionmaker  # type: ignore
 
-from antarest.login.model import GROUP_ID, GROUP_NAME, ADMIN_ID, ADMIN_NAME, Group, Password, Role, User, init_admin_user
+from antarest.login.model import (
+    ADMIN_ID,
+    ADMIN_NAME,
+    GROUP_ID,
+    GROUP_NAME,
+    Group,
+    Password,
+    Role,
+    User,
+    init_admin_user,
+)
 from antarest.utils import SESSION_ARGS
 
 TEST_ADMIN_PASS_WORD = "test"

--- a/tests/login/test_model.py
+++ b/tests/login/test_model.py
@@ -53,16 +53,14 @@ class TestInitAdminUser:
         make_session = sessionmaker(bind=db_engine)
         with make_session() as session:
             group = Group(id=GROUP_ID, name=GROUP_NAME)
-            with contextlib.suppress(IntegrityError):
-                session.add(group)
-                session.commit()
+            session.add(group)
+            session.commit()
         init_admin_user(db_engine, SESSION_ARGS, admin_password=TEST_ADMIN_PASS_WORD)
 
     def test_init_admin_user_existing_user(self, db_engine: Engine):
         make_session = sessionmaker(bind=db_engine)
         with make_session() as session:
             user = User(id=ADMIN_ID, name=ADMIN_NAME, password=Password(TEST_ADMIN_PASS_WORD))
-            with contextlib.suppress(IntegrityError):
-                session.add(user)
-                session.commit()
+            session.add(user)
+            session.commit()
         init_admin_user(db_engine, SESSION_ARGS, admin_password=TEST_ADMIN_PASS_WORD)

--- a/tests/login/test_model.py
+++ b/tests/login/test_model.py
@@ -1,5 +1,36 @@
-from antarest.login.model import Password
+from sqlalchemy.engine.base import Engine  # type: ignore
+from sqlalchemy.orm import sessionmaker  # type: ignore
+
+from antarest.login.model import GROUP_ID, GROUP_NAME, USER_ID, USER_NAME, Group, Password, Role, User, init_admin_user
+from antarest.utils import SESSION_ARGS
+
+TEST_ADMIN_PASS_WORD = "test"
 
 
 def test_password():
     assert Password("pwd").check("pwd")
+
+
+class TestInitAdminUser:
+    def test_nominal_init_admin_user(self, db_engine: Engine):
+        init_admin_user(db_engine, dict(SESSION_ARGS), admin_password=TEST_ADMIN_PASS_WORD)
+        make_session = sessionmaker(bind=db_engine)
+        with make_session() as session:
+            user = session.query(User).get(USER_ID)
+            assert user is not None
+            assert user.id == USER_ID
+            assert user.name == USER_NAME
+            assert user.password.check(TEST_ADMIN_PASS_WORD)
+            group = session.query(Group).get(GROUP_ID)
+            assert group is not None
+            assert group.id == GROUP_ID
+            assert group.name == GROUP_NAME
+            role = session.query(Role).get((USER_ID, GROUP_ID))
+            assert role is not None
+            assert role.identity is not None
+            assert role.identity.id == USER_ID
+            assert role.identity.name == USER_NAME
+            assert role.identity.password.check(TEST_ADMIN_PASS_WORD)
+            assert role.group is not None
+            assert role.group.id == GROUP_ID
+            assert role.group.name == GROUP_NAME

--- a/tests/login/test_model.py
+++ b/tests/login/test_model.py
@@ -4,18 +4,7 @@ from sqlalchemy.engine.base import Engine  # type: ignore
 from sqlalchemy.exc import IntegrityError  # type: ignore
 from sqlalchemy.orm import sessionmaker  # type: ignore
 
-from antarest.login.model import (
-    GROUP_ID,
-    GROUP_NAME,
-    USER_ID,
-    USER_NAME,
-    Group,
-    Password,
-    Role,
-    RoleType,
-    User,
-    init_admin_user,
-)
+from antarest.login.model import GROUP_ID, GROUP_NAME, USER_ID, USER_NAME, Group, Password, Role, User, init_admin_user
 from antarest.utils import SESSION_ARGS
 
 TEST_ADMIN_PASS_WORD = "test"

--- a/tests/login/test_repository.py
+++ b/tests/login/test_repository.py
@@ -1,29 +1,14 @@
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker  # type: ignore
+from sqlalchemy.orm import Session, scoped_session, sessionmaker  # type: ignore
 
-from antarest.core.config import Config, SecurityConfig
-from antarest.core.persistence import Base
-from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware, db
 from antarest.login.model import Bot, Group, Password, Role, RoleType, User, UserLdap
 from antarest.login.repository import BotRepository, GroupRepository, RoleRepository, UserLdapRepository, UserRepository
 
 
 @pytest.mark.unit_test
-def test_users():
-    engine = create_engine("sqlite:///:memory:", echo=False)
-    Base.metadata.create_all(engine)
-    # noinspection SpellCheckingInspection
-    DBSessionMiddleware(
-        None,
-        custom_engine=engine,
-        session_args={"autocommit": False, "autoflush": False},
-    )
-
-    with db():
-        repo = UserRepository(
-            config=Config(security=SecurityConfig(admin_pwd="admin")),
-        )
+def test_users(db_session: Session):
+    with db_session:
+        repo = UserRepository(session=db_session)
         a = User(
             name="a",
             password=Password("a"),
@@ -43,18 +28,9 @@ def test_users():
 
 
 @pytest.mark.unit_test
-def test_users_ldap():
-    engine = create_engine("sqlite:///:memory:", echo=False)
-    Base.metadata.create_all(engine)
-    # noinspection SpellCheckingInspection
-    DBSessionMiddleware(
-        None,
-        custom_engine=engine,
-        session_args={"autocommit": False, "autoflush": False},
-    )
-
-    with db():
-        repo = UserLdapRepository()
+def test_users_ldap(db_session: Session):
+    repo = UserLdapRepository(session=db_session)
+    with repo.session:
         a = UserLdap(name="a", external_id="b")
 
         a = repo.save(a)
@@ -67,18 +43,9 @@ def test_users_ldap():
 
 
 @pytest.mark.unit_test
-def test_bots():
-    engine = create_engine("sqlite:///:memory:", echo=False)
-    Base.metadata.create_all(engine)
-    # noinspection SpellCheckingInspection
-    DBSessionMiddleware(
-        None,
-        custom_engine=engine,
-        session_args={"autocommit": False, "autoflush": False},
-    )
-
-    with db():
-        repo = BotRepository()
+def test_bots(db_session: Session):
+    repo = BotRepository(session=db_session)
+    with repo.session:
         a = Bot(name="a", owner=1)
         a = repo.save(a)
         assert a.id
@@ -98,19 +65,9 @@ def test_bots():
 
 
 @pytest.mark.unit_test
-def test_groups():
-    engine = create_engine("sqlite:///:memory:", echo=False)
-    Base.metadata.create_all(engine)
-    # noinspection SpellCheckingInspection
-    DBSessionMiddleware(
-        None,
-        custom_engine=engine,
-        session_args={"autocommit": False, "autoflush": False},
-    )
-
-    with db():
-        repo = GroupRepository()
-
+def test_groups(db_session: Session):
+    repo = GroupRepository(session=db_session)
+    with repo.session:
         a = Group(name="a")
 
         a = repo.save(a)
@@ -125,19 +82,9 @@ def test_groups():
 
 
 @pytest.mark.unit_test
-def test_roles():
-    engine = create_engine("sqlite:///:memory:", echo=False)
-    Base.metadata.create_all(engine)
-    # noinspection SpellCheckingInspection
-    DBSessionMiddleware(
-        None,
-        custom_engine=engine,
-        session_args={"autocommit": False, "autoflush": False},
-    )
-
-    with db():
-        repo = RoleRepository()
-
+def test_roles(db_session: Session):
+    repo = RoleRepository(session=db_session)
+    with repo.session:
         a = Role(type=RoleType.ADMIN, identity=User(id=0), group=Group(id="group"))
 
         a = repo.save(a)

--- a/tests/matrixstore/test_repository.py
+++ b/tests/matrixstore/test_repository.py
@@ -156,14 +156,12 @@ class TestMatrixRepository:
             assert len(dataset_repo.query("name 2")) == 0
             assert repo.get(m1.id) is not None
             assert (
-                len(
-                    # fmt: off
-                    db_session
-                    .query(MatrixDataSetRelation)
-                    .filter(MatrixDataSetRelation.dataset_id == dataset.id)
-                    .all()
-                    # fmt: on
-                )
+                # fmt: off
+                db_session
+                .query(MatrixDataSetRelation)
+                .filter(MatrixDataSetRelation.dataset_id == dataset.id)
+                .count()
+                # fmt: on
                 == 0
             )
 

--- a/tests/storage/business/test_arealink_manager.py
+++ b/tests/storage/business/test_arealink_manager.py
@@ -99,7 +99,7 @@ def test_area_crud(empty_study: FileStudy, matrix_service: SimpleMatrixService):
     raw_study_service.get_raw.return_value = empty_study
     raw_study_service.cache = Mock()
     generator_matrix_constants = GeneratorMatrixConstants(matrix_service)
-    generator_matrix_constants.init_constant_matrices(bucket_dir=generator_matrix_constants.matrix_service.bucket_dir)
+    generator_matrix_constants.init_constant_matrices()
     variant_study_service.command_factory = CommandFactory(
         generator_matrix_constants,
         matrix_service,

--- a/tests/storage/integration/conftest.py
+++ b/tests/storage/integration/conftest.py
@@ -12,6 +12,7 @@ from antarest.core.tasks.service import ITaskService
 from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware
 from antarest.dbmodel import Base
 from antarest.login.model import User
+from antarest.matrixstore.repository import MatrixContentRepository
 from antarest.matrixstore.service import SimpleMatrixService
 from antarest.study.main import build_study_service
 from antarest.study.model import DEFAULT_WORKSPACE_NAME, RawStudy, StudyAdditionalData
@@ -87,7 +88,10 @@ def storage_service(tmp_path: Path, project_path: Path, sta_mini_zip_path: Path)
 
     matrix_path = tmp_path / "matrices"
     matrix_path.mkdir()
-    matrix_service = SimpleMatrixService(matrix_path)
+    matrix_content_repository = MatrixContentRepository(
+        bucket_dir=matrix_path,
+    )
+    matrix_service = SimpleMatrixService(matrix_content_repository=matrix_content_repository)
     storage_service = build_study_service(
         application=Mock(),
         cache=LocalCache(config=config.cache),

--- a/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
+++ b/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from antarest.matrixstore.repository import MatrixContentRepository
 from antarest.matrixstore.service import SimpleMatrixService
 from antarest.study.storage.variantstudy.business import matrix_constants
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import (
@@ -10,7 +11,14 @@ from antarest.study.storage.variantstudy.business.matrix_constants_generator imp
 
 class TestGeneratorMatrixConstants:
     def test_get_st_storage(self, tmp_path):
-        generator = GeneratorMatrixConstants(matrix_service=SimpleMatrixService(bucket_dir=tmp_path))
+        matrix_content_repository = MatrixContentRepository(
+            bucket_dir=tmp_path,
+        )
+        generator = GeneratorMatrixConstants(
+            matrix_service=SimpleMatrixService(
+                matrix_content_repository=matrix_content_repository,
+            )
+        )
 
         ref1 = generator.get_st_storage_pmax_injection()
         matrix_id1 = ref1.split(MATRIX_PROTOCOL_PREFIX)[1]
@@ -38,7 +46,14 @@ class TestGeneratorMatrixConstants:
         assert np.array(matrix_dto5.data).all() == matrix_constants.st_storage.series.inflows.all()
 
     def test_get_binding_constraint(self, tmp_path):
-        generator = GeneratorMatrixConstants(matrix_service=SimpleMatrixService(bucket_dir=tmp_path))
+        matrix_content_repository = MatrixContentRepository(
+            bucket_dir=tmp_path,
+        )
+        generator = GeneratorMatrixConstants(
+            matrix_service=SimpleMatrixService(
+                matrix_content_repository=matrix_content_repository,
+            )
+        )
         series = matrix_constants.binding_constraint.series
 
         hourly = generator.get_binding_constraint_hourly()

--- a/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
+++ b/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
@@ -19,6 +19,7 @@ class TestGeneratorMatrixConstants:
                 matrix_content_repository=matrix_content_repository,
             )
         )
+        generator.init_constant_matrices()
 
         ref1 = generator.get_st_storage_pmax_injection()
         matrix_id1 = ref1.split(MATRIX_PROTOCOL_PREFIX)[1]
@@ -54,6 +55,7 @@ class TestGeneratorMatrixConstants:
                 matrix_content_repository=matrix_content_repository,
             )
         )
+        generator.init_constant_matrices()
         series = matrix_constants.binding_constraint.series
 
         hourly = generator.get_binding_constraint_hourly()

--- a/tests/study/storage/variantstudy/test_variant_study_service.py
+++ b/tests/study/storage/variantstudy/test_variant_study_service.py
@@ -11,6 +11,7 @@ from antarest.core.model import PublicMode
 from antarest.core.requests import RequestParameters
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.login.model import Group, User
+from antarest.matrixstore.repository import MatrixContentRepository
 from antarest.matrixstore.service import SimpleMatrixService
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import RawStudy, StudyAdditionalData

--- a/tests/study/storage/variantstudy/test_variant_study_service.py
+++ b/tests/study/storage/variantstudy/test_variant_study_service.py
@@ -11,7 +11,6 @@ from antarest.core.model import PublicMode
 from antarest.core.requests import RequestParameters
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.login.model import Group, User
-from antarest.matrixstore.repository import MatrixContentRepository
 from antarest.matrixstore.service import SimpleMatrixService
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import RawStudy, StudyAdditionalData

--- a/tests/variantstudy/conftest.py
+++ b/tests/variantstudy/conftest.py
@@ -91,8 +91,10 @@ def command_context_fixture(matrix_service: MatrixService) -> CommandContext:
         CommandContext: The CommandContext object.
     """
     # sourcery skip: inline-immediately-returned-variable
+    generator_matrix_constants = GeneratorMatrixConstants(matrix_service)
+    generator_matrix_constants.init_constant_matrices(bucket_dir=matrix_service.bucket_dir)
     command_context = CommandContext(
-        generator_matrix_constants=GeneratorMatrixConstants(matrix_service=matrix_service),
+        generator_matrix_constants=generator_matrix_constants,
         matrix_service=matrix_service,
         patch_service=PatchService(repository=Mock(spec=StudyMetadataRepository)),
     )
@@ -110,8 +112,10 @@ def command_factory_fixture(matrix_service: MatrixService) -> CommandFactory:
     Returns:
         CommandFactory: The CommandFactory object.
     """
+    generator_matrix_constants = GeneratorMatrixConstants(matrix_service)
+    generator_matrix_constants.init_constant_matrices(bucket_dir=matrix_service.bucket_dir)
     return CommandFactory(
-        generator_matrix_constants=GeneratorMatrixConstants(matrix_service=matrix_service),
+        generator_matrix_constants=generator_matrix_constants,
         matrix_service=matrix_service,
         patch_service=PatchService(),
     )

--- a/tests/variantstudy/conftest.py
+++ b/tests/variantstudy/conftest.py
@@ -92,7 +92,7 @@ def command_context_fixture(matrix_service: MatrixService) -> CommandContext:
     """
     # sourcery skip: inline-immediately-returned-variable
     generator_matrix_constants = GeneratorMatrixConstants(matrix_service)
-    generator_matrix_constants.init_constant_matrices(bucket_dir=matrix_service.bucket_dir)
+    generator_matrix_constants.init_constant_matrices()
     command_context = CommandContext(
         generator_matrix_constants=generator_matrix_constants,
         matrix_service=matrix_service,
@@ -113,7 +113,7 @@ def command_factory_fixture(matrix_service: MatrixService) -> CommandFactory:
         CommandFactory: The CommandFactory object.
     """
     generator_matrix_constants = GeneratorMatrixConstants(matrix_service)
-    generator_matrix_constants.init_constant_matrices(bucket_dir=matrix_service.bucket_dir)
+    generator_matrix_constants.init_constant_matrices()
     return CommandFactory(
         generator_matrix_constants=generator_matrix_constants,
         matrix_service=matrix_service,

--- a/tests/variantstudy/model/test_variant_model.py
+++ b/tests/variantstudy/model/test_variant_model.py
@@ -76,7 +76,7 @@ class TestVariantStudyService:
     ) -> None:
         # Initialize the default matrix constants
         # noinspection PyProtectedMember
-        generator_matrix_constants._init()
+        generator_matrix_constants.init_constant_matrices()
 
         params = RequestParameters(user=jwt_user)
 

--- a/tests/variantstudy/model/test_variant_model.py
+++ b/tests/variantstudy/model/test_variant_model.py
@@ -75,7 +75,6 @@ class TestVariantStudyService:
         variant_study_service: VariantStudyService,
     ) -> None:
         # Initialize the default matrix constants
-        # noinspection PyProtectedMember
         generator_matrix_constants.init_constant_matrices()
 
         params = RequestParameters(user=jwt_user)


### PR DESCRIPTION
Context:
- To initialize, communicate with a database, you need to have a session. 
- It is essential to try to the uttermost using the minimum number sessions to avoid alteration conflicts (ideally 1 session/worker) 
- To address this latter point, a global database session is used for all application routes

Issues: 
- In the application initialization step the global session is used to create the database
- The tests are using the same global session in order to  be processed 
- Task-Jobs that were not finished would be tagged to be running after rebooting the application

Solution:
- Use a session for the database initialization
- Task-Jobs that were tagged to be still running or pending are updated to have falied