### PR TITLE
perf(db): improve performance by using joins instead of N+1 queries

### DIFF
--- a/antarest/launcher/service.py
+++ b/antarest/launcher/service.py
@@ -304,9 +304,14 @@ class LauncherService:
 
         orphan_visibility_threshold = datetime.utcnow() - timedelta(days=ORPHAN_JOBS_VISIBILITY_THRESHOLD)
         allowed_job_results = []
+
         studies = {
-            study.id: study for study in self.study_service.repository.get_list([job.study_id for job in job_results])
+            study.id: study
+            for study in self.study_service.repository.get_all(
+                studies_ids=[job_result.study_id for job_result in job_results]
+            )
         }
+
         for job_result in job_results:
             if job_result.study_id in studies:
                 if assert_permission(

--- a/antarest/launcher/service.py
+++ b/antarest/launcher/service.py
@@ -305,12 +305,8 @@ class LauncherService:
         orphan_visibility_threshold = datetime.utcnow() - timedelta(days=ORPHAN_JOBS_VISIBILITY_THRESHOLD)
         allowed_job_results = []
 
-        studies = {
-            study.id: study
-            for study in self.study_service.repository.get_all(
-                studies_ids=[job_result.study_id for job_result in job_results]
-            )
-        }
+        studies_ids = [job_result.study_id for job_result in job_results]
+        studies = {study.id: study for study in self.study_service.repository.get_all(studies_ids=studies_ids)}
 
         for job_result in job_results:
             if job_result.study_id in studies:

--- a/antarest/study/repository.py
+++ b/antarest/study/repository.py
@@ -114,7 +114,8 @@ class StudyMetadataRepository:
         # efficiently (see: `utils.get_study_information`)
         entity = with_polymorphic(Study, "*")
         # noinspection PyTypeChecker
-        q = self.session.query(entity).filter(RawStudy.missing.is_(None))
+        q = self.session.query(entity)
+        # q = q.filter(RawStudy.missing.is_(None))
         q = q.options(joinedload(entity.owner))
         q = q.options(joinedload(entity.groups))
         q = q.options(joinedload(entity.additional_data))
@@ -126,8 +127,7 @@ class StudyMetadataRepository:
             q = q.filter(entity.archived == archived)
         if managed is not None:
             if managed:
-                smt = or_(entity.type == "variantstudy", RawStudy.workspace == DEFAULT_WORKSPACE_NAME)
-                q.filter(smt)
+                q = q.filter(or_(entity.type == "variantstudy", RawStudy.workspace == DEFAULT_WORKSPACE_NAME))
             else:
                 q = q.filter(entity.type == "rawstudy")
                 q = q.filter(RawStudy.workspace != DEFAULT_WORKSPACE_NAME)

--- a/antarest/study/repository.py
+++ b/antarest/study/repository.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import typing as t
 
-from sqlalchemy import or_, and_  # type: ignore
+from sqlalchemy import and_, or_  # type: ignore
 from sqlalchemy.orm import Session, joinedload, with_polymorphic  # type: ignore
 
 from antarest.core.interfaces.cache import CacheConstants, ICache
@@ -107,15 +107,17 @@ class StudyMetadataRepository:
         managed: t.Optional[bool] = None,
         studies_ids: t.Optional[t.List[str]] = None,
         study_type: t.Optional[str] = None,
+        raw_study_missing: bool = True,
     ) -> t.List[Study]:
         # When we fetch a study, we also need to fetch the associated owner and groups
         # to check the permissions of the current user efficiently.
         # We also need to fetch the additional data to display the study information
         # efficiently (see: `utils.get_study_information`)
         entity = with_polymorphic(Study, "*")
-        # noinspection PyTypeChecker
+
         q = self.session.query(entity)
-        # q = q.filter(RawStudy.missing.is_(None))
+        if raw_study_missing:
+            q = q.filter(RawStudy.missing.is_(None))
         q = q.options(joinedload(entity.owner))
         q = q.options(joinedload(entity.groups))
         q = q.options(joinedload(entity.additional_data))

