### PR TITLE
fix(thermals): correct TS Generator matrix index for thermal clusters

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/thermal/prepro/area/thermal/thermal.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/thermal/prepro/area/thermal/thermal.py
@@ -1,12 +1,22 @@
 from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
 from antarest.study.storage.rawstudy.model.filesystem.inode import TREE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
+from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
 
 
 class InputThermalPreproAreaThermal(FolderNode):
+    """
+    Folder containing thermal cluster data: `input/thermal/prepro/{area_id}/{cluster_id}`.
+
+    This folder contains the following files:
+
+    - `data.txt` (matrix): TS Generator matrix (daily)
+    - `modulation.txt` (matrix): Modulation matrix (hourly)
+    """
+
     def build(self) -> TREE:
         children: TREE = {
-            "data": InputSeriesMatrix(self.context, self.config.next_file("data.txt")),
+            "data": InputSeriesMatrix(self.context, self.config.next_file("data.txt"), freq=MatrixFrequency.DAILY),
             "modulation": InputSeriesMatrix(self.context, self.config.next_file("modulation.txt")),
         }
         return children

--- a/tests/integration/studies_blueprint/test_study_matrix_index.py
+++ b/tests/integration/studies_blueprint/test_study_matrix_index.py
@@ -1,0 +1,100 @@
+from starlette.testclient import TestClient
+
+
+class TestStudyMatrixIndex:
+    """
+    The goal of this test is to check that the API allows to retrieve
+    information about the data matrices of a study.
+
+    The values are used byt the frontend to display the time series
+    with the right time column.
+    """
+
+    def test_get_study_matrix_index(
+        self,
+        client: TestClient,
+        user_access_token: str,
+        study_id: str,
+    ) -> None:
+        user_access_token = {"Authorization": f"Bearer {user_access_token}"}
+
+        # Check the matrix index for Thermal clusters
+        # ===========================================
+
+        # Check the Common matrix index
+        res = client.get(
+            f"/v1/studies/{study_id}/matrixindex",
+            headers=user_access_token,
+            params={"path": "input/thermal/prepro/fr/01_solar/modulation"},
+        )
+        assert res.status_code == 200, res.json()
+        actual = res.json()
+        # We expect to have an "hourly" time series with 8760 hours
+        expected = {
+            "first_week_size": 7,
+            "level": "hourly",
+            "start_date": "2001-01-01 00:00:00",
+            "steps": 8760,
+        }
+        assert actual == expected
+
+        # Check the TS Generator matrix index
+        res = client.get(
+            f"/v1/studies/{study_id}/matrixindex",
+            headers=user_access_token,
+            params={"path": "input/thermal/prepro/fr/01_solar/data"},
+        )
+        assert res.status_code == 200, res.json()
+        actual = res.json()
+        # We expect to have a "daily" time series with 365 days
+        expected = {
+            "first_week_size": 7,
+            "level": "daily",
+            "start_date": "2001-01-01 00:00:00",
+            "steps": 365,
+        }
+        assert actual == expected
+
+        # Check the time series
+        res = client.get(
+            f"/v1/studies/{study_id}/matrixindex",
+            headers=user_access_token,
+            params={"path": "input/thermal/series/fr/01_solar/series"},
+        )
+        assert res.status_code == 200, res.json()
+        actual = res.json()
+        # We expect to have an "hourly" time series with 8760 hours
+        expected = {
+            "first_week_size": 7,
+            "level": "hourly",
+            "start_date": "2001-01-01 00:00:00",
+            "steps": 8760,
+        }
+        assert actual == expected
+
+        # Check the default matrix index
+        # ==============================
+
+        res = client.get(f"/v1/studies/{study_id}/matrixindex", headers=user_access_token)
+        assert res.status_code == 200
+        actual = res.json()
+        expected = {
+            "first_week_size": 7,
+            "start_date": "2001-01-01 00:00:00",
+            "steps": 8760,
+            "level": "hourly",
+        }
+        assert actual == expected
+
+        # Check the matrix index of a daily time series stored in the output folder
+        # =========================================================================
+
+        res = client.get(
+            f"/v1/studies/{study_id}/matrixindex",
+            headers=user_access_token,
+            params={"path": "output/20201014-1427eco/economy/mc-all/areas/es/details-daily"},
+        )
+        assert res.status_code == 200
+        actual = res.json()
+        expected = {"first_week_size": 7, "start_date": "2001-01-01 00:00:00", "steps": 7, "level": "daily"}
+        assert actual == expected

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -23,7 +23,6 @@ from antarest.study.business.table_mode_management import (
     TableTemplateType,
     TransmissionCapacity,
 )
-from antarest.study.model import MatrixIndex, StudyDownloadLevelDTO
 from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint import BindingConstraintFrequency
 from antarest.study.storage.rawstudy.model.filesystem.config.renewable import RenewableClusterGroup
 from antarest.study.storage.rawstudy.model.filesystem.config.thermal import LawOption, TimeSeriesGenerationOption
@@ -92,7 +91,6 @@ def test_main(client: TestClient, admin_access_token: str, study_id: str) -> Non
     )
     assert len(res.json()) == 1
     study_id = next(iter(res.json()))
-    comments = "<text>Hello</text>"
 
     res = client.get(
         f"/v1/studies/{study_id}/outputs",
@@ -171,37 +169,6 @@ def test_main(client: TestClient, admin_access_token: str, study_id: str) -> Non
         headers={"Authorization": f'Bearer {george_credentials["access_token"]}'},
     )
     assert res.status_code == 200
-
-    # study matrix index
-    res = client.get(
-        f"/v1/studies/{study_id}/matrixindex",
-        headers={"Authorization": f'Bearer {george_credentials["access_token"]}'},
-    )
-    assert res.status_code == 200
-    assert (
-        res.json()
-        == MatrixIndex(
-            first_week_size=7,
-            start_date="2001-01-01 00:00:00",
-            steps=8760,
-            level=StudyDownloadLevelDTO.HOURLY,
-        ).dict()
-    )
-
-    res = client.get(
-        f"/v1/studies/{study_id}/matrixindex?path=output/20201014-1427eco/economy/mc-all/areas/es/details-daily",
-        headers={"Authorization": f'Bearer {george_credentials["access_token"]}'},
-    )
-    assert res.status_code == 200
-    assert (
-        res.json()
-        == MatrixIndex(
-            first_week_size=7,
-            start_date="2001-01-01 00:00:00",
-            steps=7,
-            level=StudyDownloadLevelDTO.DAILY,
-        ).dict()
-    )
 
     res = client.delete(
         f"/v1/studies/{study_id}/outputs/20201014-1427eco",


### PR DESCRIPTION
Cette PR corrige le problème d'affichage des libellés de la colonne "Time" dans le cas de la matrice "TS Generator" d'un cluster thermique. La matrice "data.txt" possède une fréquence journalière (alors qu'on affichait une fréquence horaire).

Note : la matrice "modulation.txt" possède bien une fréquence horaire, il n'y a pas d'erreur pour cette matrice.

**Capture d'écran**

Dans la capture d'écran, on vérifie bien que les libellés de la colonne "Time" correspond bien à des jours.

![image](https://github.com/AntaresSimulatorTeam/AntaREST/assets/43534797/81a25b49-6a30-4a70-b17d-f061bc0dd372)

