### PR TITLE
fix(bc): correct the name and shape of the binding constraint matrices

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/bindingconstraints/bindingconstraints_ini.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/bindingconstraints/bindingconstraints_ini.py
@@ -3,6 +3,23 @@ from antarest.study.storage.rawstudy.model.filesystem.context import ContextServ
 from antarest.study.storage.rawstudy.model.filesystem.ini_file_node import IniFileNode
 
 
+# noinspection SpellCheckingInspection
 class BindingConstraintsIni(IniFileNode):
+    """
+    Handle the binding constraints configuration file: `/input/bindingconstraints/bindingconstraints.ini`.
+
+    This files contains a list of sections numbered from 1 to n.
+
+    Each section contains the following fields:
+
+    - `name`: the name of the binding constraint.
+    - `id`: the id of the binding constraint (normalized name in lower case).
+    - `enabled`: whether the binding constraint is enabled or not.
+    - `type`: the frequency of the binding constraint ("hourly", "daily" or "weekly")
+    - `operator`: the operator of the binding constraint ("both", "equal", "greater", "less")
+    - `comment`: a comment
+    - and a list of coefficients (one per line) of the form `{area1}%{area2} = {coeff}`.
+    """
+
     def __init__(self, context: ContextServer, config: FileStudyTreeConfig):
-        IniFileNode.__init__(self, context, config, types={})
+        super().__init__(context, config, types={})

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/bindingconstraints/bindingcontraints.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/bindingconstraints/bindingcontraints.py
@@ -7,18 +7,22 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.bindingconstrai
     BindingConstraintsIni,
 )
 from antarest.study.storage.variantstudy.business.matrix_constants.binding_constraint.series import (
-    default_binding_constraint_daily,
-    default_binding_constraint_hourly,
-    default_binding_constraint_weekly,
+    default_bc_hourly,
+    default_bc_weekly_daily,
 )
 
 
 class BindingConstraints(FolderNode):