--- a/antarest/study/repository.py
+++ b/antarest/study/repository.py
@@ -153,11 +153,6 @@ class StudyMetadataRepository:
         session.commit()
         self._remove_study_from_cache_listing(id)
 
-    def multi_delete(self, ids: t.List[str]) -> None:
-        logger.debug(f"Deleting study {ids}")
-        self.session.query(Study).filter(Study.id.in_(ids)).delete(synchronize_session="fetch")
-        self.session.commit()
-
     def _remove_study_from_cache_listing(self, study_id: str) -> None:
         try:
             cached_studies = self.cache_service.get(CacheConstants.STUDY_LISTING.value)

--- a/antarest/study/repository.py
+++ b/antarest/study/repository.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import typing as t
 
-from sqlalchemy import or_  # type: ignore
+from sqlalchemy import or_, and_  # type: ignore
 from sqlalchemy.orm import Session, joinedload, with_polymorphic  # type: ignore
 
 from antarest.core.interfaces.cache import CacheConstants, ICache
@@ -126,10 +126,11 @@ class StudyMetadataRepository:
             q = q.filter(entity.archived == archived)
         if managed is not None:
             if managed:
-                q = q.filter(or_(entity.type != "rawstudy", entity.workspace == DEFAULT_WORKSPACE_NAME))
+                smt = or_(entity.type == "variantstudy", RawStudy.workspace == DEFAULT_WORKSPACE_NAME)
+                q.filter(smt)
             else:
                 q = q.filter(entity.type == "rawstudy")
-                q = q.filter(entity.workspace != DEFAULT_WORKSPACE_NAME)
+                q = q.filter(RawStudy.workspace != DEFAULT_WORKSPACE_NAME)
         if studies_ids is not None:
             q = q.filter(entity.id.in_(studies_ids))
         if study_type is not None:

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -452,11 +452,12 @@ class StudyService:
             for k in cached_studies:
                 studies[k] = StudyMetadataDTO.parse_obj(cached_studies[k])
         else:
-            logger.info("Retrieving all studies")
-            if not managed:
-                all_studies = self.repository.get_all()
-            else:
+            if managed:
+                logger.info("Retrieving all managed studies")
                 all_studies = self.repository.get_all(managed=True)
+            else:
+                logger.info("Retrieving all studies")
+                all_studies = self.repository.get_all()
             logger.info("Studies retrieved")
             for study in all_studies:
                 study_metadata = self._try_get_studies_information(study)

--- a/antarest/study/storage/auto_archive_service.py
+++ b/antarest/study/storage/auto_archive_service.py
@@ -28,7 +28,7 @@ class AutoArchiveService(IService):
     def _try_archive_studies(self) -> None:
         old_date = datetime.datetime.utcnow() - datetime.timedelta(days=self.config.storage.auto_archive_threshold_days)
         with db():
