### PR TITLE
fix(ui-output): add the missing "ST Storages" option in the Display selector in results view

### DIFF
--- a/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
@@ -296,6 +296,7 @@ function ResultDetails() {
                           { value: DataType.Thermal, label: "Thermal plants" },
                           { value: DataType.Renewable, label: "Ren. clusters" },
                           { value: DataType.Record, label: "RecordYears" },
+                          { value: DataType.STStorage, label: "ST Storages" },
                         ]}
                         size="small"
                         variant="outlined"

--- a/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/utils.ts
+++ b/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/utils.ts
@@ -11,6 +11,7 @@ export enum DataType {
   Thermal = "details",
   Renewable = "details-res",
   Record = "id",
+  STStorage = "details-STstorage",
 }
 
 export enum Timestep {


### PR DESCRIPTION
Added the 'ST Storage' option to the dropdown list for selecting the view to display simulation results related to short-term storage.