### PR TITLE
ci(docker): add the `ll` alias in `.bashrc` to simplify debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-slim-bullseye
 # RUN apt update && apt install -y procps gdb
 
 # Add the `ls` alias to simplify debugging
-RUN echo "alias ls='/bin/ls -l --color=auto'" >> /root/.bashrc
+RUN echo "alias ll='/bin/ls -l --color=auto'" >> /root/.bashrc
 
 ENV ANTAREST_CONF /resources/application.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.8-slim-bullseye
 
 # RUN apt update && apt install -y procps gdb
 
+# Add the `ls` alias to simplify debugging
+RUN echo "alias ls='/bin/ls -l --color=auto'" >> /root/.bashrc
+
 ENV ANTAREST_CONF /resources/application.yaml
 
 RUN mkdir -p examples/studies


### PR DESCRIPTION
L'objectif de cette PR est simplement d'ajouter l'alias `ll` dans le `.bashrc` afin de simplifier le débogage en intégration ou recette.