-            studies: List[Study] = self.study_service.repository.get_all(managed=True)
+            studies: List[Study] = self.study_service.repository.get_all(managed=True, raw_study_missing=False)
             # list of study id and boolean indicating if it's a raw study (True) or a variant (False)
             study_ids_to_archive = [
                 (study.id, isinstance(study, RawStudy))

--- a/antarest/study/storage/auto_archive_service.py
+++ b/antarest/study/storage/auto_archive_service.py
@@ -28,7 +28,7 @@ class AutoArchiveService(IService):
     def _try_archive_studies(self) -> None:
         old_date = datetime.datetime.utcnow() - datetime.timedelta(days=self.config.storage.auto_archive_threshold_days)
         with db():
-            studies: List[Study] = self.study_service.repository.get_all(managed=True, raw_study_missing=False)
+            studies: List[Study] = self.study_service.repository.get_all(managed=True, exists=False)
             # list of study id and boolean indicating if it's a raw study (True) or a variant (False)
             study_ids_to_archive = [
                 (study.id, isinstance(study, RawStudy))

--- a/antarest/study/storage/auto_archive_service.py
+++ b/antarest/study/storage/auto_archive_service.py
@@ -26,16 +26,14 @@ class AutoArchiveService(IService):
         self.max_parallel = self.config.storage.auto_archive_max_parallel
 
     def _try_archive_studies(self) -> None:
-        now = datetime.datetime.utcnow()
-        study_ids_to_archive: List[Tuple[str, bool]] = []
+        old_date = datetime.datetime.utcnow() - datetime.timedelta(days=self.config.storage.auto_archive_threshold_days)
         with db():
             studies: List[Study] = self.study_service.repository.get_all(managed=True)
             # list of study id and boolean indicating if it's a raw study (True) or a variant (False)
             study_ids_to_archive = [
                 (study.id, isinstance(study, RawStudy))
                 for study in studies
-                if (study.last_access or study.updated_at)
-                < now - datetime.timedelta(days=self.config.storage.auto_archive_threshold_days)
+                if (study.last_access or study.updated_at) < old_date
                 and (isinstance(study, VariantStudy) or not study.archived)
             ]
         for study_id, is_raw_study in study_ids_to_archive[0 : self.max_parallel]:

--- a/antarest/study/storage/auto_archive_service.py
+++ b/antarest/study/storage/auto_archive_service.py
@@ -29,13 +29,12 @@ class AutoArchiveService(IService):
         now = datetime.datetime.utcnow()
         study_ids_to_archive: List[Tuple[str, bool]] = []
         with db():
-            studies: List[Study] = self.study_service.repository.get_all()
+            studies: List[Study] = self.study_service.repository.get_all(managed=True)
             # list of study id and boolean indicating if it's a raw study (True) or a variant (False)
             study_ids_to_archive = [
                 (study.id, isinstance(study, RawStudy))
                 for study in studies
-                if is_managed(study)
-                and (study.last_access or study.updated_at)
+                if (study.last_access or study.updated_at)
                 < now - datetime.timedelta(days=self.config.storage.auto_archive_threshold_days)
                 and (isinstance(study, VariantStudy) or not study.archived)
             ]

--- a/tests/launcher/test_service.py
+++ b/tests/launcher/test_service.py
@@ -207,9 +207,8 @@ class TestLauncherService:
             == fake_execution_result
         )
 
-    @with_db_context
     @pytest.mark.unit_test
-    def test_service_get_jobs_from_database(self) -> None:
+    def test_service_get_jobs_from_database(self, db_session) -> None:
         launcher_mock = Mock()
         now = datetime.utcnow()
         identity_instance = Identity(id=1)
@@ -263,8 +262,7 @@ class TestLauncherService:
         repository.get_all.return_value = all_faked_execution_results
 
         study_service = Mock(spec=StudyService)
-        study_service.repository = StudyMetadataRepository(cache_service=Mock(spec=ICache))
-        db_session = study_service.repository.session
+        study_service.repository = StudyMetadataRepository(cache_service=Mock(spec=ICache), session=db_session)
         for elm in fake_execution_result:
             db_session.add(elm)
         for elm in all_faked_execution_results:

--- a/tests/launcher/test_service.py
+++ b/tests/launcher/test_service.py
@@ -39,11 +39,10 @@ from antarest.launcher.service import (
     LauncherService,
 )
 from antarest.login.auth import Auth
-from antarest.login.model import Identity, User
+from antarest.login.model import Identity
 from antarest.study.model import OwnerInfo, PublicMode, Study, StudyMetadataDTO
 from antarest.study.repository import StudyMetadataRepository
 from antarest.study.service import StudyService
-from tests.helpers import with_db_context
 
 
 class TestLauncherService:
@@ -263,10 +262,8 @@ class TestLauncherService:
 
         study_service = Mock(spec=StudyService)
         study_service.repository = StudyMetadataRepository(cache_service=Mock(spec=ICache), session=db_session)
-        for elm in fake_execution_result:
-            db_session.add(elm)
-        for elm in all_faked_execution_results:
-            db_session.add(elm)
+        db_session.add_all(fake_execution_result)
+        db_session.add_all(all_faked_execution_results)
         db_session.commit()
 
         launcher_service = LauncherService(

--- a/tests/storage/business/test_autoarchive_service.py
+++ b/tests/storage/business/test_autoarchive_service.py
@@ -29,41 +29,35 @@ def test_auto_archival(tmp_path: Path):
 
     # Add some studies in the database
     db_session = repository.session
-    db_session.add(
-        RawStudy(
-            id="a",
-            workspace="not default",
-            updated_at=now - datetime.timedelta(days=61),
-        )
-    )
-    db_session.add(
-        RawStudy(
-            id="b",
-            workspace=DEFAULT_WORKSPACE_NAME,
-            updated_at=now - datetime.timedelta(days=59),
-        )
-    )
-    db_session.add(
-        RawStudy(
-            id="c",
-            workspace=DEFAULT_WORKSPACE_NAME,
-            updated_at=now - datetime.timedelta(days=61),
-            archived=True,
-        )
-    )
-    db_session.add(
-        RawStudy(
-            id="d",
-            workspace=DEFAULT_WORKSPACE_NAME,
-            updated_at=now - datetime.timedelta(days=61),
-            archived=False,
-        )
-    )
-    db_session.add(
-        VariantStudy(
-            id="e",
-            updated_at=now - datetime.timedelta(days=61),
-        )
+    db_session.add_all(
+        [
+            RawStudy(
+                id="a",
+                workspace="not default",
+                updated_at=now - datetime.timedelta(days=61),
+            ),
+            RawStudy(
+                id="b",
+                workspace=DEFAULT_WORKSPACE_NAME,
+                updated_at=now - datetime.timedelta(days=59),
+            ),
+            RawStudy(
+                id="c",
+                workspace=DEFAULT_WORKSPACE_NAME,
+                updated_at=now - datetime.timedelta(days=61),
+                archived=True,
+            ),
+            RawStudy(
+                id="d",
+                workspace=DEFAULT_WORKSPACE_NAME,
+                updated_at=now - datetime.timedelta(days=61),
+                archived=False,
+            ),
+            VariantStudy(
+                id="e",
+                updated_at=now - datetime.timedelta(days=61),
+            ),
+        ]
     )
     db_session.commit()
 

--- a/tests/storage/business/test_autoarchive_service.py
+++ b/tests/storage/business/test_autoarchive_service.py
@@ -29,30 +29,64 @@ def test_auto_archival(tmp_path: Path):
 
     # Add some studies in the database
     db_session = repository.session
-    db_session.add(RawStudy(id="a", workspace="test", updated_at=now - datetime.timedelta(days=61)))
-    db_session.add(RawStudy(id="b", workspace="test", updated_at=now - datetime.timedelta(days=59)))
-    db_session.add(RawStudy(id="c", workspace="test", updated_at=now - datetime.timedelta(days=61), archived=True))
-    db_session.add(RawStudy(id="d", workspace="test", updated_at=now - datetime.timedelta(days=61), archived=False))
-    db_session.add(VariantStudy(id="e", updated_at=now - datetime.timedelta(days=61)))
+    db_session.add(
+        RawStudy(
+            id="a",
+            workspace="not default",
+            updated_at=now - datetime.timedelta(days=61),
+        )
+    )
+    db_session.add(
+        RawStudy(
+            id="b",
+            workspace=DEFAULT_WORKSPACE_NAME,
+            updated_at=now - datetime.timedelta(days=59),
+        )
+    )
+    db_session.add(
+        RawStudy(
+            id="c",
+            workspace=DEFAULT_WORKSPACE_NAME,
+            updated_at=now - datetime.timedelta(days=61),
+            archived=True,
+        )
+    )
+    db_session.add(
+        RawStudy(
+            id="d",
+            workspace=DEFAULT_WORKSPACE_NAME,
+            updated_at=now - datetime.timedelta(days=61),
+            archived=False,
+        )
+    )
+    db_session.add(
+        VariantStudy(
+            id="e",
+            updated_at=now - datetime.timedelta(days=61),
+        )
+    )
     db_session.commit()
 
-    auto_archive_service.study_service.repository = repository
+    study_service = auto_archive_service.study_service
+    study_service.repository = repository
 
-    auto_archive_service.study_service.storage_service = Mock()
-    auto_archive_service.study_service.storage_service.variant_study_service = Mock()
-    auto_archive_service.study_service.archive.side_effect = TaskAlreadyRunning
-    auto_archive_service.study_service.get_study.return_value = VariantStudy(
-        id="e", updated_at=now - datetime.timedelta(days=61)
-    )
+    study_service.storage_service = Mock()
+    study_service.storage_service.variant_study_service = Mock()
+    study_service.archive.side_effect = TaskAlreadyRunning
+    study_service.get_study = repository.get
 
     auto_archive_service._try_archive_studies()
 
-    auto_archive_service.study_service.archive.assert_called_once_with(
-        "d", params=RequestParameters(DEFAULT_ADMIN_USER)
-    )
-    auto_archive_service.study_service.storage_service.variant_study_service.clear_snapshot.assert_called_once_with(
-        VariantStudy(id="e", updated_at=now - datetime.timedelta(days=61))
-    )
-    auto_archive_service.study_service.archive_outputs.assert_called_once_with(
-        "e", params=RequestParameters(DEFAULT_ADMIN_USER)
-    )
+    # Check that the raw study "d" was about to be archived but failed because the task was already running
+    study_service.archive.assert_called_once_with("d", params=RequestParameters(DEFAULT_ADMIN_USER))
+
+    # Check that the snapshot of the variant study "e" is cleared
+    study_service.storage_service.variant_study_service.clear_snapshot.assert_called_once()
+    calls = study_service.storage_service.variant_study_service.clear_snapshot.call_args_list
+    assert len(calls) == 1
+    clear_snapshot_call = calls[0]
+    actual_study = clear_snapshot_call[0][0]
+    assert actual_study.id == "e"
+
+    # Check that the variant outputs are deleted for the variant study "e"
+    study_service.archive_outputs.assert_called_once_with("e", params=RequestParameters(DEFAULT_ADMIN_USER))

--- a/tests/storage/business/test_autoarchive_service.py
+++ b/tests/storage/business/test_autoarchive_service.py
@@ -4,9 +4,12 @@ from unittest.mock import Mock
 
 from antarest.core.config import Config, StorageConfig, WorkspaceConfig
 from antarest.core.exceptions import TaskAlreadyRunning
+from antarest.core.interfaces.cache import ICache
 from antarest.core.jwt import DEFAULT_ADMIN_USER
 from antarest.core.requests import RequestParameters
 from antarest.study.model import DEFAULT_WORKSPACE_NAME, RawStudy
+from antarest.study.repository import StudyMetadataRepository
+from antarest.study.service import StudyService
 from antarest.study.storage.auto_archive_service import AutoArchiveService
 from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
 from tests.helpers import with_db_context
@@ -16,41 +19,28 @@ from tests.helpers import with_db_context
 def test_auto_archival(tmp_path: Path):
     workspace_path = tmp_path / "workspace_test"
     auto_archive_service = AutoArchiveService(
-        Mock(),
+        Mock(spec=StudyService),
         Config(storage=StorageConfig(workspaces={"test": WorkspaceConfig(path=workspace_path)})),
     )
 
     now = datetime.datetime.now()
 
-    auto_archive_service.study_service.repository = Mock()
-    auto_archive_service.study_service.repository.get_all.return_value = [
-        RawStudy(
-            id="a",
-            workspace="not default",
-            updated_at=now - datetime.timedelta(days=61),
-        ),
-        RawStudy(
-            id="b",
-            workspace=DEFAULT_WORKSPACE_NAME,
-            updated_at=now - datetime.timedelta(days=59),
-        ),
-        RawStudy(
-            id="c",
-            workspace=DEFAULT_WORKSPACE_NAME,
-            updated_at=now - datetime.timedelta(days=61),
-            archived=True,
-        ),
-        RawStudy(
-            id="d",
-            workspace=DEFAULT_WORKSPACE_NAME,
-            updated_at=now - datetime.timedelta(days=61),
-            archived=False,
-        ),
-        VariantStudy(id="e", updated_at=now - datetime.timedelta(days=61)),
-    ]
+    repository = StudyMetadataRepository(cache_service=Mock(spec=ICache))
+
+    # Add some studies in the database
+    db_session = repository.session
+    db_session.add(RawStudy(id="a", workspace="test", updated_at=now - datetime.timedelta(days=61)))
+    db_session.add(RawStudy(id="b", workspace="test", updated_at=now - datetime.timedelta(days=59)))
+    db_session.add(RawStudy(id="c", workspace="test", updated_at=now - datetime.timedelta(days=61), archived=True))
+    db_session.add(RawStudy(id="d", workspace="test", updated_at=now - datetime.timedelta(days=61), archived=False))
+    db_session.add(VariantStudy(id="e", updated_at=now - datetime.timedelta(days=61)))
+    db_session.commit()
+
+    auto_archive_service.study_service.repository = repository
+
     auto_archive_service.study_service.storage_service = Mock()
     auto_archive_service.study_service.storage_service.variant_study_service = Mock()
-    auto_archive_service.study_service.archive.return_value = TaskAlreadyRunning
+    auto_archive_service.study_service.archive.side_effect = TaskAlreadyRunning
     auto_archive_service.study_service.get_study.return_value = VariantStudy(
         id="e", updated_at=now - datetime.timedelta(days=61)
     )

--- a/tests/storage/test_service.py
+++ b/tests/storage/test_service.py
@@ -160,9 +160,7 @@ def test_study_listing(db_session: Session) -> None:
     )
 
     # Add some studies in the database
-    db_session.add(a)
-    db_session.add(b)
-    db_session.add(c)
+    db_session.add_all([a, b, c])
     db_session.commit()
 
     raw_study_service = Mock(spec=RawStudyService)

--- a/tests/storage/test_service.py
+++ b/tests/storage/test_service.py
@@ -116,7 +116,7 @@ def study_to_dto(study: Study) -> StudyMetadataDTO:
     )
 
 
-# noinspection PyArgumentList
+@with_db_context
 @pytest.mark.unit_test
 def test_study_listing() -> None:
     bob = User(id=2, name="bob")
@@ -160,8 +160,14 @@ def test_study_listing() -> None:
     )
 
     # Mock
