### PR TITLE
perf(variant): avoid snapshot generation if the snapshot directory already exists

### DIFF
--- a/antarest/study/storage/variantstudy/model/dbmodel.py
+++ b/antarest/study/storage/variantstudy/model/dbmodel.py
@@ -99,7 +99,7 @@ class VariantStudy(Study):
         """Get the path of the snapshot directory."""
         return Path(self.path) / "snapshot"
 
-    def is_snapshot_recent(self) -> bool:
+    def is_snapshot_up_to_date(self) -> bool:
         """Check if the snapshot exists and is up-to-date."""
         return (
             (self.snapshot is not None)

--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -654,7 +654,7 @@ class VariantStudyService(AbstractStorageService[VariantStudy]):
         if variant_study.parent_id is None:
             raise NoParentStudyError(variant_study_id)
 
-        return self.generate_task(variant_study, denormalize)
+        return self.generate_task(variant_study, denormalize, from_scratch=from_scratch)
 
     def generate_study_config(
         self,

--- a/tests/study/storage/variantstudy/model/test_dbmodel.py
+++ b/tests/study/storage/variantstudy/model/test_dbmodel.py
@@ -215,7 +215,7 @@ class TestVariantStudy:
 
         # check Variant-specific properties
         assert obj.snapshot_dir == Path(variant_study_path).joinpath("snapshot")
-        assert obj.is_snapshot_recent() is False
+        assert obj.is_snapshot_up_to_date() is False
 
     @pytest.mark.parametrize(
         "created_at, updated_at, study_antares_file, expected",
@@ -294,4 +294,4 @@ class TestVariantStudy:
 
         # Check the snapshot_uptodate() method
         obj: VariantStudy = db_session.query(VariantStudy).filter(VariantStudy.id == variant_id).one()
-        assert obj.is_snapshot_recent() == expected
+        assert obj.is_snapshot_up_to_date() == expected


### PR DESCRIPTION
Cette PR permet de corriger (en partie) le problème de lenteur de la génération des variants en évitant de générer le snapshot s'il existe déjà.

En effet, lorsqu'un variant est modifié, son snapshot n'est plus à jour et il suffit d'appliquer les nouvelles commandes pour le mettre à jour.

Dans de rares cas, par exemple si l'utilisateur modifie l'historique des commandes, le snapshot ne sera pas mis à jour correctement. Cette situation n'est pour l'instant pas gérée automatiquement.