### PR TITLE
feat(study-size): add new route to get a study disk usage (in bytes)

### DIFF
--- a/antarest/study/business/binding_constraint_management.py
+++ b/antarest/study/business/binding_constraint_management.py
@@ -6,10 +6,10 @@ from antarest.core.exceptions import (
     ConstraintAlreadyExistError,
     ConstraintIdNotFoundError,
     DuplicateConstraintName,
+    InvalidConstraintName,
     MissingDataError,
     NoBindingConstraintError,
     NoConstraintError,
-    InvalidConstraintName,
 )
 from antarest.matrixstore.model import MatrixData
 from antarest.study.business.utils import execute_or_add_commands

--- a/antarest/study/common/studystorage.py
+++ b/antarest/study/common/studystorage.py
@@ -8,7 +8,6 @@ from antarest.core.requests import RequestParameters
 from antarest.study.model import Study, StudyMetadataDTO, StudyMetadataPatchDTO, StudySimResultDTO
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
 
 T = TypeVar("T", bound=Study)
 
@@ -187,11 +186,7 @@ class IStudyStorageService(ABC, Generic[T]):
         Returns: study path
 
         """
-
-        if isinstance(metadata, VariantStudy):
-            return metadata.snapshot_dir
-        else:
-            return Path(metadata.path)
+        raise NotImplementedError()
 
     def _check_study_exists(self, metadata: Study) -> None:
         """

--- a/antarest/study/common/studystorage.py
+++ b/antarest/study/common/studystorage.py
@@ -8,6 +8,7 @@ from antarest.core.requests import RequestParameters
 from antarest.study.model import Study, StudyMetadataDTO, StudyMetadataPatchDTO, StudySimResultDTO
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
+from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
 
 T = TypeVar("T", bound=Study)
 
@@ -186,7 +187,11 @@ class IStudyStorageService(ABC, Generic[T]):
         Returns: study path
 
         """
-        raise NotImplementedError()
+
+        if isinstance(metadata, VariantStudy):
+            return metadata.snapshot_dir
+        else:
+            return Path(metadata.path)
 
     def _check_study_exists(self, metadata: Study) -> None:
         """

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -4,7 +4,6 @@ import io
 import json
 import logging
 import os
-
 from datetime import datetime, timedelta
 from http import HTTPStatus
 from pathlib import Path, PurePosixPath
@@ -129,10 +128,11 @@ logger = logging.getLogger(__name__)
 MAX_MISSING_STUDY_TIMEOUT = 2  # days
 
 
-def get_disk_usage(path: str) -> int:
-    total_size = 0
-    if path.endswith(".zip"):
+def get_disk_usage(path: Union[str, Path]) -> int:
+    path = Path(path)
+    if path.suffix.lower() in {".zip", "7z"}:
         return os.path.getsize(path)
+    total_size = 0
     with os.scandir(path) as it:
         for entry in it:
             if entry.is_file():

