### PR TITLE
fix(services): rollback the loop for services

### DIFF
--- a/antarest/singleton_services.py
+++ b/antarest/singleton_services.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 from typing import Dict, List, cast
 
@@ -17,6 +18,8 @@ from antarest.utils import (
     create_watcher,
     init_db_engine,
 )
+
+SLEEP_TIME = 2
 
 
 def _init(config_file: Path, services_list: List[Module]) -> Dict[Module, IService]:
@@ -74,3 +77,6 @@ def start_all_services(config_file: Path, services_list: List[Module]) -> None:
     services = _init(config_file, services_list)
     for service in services:
         services[service].start(threaded=True)
+    # this loop may be interrupted using Crl+C
+    while True:
+        time.sleep(SLEEP_TIME)

--- a/antarest/singleton_services.py
+++ b/antarest/singleton_services.py
@@ -19,8 +19,6 @@ from antarest.utils import (
     init_db_engine,
 )
 
-SLEEP_TIME = 2
-
 
 def _init(config_file: Path, services_list: List[Module]) -> Dict[Module, IService]:
     res = get_local_path() / "resources"
@@ -74,9 +72,20 @@ def _init(config_file: Path, services_list: List[Module]) -> Dict[Module, IServi
 
 
 def start_all_services(config_file: Path, services_list: List[Module]) -> None:
+    """
+    Start all services in a worker.
+
+    This function is used to start all services in a worker.
+    Each worker is started in a different docker image.
+
+    Args:
+        config_file: Path to the configuration file (`application.yaml`)
+        services_list: List of services to start.
+    """
     services = _init(config_file, services_list)
     for service in services:
         services[service].start(threaded=True)
-    # this loop may be interrupted using Crl+C
+    # Once started, the worker must wait indefinitely (demon service).
+    # This loop may be interrupted using Crl+C
     while True:
-        time.sleep(SLEEP_TIME)
+        time.sleep(2)


### PR DESCRIPTION
Context: 
- In previous PR #1837 we found no direct usage of SingletonServices but in the `main` program. So we decided to remove it and to include all of its functionalities in a function `start_all_services`.
- When we included all the functionalities in `start_all_services`, we noticed a loop that does no thing but running for eternity 
- From there we decided to remove that loop

Issue:
- That loop was essential to keep the program and thus the services running when we only want build containers for services without the application 

Solution:
- re-insert the loop in start_all_services