-    repository = Mock()
-    repository.get_all.return_value = [a, b, c]
+    repository = StudyMetadataRepository(cache_service=Mock(spec=ICache))
+
+    # Add some studies in the database
+    db_session = repository.session
+    db_session.add(a)
+    db_session.add(b)
+    db_session.add(c)
+    db_session.commit()
 
     raw_study_service = Mock(spec=RawStudyService)
     raw_study_service.get_study_information.side_effect = study_to_dto

--- a/tests/storage/test_service.py
+++ b/tests/storage/test_service.py
@@ -67,6 +67,7 @@ from antarest.study.storage.variantstudy.model.command_context import CommandCon
 from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 from antarest.worker.archive_worker import ArchiveTaskArgs
+from tests.db_statement_recorder import DBStatementRecorder
 from tests.helpers import with_db_context
 
 
@@ -116,9 +117,8 @@ def study_to_dto(study: Study) -> StudyMetadataDTO:
     )
 
 
-@with_db_context
 @pytest.mark.unit_test
-def test_study_listing() -> None:
+def test_study_listing(db_session: Session) -> None:
     bob = User(id=2, name="bob")
     alice = User(id=3, name="alice")
 
@@ -159,11 +159,7 @@ def test_study_listing() -> None:
         additional_data=StudyAdditionalData(),
     )
 
