### PR TITLE
fix(disk-usage): fix bug on variants

### DIFF
--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -2373,5 +2373,6 @@ class StudyService:
         """
         study = self.get_study(uuid=uuid)
         assert_permission(params.user, study, StudyPermissionType.READ)
-        path = str(self.storage_service.get_storage(study).get_study_path(study))
-        return get_disk_usage(path=path)
+        study_path = self.storage_service.get_storage(study).get_study_path(study)
+        # If the study is a variant, it's possible that it only exists in db and not on disk. If so, we return 0.
+        return get_disk_usage(path=str(study_path)) if study_path.exists() else 0

--- a/tests/integration/studies_blueprint/test_disk_usage.py
+++ b/tests/integration/studies_blueprint/test_disk_usage.py
@@ -1,10 +1,14 @@
 from starlette.testclient import TestClient
 
+from antarest.core.tasks.model import TaskStatus
+from tests.integration.utils import wait_task_completion
+
 
 class TestDiskUsage:
     def test_disk_usage_endpoint(
         self,
         client: TestClient,
+        admin_access_token: str,
         user_access_token: str,
         study_id: str,
     ) -> None:
@@ -14,6 +18,7 @@ class TestDiskUsage:
         - Ensure a successful response is received.
         - Confirm that the JSON response is an integer which represent a (big enough) directory size.
         """
+        admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
         res = client.get(
             f"/v1/studies/{study_id}/disk-usage",
             headers={"Authorization": f"Bearer {user_access_token}"},
@@ -21,3 +26,27 @@ class TestDiskUsage:
         assert res.status_code == 200, res.json()
         disk_usage = res.json()  # currently: 7.47 Mio on Ubuntu
         assert 7 * 1024 * 1024 < disk_usage < 8 * 1024 * 1024
+
+        # Study copy
+        copied = client.post(
+            f"/v1/studies/{study_id}/copy?dest=copied&use_task=false",
+            headers=admin_headers,
+        )
+        assert copied.status_code == 201
+        parent_id = copied.json()
+
+        # Create variant
+        res = client.post(
+            f"/v1/studies/{parent_id}/variants",
+            headers=admin_headers,
+            params={"name": "Variant Test"},
+        )
+        assert res.status_code == 200
+        variant_id = res.json()
+
+        res = client.get(
+            f"/v1/studies/{variant_id}/disk-usage",
+            headers=admin_headers,
+        )
+        assert res.status_code == 200
+        assert res.json() == 0

--- a/tests/integration/studies_blueprint/test_disk_usage.py
+++ b/tests/integration/studies_blueprint/test_disk_usage.py
@@ -1,14 +1,10 @@
 from starlette.testclient import TestClient
 
-from antarest.core.tasks.model import TaskStatus
-from tests.integration.utils import wait_task_completion
-
 
 class TestDiskUsage:
     def test_disk_usage_endpoint(
         self,
         client: TestClient,
-        admin_access_token: str,
         user_access_token: str,
         study_id: str,
     ) -> None:
@@ -18,7 +14,7 @@ class TestDiskUsage:
         - Ensure a successful response is received.
         - Confirm that the JSON response is an integer which represent a (big enough) directory size.
         """
-        admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
+        user_headers = {"Authorization": f"Bearer {user_access_token}"}
         res = client.get(
             f"/v1/studies/{study_id}/disk-usage",
             headers={"Authorization": f"Bearer {user_access_token}"},
@@ -30,7 +26,7 @@ class TestDiskUsage:
         # Study copy
         copied = client.post(
             f"/v1/studies/{study_id}/copy?dest=copied&use_task=false",
-            headers=admin_headers,
+            headers=user_headers,
         )
         assert copied.status_code == 201
         parent_id = copied.json()
@@ -38,7 +34,7 @@ class TestDiskUsage:
         # Create variant
         res = client.post(
             f"/v1/studies/{parent_id}/variants",
-            headers=admin_headers,
+            headers=user_headers,
             params={"name": "Variant Test"},
         )
         assert res.status_code == 200
@@ -46,7 +42,7 @@ class TestDiskUsage:
 
         res = client.get(
             f"/v1/studies/{variant_id}/disk-usage",
-            headers=admin_headers,
+            headers=user_headers,
         )
         assert res.status_code == 200
         assert res.json() == 0


### PR DESCRIPTION
If the study is a variant, it's possible that it only exists in db and not on disk.
If so, we used to throw a HTTP 500 Exception. Now, we return 0.
