### PR TITLE
fix(bc): correct case sensitivity for binding constraint term IDs

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -174,7 +174,7 @@ class WritingInsideZippedFileException(HTTPException):
         super().__init__(HTTPStatus.BAD_REQUEST, message)
 
 
-class NoBindingConstraintError(HTTPException):
+class BindingConstraintNotFoundError(HTTPException):
     def __init__(self, message: str) -> None:
         super().__init__(HTTPStatus.NOT_FOUND, message)
 

--- a/antarest/study/storage/variantstudy/business/utils_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/business/utils_binding_constraint.py
@@ -53,7 +53,7 @@ def apply_binding_constraint(
             # Cluster IDs are stored in lower case in the binding constraints file.
             area, cluster_id = link_or_cluster.split(".")
             thermal_ids = {thermal.id.lower() for thermal in study_data.config.areas[area].thermals}
-            if area not in study_data.config.areas or cluster_id not in thermal_ids:
+            if area not in study_data.config.areas or cluster_id.lower() not in thermal_ids:
                 return CommandOutput(
                     status=False,
                     message=f"Cluster '{link_or_cluster}' does not exist in binding constraint '{bd_id}'",

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -873,7 +873,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
     @bp.get(
         "/studies/{uuid}/bindingconstraints/{binding_constraint_id}",
         tags=[APITag.study_data],
-        summary="Get binding constraint list",
+        summary="Get binding constraint",
         response_model=None,  # Dict[str, bool],
     )
     def get_binding_constraint(
@@ -929,45 +929,45 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
     @bp.post(
         "/studies/{uuid}/bindingconstraints/{binding_constraint_id}/term",
         tags=[APITag.study_data],
-        summary="update constraint term",
+        summary="Create a binding constraint term",
     )
     def add_constraint_term(
         uuid: str,
         binding_constraint_id: str,
-        data: ConstraintTermDTO,
+        term: ConstraintTermDTO,
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> Any:
         logger.info(
-            f"add constraint term from {binding_constraint_id} for study {uuid}",
+            f"Add constraint term {term.id} to {binding_constraint_id} for study {uuid}",
             extra={"user": current_user.id},
         )
         params = RequestParameters(user=current_user)
         study = study_service.check_study_access(uuid, StudyPermissionType.WRITE, params)
-        return study_service.binding_constraint_manager.add_new_constraint_term(study, binding_constraint_id, data)
+        return study_service.binding_constraint_manager.add_new_constraint_term(study, binding_constraint_id, term)
 
     @bp.put(
         "/studies/{uuid}/bindingconstraints/{binding_constraint_id}/term",
         tags=[APITag.study_data],
-        summary="update constraint term",
+        summary="Update a binding constraint term",
     )
     def update_constraint_term(
         uuid: str,
         binding_constraint_id: str,
-        data: ConstraintTermDTO,
+        term: ConstraintTermDTO,
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> Any:
         logger.info(
-            f"update constraint term from {binding_constraint_id} for study {uuid}",
+            f"Update constraint term {term.id} from {binding_constraint_id} for study {uuid}",
             extra={"user": current_user.id},
         )
         params = RequestParameters(user=current_user)
         study = study_service.check_study_access(uuid, StudyPermissionType.WRITE, params)
-        return study_service.binding_constraint_manager.update_constraint_term(study, binding_constraint_id, data)
+        return study_service.binding_constraint_manager.update_constraint_term(study, binding_constraint_id, term)
 
     @bp.delete(
         "/studies/{uuid}/bindingconstraints/{binding_constraint_id}/term/{term_id}",
         tags=[APITag.study_data],
-        summary="update constraint term",
+        summary="Remove a binding constraint term",
     )
     def remove_constraint_term(
         uuid: str,
@@ -976,7 +976,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> None:
         logger.info(
-            f"delete constraint term {term_id} from {binding_constraint_id} for study {uuid}",
+            f"Remove constraint term {term_id} from {binding_constraint_id} for study {uuid}",
             extra={"user": current_user.id},
         )
         params = RequestParameters(user=current_user)

--- a/tests/integration/study_data_blueprint/test_binding_constraints.py
+++ b/tests/integration/study_data_blueprint/test_binding_constraints.py
@@ -3,7 +3,7 @@ from starlette.testclient import TestClient
 
 
 @pytest.mark.unit_test
-class TestSTStorage:
+class TestBindingConstraints:
     """
     Test the end points related to binding constraints.
     """
@@ -11,6 +11,7 @@ class TestSTStorage:
     def test_lifecycle__nominal(self, client: TestClient, user_access_token: str) -> None:
         user_headers = {"Authorization": f"Bearer {user_access_token}"}
 
+        # Create a Study
         res = client.post(
             "/v1/studies",
             headers=user_headers,
@@ -19,6 +20,7 @@ class TestSTStorage:
         assert res.status_code == 201, res.json()
         study_id = res.json()
 
+        # Create Areas
         area1_name = "area1"
         area2_name = "area2"
         res = client.post(
@@ -43,6 +45,7 @@ class TestSTStorage:
         )
         assert res.status_code == 200, res.json()
 
+        # Create a link between the two areas
         res = client.post(
             f"/v1/studies/{study_id}/links",
             headers=user_headers,
@@ -52,6 +55,193 @@ class TestSTStorage:
             },
         )
         assert res.status_code == 200, res.json()
+
+        # Create a cluster in area1
+        res = client.post(
+            f"/v1/studies/{study_id}/areas/area1/clusters/thermal",
+            headers=user_headers,
+            json={
+                "name": "cluster1",
+                "group": "Nuclear",
+            },
+        )
+        assert res.status_code == 200, res.json()
+        cluster_id = res.json()["id"]
+        assert cluster_id == "Cluster 1"
+
+        # Get clusters list to check created cluster in area1
+        res = client.get(f"/v1/studies/{study_id}/areas/area1/clusters/thermal", headers=user_headers)
+        clusters_list = res.json()
+        assert res.status_code == 200, res.json()
+        assert len(clusters_list) == 1
+        assert clusters_list[0]["name"] == "cluster1"
+        assert clusters_list[0]["group"] == "Nuclear"
+
+        # Create two binding constraints in the study
+        res = client.post(
+            f"/v1/studies/{study_id}/bindingconstraints",
+            json={
+                "name": "binding_constraint_1",
+                "enabled": True,
+                "time_step": "hourly",
+                "operator": "less",
+                "coeffs": {},
+                "comments": "",
+            },
+            headers=user_headers,
+        )
+        assert res.status_code == 200, res.json()
+
+        res = client.post(
+            f"/v1/studies/{study_id}/bindingconstraints",
+            json={
+                "name": "binding_constraint_2",
+                "enabled": True,
+                "time_step": "hourly",
+                "operator": "less",
+                "coeffs": {},
+                "comments": "",
+            },
+            headers=user_headers,
+        )
+        assert res.status_code == 200, res.json()
+
+        # Get binding constraints list to check created binding constraints
+        res = client.get(f"/v1/studies/{study_id}/bindingconstraints", headers=user_headers)
+        binding_constraints_list = res.json()
+        assert res.status_code == 200, res.json()
+        assert len(binding_constraints_list) == 2
+        assert binding_constraints_list[0]["id"] == "binding_constraint_1"
+        assert binding_constraints_list[1]["id"] == "binding_constraint_2"
+
+        bc_id = binding_constraints_list[0]["id"]
+
+        # Add binding constraint link term
+        res = client.post(
+            f"/v1/studies/{study_id}/bindingconstraints/{bc_id}/term",
+            json={
+                "weight": 1,
+                "offset": 2,
+                "data": {"area1": area1_name, "area2": area2_name},
+            },
+            headers=user_headers,
+        )
+        assert res.status_code == 200, res.json()
+
+        # Add binding constraint cluster term
+        res = client.post(
+            f"/v1/studies/{study_id}/bindingconstraints/{bc_id}/term",
+            json={
+                "weight": 1,
+                "offset": 2,
+                "data": {"area": area1_name, "cluster": "cluster1"},
+            },
+            headers=user_headers,
+        )
+        assert res.status_code == 200, res.json()
+
+        # Get binding constraints list to check added terms
+        res = client.get(
+            f"/v1/studies/{study_id}/bindingconstraints/{bc_id}",
+            headers=user_headers,
+        )
+        binding_constraint = res.json()
+        constraints = binding_constraint["constraints"]
+        assert res.status_code == 200, res.json()
+        assert binding_constraint["id"] == bc_id
+        assert len(constraints) == 2
+        assert constraints[0]["id"] == f"{area1_name}%{area2_name}"
+        assert constraints[0]["weight"] == 1
+        assert constraints[0]["offset"] == 2
+        assert constraints[0]["data"]["area1"] == area1_name
+        assert constraints[0]["data"]["area2"] == area2_name
+        assert constraints[1]["id"] == f"{area1_name}.cluster1"
+        assert constraints[1]["weight"] == 1
+        assert constraints[1]["offset"] == 2
+        assert constraints[1]["data"]["area"] == area1_name
+        assert constraints[1]["data"]["cluster"] == "cluster1"
+
+        # Update constraint cluster term
+        res = client.put(
+            f"/v1/studies/{study_id}/bindingconstraints/{bc_id}/term",
+            json={
+                "id": f"{area1_name}.cluster1",
+                "weight": 3,
+            },
+            headers=user_headers,
+        )
+        assert res.status_code == 200, res.json()
+
+        # Get binding constraints list to check updated term
+        res = client.get(
+            f"/v1/studies/{study_id}/bindingconstraints/{bc_id}",
+            headers=user_headers,
+        )
+        binding_constraint = res.json()
+        constraints = binding_constraint["constraints"]
+        assert res.status_code == 200, res.json()
+        assert binding_constraint["id"] == bc_id
+        assert len(constraints) == 2
+        assert constraints[1]["id"] == f"{area1_name}.cluster1"
+        assert constraints[1]["weight"] == 3
+        assert constraints[1]["offset"] is None
+        assert constraints[1]["data"]["area"] == area1_name
+        assert constraints[1]["data"]["cluster"] == "cluster1"
+
+        # Update constraint cluster term with case-insensitive id
+        res = client.put(
+            f"/v1/studies/{study_id}/bindingconstraints/{bc_id}/term",
+            json={
+                "id": f"{area1_name}.Cluster1",
+                "weight": 4,
+            },
+            headers=user_headers,
+        )
+        assert res.status_code == 200, res.json()
+
+        # The term should be successfully updated
+        res = client.get(
+            f"/v1/studies/{study_id}/bindingconstraints/{bc_id}",
+            headers=user_headers,
+        )
+        binding_constraint = res.json()
+        constraints = binding_constraint["constraints"]
+        assert res.status_code == 200, res.json()
+        assert binding_constraint["id"] == bc_id
+        assert len(constraints) == 2
+        assert constraints[1]["id"] == f"{area1_name}.cluster1"
+        assert constraints[1]["weight"] == 4
+
+        # Update constraint cluster term with invalid id
+        res = client.put(
+            f"/v1/studies/{study_id}/bindingconstraints/{bc_id}/term",
+            json={
+                "id": f"{area1_name}.cluster2",
+                "weight": 4,
+            },
+            headers=user_headers,
+        )
+        assert res.status_code == 404, res.json()
+        assert res.json() == {
+            "description": f"{study_id}",
+            "exception": "ConstraintIdNotFoundError",
+        }
+
+        # Update constraint cluster term with empty data
+        res = client.put(
+            f"/v1/studies/{study_id}/bindingconstraints/{bc_id}/term",
+            json={
+                "id": f"{area1_name}.cluster1",
+                "data": {},
+            },
+            headers=user_headers,
+        )
+        assert res.status_code == 422, res.json()
+        assert res.json() == {
+            "body": {"data": {}, "id": "area1.cluster1"},
+            "description": "field required",
+            "exception": "RequestValidationError",
+        }
 
         # Create Variant
         res = client.post(
@@ -69,7 +259,7 @@ class TestSTStorage:
                 {
                     "action": "create_binding_constraint",
                     "args": {
-                        "name": "binding_constraint_1",
+                        "name": "binding_constraint_3",
                         "enabled": True,
                         "time_step": "hourly",
                         "operator": "less",
@@ -88,7 +278,7 @@ class TestSTStorage:
                 {
                     "action": "create_binding_constraint",
                     "args": {
-                        "name": "binding_constraint_2",
+                        "name": "binding_constraint_4",
                         "enabled": True,
                         "time_step": "hourly",
                         "operator": "less",
@@ -105,11 +295,11 @@ class TestSTStorage:
         res = client.get(f"/v1/studies/{variant_id}/bindingconstraints", headers=user_headers)
         binding_constraints_list = res.json()
         assert res.status_code == 200, res.json()
-        assert len(binding_constraints_list) == 2
-        assert binding_constraints_list[0]["id"] == "binding_constraint_1"
-        assert binding_constraints_list[1]["id"] == "binding_constraint_2"
+        assert len(binding_constraints_list) == 4
+        assert binding_constraints_list[2]["id"] == "binding_constraint_3"
+        assert binding_constraints_list[3]["id"] == "binding_constraint_4"
 
-        bc_id = binding_constraints_list[0]["id"]
+        bc_id = binding_constraints_list[2]["id"]
 
         # Update element of Binding constraint
         new_comment = "We made it !"
@@ -130,7 +320,7 @@ class TestSTStorage:
         assert res.status_code == 200, res.json()
         assert comments == new_comment
 
-        # Add Constraint term
+        # Add Binding Constraint term
         area1_name = "area1"
         area2_name = "area2"
 
@@ -209,7 +399,7 @@ class TestSTStorage:
         res = client.post(
             f"/v1/studies/{variant_id}/bindingconstraints",
             json={
-                "name": "binding_constraint_3",
+                "name": "binding_constraint_5",
                 "enabled": True,
                 "time_step": "hourly",
                 "operator": "less",
@@ -224,7 +414,7 @@ class TestSTStorage:
         res = client.post(
             f"/v1/studies/{variant_id}/bindingconstraints",
             json={
-                "name": "binding_constraint_3",
+                "name": "binding_constraint_5",
                 "enabled": True,
                 "time_step": "hourly",
                 "operator": "less",
@@ -235,7 +425,7 @@ class TestSTStorage:
         )
         assert res.status_code == 409, res.json()
         assert res.json() == {
-            "description": "A binding constraint with the same name already exists: binding_constraint_3.",
+            "description": "A binding constraint with the same name already exists: binding_constraint_5.",
             "exception": "DuplicateConstraintName",
         }
 
@@ -277,10 +467,10 @@ class TestSTStorage:
             "exception": "InvalidConstraintName",
         }
 
-        # Asserts that only 3 binding constraints have been created
+        # Asserts that 5 binding constraints have been created
         res = client.get(f"/v1/studies/{variant_id}/bindingconstraints", headers=user_headers)
         assert res.status_code == 200, res.json()
-        assert len(res.json()) == 3
+        assert len(res.json()) == 5
 
         # The user change the time_step to daily instead of hourly.
         # We must check that the matrix is a daily/weekly matrix.

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintTerm/OptionsList.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintTerm/OptionsList.tsx
@@ -63,7 +63,7 @@ export default function OptionsList(props: Props) {
       )
       .map((elm) => ({
         name: elm.name,
-        id: elm.id,
+        id: elm.id.toLowerCase(),
       }));
     return tmp;
   }, [constraintsTerm, isLink, options, value1, value2]);
@@ -144,7 +144,7 @@ export default function OptionsList(props: Props) {
         name="value2"
         list={options2}
         label={t(`study.${name2}`)}
-        data={value2}
+        data={value2.toLowerCase()}
         handleChange={(key, value) => handleValue2(value as string)}
         sx={{
           flexGrow: 1,


### PR DESCRIPTION
### Description

This PR introduces changes to ensure consistent handling of case sensitivity in binding constraint term IDs across the backend and frontend. It also includes additional tests to validate this behavior.

### Backend

Updated the `update_constraint_term` function, to handle term IDs in a case-insensitive manner. This ensures that term IDs are processed consistently, regardless of their case.
Modified ID comparisons and processing logic to use lowercase versions of term IDs, aligning with the frontend changes for uniformity and reducing the likelihood of mismatches due to case differences.

### Frontend

In the `OptionsList` component, normalized the cluster IDs to lowercase. This change allow the frontend to display clusters names for BC terms regardless of their ID case.