-    # Mock
-    repository = StudyMetadataRepository(cache_service=Mock(spec=ICache))
-
     # Add some studies in the database
-    db_session = repository.session
     db_session.add(a)
     db_session.add(b)
     db_session.add(c)
@@ -176,40 +172,59 @@ def test_study_listing() -> None:
     cache.get.return_value = None
 
     config = Config(storage=StorageConfig(workspaces={DEFAULT_WORKSPACE_NAME: WorkspaceConfig()}))
+    repository = StudyMetadataRepository(cache_service=Mock(spec=ICache), session=db_session)
     service = build_study_service(raw_study_service, repository, config, cache_service=cache)
 
-    studies = service.get_studies_information(
-        managed=False,
-        name=None,
-        workspace=None,
-        folder=None,
-        params=RequestParameters(user=JWTUser(id=2, impersonator=2, type="users")),
-    )
+    # use the db recorder to check that:
+    # 1- retrieving studies information requires only 1 query
+    # 2- having an exact total of queries equals to 1
+    with DBStatementRecorder(db_session.bind) as db_recorder:
+        studies = service.get_studies_information(
+            managed=False,
+            name=None,
+            workspace=None,
+            folder=None,
+            params=RequestParameters(user=JWTUser(id=2, impersonator=2, type="users")),
+        )
+    assert len(db_recorder.sql_statements) == 1, str(db_recorder)
 
