### PR TITLE
feat(api-ui): add inflow structure form

### DIFF
--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -11,9 +11,10 @@ INFLOW_PATH = "input/hydro/prepro/{area_id}/prepro/prepro"
 
 
 class InflowStructure(FormFieldsBaseModel):
-    """Represents the inflow structure form values in the hydrolic configuration."""
+    """Represents the inflow structure form values in the hydraulic configuration."""
 
-    # NOTE: Currently, there is only one field for the inflow structure model due to the scope of hydro config requirements, it may change.
+    # NOTE: Currently, there is only one field for the inflow structure model
+    # due to the scope of hydro config requirements, it may change.
     inter_monthly_correlation: float = Field(default=0.5, ge=0, le=1, description="Inter-monthly correlation value")
 
 
@@ -131,7 +132,8 @@ class HydroManager:
             file_study = self.storage_service.get_storage(study).get_raw(study)
             execute_or_add_commands(study, file_study, commands, self.storage_service)
 
-    def get_inflowstructure(self, study: Study, area_id: str) -> InflowStructure:
+    # noinspection SpellCheckingInspection
+    def get_inflow_structure(self, study: Study, area_id: str) -> InflowStructure:
         """
         Retrieves inflow structure values for a specific area within a study.
 
@@ -144,14 +146,15 @@ class HydroManager:
         inter_monthly_correlation = file_study.tree.get(path.split("/")).get("intermonthly-correlation", 0.5)
         return InflowStructure(inter_monthly_correlation=inter_monthly_correlation)
 
-    def update_inflowstructure(self, study: Study, area_id: str, values: InflowStructure) -> None:
+    # noinspection SpellCheckingInspection
+    def update_inflow_structure(self, study: Study, area_id: str, values: InflowStructure) -> None:
         """
         Updates inflow structure values for a specific area within a study.
 
-        Parameters:
+        Args:
             study: The study instance to update the inflow data for.
             area_id: The area identifier to update data for.
-            values (InflowStructure): The new inflow structure values to be updated.
+            values: The new inflow structure values to be updated.
 
         Raises:
             RequestValidationError: If the provided `values` parameter is None or invalid.

--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -11,11 +11,17 @@ INFLOW_PATH = "input/hydro/prepro/{area_id}/prepro/prepro"
 
 
 class InflowStructure(FormFieldsBaseModel):
-    """Represents the inflow structure form values in the hydraulic configuration."""
+    """Represents the inflow structure values in the hydraulic configuration."""
 
     # NOTE: Currently, there is only one field for the inflow structure model
     # due to the scope of hydro config requirements, it may change.
-    inter_monthly_correlation: float = Field(default=0.5, ge=0, le=1, description="Inter-monthly correlation value")
+    inter_monthly_correlation: float = Field(
+        default=0.5,
+        ge=0,
+        le=1,
+        description="Average correlation between the energy of a month and that of the next month",
+        title="Inter-monthly correlation",
+    )
 
 
 class ManagementOptionsFormFields(FormFieldsBaseModel):

--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -7,6 +7,15 @@ from antarest.study.model import Study
 from antarest.study.storage.storage_service import StudyStorageService
 from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 
+INFLOW_PATH = "input/hydro/prepro/{area_id}/prepro/prepro"
+
+
+class InflowStructure(FormFieldsBaseModel):
+    """Represents the inflow structure form values in the hydrolic configuration."""
+
+    # NOTE: Currently, there is only one field for the inflow structure model due to the scope of hydro config requirements, it may change.
+    inter_monthly_correlation: float = Field(default=0.5, ge=0, le=1, description="Inter-monthly correlation value")
+
 
 class ManagementOptionsFormFields(FormFieldsBaseModel):
     inter_daily_breakdown: Optional[float] = Field(ge=0)
@@ -121,3 +130,38 @@ class HydroManager:
         if len(commands) > 0:
             file_study = self.storage_service.get_storage(study).get_raw(study)
             execute_or_add_commands(study, file_study, commands, self.storage_service)