--- a/antarest/study/web/studies_blueprint.py
+++ b/antarest/study/web/studies_blueprint.py
@@ -727,7 +727,7 @@ def create_study_routes(study_service: StudyService, ftm: FileTransferManager, c
         return study_service.invalidate_cache_listing(params)
 
     @bp.get(
-        "/v1/studies/{uuid}/disk-usage",
+        "/studies/{uuid}/disk-usage",
         summary="Compute study disk usage",
         tags=[APITag.study_management],
     )
@@ -736,10 +736,10 @@ def create_study_routes(study_service: StudyService, ftm: FileTransferManager, c
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> int:
         """
-        # TODO write the doc in md format
+        Compute disk usage of an input study
 
         Args:
-        - `uuid`: the uuid of the study whose disk usage is to be retrieved.
+        - `uuid`: the UUID of the study whose disk usage is to be retrieved.
 
         Return:
         - The disk usage of the study in bytes.

--- a/antarest/study/web/studies_blueprint.py
+++ b/antarest/study/web/studies_blueprint.py
@@ -726,4 +726,26 @@ def create_study_routes(study_service: StudyService, ftm: FileTransferManager, c
         params = RequestParameters(user=current_user)
         return study_service.invalidate_cache_listing(params)
 
+    @bp.get(
+        "/v1/studies/{uuid}/disk-usage",
+        summary="Compute study disk usage",
+        tags=[APITag.study_management],
+    )
+    def study_disk_usage(
+        uuid: str,
+        current_user: JWTUser = Depends(auth.get_current_user),
+    ) -> int:
+        """
+        # TODO write the doc in md format
+
+        Args:
+        - `uuid`: the uuid of the study whose disk usage is to be retrieved.
+
+        Return:
+        - The disk usage of the study in bytes.
+        """
+        logger.info("Retrieving study disk usage", extra={"user": current_user.id})
+        params = RequestParameters(user=current_user)
+        return study_service.get_disk_usage(uuid=uuid, params=params)
+
     return bp

--- a/tests/integration/studies_blueprint/test_disk_usage.py
+++ b/tests/integration/studies_blueprint/test_disk_usage.py
@@ -1,0 +1,22 @@
+from starlette.testclient import TestClient
+
+
+class TestDiskUsage:
+    def test_disk_usage_endpoint(
+        self,
+        client: TestClient,
+        user_access_token: str,
+        study_id: str,
+    ) -> None:
+        """
+        we verify the endpoint work:
+        - we get a response
+        - the length of the response json is big enough
+        """
+        res = client.get(
+            f"/v1/studies/{study_id}/disk-usage",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+        )
+        assert res.status_code == 200, res.json()
+        actual = res.json()
+        assert actual > 1000

--- a/tests/integration/studies_blueprint/test_disk_usage.py
+++ b/tests/integration/studies_blueprint/test_disk_usage.py
@@ -9,14 +9,15 @@ class TestDiskUsage:
         study_id: str,
     ) -> None:
         """
-        we verify the endpoint work:
-        - we get a response
-        - the length of the response json is big enough
+        Verify the functionality of the disk usage endpoint:
+
+        - Ensure a successful response is received.
+        - Confirm that the JSON response is an integer which represent a (big enough) directory size.
         """
         res = client.get(
             f"/v1/studies/{study_id}/disk-usage",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
-        actual = res.json()
-        assert actual > 1000
+        disk_usage = res.json()  # currently: 7.47 Mio on Ubuntu
+        assert 7 * 1024 * 1024 < disk_usage < 8 * 1024 * 1024

--- a/tests/study/test_service.py
+++ b/tests/study/test_service.py
@@ -1,0 +1,11 @@
+import os
+import tempfile
+
+from antarest.study.service import get_disk_usage
+
+
+def test_get_disk_usage():
+    test_study_id = "1edf11fe-cc77-40d3-980a-20790137cfb7"
+    test_dir = os.path.join(tempfile.gettempdir(), test_study_id)
+    os.makedirs(test_dir, exist_ok=True)
+    assert get_disk_usage(test_dir) == 0

--- a/tests/study/test_service.py
+++ b/tests/study/test_service.py
@@ -5,8 +5,10 @@ import pytest
 from antarest.study.service import get_disk_usage
 
 
-def test_get_disk_usage__nominal_case(tmp_path: Path):
-    """Nominal case: the study path in a directory."""
+def test_get_disk_usage__nominal_case(tmp_path: Path) -> None:
+    """
+    This test ensures that the 'get_disk_usage' function handles a typical directory structure correctly.
+    """
     tmp_path.joinpath("input").mkdir()
     ini_data = b"[config]\nkey = value"
     tmp_path.joinpath("input/params.ini").write_bytes(ini_data)
@@ -17,8 +19,10 @@ def test_get_disk_usage__nominal_case(tmp_path: Path):
 
 
 @pytest.mark.parametrize("suffix", [".zip", ".7z", ".ZIP"])
-def test_get_disk__usage_archive(tmp_path: Path, suffix: str):
-    """Test archived files .7z and .zip"""
+def test_get_disk__usage_archive(tmp_path: Path, suffix: str) -> None:
+    """
+    This test ensures that the 'get_disk_usage' function correctly handles archive files (.zip, .7z).
+    """
     compressed_path = tmp_path.joinpath("study").with_suffix(suffix)
     compressed_data = b"dummy archive content"
     compressed_path.write_bytes(compressed_data)
@@ -26,7 +30,9 @@ def test_get_disk__usage_archive(tmp_path: Path, suffix: str):
 
 
 def test_gest_disk_usage__unknown_format(tmp_path: Path) -> None:
-    """Test unusual directories"""
+    """
+    This test ensures that the 'get_disk_usage' function handles unknown directory formats appropriately.
+    """
     path = tmp_path.joinpath("study.dat")
     path.touch()
     with pytest.raises(NotADirectoryError):

--- a/tests/study/test_service.py
+++ b/tests/study/test_service.py
@@ -1,11 +1,33 @@
-import os
-import tempfile
+from pathlib import Path
+
+import pytest
 
 from antarest.study.service import get_disk_usage
 
 
-def test_get_disk_usage():
-    test_study_id = "1edf11fe-cc77-40d3-980a-20790137cfb7"
-    test_dir = os.path.join(tempfile.gettempdir(), test_study_id)
-    os.makedirs(test_dir, exist_ok=True)
-    assert get_disk_usage(test_dir) == 0
+def test_get_disk_usage__nominal_case(tmp_path: Path):
+    """Nominal case: the study path in a directory."""
+    tmp_path.joinpath("input").mkdir()
+    ini_data = b"[config]\nkey = value"
+    tmp_path.joinpath("input/params.ini").write_bytes(ini_data)
+    tmp_path.joinpath("input/series").mkdir()
+    series_data = b"10\n20\n"
+    tmp_path.joinpath("input/series/data.tsv").write_bytes(series_data)
+    assert get_disk_usage(tmp_path) == len(ini_data) + len(series_data)
+
+
+@pytest.mark.parametrize("suffix", [".zip", ".7z", ".ZIP"])
+def test_get_disk__usage_archive(tmp_path: Path, suffix: str):
+    """Test archived files .7z and .zip"""
+    compressed_path = tmp_path.joinpath("study").with_suffix(suffix)
+    compressed_data = b"dummy archive content"
+    compressed_path.write_bytes(compressed_data)
+    assert get_disk_usage(tmp_path) == len(compressed_data)
+
+
+def test_gest_disk_usage__unknown_format(tmp_path: Path) -> None:
+    """Test unusual directories"""
+    path = tmp_path.joinpath("study.dat")
+    path.touch()
+    with pytest.raises(NotADirectoryError):
+        get_disk_usage(path)


### PR DESCRIPTION
This PR goal is to create a new endpoint so a user can get the memory size of a given study on drive.