+    # verify that we get the expected studies information
     expected_result = {e.id: e for e in map(lambda x: study_to_dto(x), [a, c])}
     assert expected_result == studies
     cache.get.return_value = {e.id: e for e in map(lambda x: study_to_dto(x), [a, b, c])}
 
-    studies = service.get_studies_information(
-        managed=False,
-        name=None,
-        workspace=None,
-        folder=None,
-        params=RequestParameters(user=JWTUser(id=2, impersonator=2, type="users")),
-    )
-
-    assert expected_result == studies
+    # check that:
+    # 1- retrieving studies information requires no query at all (cache is used)
+    # 2- the `put` method of `cache` was used once
+    with DBStatementRecorder(db_session.bind) as db_recorder:
+        studies = service.get_studies_information(
+            managed=False,
+            name=None,
+            workspace=None,
+            folder=None,
+            params=RequestParameters(user=JWTUser(id=2, impersonator=2, type="users")),
+        )
+    assert len(db_recorder.sql_statements) == 0, str(db_recorder)
     cache.put.assert_called_once()
 
-    cache.get.return_value = None
-    studies = service.get_studies_information(
-        managed=True,
-        name=None,
-        workspace=None,
-        folder=None,
-        params=RequestParameters(user=JWTUser(id=2, impersonator=2, type="users")),
-    )
+    # verify that we get the expected studies information
+    assert expected_result == studies
 