+
+    def get_inflowstructure(self, study: Study, area_id: str) -> InflowStructure:
+        """
+        Retrieves inflow structure values for a specific area within a study.
+
+        Returns:
+            InflowStructure: The inflow structure values.
+        """
+        # NOTE: Focusing on the single field "intermonthly-correlation" due to current model scope.
+        path = INFLOW_PATH.format(area_id=area_id)
+        file_study = self.storage_service.get_storage(study).get_raw(study)
+        inter_monthly_correlation = file_study.tree.get(path.split("/")).get("intermonthly-correlation", 0.5)
+        return InflowStructure(inter_monthly_correlation=inter_monthly_correlation)
+
+    def update_inflowstructure(self, study: Study, area_id: str, values: InflowStructure) -> None:
+        """
+        Updates inflow structure values for a specific area within a study.
+
+        Parameters:
+            study: The study instance to update the inflow data for.
+            area_id: The area identifier to update data for.
+            values (InflowStructure): The new inflow structure values to be updated.
+
+        Raises:
+            RequestValidationError: If the provided `values` parameter is None or invalid.
+        """
+        # NOTE: Updates only "intermonthly-correlation" due to current model scope.
+        path = INFLOW_PATH.format(area_id=area_id)
+        command = UpdateConfig(
+            target=path,
+            data={"intermonthly-correlation": values.inter_monthly_correlation},
+            command_context=self.storage_service.variant_study_service.command_factory.command_context,
+        )
+        file_study = self.storage_service.get_storage(study).get_raw(study)
+        execute_or_add_commands(study, file_study, [command], self.storage_service)

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/prepro/area/prepro.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/prepro/area/prepro.py
@@ -3,7 +3,17 @@ from antarest.study.storage.rawstudy.model.filesystem.context import ContextServ
 from antarest.study.storage.rawstudy.model.filesystem.ini_file_node import IniFileNode
 
 
+# noinspection SpellCheckingInspection
 class InputHydroPreproAreaPrepro(IniFileNode):
+    """
+    Configuration for the hydraulic Inflow Structure:
+
+    - intermonthly-correlation: Average correlation between the energy of a month and
+      that of the next month (inter-monthly correlation).
+
+    See: https://antares-simulator.readthedocs.io/en/latest/reference-guide/04-active_windows/#hydro
+    """
+
     def __init__(self, context: ContextServer, config: FileStudyTreeConfig):
         types = {"prepro": {"intermonthly-correlation": float}}
         IniFileNode.__init__(self, context, config, types)

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -18,7 +18,7 @@ from antarest.study.business.adequacy_patch_management import AdequacyPatchFormF
 from antarest.study.business.advanced_parameters_management import AdvancedParamsFormFields
 from antarest.study.business.allocation_management import AllocationFormFields, AllocationMatrix
 from antarest.study.business.area_management import AreaCreationDTO, AreaInfoDTO, AreaType, AreaUI, LayerInfoDTO