+    """
+    Handle the binding constraints folder which contains the binding constraints
+    configuration and matrices.
+    """
+
     def build(self) -> TREE:
         default_matrices = {
-            BindingConstraintFrequency.HOURLY: default_binding_constraint_hourly,
-            BindingConstraintFrequency.DAILY: default_binding_constraint_daily,
-            BindingConstraintFrequency.WEEKLY: default_binding_constraint_weekly,
+            BindingConstraintFrequency.HOURLY: default_bc_hourly,
+            BindingConstraintFrequency.DAILY: default_bc_weekly_daily,
+            BindingConstraintFrequency.WEEKLY: default_bc_weekly_daily,
         }
         children: TREE = {
             binding.id: InputSeriesMatrix(
@@ -31,6 +35,7 @@ class BindingConstraints(FolderNode):
             for binding in self.config.bindings
         }
 
+        # noinspection SpellCheckingInspection
         children["bindingconstraints"] = BindingConstraintsIni(
             self.context, self.config.next_file("bindingconstraints.ini")
         )

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/input.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/input.py
@@ -18,7 +18,12 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.wind.wind impor
 
 
 class Input(FolderNode):
+    """
+    Handle the input folder which contains all the input data of the study.
+    """
+
     def build(self) -> TREE:
+        # noinspection SpellCheckingInspection
         children: TREE = {
             "areas": InputAreas(self.context, self.config.next_file("areas")),
             "bindingconstraints": BindingConstraints(self.context, self.config.next_file("bindingconstraints")),

--- a/antarest/study/storage/variantstudy/business/matrix_constants/binding_constraint/series.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/binding_constraint/series.py
@@ -1,10 +1,13 @@
 import numpy as np
 
-default_binding_constraint_hourly = np.zeros((8760, 3), dtype=np.float64)
-default_binding_constraint_hourly.flags.writeable = False
+# Matrice shapes for binding constraints are different from usual shapes,
+# because we need to take leap years into account, which contains 366 days and 8784 hours.
+# Also, we use the same matrices for "weekly" and "daily" frequencies,
+# because the solver calculates the weekly matrix from the daily matrix.
+# See https://github.com/AntaresSimulatorTeam/AntaREST/issues/1843
 
-default_binding_constraint_daily = np.zeros((365, 3), dtype=np.float64)
-default_binding_constraint_daily.flags.writeable = False
+default_bc_hourly = np.zeros((8784, 3), dtype=np.float64)
+default_bc_hourly.flags.writeable = False
 
-default_binding_constraint_weekly = np.zeros((52, 3), dtype=np.float64)
-default_binding_constraint_weekly.flags.writeable = False
+default_bc_weekly_daily = np.zeros((366, 3), dtype=np.float64)
+default_bc_weekly_daily.flags.writeable = False

--- a/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
@@ -37,7 +37,7 @@ ONES_SCENARIO_MATRIX = "ones_scenario_matrix"
 # Binding constraint aliases
 BINDING_CONSTRAINT_HOURLY = "empty_2nd_member_hourly"
 BINDING_CONSTRAINT_DAILY = "empty_2nd_member_daily"
-BINDING_CONSTRAINT_WEEKLY = "empty_2nd_member_daily"
+BINDING_CONSTRAINT_WEEKLY = "empty_2nd_member_weekly"
 
 # Short-term storage aliases
 ST_STORAGE_PMAX_INJECTION = ONES_SCENARIO_MATRIX

--- a/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
@@ -36,8 +36,10 @@ ONES_SCENARIO_MATRIX = "ones_scenario_matrix"
 
 # Binding constraint aliases
 BINDING_CONSTRAINT_HOURLY = "empty_2nd_member_hourly"
-BINDING_CONSTRAINT_DAILY = "empty_2nd_member_daily"
-BINDING_CONSTRAINT_WEEKLY = "empty_2nd_member_weekly"
+"""2D-matrix of shape (8784, 3), filled-in with zeros for hourly binding constraints."""
+
+BINDING_CONSTRAINT_WEEKLY_DAILY = "empty_2nd_member_weekly_daily"
+"""2D-matrix of shape (366, 3), filled-in with zeros for weekly/daily binding constraints."""
 
 # Short-term storage aliases
 ST_STORAGE_PMAX_INJECTION = ONES_SCENARIO_MATRIX
@@ -90,9 +92,8 @@ class GeneratorMatrixConstants:
 
         # Binding constraint matrices
         series = matrix_constants.binding_constraint.series
-        self.hashes[BINDING_CONSTRAINT_HOURLY] = self.matrix_service.create(series.default_binding_constraint_hourly)
-        self.hashes[BINDING_CONSTRAINT_DAILY] = self.matrix_service.create(series.default_binding_constraint_daily)
-        self.hashes[BINDING_CONSTRAINT_WEEKLY] = self.matrix_service.create(series.default_binding_constraint_weekly)
+        self.hashes[BINDING_CONSTRAINT_HOURLY] = self.matrix_service.create(series.default_bc_hourly)
+        self.hashes[BINDING_CONSTRAINT_WEEKLY_DAILY] = self.matrix_service.create(series.default_bc_weekly_daily)
 
         # Some short-term storage matrices use np.ones((8760, 1))
         self.hashes[ONES_SCENARIO_MATRIX] = self.matrix_service.create(
@@ -152,16 +153,16 @@ class GeneratorMatrixConstants:
         return MATRIX_PROTOCOL_PREFIX + self.hashes[MISCGEN_TS]
 
     def get_binding_constraint_hourly(self) -> str:
-        """2D-matrix of shape (8760, 3), filled-in with zeros."""
+        """2D-matrix of shape (8784, 3), filled-in with zeros."""
         return MATRIX_PROTOCOL_PREFIX + self.hashes[BINDING_CONSTRAINT_HOURLY]
 
     def get_binding_constraint_daily(self) -> str:
-        """2D-matrix of shape (365, 3), filled-in with zeros."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[BINDING_CONSTRAINT_DAILY]
+        """2D-matrix of shape (366, 3), filled-in with zeros."""
+        return MATRIX_PROTOCOL_PREFIX + self.hashes[BINDING_CONSTRAINT_WEEKLY_DAILY]
 
     def get_binding_constraint_weekly(self) -> str:
-        """2D-matrix of shape (52, 3), filled-in with zeros."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[BINDING_CONSTRAINT_WEEKLY]
+        """2D-matrix of shape (366, 3), filled-in with zeros, same as daily."""
+        return MATRIX_PROTOCOL_PREFIX + self.hashes[BINDING_CONSTRAINT_WEEKLY_DAILY]
 
     def get_st_storage_pmax_injection(self) -> str:
         """2D-matrix of shape (8760, 1), filled-in with ones."""

--- a/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
@@ -40,10 +40,15 @@ def check_matrix_values(time_step: BindingConstraintFrequency, values: MatrixTyp
             If the matrix shape does not match the expected shape for the given time step.
             If the matrix values contain NaN (Not-a-Number).
     """
+    # Matrice shapes for binding constraints are different from usual shapes,
+    # because we need to take leap years into account, which contains 366 days and 8784 hours.
+    # Also, we use the same matrices for "weekly" and "daily" frequencies,
+    # because the solver calculates the weekly matrix from the daily matrix.
+    # See https://github.com/AntaresSimulatorTeam/AntaREST/issues/1843
     shapes = {
-        BindingConstraintFrequency.HOURLY: (8760, 3),
-        BindingConstraintFrequency.DAILY: (365, 3),
-        BindingConstraintFrequency.WEEKLY: (52, 3),
+        BindingConstraintFrequency.HOURLY: (8784, 3),
+        BindingConstraintFrequency.DAILY: (366, 3),
+        BindingConstraintFrequency.WEEKLY: (366, 3),
     }
     # Check the matrix values and create the corresponding matrix link
     array = np.array(values, dtype=np.float64)

--- a/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
+++ b/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
@@ -44,14 +44,14 @@ class TestGeneratorMatrixConstants:
         hourly = generator.get_binding_constraint_hourly()
         hourly_matrix_id = hourly.split(MATRIX_PROTOCOL_PREFIX)[1]
         hourly_matrix_dto = generator.matrix_service.get(hourly_matrix_id)
-        assert np.array(hourly_matrix_dto.data).all() == series.default_binding_constraint_hourly.all()
+        assert np.array(hourly_matrix_dto.data).all() == series.default_bc_hourly.all()
 
         daily = generator.get_binding_constraint_daily()
         daily_matrix_id = daily.split(MATRIX_PROTOCOL_PREFIX)[1]
         daily_matrix_dto = generator.matrix_service.get(daily_matrix_id)
-        assert np.array(daily_matrix_dto.data).all() == series.default_binding_constraint_daily.all()
+        assert np.array(daily_matrix_dto.data).all() == series.default_bc_weekly_daily.all()
 
         weekly = generator.get_binding_constraint_weekly()
         weekly_matrix_id = weekly.split(MATRIX_PROTOCOL_PREFIX)[1]
         weekly_matrix_dto = generator.matrix_service.get(weekly_matrix_id)
-        assert np.array(weekly_matrix_dto.data).all() == series.default_binding_constraint_weekly.all()
+        assert np.array(weekly_matrix_dto.data).all() == series.default_bc_weekly_daily.all()

--- a/tests/variantstudy/model/command/test_manage_binding_constraints.py
+++ b/tests/variantstudy/model/command/test_manage_binding_constraints.py
@@ -8,9 +8,8 @@ from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.business.command_extractor import CommandExtractor
 from antarest.study.storage.variantstudy.business.command_reverter import CommandReverter
 from antarest.study.storage.variantstudy.business.matrix_constants.binding_constraint.series import (
-    default_binding_constraint_daily,
-    default_binding_constraint_hourly,
-    default_binding_constraint_weekly,
+    default_bc_hourly,
+    default_bc_weekly_daily,
 )
 from antarest.study.storage.variantstudy.model.command.common import BindingConstraintOperator
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
@@ -109,7 +108,7 @@ def test_manage_binding_constraint(
         "type": "daily",
     }
 
-    weekly_values = default_binding_constraint_weekly.tolist()
+    weekly_values = default_bc_weekly_daily.tolist()
     bind_update = UpdateBindingConstraint(
         id="bd 1",
         enabled=False,
@@ -148,7 +147,7 @@ def test_manage_binding_constraint(
 
 
 def test_match(command_context: CommandContext):
-    values = default_binding_constraint_daily.tolist()
+    values = default_bc_weekly_daily.tolist()
     base = CreateBindingConstraint(
         name="foo",
         enabled=False,
@@ -231,9 +230,9 @@ def test_match(command_context: CommandContext):
 
 
 def test_revert(command_context: CommandContext):
-    hourly_values = default_binding_constraint_hourly.tolist()
-    daily_values = default_binding_constraint_daily.tolist()
-    weekly_values = default_binding_constraint_weekly.tolist()
+    hourly_values = default_bc_hourly.tolist()
+    daily_values = default_bc_weekly_daily.tolist()
+    weekly_values = default_bc_weekly_daily.tolist()
     base = CreateBindingConstraint(
         name="foo",
         enabled=False,
@@ -339,7 +338,7 @@ def test_revert(command_context: CommandContext):
 
 
 def test_create_diff(command_context: CommandContext):
-    values_a = np.random.rand(365, 3).tolist()
+    values_a = np.random.rand(366, 3).tolist()
     base = CreateBindingConstraint(
         name="foo",
         enabled=False,
@@ -350,7 +349,7 @@ def test_create_diff(command_context: CommandContext):
         command_context=command_context,
     )
 
-    values_b = np.random.rand(8760, 3).tolist()
+    values_b = np.random.rand(8784, 3).tolist()
     other_match = CreateBindingConstraint(
         name="foo",
         enabled=True,
@@ -372,7 +371,7 @@ def test_create_diff(command_context: CommandContext):
         )
     ]
 
-    values = default_binding_constraint_daily.tolist()
+    values = default_bc_weekly_daily.tolist()
     base = UpdateBindingConstraint(
         id="foo",
         enabled=False,


### PR DESCRIPTION
We correct the matrix constants generator according to those rules :

- Matrice shapes for binding constraints are different from usual shapes, because we need to take leap years into account, which contains 366 days and 8784 hours.
- We use the same matrices for "weekly" and "daily" frequencies, because the solver calculates the weekly matrix from the daily matrix.

closes #1843 