+    cache.get.return_value = None
+    # use the db recorder to check that:
+    # 1- retrieving studies information requires only 1 query (cache reset to None)
+    # 2- having an exact total of queries equals to 1
+    with DBStatementRecorder(db_session.bind) as db_recorder:
+        studies = service.get_studies_information(
+            managed=True,
+            name=None,
+            workspace=None,
+            folder=None,
+            params=RequestParameters(user=JWTUser(id=2, impersonator=2, type="users")),
+        )
+    assert len(db_recorder.sql_statements) == 1, str(db_recorder)
+
+    # verify that we get the expected studies information
     expected_result = {e.id: e for e in map(lambda x: study_to_dto(x), [a])}
     assert expected_result == studies
 

--- a/tests/study/test_repository.py
+++ b/tests/study/test_repository.py
@@ -50,14 +50,7 @@ def test_repository_get_all(
     study_7 = RawStudy(id=7, missing=None, workspace=test_workspace)
     study_8 = RawStudy(id=8, missing=None, workspace=DEFAULT_WORKSPACE_NAME)
 
-    db_session.add(study_1)
-    db_session.add(study_2)
-    db_session.add(study_3)
-    db_session.add(study_4)
-    db_session.add(study_5)
-    db_session.add(study_6)
-    db_session.add(study_7)
-    db_session.add(study_8)
+    db_session.add_all([study_1, study_2, study_3, study_4, study_5, study_6, study_7, study_8])
     db_session.commit()
 
     # use the db recorder to check that:

--- a/tests/study/test_repository.py
+++ b/tests/study/test_repository.py
@@ -1,0 +1,66 @@
+import typing as t
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from antarest.core.interfaces.cache import ICache
+from antarest.study.model import DEFAULT_WORKSPACE_NAME, RawStudy
+from antarest.study.repository import StudyMetadataRepository
+from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
+from tests.helpers import with_db_context
+
+
+@with_db_context
+@pytest.mark.parametrize(
+    "managed, studies_ids, exists, expected_ids",
+    [
+        (None, None, False, {"1", "2", "3", "4", "5", "6", "7", "8"}),
+        (None, None, True, {"1", "2", "3", "4", "7", "8"}),
+        (None, [1, 3, 5, 7], False, {"1", "3", "5", "7"}),
+        (None, [1, 3, 5, 7], True, {"1", "3", "7"}),
+        (True, None, False, {"1", "2", "3", "4", "5", "8"}),
+        (True, None, True, {"1", "2", "3", "4", "8"}),
+        (True, [1, 3, 5, 7], False, {"1", "3", "5"}),
+        (True, [1, 3, 5, 7], True, {"1", "3"}),
+        (True, [2, 4, 6, 8], True, {"2", "4", "8"}),
+        (False, None, False, {"6", "7"}),
+        (False, None, True, {"7"}),
+        (False, [1, 3, 5, 7], False, {"7"}),
+        (False, [1, 3, 5, 7], True, {"7"}),
+    ],
+)
+def test_repository_get_all(
+    managed: t.Union[bool, None],
+    studies_ids: t.Union[t.List[str], None],
+    exists: bool,
+    expected_ids: set,
+):
+    test_workspace = "test-repository"
+    icache: Mock = Mock(spec=ICache)
+    repository = StudyMetadataRepository(cache_service=icache)
+
+    study_1 = VariantStudy(id=1)
+    study_2 = VariantStudy(id=2)
+    study_3 = VariantStudy(id=3)
+    study_4 = VariantStudy(id=4)
+    study_5 = RawStudy(id=5, missing=datetime.now(), workspace=DEFAULT_WORKSPACE_NAME)
+    study_6 = RawStudy(id=6, missing=datetime.now(), workspace=test_workspace)
+    study_7 = RawStudy(id=7, missing=None, workspace=test_workspace)
+    study_8 = RawStudy(id=8, missing=None, workspace=DEFAULT_WORKSPACE_NAME)
+
+    db_session = repository.session
+    db_session.add(study_1)
+    db_session.add(study_2)
+    db_session.add(study_3)
+    db_session.add(study_4)
+    db_session.add(study_5)
+    db_session.add(study_6)
+    db_session.add(study_7)
+    db_session.add(study_8)
+    db_session.commit()
+
+    all_studies = repository.get_all(managed=managed, studies_ids=studies_ids, exists=exists)
+
+    if expected_ids is not None:
+        assert set([s.id for s in all_studies]) == expected_ids


### PR DESCRIPTION
## Description

L'objectif de cette PR est d'améliorer les requêtes SQL en utilisant des jointures (au lieu des requêtes N+1) afin
d'améliorer les performances de recherche et d'affichage de la liste des études.

Cette PR touche à la fois le endpoint `/v1/studies`, mais aussi les requêtes effectuées par le `Watcher`,
et le `AutoArchiveService`.

Les fonctions optimisées dans `antarest.study.repository.StudyMetadataRepository` sont :

- get_all
- get_list

Développements à réaliser :

- faire refactoring de get_all et get_list car les deux fonctions sont similaires (supprimer get_list),
  en ajoutant des paramètres de filtrage.
- Implémenter les jointures dans les requêtes SqlAlchemy
- Ajouter des tests unitaires pour monitorer la fonction get_all
- Ajouter des requêtes spécifiques à la place de get_all, là où c'est nécessaire (Watcher, AutoArchiveService).