-from antarest.study.business.areas.hydro_management import ManagementOptionsFormFields, InflowStructure
+from antarest.study.business.areas.hydro_management import InflowStructure, ManagementOptionsFormFields
 from antarest.study.business.areas.properties_management import PropertiesFormFields
 from antarest.study.business.areas.renewable_management import (
     RenewableClusterCreation,
@@ -424,7 +424,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         study_service.hydro_manager.set_field_values(study, data, area_id)
 
     @bp.get(
-        "/studies/{study_id}/areas/{area_id}/hydro/inflowstructure",
+        "/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
         tags=[APITag.study_data],
         summary="Get inflow structure form values",
         response_model=InflowStructure,
@@ -443,7 +443,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         return study_service.hydro_manager.get_inflow_structure(study, area_id)
 
     @bp.put(
-        "/studies/{study_id}/areas/{area_id}/hydro/inflowstructure",
+        "/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
         tags=[APITag.study_data],
         summary="Update inflow structure form values",
         response_model=InflowStructure,

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -423,43 +423,46 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
 
         study_service.hydro_manager.set_field_values(study, data, area_id)
 
+    # noinspection SpellCheckingInspection
     @bp.get(
-        "/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+        "/studies/{uuid}/areas/{area_id}/hydro/inflow-structure",
         tags=[APITag.study_data],
-        summary="Get inflow structure form values",
+        summary="Get inflow structure values",
         response_model=InflowStructure,
     )
     def get_inflow_structure(
-        study_id: str,
+        uuid: str,
         area_id: str,
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> InflowStructure:
+        """Get the configuration for the hydraulic inflow structure of the given area."""
         logger.info(
-            msg=f"Getting inflow structure values for area {area_id} of study {study_id}",
+            msg=f"Getting inflow structure values for area {area_id} of study {uuid}",
             extra={"user": current_user.id},
         )
         params = RequestParameters(user=current_user)
-        study = study_service.check_study_access(study_id, StudyPermissionType.READ, params)
+        study = study_service.check_study_access(uuid, StudyPermissionType.READ, params)
         return study_service.hydro_manager.get_inflow_structure(study, area_id)
 
     @bp.put(
-        "/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+        "/studies/{uuid}/areas/{area_id}/hydro/inflow-structure",
         tags=[APITag.study_data],
-        summary="Update inflow structure form values",
+        summary="Update inflow structure values",
         response_model=InflowStructure,
     )
     def update_inflow_structure(
-        study_id: str,
+        uuid: str,
         area_id: str,
         values: InflowStructure,
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> None:
+        """Update the configuration for the hydraulic inflow structure of the given area."""
         logger.info(
-            msg=f"Updating inflow structure values for area {area_id} of study {study_id}",
+            msg=f"Updating inflow structure values for area {area_id} of study {uuid}",
             extra={"user": current_user.id},
         )
         params = RequestParameters(user=current_user)
-        study = study_service.check_study_access(study_id, StudyPermissionType.WRITE, params)
+        study = study_service.check_study_access(uuid, StudyPermissionType.WRITE, params)
         return study_service.hydro_manager.update_inflow_structure(study, area_id, values)
 
     @bp.put(

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -18,7 +18,7 @@ from antarest.study.business.adequacy_patch_management import AdequacyPatchFormF
 from antarest.study.business.advanced_parameters_management import AdvancedParamsFormFields
 from antarest.study.business.allocation_management import AllocationFormFields, AllocationMatrix
 from antarest.study.business.area_management import AreaCreationDTO, AreaInfoDTO, AreaType, AreaUI, LayerInfoDTO
-from antarest.study.business.areas.hydro_management import ManagementOptionsFormFields
+from antarest.study.business.areas.hydro_management import ManagementOptionsFormFields, InflowStructure
 from antarest.study.business.areas.properties_management import PropertiesFormFields
 from antarest.study.business.areas.renewable_management import (
     RenewableClusterCreation,
@@ -422,6 +422,45 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         study = study_service.check_study_access(uuid, StudyPermissionType.WRITE, params)
 
         study_service.hydro_manager.set_field_values(study, data, area_id)
+
+    @bp.get(
+        "/studies/{study_id}/areas/{area_id}/hydro/inflowstructure",
+        tags=[APITag.study_data],
+        summary="Get inflow structure form values",
+        response_model=InflowStructure,
+    )
+    def get_inflowstructure(
+        study_id: str,
+        area_id: str,
+        current_user: JWTUser = Depends(auth.get_current_user),
+    ) -> InflowStructure:
+        logger.info(
+            msg=f"Getting inflow structure values for area {area_id} of study {study_id}",
+            extra={"user": current_user.id},
+        )
+        params = RequestParameters(user=current_user)
+        study = study_service.check_study_access(study_id, StudyPermissionType.READ, params)
+        return study_service.hydro_manager.get_inflowstructure(study, area_id)
+
+    @bp.put(
+        "/studies/{study_id}/areas/{area_id}/hydro/inflowstructure",
+        tags=[APITag.study_data],
+        summary="Update inflow structure form values",
+        response_model=InflowStructure,
+    )
+    def update_inflowstructure(
+        study_id: str,
+        area_id: str,
+        values: InflowStructure,
+        current_user: JWTUser = Depends(auth.get_current_user),
+    ) -> None:
+        logger.info(
+            msg=f"Updating inflow structure values for area {area_id} of study {study_id}",
+            extra={"user": current_user.id},
+        )
+        params = RequestParameters(user=current_user)
+        study = study_service.check_study_access(study_id, StudyPermissionType.WRITE, params)
+        return study_service.hydro_manager.update_inflowstructure(study, area_id, values)
 
     @bp.put(
         "/studies/{uuid}/matrix",

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -429,7 +429,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         summary="Get inflow structure form values",
         response_model=InflowStructure,
     )
-    def get_inflowstructure(
+    def get_inflow_structure(
         study_id: str,
         area_id: str,
         current_user: JWTUser = Depends(auth.get_current_user),
@@ -440,7 +440,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         )
         params = RequestParameters(user=current_user)
         study = study_service.check_study_access(study_id, StudyPermissionType.READ, params)
-        return study_service.hydro_manager.get_inflowstructure(study, area_id)
+        return study_service.hydro_manager.get_inflow_structure(study, area_id)
 
     @bp.put(
         "/studies/{study_id}/areas/{area_id}/hydro/inflowstructure",
@@ -448,7 +448,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         summary="Update inflow structure form values",
         response_model=InflowStructure,
     )
-    def update_inflowstructure(
+    def update_inflow_structure(
         study_id: str,
         area_id: str,
         values: InflowStructure,
@@ -460,7 +460,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         )
         params = RequestParameters(user=current_user)
         study = study_service.check_study_access(study_id, StudyPermissionType.WRITE, params)
-        return study_service.hydro_manager.update_inflowstructure(study, area_id, values)
+        return study_service.hydro_manager.update_inflow_structure(study, area_id, values)
 
     @bp.put(
         "/studies/{uuid}/matrix",

--- a/tests/integration/study_data_blueprint/test_hydro_inflow_structure.py
+++ b/tests/integration/study_data_blueprint/test_hydro_inflow_structure.py
@@ -1,0 +1,155 @@
+from http import HTTPStatus
+from unittest.mock import ANY
+
+import pytest
+from starlette.testclient import TestClient
+
+
+@pytest.mark.unit_test
+class TestHydroInflowStructure:
+    """
+    Test the end points related to hydraulic inflow-structure.
+
+    Those tests use the "examples/studies/STA-mini.zip" Study,
+    which contains the following areas: ["de", "es", "fr", "it"].
+    """
+
+    def test_get_inflow_structure(
+        self,
+        client: TestClient,
+        user_access_token: str,
+        study_id: str,
+    ):
+        user_header = {"Authorization": f"Bearer {user_access_token}"}
+        area_id = "fr"
+
+        # ====================
+        # Use case : RAW study
+        # ====================
+
+        # Check that the default values are returned
+        res = client.get(
+            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            headers=user_header,
+        )
+        assert res.status_code == HTTPStatus.OK, res.json()
+        actual = res.json()
+        expected = {"interMonthlyCorrelation": 0.5}
+        assert actual == expected
+
+        # Update the values
+        obj = {"interMonthlyCorrelation": 0.8}
+        res = client.put(
+            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            headers=user_header,
+            json=obj,
+        )
+        assert res.status_code == HTTPStatus.OK, res.json()
+
+        # Check that the right values are returned
+        res = client.get(
+            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            headers=user_header,
+        )
+        assert res.status_code == HTTPStatus.OK, res.json()
+        actual = res.json()
+        expected = {"interMonthlyCorrelation": 0.8}
+        assert actual == expected
+
+        # ========================
+        # Use case : Variant study
+        # ========================
+
+        # Create a managed study from the RAW study.
+        res = client.post(
+            f"/v1/studies/{study_id}/copy",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            params={"dest": "Clone", "with_outputs": False, "use_task": False},
+        )
+        res.raise_for_status()
+        managed_id = res.json()
+        assert managed_id is not None
+
+        # Create a variant from the managed study.
+        res = client.post(
+            f"/v1/studies/{managed_id}/variants",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            params={"name": "Variant"},
+        )
+        res.raise_for_status()
+        variant_id = res.json()
+        assert variant_id is not None
+
+        # Check that the return values match the RAW study values
+        res = client.get(
+            f"/v1/studies/{variant_id}/areas/{area_id}/hydro/inflow-structure",
+            headers=user_header,
+        )
+        assert res.status_code == HTTPStatus.OK, res.json()
+        actual = res.json()
+        expected = {"interMonthlyCorrelation": 0.8}
+        assert actual == expected
+
+        # Update the values
+        obj = {"interMonthlyCorrelation": 0.9}
+        res = client.put(
+            f"/v1/studies/{variant_id}/areas/{area_id}/hydro/inflow-structure",
+            headers=user_header,
+            json=obj,
+        )
+        assert res.status_code == HTTPStatus.OK, res.json()
+
+        # Check that the right values are returned
+        res = client.get(
+            f"/v1/studies/{variant_id}/areas/{area_id}/hydro/inflow-structure",
+            headers=user_header,
+        )
+        assert res.status_code == HTTPStatus.OK, res.json()
+        actual = res.json()
+        expected = {"interMonthlyCorrelation": 0.9}
+        assert actual == expected
+
+        # Check the variant commands
+        res = client.get(
+            f"/v1/studies/{variant_id}/commands",
+            headers=user_header,
+        )
+        assert res.status_code == HTTPStatus.OK, res.json()
+        actual = res.json()
+        assert len(actual) == 2
+        expected = {
+            "id": ANY,
+            "action": "update_config",
+            "args": {
+                "target": "input/hydro/prepro/fr/prepro/prepro",
+                "data": {"intermonthly-correlation": 0.9},
+            },
+            "version": 1,
+        }
+        assert actual[1] == expected
+
+    def test_update_inflow_structure__invalid_values(
+        self,
+        client: TestClient,
+        user_access_token: str,
+        study_id: str,
+    ):
+        user_header = {"Authorization": f"Bearer {user_access_token}"}
+        area_id = "fr"
+
+        # Update the values with invalid values
+        obj = {"interMonthlyCorrelation": 1.1}
+        res = client.put(
+            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            headers=user_header,
+            json=obj,
+        )
+        assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, res.json()
+
+        obj = {"interMonthlyCorrelation": -0.1}
+        res = client.put(
+            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            headers=user_header,
+            json=obj,
+        )
+        assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, res.json()

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/index.tsx
@@ -1,0 +1,79 @@
+import { useOutletContext } from "react-router";
+import { StudyMetadata } from "../../../../../../../../common/types";
+import useAppSelector from "../../../../../../../../redux/hooks/useAppSelector";
+import { getCurrentAreaId } from "../../../../../../../../redux/selectors";
+import Form from "../../../../../../../common/Form";
+import {
+  type InflowStructureFields,
+  getInflowStructureFields,
+  updatetInflowStructureFields,
+} from "./utils";
+import NumberFE from "../../../../../../../common/fieldEditors/NumberFE";
+import { SubmitHandlerPlus } from "../../../../../../../common/Form/types";
+import { Box } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+function InflowStructure() {
+  const [t] = useTranslation();
+  const { study } = useOutletContext<{ study: StudyMetadata }>();
+  const areaId = useAppSelector(getCurrentAreaId);
+
+  ////////////////////////////////////////////////////////////////
+  // Event handlers
+  ////////////////////////////////////////////////////////////////
+
+  const handleSubmit = (data: SubmitHandlerPlus<InflowStructureFields>) => {
+    return updatetInflowStructureFields(study.id, areaId, data.values);
+  };
+
+  ////////////////////////////////////////////////////////////////
+  // JSX
+  ////////////////////////////////////////////////////////////////
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        width: 1,
+      }}
+    >
+      <Form
+        key={study.id + areaId}
+        config={{
+          defaultValues: () => getInflowStructureFields(study.id, areaId),
+        }}
+        onSubmit={handleSubmit}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          py: 1,
+        }}
+        enableUndoRedo
+      >
+        {({ control }) => (
+          <NumberFE
+            label="Inter-Monthly Correlation"
+            name="interMonthlyCorrelation"
+            control={control}
+            fullWidth
+            rules={{
+              min: {
+                value: 0,
+                message: t("form.field.minValue", { 0: 0 }),
+              },
+              max: {
+                value: 1,
+                message: t("form.field.maxValue", { 0: 1 }),
+              },
+            }}
+            inputProps={{ step: 0.1 }}
+          />
+        )}
+      </Form>
+    </Box>
+  );
+}
+
+export default InflowStructure;

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/index.tsx
@@ -10,7 +10,6 @@ import {
 } from "./utils";
 import NumberFE from "../../../../../../../common/fieldEditors/NumberFE";
 import { SubmitHandlerPlus } from "../../../../../../../common/Form/types";
-import { Box } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 function InflowStructure() {
@@ -31,48 +30,37 @@ function InflowStructure() {
   ////////////////////////////////////////////////////////////////
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "row",
-        width: 1,
+    <Form
+      key={study.id + areaId}
+      config={{
+        defaultValues: () => getInflowStructureFields(study.id, areaId),
       }}
+      onSubmit={handleSubmit}
+      miniSubmitButton
+      enableUndoRedo
+      sx={{ display: "flex", alignItems: "center", ".Form__Footer": { p: 0 } }}
     >
-      <Form
-        key={study.id + areaId}
-        config={{
-          defaultValues: () => getInflowStructureFields(study.id, areaId),
-        }}
-        onSubmit={handleSubmit}
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          py: 1,
-        }}
-        enableUndoRedo
-      >
-        {({ control }) => (
-          <NumberFE
-            label="Inter-Monthly Correlation"
-            name="interMonthlyCorrelation"
-            control={control}
-            fullWidth
-            rules={{
-              min: {
-                value: 0,
-                message: t("form.field.minValue", { 0: 0 }),
-              },
-              max: {
-                value: 1,
-                message: t("form.field.maxValue", { 0: 1 }),
-              },
-            }}
-            inputProps={{ step: 0.1 }}
-          />
-        )}
-      </Form>
-    </Box>
+      {({ control }) => (
+        <NumberFE
+          label="Inter-Monthly Correlation"
+          name="interMonthlyCorrelation"
+          control={control}
+          rules={{
+            min: {
+              value: 0,
+              message: t("form.field.minValue", { 0: 0 }),
+            },
+            max: {
+              value: 1,
+              message: t("form.field.maxValue", { 0: 1 }),
+            },
+          }}
+          inputProps={{ step: 0.1 }}
+          size="small"
+          sx={{ width: 180 }}
+        />
+      )}
+    </Form>
   );
 }
 

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/index.tsx
@@ -6,7 +6,7 @@ import Form from "../../../../../../../common/Form";
 import {
   type InflowStructureFields,
   getInflowStructureFields,
-  updatetInflowStructureFields,
+  updateInflowStructureFields,
 } from "./utils";
 import NumberFE from "../../../../../../../common/fieldEditors/NumberFE";
 import { SubmitHandlerPlus } from "../../../../../../../common/Form/types";
@@ -23,7 +23,7 @@ function InflowStructure() {
   ////////////////////////////////////////////////////////////////
 
   const handleSubmit = (data: SubmitHandlerPlus<InflowStructureFields>) => {
-    return updatetInflowStructureFields(study.id, areaId, data.values);
+    return updateInflowStructureFields(study.id, areaId, data.values);
   };
 
   ////////////////////////////////////////////////////////////////

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/utils.ts
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/utils.ts
@@ -25,7 +25,7 @@ export async function getInflowStructureFields(
   return res.data;
 }
 
-export function updatetInflowStructureFields(
+export function updateInflowStructureFields(
   studyId: StudyMetadata["id"],
   areaId: string,
   values: InflowStructureFields,

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/utils.ts
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/utils.ts
@@ -14,7 +14,7 @@ export interface InflowStructureFields {
 ////////////////////////////////////////////////////////////////
 
 function makeRequestURL(studyId: StudyMetadata["id"], areaId: string): string {
-  return `v1/studies/${studyId}/areas/${areaId}/hydro/inflowstructure`;
+  return `v1/studies/${studyId}/areas/${areaId}/hydro/inflow-structure`;
 }
 
 export async function getInflowStructureFields(

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/utils.ts
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/InflowStructure/utils.ts
@@ -1,0 +1,34 @@
+import { type StudyMetadata } from "../../../../../../../../common/types";
+import client from "../../../../../../../../services/api/client";
+
+////////////////////////////////////////////////////////////////
+// Types
+////////////////////////////////////////////////////////////////
+
+export interface InflowStructureFields {
+  interMonthlyCorrelation: number;
+}
+
+////////////////////////////////////////////////////////////////
+// Utils
+////////////////////////////////////////////////////////////////
+
+function makeRequestURL(studyId: StudyMetadata["id"], areaId: string): string {
+  return `v1/studies/${studyId}/areas/${areaId}/hydro/inflowstructure`;
+}
+
+export async function getInflowStructureFields(
+  studyId: StudyMetadata["id"],
+  areaId: string,
+): Promise<InflowStructureFields> {
+  const res = await client.get(makeRequestURL(studyId, areaId));
+  return res.data;
+}
+
+export function updatetInflowStructureFields(
+  studyId: StudyMetadata["id"],
+  areaId: string,
+  values: InflowStructureFields,
+): Promise<void> {
+  return client.put(makeRequestURL(studyId, areaId), values);
+}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/SplitHydroMatrix.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/SplitHydroMatrix.tsx
@@ -1,3 +1,4 @@
+import { Box } from "@mui/material";
 import SplitView, { SplitViewProps } from "../../../../../../common/SplitView";
 import HydroMatrix from "./HydroMatrix";
 import { HydroMatrixType } from "./utils";
@@ -12,7 +13,11 @@ interface Props {
 function SplitHydroMatrix({ types, direction, sizes, form: Form }: Props) {
   return (
     <>
-      {Form && <Form />}
+      {Form && (
+        <Box sx={{ width: 1, py: 1 }}>
+          <Form />
+        </Box>
+      )}
       <SplitView direction={direction} sizes={sizes}>
         <HydroMatrix type={types[0]} />
         <HydroMatrix type={types[1]} />

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/SplitHydroMatrix.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/SplitHydroMatrix.tsx
@@ -6,14 +6,18 @@ interface Props {
   types: [HydroMatrixType, HydroMatrixType];
   direction?: SplitViewProps["direction"];
   sizes: [number, number];
+  form?: React.ComponentType;
 }
 
-function SplitHydroMatrix({ types, direction, sizes }: Props) {
+function SplitHydroMatrix({ types, direction, sizes, form: Form }: Props) {
   return (
-    <SplitView direction={direction} sizes={sizes}>
-      <HydroMatrix type={types[0]} />
-      <HydroMatrix type={types[1]} />
-    </SplitView>
+    <>
+      {Form && <Form />}
+      <SplitView direction={direction} sizes={sizes}>
+        <HydroMatrix type={types[0]} />
+        <HydroMatrix type={types[1]} />
+      </SplitView>
+    </>
   );
 }
 

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/index.tsx
@@ -19,7 +19,7 @@ function Hydro() {
 
     return [
       { label: "Management options", path: `${basePath}/management` },
-      { label: "Inflow structure", path: `${basePath}/inflowstructure` },
+      { label: "Inflow structure", path: `${basePath}/inflow-structure` },
       { label: "Allocation", path: `${basePath}/allocation` },
       { label: "Correlation", path: `${basePath}/correlation` },
       {

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/utils.ts
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/utils.ts
@@ -2,6 +2,7 @@ import { MatrixStats, MatrixType } from "../../../../../../../common/types";
 import { SplitViewProps } from "../../../../../../common/SplitView";
 import { getAllocationMatrix } from "./Allocation/utils";
 import { getCorrelationMatrix } from "./Correlation/utils";
+import InflowStructure from "./InflowStructure";
 
 ////////////////////////////////////////////////////////////////
 // Enums
@@ -48,6 +49,7 @@ export interface HydroRoute {
     partnerType: HydroMatrixType;
     sizes: [number, number];
   };
+  form?: React.ComponentType;
 }
 
 export interface AreaCoefficientItem {
@@ -69,6 +71,7 @@ export const HYDRO_ROUTES: HydroRoute[] = [
       partnerType: HydroMatrixType.OverallMonthlyHydro,
       sizes: [50, 50],
     },
+    form: InflowStructure,
   },
   {
     path: "dailypower&energy",

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/utils.ts
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/utils.ts
@@ -63,7 +63,7 @@ export interface AreaCoefficientItem {
 
 export const HYDRO_ROUTES: HydroRoute[] = [
   {
-    path: "inflowstructure",
+    path: "inflow-structure",
     type: HydroMatrixType.InflowPattern,
     isSplitView: true,
     splitConfig: {

--- a/webapp/src/components/App/index.tsx
+++ b/webapp/src/components/App/index.tsx
@@ -109,7 +109,13 @@ function App() {
                                 element={<Correlation />}
                               />
                               {HYDRO_ROUTES.map(
-                                ({ path, type, isSplitView, splitConfig }) => {
+                                ({
+                                  path,
+                                  type,
+                                  isSplitView,
+                                  splitConfig,
+                                  form,
+                                }) => {
                                   return isSplitView && splitConfig ? (
                                     <Route
                                       key={path}
@@ -122,6 +128,7 @@ function App() {
                                           ]}
                                           direction={splitConfig.direction}
                                           sizes={splitConfig.sizes}
+                                          form={form}
                                         />
                                       }
                                     />

--- a/webapp/src/components/common/Form/index.tsx
+++ b/webapp/src/components/common/Form/index.tsx
@@ -74,6 +74,7 @@ export interface FormProps<
     | React.ReactNode;
   submitButtonText?: string;
   submitButtonIcon?: LoadingButtonProps["startIcon"];
+  miniSubmitButton?: boolean;
   hideSubmitButton?: boolean;
   onStateChange?: (state: FormState<TFieldValues>) => void;
   autoSubmit?: boolean | AutoSubmitConfig;
@@ -96,7 +97,8 @@ function Form<TFieldValues extends FieldValues, TContext>(
     onInvalid,
     children,
     submitButtonText,
-    submitButtonIcon,
+    submitButtonIcon = <SaveIcon />,
+    miniSubmitButton,
     hideSubmitButton,
     onStateChange,
     autoSubmit,
@@ -358,20 +360,19 @@ function Form<TFieldValues extends FieldValues, TContext>(
             <>
               <LoadingButton
                 type="submit"
-                variant="contained"
                 disabled={!isSubmitAllowed}
                 loading={isSubmitting}
-                loadingPosition="start"
-                startIcon={
-                  RA.isNotUndefined(submitButtonIcon) ? (
-                    submitButtonIcon
-                  ) : (
-                    <SaveIcon />
-                  )
-                }
-              >
-                {submitButtonText || t("global.save")}
-              </LoadingButton>
+                {...(miniSubmitButton
+                  ? {
+                      children: submitButtonIcon,
+                    }
+                  : {
+                      loadingPosition: "start",
+                      startIcon: submitButtonIcon,
+                      variant: "contained",
+                      children: submitButtonText || t("global.save"),
+                    })}
+              />
               {enableUndoRedo && (
                 <Divider sx={{ mx: 2 }} orientation="vertical" flexItem />
               )}


### PR DESCRIPTION
ANT-983: [https://gopro-tickets.rte-france.com/browse/ANT-983](url)

This PR introduces backend and frontend changes to support the management of inflow structure form values within the hydraulic configuration of a study. It includes the implementation of RESTful API endpoints for retrieving and updating inflow structure values, as well as the corresponding frontend UI components to interact with these endpoints.
## Backend Changes

### New Endpoints:
`GET` `/studies/{study_id}/areas/{area_id}/hydro/inflowstructure`
 Retrieves the inflow structure form values for a given area of a study. 
`PUT` `/studies/{study_id}/areas/{area_id}/hydro/inflowstructure`
Updates the inflow structure form values for a given area of a study. 

### Models:
Introduced a new model `InflowStructure` to represent the inflow structure form values, currently encapsulating an inter_monthly_correlation field with validation constraints.

### Services:
Modified study_service to include `hydro_manager` methods for getting and updating the inflow structure values based on the study and area ID.

## Frontend Changes

- Implemented a new form component `InflowStructure` within the study configuration area to provide a UI for viewing and modifying the inflow structure values. This component includes validation and error handling for the input field.
- New form prop added on `SplitHydroMatrix` to enable the display of a form in the same view
- Implemented utility functions `getInflowStructureFields` and `updateInflowStructureField`s to interact with the backend API for fetching and updating inflow structure data.

