### PR TITLE
fix(ui-matrix): calculate the prepend index according to the existence of a time column

### DIFF
--- a/webapp/src/components/common/EditableMatrix/index.tsx
+++ b/webapp/src/components/common/EditableMatrix/index.tsx
@@ -83,7 +83,7 @@ function EditableMatrix(props: PropTypes) {
     );
 
     if (filteredChanges.length > 0) {
-      const edits = cellChangesToMatrixEdits(filteredChanges);
+      const edits = cellChangesToMatrixEdits(filteredChanges, matrixTime);
       onUpdate(edits, source);
     }
   };

--- a/webapp/src/components/common/EditableMatrix/utils.ts
+++ b/webapp/src/components/common/EditableMatrix/utils.ts
@@ -84,11 +84,17 @@ export const createDateFromIndex = (
 
 export const cellChangesToMatrixEdits = (
   cellChanges: CellChange[],
+  matrixTime: boolean,
 ): MatrixEditDTO[] =>
-  cellChanges.map(([row, column, , value]) => ({
-    coordinates: [[row, (column as number) - 1]],
-    operation: { operation: Operator.EQ, value: parseFloat(value) },
-  }));
+  cellChanges.map(([row, column, , value]) => {
+    const rowIndex = parseFloat(row.toString());
+    const colIndex = parseFloat(column.toString()) - (matrixTime ? 1 : 0);
+
+    return {
+      coordinates: [[rowIndex, colIndex]],
+      operation: { operation: Operator.EQ, value: parseFloat(value) },
+    };
+  });
 
 export const computeStats = (
   statsType: string,


### PR DESCRIPTION
This pull request addresses the column number offset issue in tables without a time column on the left.

Changes in `EditableMatrix`:
- Modified the `prependIndex` variable to use an integer (0 or 1) instead of a boolean to indicate the offset between the column number being modified and the column index in the matrix.

Change in `utils.ts`:
- Added this parameter to the `cellChangesToMatrixEdits` function, which converts `CellChange` objects to `MatrixEditDTO` objects, to account for the column offset.

This fix resolves the problem for the "Overall Monthly Hydro" and "Daily power" tables, which are not time series. No regressions have been observed in the other time series tables.