### PR TITLE
fix(study-factory): ignore non-existent files in archived studies during build

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/config/files.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/files.py
@@ -394,7 +394,14 @@ def _parse_renewables(root: Path, area: str) -> t.List[RenewableConfigType]:
     """
     Parse the renewables INI file, return an empty list if missing.
     """
+
+    # Before version 8.1, we only have "Load", "Wind" and "Solar" objects.
+    # We can't use renewable clusters.
     version = _parse_version(root)
+    if version < 810:
+        return []
+
+    # Since version 8.1 of the solver, we can use "renewable clusters" objects.
     relpath = Path(f"input/renewables/clusters/{area}/list.ini")
     config_dict: t.Dict[str, t.Any] = _extract_data_from_file(
         root=root,

--- a/tests/storage/rawstudies/samples/__init__.py
+++ b/tests/storage/rawstudies/samples/__init__.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+ASSETS_DIR = Path(__file__).parent.resolve()

--- a/tests/storage/rawstudies/samples/v810/sample1/study.antares
+++ b/tests/storage/rawstudies/samples/v810/sample1/study.antares
@@ -1,5 +1,5 @@
 [antares]
-version = 800
+version = 810
 caption = renewable-2-clusters-ts-prod-factor
 created = 1618413128
 lastsave = 1625583204

--- a/tests/storage/rawstudies/test_factory.py
+++ b/tests/storage/rawstudies/test_factory.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import Mock
 
 from antarest.core.interfaces.cache import CacheConstants
@@ -7,10 +6,11 @@ from antarest.study.storage.rawstudy.model.filesystem.config.model import FileSt
 from antarest.study.storage.rawstudy.model.filesystem.context import ContextServer
 from antarest.study.storage.rawstudy.model.filesystem.factory import StudyFactory
 from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
+from tests.storage.rawstudies.samples import ASSETS_DIR
 
 
-def test_renewable_subtree():
-    path = Path(__file__).parent / "samples/v810/sample1"
+def test_renewable_subtree() -> None:
+    path = ASSETS_DIR / "v810/sample1"
     context: ContextServer = Mock(specs=ContextServer)
     config = build(path, "")
     assert config.get_renewable_ids("area") == ["la_rochelle", "oleron"]
@@ -41,8 +41,8 @@ def test_renewable_subtree():
     }
 
 
-def test_factory_cache():
-    path = Path(__file__).parent / "samples/v810/sample1"
+def test_factory_cache() -> None:
+    path = ASSETS_DIR / "v810/sample1"
 
     cache = Mock()
     factory = StudyFactory(matrix=Mock(), resolver=Mock(), cache=cache)

--- a/tests/storage/repository/filesystem/config/test_config_files.py
+++ b/tests/storage/repository/filesystem/config/test_config_files.py
@@ -363,7 +363,7 @@ nominalcapacity = 456.5
 
 def test_parse_renewables(tmp_path: Path) -> None:
     study_path = build_empty_files(tmp_path)
-    study_path.joinpath("study.antares").write_text("[antares] \n version = 700")
+    study_path.joinpath("study.antares").write_text("[antares] \n version = 810")
     ini_path = study_path.joinpath("input/renewables/clusters/fr/list.ini")
 
     # Error case: `input/renewables/clusters/fr` directory is missing.


### PR DESCRIPTION
## Description

Fixes issue: Unexpected server error: "There is no item named 'settings/generaldata.ini' in the archive"

## Changes Made

- Ignore non-existent files in the ZIP archive, such as renewable cluster configuration files.
- Avoid parsing renewable cluster configuration, when the study version is less than 8.1.
- Optimize reading configuration from within an INI file to eliminate the need for decompressing into a temporary directory. Decompression now occurs in memory, resulting in faster processing.

## How to Test

1. Attempt to open an archived study with a version less than to 8.1.
2. Verify that the application no longer displays the "Unexpected server error" error.
3. Confirm that the study opens successfully without any issues.

## Screenshots

![image](https://github.com/AntaresSimulatorTeam/AntaREST/assets/43534797/670dcf89-ced8-4b25-90d4-9579fb4934a9)


## Checklist

- [x] I have tested these changes locally.
- [x] I have updated existing documentation (docstring and comments).
- [x] I have ensured that my code follows the project's coding standards.
