### PR TITLE
fix(api-model): correct `AllOptionalMetaclass` for field validation in form models

### DIFF
--- a/antarest/launcher/ssh_client.py
+++ b/antarest/launcher/ssh_client.py
@@ -1,6 +1,6 @@
 import contextlib
-import socket
 import shlex
+import socket
 from typing import Any, List, Tuple
 
 import paramiko

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Tuple, cast
 
 import pydantic
-import sqlalchemy.ext.baked  # type: ignore
 import uvicorn  # type: ignore
 import uvicorn.config  # type: ignore
 from fastapi import FastAPI, HTTPException
@@ -56,18 +55,16 @@ class PathType:
     which specify whether the path argument must exist, whether it can be a file,
     and whether it can be a directory, respectively.
 
-    Example Usage:
+    Example Usage::
 
-    ```python
-    import argparse
-    from antarest.main import PathType
+        import argparse
+        from antarest.main import PathType
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--input', type=PathType(file_ok=True, exists=True))
-    args = parser.parse_args()
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--input', type=PathType(file_ok=True, exists=True))
+        args = parser.parse_args()
 
-    print(args.input)
-    ```
+        print(args.input)
 
     In the above example, `PathType` is used to specify the type of the `--input`
     argument for the `argparse` parser. The argument must be an existing file path.
@@ -401,9 +398,11 @@ def fastapi_app(
     application.add_middleware(
         RateLimitMiddleware,
         authenticate=auth_manager.create_auth_function(),
-        backend=RedisBackend(config.redis.host, config.redis.port, 1, config.redis.password)
-        if config.redis is not None
-        else MemoryBackend(),
+        backend=(
+            MemoryBackend()
+            if config.redis is None
+            else RedisBackend(config.redis.host, config.redis.port, 1, config.redis.password)
+        ),
         config=RATE_LIMIT_CONFIG,
     )
 

--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -163,7 +163,7 @@ class HydroManager:
             values: The new inflow structure values to be updated.
 
         Raises:
-            RequestValidationError: If the provided `values` parameter is None or invalid.
+            ValidationError: If the provided `values` parameter is None or invalid.
         """
         # NOTE: Updates only "intermonthly-correlation" due to current model scope.
         path = INFLOW_PATH.format(area_id=area_id)

--- a/antarest/study/business/areas/renewable_management.py
+++ b/antarest/study/business/areas/renewable_management.py
@@ -248,6 +248,7 @@ class RenewableManager:
             command_context=self.storage_service.variant_study_service.command_factory.command_context,
         )
 
+        # fixme: The `file_study` is already retrieved at the beginning of the function.
         file_study = self.storage_service.get_storage(study).get_raw(study)
         execute_or_add_commands(study, file_study, [command], self.storage_service)
         return RenewableClusterOutput(**new_config.dict(by_alias=False))

--- a/antarest/study/business/areas/renewable_management.py
+++ b/antarest/study/business/areas/renewable_management.py
@@ -37,7 +37,7 @@ class TimeSeriesInterpretation(EnumIgnoreCase):
 
 
 @camel_case_model
-class RenewableClusterInput(RenewableProperties, metaclass=AllOptionalMetaclass):
+class RenewableClusterInput(RenewableProperties, metaclass=AllOptionalMetaclass, use_none=True):
     """
     Model representing the data structure required to edit an existing renewable cluster.
     """
@@ -76,7 +76,7 @@ class RenewableClusterCreation(RenewableClusterInput):
 
 
 @camel_case_model
-class RenewableClusterOutput(RenewableConfig, metaclass=AllOptionalMetaclass):
+class RenewableClusterOutput(RenewableConfig, metaclass=AllOptionalMetaclass, use_none=True):
     """
     Model representing the output data structure to display the details of a renewable cluster.
     """

--- a/antarest/study/business/areas/st_storage_management.py
+++ b/antarest/study/business/areas/st_storage_management.py
@@ -1,7 +1,7 @@
 import functools
 import json
 import operator
-from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence
+import typing as t
 
 import numpy as np
 from pydantic import BaseModel, Extra, root_validator, validator
@@ -44,7 +44,7 @@ class STStorageInput(STStorageProperties, metaclass=AllOptionalMetaclass, use_no
 
     class Config:
         @staticmethod
-        def schema_extra(schema: MutableMapping[str, Any]) -> None:
+        def schema_extra(schema: t.MutableMapping[str, t.Any]) -> None:
             schema["example"] = STStorageInput(
                 name="Siemens Battery",
                 group=STStorageGroup.BATTERY,
@@ -64,7 +64,7 @@ class STStorageCreation(STStorageInput):
 
     # noinspection Pydantic
     @validator("name", pre=True)
-    def validate_name(cls, name: Optional[str]) -> str:
+    def validate_name(cls, name: t.Optional[str]) -> str:
         """
         Validator to check if the name is not empty.
         """
@@ -86,7 +86,7 @@ class STStorageOutput(STStorageConfig):
 
     class Config:
         @staticmethod
-        def schema_extra(schema: MutableMapping[str, Any]) -> None:
+        def schema_extra(schema: t.MutableMapping[str, t.Any]) -> None:
             schema["example"] = STStorageOutput(
                 id="siemens_battery",
                 name="Siemens Battery",
@@ -99,7 +99,7 @@ class STStorageOutput(STStorageConfig):
             )
 
     @classmethod
-    def from_config(cls, storage_id: str, config: Mapping[str, Any]) -> "STStorageOutput":
+    def from_config(cls, storage_id: str, config: t.Mapping[str, t.Any]) -> "STStorageOutput":
         storage = STStorageConfig(**config, id=storage_id)
         values = storage.dict(by_alias=False)
         return cls(**values)
@@ -126,12 +126,12 @@ class STStorageMatrix(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    data: List[List[float]]
-    index: List[int]
-    columns: List[int]
+    data: t.List[t.List[float]]
+    index: t.List[int]
+    columns: t.List[int]
 
     @validator("data")
-    def validate_time_series(cls, data: List[List[float]]) -> List[List[float]]:
+    def validate_time_series(cls, data: t.List[t.List[float]]) -> t.List[t.List[float]]:
         """
         Validator to check the integrity of the time series data.
 
@@ -189,7 +189,9 @@ class STStorageMatrices(BaseModel):
         return matrix
 
     @root_validator()
-    def validate_rule_curve(cls, values: MutableMapping[str, STStorageMatrix]) -> MutableMapping[str, STStorageMatrix]:
+    def validate_rule_curve(
+        cls, values: t.MutableMapping[str, STStorageMatrix]
+    ) -> t.MutableMapping[str, STStorageMatrix]:
         """
         Validator to ensure 'lower_rule_curve' values are less than
         or equal to 'upper_rule_curve' values.
@@ -275,7 +277,7 @@ class STStorageManager:
         self,
         study: Study,
         area_id: str,
-    ) -> Sequence[STStorageOutput]:
+    ) -> t.Sequence[STStorageOutput]:
         """
         Get the list of short-term storage configurations for the given `study`, and `area_id`.
 
@@ -375,7 +377,7 @@ class STStorageManager:
         new_data = json.loads(new_config.json(by_alias=True, exclude={"id"}))
 
         # create the dict containing the new values using aliases
-        data: Dict[str, Any] = {
+        data: t.Dict[str, t.Any] = {
             field.alias: new_data[field.alias]
             for field_name, field in new_config.__fields__.items()
             if field_name in new_values
@@ -396,7 +398,7 @@ class STStorageManager:
         self,
         study: Study,
         area_id: str,
-        storage_ids: Sequence[str],
+        storage_ids: t.Sequence[str],
     ) -> None:
         """
         Delete short-term storage configurations form the given study and area_id.
@@ -444,7 +446,7 @@ class STStorageManager:
         area_id: str,
         storage_id: str,
         ts_name: STStorageTimeSeries,
-    ) -> MutableMapping[str, Any]:
+    ) -> t.MutableMapping[str, t.Any]:
         file_study = self._get_file_study(study)
         path = STORAGE_SERIES_PATH.format(area_id=area_id, storage_id=storage_id, ts_name=ts_name)
         try:
@@ -480,7 +482,7 @@ class STStorageManager:
         area_id: str,
         storage_id: str,
         ts_name: STStorageTimeSeries,
-        matrix_obj: Dict[str, Any],
+        matrix_obj: t.Dict[str, t.Any],
     ) -> None:
         file_study = self._get_file_study(study)
         path = STORAGE_SERIES_PATH.format(area_id=area_id, storage_id=storage_id, ts_name=ts_name)

--- a/antarest/study/business/areas/st_storage_management.py
+++ b/antarest/study/business/areas/st_storage_management.py
@@ -37,7 +37,7 @@ __all__ = (
 
 
 @camel_case_model
-class STStorageInput(STStorageProperties, metaclass=AllOptionalMetaclass):
+class STStorageInput(STStorageProperties, metaclass=AllOptionalMetaclass, use_none=True):
     """
     Model representing the form used to EDIT an existing short-term storage.
     """

--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -265,6 +265,7 @@ class ThermalManager:
         # create the update config command with the modified data
         command_context = self.storage_service.variant_study_service.command_factory.command_context
         command = UpdateConfig(target=path, data=data, command_context=command_context)
+        # fixme: The `file_study` is already retrieved at the beginning of the function.
         file_study = self.storage_service.get_storage(study).get_raw(study)
         execute_or_add_commands(study, file_study, [command], self.storage_service)
 

--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -30,7 +30,7 @@ _CLUSTERS_PATH = "input/thermal/clusters/{area_id}/list"
 
 
 @camel_case_model
-class ThermalClusterInput(Thermal860Properties, metaclass=AllOptionalMetaclass):
+class ThermalClusterInput(Thermal860Properties, metaclass=AllOptionalMetaclass, use_none=True):
     """
     Model representing the data structure required to edit an existing thermal cluster within a study.
     """
@@ -70,7 +70,7 @@ class ThermalClusterCreation(ThermalClusterInput):
 
 
 @camel_case_model
-class ThermalClusterOutput(Thermal860Config, metaclass=AllOptionalMetaclass):
+class ThermalClusterOutput(Thermal860Config, metaclass=AllOptionalMetaclass, use_none=True):
     """
     Model representing the output data structure to display the details of a thermal cluster within a study.
     """

--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -245,32 +245,27 @@ class ThermalManager:
             old_config = create_thermal_config(study_version, **values)
 
         # Use Python values to synchronize Config and Form values
-        old_values = old_config.dict(exclude={"id"})
         new_values = cluster_data.dict(by_alias=False, exclude_none=True)
-        updated = {**old_values, **new_values}
-        new_config = create_thermal_config(study_version, **updated, id=cluster_id)
+        new_config = old_config.copy(exclude={"id"}, update=new_values)
         new_data = json.loads(new_config.json(by_alias=True, exclude={"id"}))
 
-        # Create the dict containing the old values (excluding defaults),
-        #  and the updated values (including defaults)
-        data: t.Dict[str, t.Any] = {}
-        for field_name, field in new_config.__fields__.items():
-            if field_name in {"id"}:
-                continue
-            value = getattr(new_config, field_name)
-            if field_name in new_values or value != field.get_default():
-                # use the JSON-converted value
-                data[field.alias] = new_data[field.alias]
+        # create the dict containing the new values using aliases
+        data: t.Dict[str, t.Any] = {
+            field.alias: new_data[field.alias]
+            for field_name, field in new_config.__fields__.items()
+            if field_name in new_values
+        }
 
-        # create the update config command with the modified data
+        # create the update config commands with the modified data
         command_context = self.storage_service.variant_study_service.command_factory.command_context
-        command = UpdateConfig(target=path, data=data, command_context=command_context)
-        # fixme: The `file_study` is already retrieved at the beginning of the function.
-        file_study = self.storage_service.get_storage(study).get_raw(study)
-        execute_or_add_commands(study, file_study, [command], self.storage_service)
+        commands = [
+            UpdateConfig(target=f"{path}/{key}", data=value, command_context=command_context)
+            for key, value in data.items()
+        ]
+        execute_or_add_commands(study, file_study, commands, self.storage_service)
 
         values = new_config.dict(by_alias=False)
-        return ThermalClusterOutput(**values)
+        return ThermalClusterOutput(**values, id=cluster_id)
 
     def delete_clusters(self, study: Study, area_id: str, cluster_ids: t.Sequence[str]) -> None:
         """

--- a/antarest/study/business/thematic_trimming_management.py
+++ b/antarest/study/business/thematic_trimming_management.py
@@ -12,7 +12,7 @@ from antarest.study.storage.storage_service import StudyStorageService
 from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 
 
-class ThematicTrimmingFormFields(FormFieldsBaseModel, metaclass=AllOptionalMetaclass):
+class ThematicTrimmingFormFields(FormFieldsBaseModel, metaclass=AllOptionalMetaclass, use_none=True):
     """
     This class manages the configuration of result filtering in a simulation.
 

--- a/antarest/study/business/xpansion_management.py
+++ b/antarest/study/business/xpansion_management.py
@@ -196,7 +196,7 @@ class GetXpansionSettings(XpansionSettings):
             return cls.construct(**config_obj)
 
 
-class UpdateXpansionSettings(XpansionSettings, metaclass=AllOptionalMetaclass):
+class UpdateXpansionSettings(XpansionSettings, metaclass=AllOptionalMetaclass, use_none=True):
     """
     DTO object used to update the Xpansion settings.
 

--- a/antarest/study/storage/rawstudy/model/filesystem/config/cluster.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/cluster.py
@@ -84,9 +84,14 @@ class ClusterProperties(ItemProperties):
 
     @property
     def installed_capacity(self) -> float:
-        """"""
+        # fields may contain `None` values if they are turned into `Optional` fields
+        if self.unit_count is None or self.nominal_capacity is None:
+            return 0.0
         return self.unit_count * self.nominal_capacity
 
     @property
     def enabled_capacity(self) -> float:
+        # fields may contain `None` values if they are turned into `Optional` fields
+        if self.enabled is None or self.installed_capacity is None:
+            return 0.0
         return self.enabled * self.installed_capacity

--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+import typing as t
 
-from pydantic import Extra, validator
+from pydantic import validator
 
 from antarest.core.model import JSON
 from antarest.core.utils.utils import assert_this
@@ -34,9 +34,9 @@ class CreateCluster(ICommand):
 
     area_id: str
     cluster_name: str
-    parameters: Dict[str, str]
-    prepro: Optional[Union[List[List[MatrixData]], str]] = None
-    modulation: Optional[Union[List[List[MatrixData]], str]] = None
+    parameters: t.Dict[str, str]
+    prepro: t.Optional[t.Union[t.List[t.List[MatrixData]], str]] = None
+    modulation: t.Optional[t.Union[t.List[t.List[MatrixData]], str]] = None
 
     @validator("cluster_name")
     def validate_cluster_name(cls, val: str) -> str:
@@ -47,8 +47,8 @@ class CreateCluster(ICommand):
 
     @validator("prepro", always=True)
     def validate_prepro(
-        cls, v: Optional[Union[List[List[MatrixData]], str]], values: Any
-    ) -> Optional[Union[List[List[MatrixData]], str]]:
+        cls, v: t.Optional[t.Union[t.List[t.List[MatrixData]], str]], values: t.Any
+    ) -> t.Optional[t.Union[t.List[t.List[MatrixData]], str]]:
         if v is None:
             v = values["command_context"].generator_matrix_constants.get_thermal_prepro_data()
             return v
@@ -58,8 +58,8 @@ class CreateCluster(ICommand):
 
     @validator("modulation", always=True)
     def validate_modulation(
-        cls, v: Optional[Union[List[List[MatrixData]], str]], values: Any
-    ) -> Optional[Union[List[List[MatrixData]], str]]:
+        cls, v: t.Optional[t.Union[t.List[t.List[MatrixData]], str]], values: t.Any
+    ) -> t.Optional[t.Union[t.List[t.List[MatrixData]], str]]:
         if v is None:
             v = values["command_context"].generator_matrix_constants.get_thermal_prepro_modulation()
             return v
@@ -67,7 +67,7 @@ class CreateCluster(ICommand):
         else:
             return validate_matrix(v, values)
 
-    def _apply_config(self, study_data: FileStudyTreeConfig) -> Tuple[CommandOutput, Dict[str, Any]]:
+    def _apply_config(self, study_data: FileStudyTreeConfig) -> t.Tuple[CommandOutput, t.Dict[str, t.Any]]:
         # Search the Area in the configuration
         if self.area_id not in study_data.areas:
             return (
@@ -173,14 +173,14 @@ class CreateCluster(ICommand):
             and self.modulation == other.modulation
         )
 
-    def _create_diff(self, other: "ICommand") -> List["ICommand"]:
-        other = cast(CreateCluster, other)
+    def _create_diff(self, other: "ICommand") -> t.List["ICommand"]:
+        other = t.cast(CreateCluster, other)
         from antarest.study.storage.variantstudy.model.command.replace_matrix import ReplaceMatrix
         from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 
         # Series identifiers are in lower case.
         series_id = transform_name_to_id(self.cluster_name, lower=True)
-        commands: List[ICommand] = []
+        commands: t.List[ICommand] = []
         if self.prepro != other.prepro:
             commands.append(
                 ReplaceMatrix(
@@ -207,8 +207,8 @@ class CreateCluster(ICommand):
             )
         return commands
 
-    def get_inner_matrices(self) -> List[str]:
-        matrices: List[str] = []
+    def get_inner_matrices(self) -> t.List[str]:
+        matrices: t.List[str] = []
         if self.prepro:
             assert_this(isinstance(self.prepro, str))
             matrices.append(strip_matrix_protocol(self.prepro))

--- a/antarest/study/storage/variantstudy/model/command/create_renewables_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_renewables_cluster.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, List, Tuple, cast
+import typing as t
 
-from pydantic import Extra, validator
+from pydantic import validator
 
 from antarest.core.model import JSON
 from antarest.study.storage.rawstudy.model.filesystem.config.model import (
@@ -32,7 +32,7 @@ class CreateRenewablesCluster(ICommand):
 
     area_id: str
     cluster_name: str
-    parameters: Dict[str, str]
+    parameters: t.Dict[str, str]
 
     @validator("cluster_name")
     def validate_cluster_name(cls, val: str) -> str:
@@ -41,7 +41,7 @@ class CreateRenewablesCluster(ICommand):
             raise ValueError("Area name must only contains [a-zA-Z0-9],&,-,_,(,) characters")
         return val
 
-    def _apply_config(self, study_data: FileStudyTreeConfig) -> Tuple[CommandOutput, Dict[str, Any]]:
+    def _apply_config(self, study_data: FileStudyTreeConfig) -> t.Tuple[CommandOutput, t.Dict[str, t.Any]]:
         if study_data.enr_modelling != ENR_MODELLING.CLUSTERS.value:
             # Since version 8.1 of the solver, we can use renewable clusters
             # instead of "Load", "Wind" and "Solar" objects for modelling.
@@ -147,11 +147,11 @@ class CreateRenewablesCluster(ICommand):
             return simple_match
         return simple_match and self.parameters == other.parameters
 
-    def _create_diff(self, other: "ICommand") -> List["ICommand"]:
-        other = cast(CreateRenewablesCluster, other)
+    def _create_diff(self, other: "ICommand") -> t.List["ICommand"]:
+        other = t.cast(CreateRenewablesCluster, other)
         from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 
-        commands: List[ICommand] = []
+        commands: t.List[ICommand] = []
         if self.parameters != other.parameters:
             commands.append(
                 UpdateConfig(
@@ -162,5 +162,5 @@ class CreateRenewablesCluster(ICommand):
             )
         return commands
 
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> t.List[str]:
         return []

--- a/antarest/study/storage/variantstudy/model/command/create_st_storage.py
+++ b/antarest/study/storage/variantstudy/model/command/create_st_storage.py
@@ -215,15 +215,10 @@ class CreateSTStorage(ICommand):
         if not output.status:
             return output
 
-        # Fill-in the "list.ini" file with the parameters
+        # Fill-in the "list.ini" file with the parameters.
+        # On creation, it's better to write all the parameters in the file.
         config = study_data.tree.get(["input", "st-storage", "clusters", self.area_id, "list"])
-        config[self.storage_id] = json.loads(
-            self.parameters.json(
-                by_alias=True,
-                exclude={"id"},
-                exclude_defaults=True,
-            )
-        )
+        config[self.storage_id] = json.loads(self.parameters.json(by_alias=True, exclude={"id"}))
 
         new_data: JSON = {
             "input": {

--- a/antarest/study/storage/variantstudy/model/command/remove_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_cluster.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+import typing as t
 
 from antarest.study.storage.rawstudy.model.filesystem.config.model import Area, FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
@@ -27,7 +27,7 @@ class RemoveCluster(ICommand):
     area_id: str
     cluster_id: str
 
-    def _apply_config(self, study_data: FileStudyTreeConfig) -> Tuple[CommandOutput, Dict[str, Any]]:
+    def _apply_config(self, study_data: FileStudyTreeConfig) -> t.Tuple[CommandOutput, t.Dict[str, t.Any]]:
         """
         Applies configuration changes to the study data: remove the thermal clusters from the storages list.
 
@@ -128,10 +128,10 @@ class RemoveCluster(ICommand):
             return False
         return self.cluster_id == other.cluster_id and self.area_id == other.area_id
 
-    def _create_diff(self, other: "ICommand") -> List["ICommand"]:
+    def _create_diff(self, other: "ICommand") -> t.List["ICommand"]:
         return []
 
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> t.List[str]:
         return []
 
     # noinspection SpellCheckingInspection

--- a/antarest/study/storage/variantstudy/model/command/remove_st_storage.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_st_storage.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+import typing as t
 
 from pydantic import Field
 
@@ -29,7 +29,7 @@ class RemoveSTStorage(ICommand):
     area_id: str = Field(description="Area ID", regex=r"[a-z0-9_(),& -]+")
     storage_id: str = Field(description="Short term storage ID", regex=r"[a-z0-9_(),& -]+")
 
-    def _apply_config(self, study_data: FileStudyTreeConfig) -> Tuple[CommandOutput, Dict[str, Any]]:
+    def _apply_config(self, study_data: FileStudyTreeConfig) -> t.Tuple[CommandOutput, t.Dict[str, t.Any]]:
         """
         Applies configuration changes to the study data: remove the storage from the storages list.
 
@@ -143,8 +143,8 @@ class RemoveSTStorage(ICommand):
         # or matrices, so that shallow and deep comparisons are identical.
         return self.__eq__(other)
 
-    def _create_diff(self, other: "ICommand") -> List["ICommand"]:
+    def _create_diff(self, other: "ICommand") -> t.List["ICommand"]:
         return []
 
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> t.List[str]:
         return []

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -25,8 +25,18 @@ from antarest.study.business.areas.renewable_management import (
     RenewableClusterInput,
     RenewableClusterOutput,
 )
-from antarest.study.business.areas.st_storage_management import *  # noqa
-from antarest.study.business.areas.thermal_management import *  # noqa
+from antarest.study.business.areas.st_storage_management import (
+    STStorageCreation,
+    STStorageInput,
+    STStorageMatrix,
+    STStorageOutput,
+    STStorageTimeSeries,
+)
+from antarest.study.business.areas.thermal_management import (
+    ThermalClusterCreation,
+    ThermalClusterInput,
+    ThermalClusterOutput,
+)
 from antarest.study.business.binding_constraint_management import (
     BindingConstraintPropertiesWithName,
     ConstraintTermDTO,

--- a/tests/integration/study_data_blueprint/test_renewable.py
+++ b/tests/integration/study_data_blueprint/test_renewable.py
@@ -201,7 +201,7 @@ class TestRenewable:
             json=bad_properties,
         )
         assert res.status_code == 422, res.json()
-        assert res.json()["exception"] == "ValidationError", res.json()
+        assert res.json()["exception"] == "RequestValidationError", res.json()
 
         # The renewable cluster properties should not have been updated.
         res = client.get(

--- a/tests/integration/study_data_blueprint/test_st_storage.py
+++ b/tests/integration/study_data_blueprint/test_st_storage.py
@@ -1,25 +1,23 @@
+import json
 import re
+from unittest.mock import ANY
 
 import numpy as np
 import pytest
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
+from antarest.study.business.areas.st_storage_management import STStorageOutput
 from antarest.study.storage.rawstudy.model.filesystem.config.model import transform_name_to_id
+from antarest.study.storage.rawstudy.model.filesystem.config.st_storage import STStorageConfig
 from tests.integration.utils import wait_task_completion
 
-DEFAULT_PROPERTIES = {
-    # `name` field is required
-    "group": "Other1",
-    "injectionNominalCapacity": 0.0,
-    "withdrawalNominalCapacity": 0.0,
-    "reservoirCapacity": 0.0,
-    "efficiency": 1.0,
-    "initialLevel": 0.0,
-    "initialLevelOptim": False,
-}
+DEFAULT_CONFIG = json.loads(STStorageConfig(id="dummy", name="dummy").json(by_alias=True, exclude={"id", "name"}))
+
+DEFAULT_PROPERTIES = json.loads(STStorageOutput(name="dummy").json(by_alias=True, exclude={"id", "name"}))
 
 
+# noinspection SpellCheckingInspection
 @pytest.mark.unit_test
 class TestSTStorage:
     # noinspection GrazieInspection
@@ -395,16 +393,7 @@ class TestSTStorage:
         res = client.post(
             f"/v1/studies/{study_id}/areas/{bad_area_id}/storages",
             headers={"Authorization": f"Bearer {user_access_token}"},
-            json={
-                "name": siemens_battery,
-                "group": "Battery",
-                "initialLevel": 0.0,
-                "initialLevelOptim": False,
-                "injectionNominalCapacity": 0.0,
-                "reservoirCapacity": 0.0,
-                "withdrawalNominalCapacity": 0.0,
-                "efficiency": 1.0,
-            },
+            json={"name": siemens_battery, "group": "Battery"},
         )
         assert res.status_code == 500, res.json()
         obj = res.json()
@@ -428,15 +417,7 @@ class TestSTStorage:
         res = client.patch(
             f"/v1/studies/{study_id}/areas/{bad_area_id}/storages/{siemens_battery_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
-            json={
-                "efficiency": 1.0,
-                "initialLevel": 0.0,
-                "initialLevelOptim": True,
-                "injectionNominalCapacity": 2450,
-                "name": "New Siemens Battery",
-                "reservoirCapacity": 2500,
-                "withdrawalNominalCapacity": 2350,
-            },
+            json={"efficiency": 1.0},
         )
         assert res.status_code == 404, res.json()
         obj = res.json()
@@ -449,15 +430,7 @@ class TestSTStorage:
         res = client.patch(
             f"/v1/studies/{study_id}/areas/{area_id}/storages/{bad_storage_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
-            json={
-                "efficiency": 1.0,
-                "initialLevel": 0.0,
-                "initialLevelOptim": True,
-                "injectionNominalCapacity": 2450,
-                "name": "New Siemens Battery",
-                "reservoirCapacity": 2500,
-                "withdrawalNominalCapacity": 2350,
-            },
+            json={"efficiency": 1.0},
         )
         assert res.status_code == 404, res.json()
         obj = res.json()
@@ -470,17 +443,192 @@ class TestSTStorage:
         res = client.patch(
             f"/v1/studies/{bad_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
-            json={
-                "efficiency": 1.0,
-                "initialLevel": 0.0,
-                "initialLevelOptim": True,
-                "injectionNominalCapacity": 2450,
-                "name": "New Siemens Battery",
-                "reservoirCapacity": 2500,
-                "withdrawalNominalCapacity": 2350,
-            },
+            json={"efficiency": 1.0},
         )
         assert res.status_code == 404, res.json()
         obj = res.json()
         description = obj["description"]
         assert bad_study_id in description
+
+    def test__default_values(
+        self,
+        client: TestClient,
+        user_access_token: str,
+    ) -> None:
+        """
+        The purpose of this integration test is to test the default values of
+        the properties of a short-term storage.
+
+        Given a new study with an area "FR", at least in version 860,
+        When I create a short-term storage with a name "Tesla Battery", with the default values,
+        Then the short-term storage is created with initialLevel = 0.0, and initialLevelOptim = False.
+        """
+        # Create a new study in version 860 (or higher)
+        res = client.post(
+            "/v1/studies",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            params={"name": "MyStudy", "version": 860},
+        )
+        assert res.status_code in {200, 201}, res.json()
+        study_id = res.json()
+
+        # Create a new area named "FR"
+        res = client.post(
+            f"/v1/studies/{study_id}/areas",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            json={"name": "FR", "type": "AREA"},
+        )
+        assert res.status_code in {200, 201}, res.json()
+        area_id = res.json()["id"]
+
+        # Create a new short-term storage named "Tesla Battery"
+        tesla_battery = "Tesla Battery"
+        res = client.post(
+            f"/v1/studies/{study_id}/areas/{area_id}/storages",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            json={"name": tesla_battery, "group": "Battery"},
+        )
+        assert res.status_code == 200, res.json()
+        tesla_battery_id = res.json()["id"]
+        tesla_config = {**DEFAULT_PROPERTIES, "id": tesla_battery_id, "name": tesla_battery, "group": "Battery"}
+        assert res.json() == tesla_config
+
+        # Use the Debug mode to make sure that the initialLevel and initialLevelOptim properties
+        # are properly set in the configuration file.
+        res = client.get(
+            f"/v1/studies/{study_id}/raw",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            params={"path": f"input/st-storage/clusters/{area_id}/list/{tesla_battery_id}"},
+        )
+        assert res.status_code == 200, res.json()
+        actual = res.json()
+        expected = {**DEFAULT_CONFIG, "name": tesla_battery, "group": "Battery"}
+        assert actual == expected
+
+        # We want to make sure that the default properties are applied to a study variant.
+        # We want to make sure that updating the initialLevel property is taken into account
+        # in the variant commands.
+
+        # Create a variant of the study
+        res = client.post(
+            f"/v1/studies/{study_id}/variants",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            params={"name": "MyVariant"},
+        )
+        assert res.status_code in {200, 201}, res.json()
+        variant_id = res.json()
+
+        # Create a new short-term storage named "Siemens Battery"
+        siemens_battery = "Siemens Battery"
+        res = client.post(
+            f"/v1/studies/{variant_id}/areas/{area_id}/storages",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            json={"name": siemens_battery, "group": "Battery"},
+        )
+        assert res.status_code == 200, res.json()
+
+        # Check the variant commands
+        res = client.get(
+            f"/v1/studies/{variant_id}/commands",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+        )
+        assert res.status_code == 200, res.json()
+        commands = res.json()
+        assert len(commands) == 1
+        actual = commands[0]
+        expected = {
+            "id": ANY,
+            "action": "create_st_storage",
+            "args": {
+                "area_id": "fr",
+                "parameters": {**DEFAULT_CONFIG, "name": siemens_battery, "group": "Battery"},
+                "pmax_injection": ANY,
+                "pmax_withdrawal": ANY,
+                "lower_rule_curve": ANY,
+                "upper_rule_curve": ANY,
+                "inflows": ANY,
+            },
+            "version": 1,
+        }
+        assert actual == expected
+
+        # Update the initialLevel property of the "Siemens Battery" short-term storage to 0.5
+        siemens_battery_id = transform_name_to_id(siemens_battery)
+        res = client.patch(
+            f"/v1/studies/{variant_id}/areas/{area_id}/storages/{siemens_battery_id}",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            json={"initialLevel": 0.5},
+        )
+        assert res.status_code == 200, res.json()
+
+        # Check the variant commands
+        res = client.get(
+            f"/v1/studies/{variant_id}/commands",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+        )
+        assert res.status_code == 200, res.json()
+        commands = res.json()
+        assert len(commands) == 2
+        actual = commands[1]
+        expected = {
+            "id": ANY,
+            "action": "update_config",
+            "args": {
+                "data": "0.5",
+                "target": "input/st-storage/clusters/fr/list/siemens battery/initiallevel",
+            },
+            "version": 1,
+        }
+        assert actual == expected
+
+        # Update the initialLevel property of the "Siemens Battery" short-term storage back to 0
+        res = client.patch(
+            f"/v1/studies/{variant_id}/areas/{area_id}/storages/{siemens_battery_id}",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            json={"initialLevel": 0.0, "injectionNominalCapacity": 1600},
+        )
+        assert res.status_code == 200, res.json()
+
+        # Check the variant commands
+        res = client.get(
+            f"/v1/studies/{variant_id}/commands",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+        )
+        assert res.status_code == 200, res.json()
+        commands = res.json()
+        assert len(commands) == 3
+        actual = commands[2]
+        expected = {
+            "id": ANY,
+            "action": "update_config",
+            "args": [
+                {
+                    "data": "1600.0",
+                    "target": "input/st-storage/clusters/fr/list/siemens battery/injectionnominalcapacity",
+                },
+                {
+                    "data": "0.0",
+                    "target": "input/st-storage/clusters/fr/list/siemens battery/initiallevel",
+                },
+            ],
+            "version": 1,
+        }
+        assert actual == expected
+
+        # Use the Debug mode to make sure that the initialLevel and initialLevelOptim properties
+        # are properly set in the configuration file.
+        res = client.get(
+            f"/v1/studies/{variant_id}/raw",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+            params={"path": f"input/st-storage/clusters/{area_id}/list/{siemens_battery_id}"},
+        )
+        assert res.status_code == 200, res.json()
+        actual = res.json()
+        expected = {
+            **DEFAULT_CONFIG,
+            "name": siemens_battery,
+            "group": "Battery",
+            "injectionnominalcapacity": 1600,
+            "initiallevel": 0.0,
+        }
+        assert actual == expected

--- a/tests/integration/study_data_blueprint/test_st_storage.py
+++ b/tests/integration/study_data_blueprint/test_st_storage.py
@@ -223,7 +223,7 @@ class TestSTStorage:
             json=bad_properties,
         )
         assert res.status_code == 422, res.json()
-        assert res.json()["exception"] == "ValidationError", res.json()
+        assert res.json()["exception"] == "RequestValidationError", res.json()
 
         # The short-term storage properties should not have been updated.
         res = client.get(

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -526,7 +526,7 @@ class TestThermal:
             json=bad_properties,
         )
         assert res.status_code == 422, res.json()
-        assert res.json()["exception"] == "ValidationError", res.json()
+        assert res.json()["exception"] == "RequestValidationError", res.json()
 
         # The thermal cluster properties should not have been updated.
         res = client.get(

--- a/tests/study/business/test_all_optional_metaclass.py
+++ b/tests/study/business/test_all_optional_metaclass.py
@@ -1,0 +1,349 @@
+import typing as t
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from antarest.study.business.utils import AllOptionalMetaclass
+
+# ==============================================
+# Classic way to use default and optional values
+# ==============================================
+
+
+class ClassicModel(BaseModel):
+    mandatory: float = Field(ge=0, le=1)
+    mandatory_with_default: float = Field(ge=0, le=1, default=0.2)
+    mandatory_with_none: float = Field(ge=0, le=1, default=None)
+    optional: t.Optional[float] = Field(ge=0, le=1)
+    optional_with_default: t.Optional[float] = Field(ge=0, le=1, default=0.2)
+    optional_with_none: t.Optional[float] = Field(ge=0, le=1, default=None)
+
+
+class ClassicSubModel(ClassicModel):
+    pass
+
+
+class TestClassicModel:
+    """
+    Test that default and optional values work as expected.
+    """
+
+    @pytest.mark.parametrize("cls", [ClassicModel, ClassicSubModel])
+    def test_classes(self, cls: t.Type[BaseModel]) -> None:
+        assert cls.__fields__["mandatory"].required is True
+        assert cls.__fields__["mandatory"].allow_none is False
+        assert cls.__fields__["mandatory"].default is None
+        assert cls.__fields__["mandatory"].default_factory is None  # undefined
+
+        assert cls.__fields__["mandatory_with_default"].required is False
+        assert cls.__fields__["mandatory_with_default"].allow_none is False
+        assert cls.__fields__["mandatory_with_default"].default == 0.2
+        assert cls.__fields__["mandatory_with_default"].default_factory is None  # undefined
+
+        assert cls.__fields__["mandatory_with_none"].required is False
+        assert cls.__fields__["mandatory_with_none"].allow_none is True
+        assert cls.__fields__["mandatory_with_none"].default is None
+        assert cls.__fields__["mandatory_with_none"].default_factory is None  # undefined
+
+        assert cls.__fields__["optional"].required is False
+        assert cls.__fields__["optional"].allow_none is True
+        assert cls.__fields__["optional"].default is None
+        assert cls.__fields__["optional"].default_factory is None  # undefined
+
+        assert cls.__fields__["optional_with_default"].required is False
+        assert cls.__fields__["optional_with_default"].allow_none is True
+        assert cls.__fields__["optional_with_default"].default == 0.2
+        assert cls.__fields__["optional_with_default"].default_factory is None  # undefined
+
+        assert cls.__fields__["optional_with_none"].required is False
+        assert cls.__fields__["optional_with_none"].allow_none is True
+        assert cls.__fields__["optional_with_none"].default is None
+        assert cls.__fields__["optional_with_none"].default_factory is None  # undefined
+
+    @pytest.mark.parametrize("cls", [ClassicModel, ClassicSubModel])
+    def test_initialization(self, cls: t.Type[ClassicModel]) -> None:
+        # We can build a model without providing optional or default values.
+        # The initialized value will be the default value or `None` for optional values.
+        obj = cls(mandatory=0.5)
+        assert obj.mandatory == 0.5
+        assert obj.mandatory_with_default == 0.2
+        assert obj.mandatory_with_none is None
+        assert obj.optional is None
+        assert obj.optional_with_default == 0.2
+        assert obj.optional_with_none is None
+
+        # We must provide a value for mandatory fields.
+        with pytest.raises(ValidationError):
+            cls()
+
+    @pytest.mark.parametrize("cls", [ClassicModel, ClassicSubModel])
+    def test_validation(self, cls: t.Type[ClassicModel]) -> None:
+        # We CANNOT use `None` as a value for a field with a default value.
+        with pytest.raises(ValidationError):
+            cls(mandatory=0.5, mandatory_with_default=None)
+
+        # We can use `None` as a value for optional fields with default value.
+        cls(mandatory=0.5, optional_with_default=None)
+
+        # We can validate a model with valid values.
+        cls(
+            mandatory=0.5,
+            mandatory_with_default=0.2,
+            mandatory_with_none=0.2,
+            optional=0.5,
+            optional_with_default=0.2,
+            optional_with_none=0.2,
+        )
+
+        # We CANNOT validate a model with invalid values.
+        with pytest.raises(ValidationError):
+            cls(mandatory=2)
+
+        with pytest.raises(ValidationError):
+            cls(mandatory=0.5, mandatory_with_default=2)
+
+        with pytest.raises(ValidationError):
+            cls(mandatory=0.5, mandatory_with_none=2)
+
+        with pytest.raises(ValidationError):
+            cls(mandatory=0.5, optional=2)
+
+        with pytest.raises(ValidationError):
+            cls(mandatory=0.5, optional_with_default=2)
+
+        with pytest.raises(ValidationError):
+            cls(mandatory=0.5, optional_with_none=2)
+
+
+# ==========================
+# Using AllOptionalMetaclass
+# ==========================
+
+
+class AllOptionalModel(BaseModel, metaclass=AllOptionalMetaclass):
+    mandatory: float = Field(ge=0, le=1)
+    mandatory_with_default: float = Field(ge=0, le=1, default=0.2)
+    mandatory_with_none: float = Field(ge=0, le=1, default=None)
+    optional: t.Optional[float] = Field(ge=0, le=1)
+    optional_with_default: t.Optional[float] = Field(ge=0, le=1, default=0.2)
+    optional_with_none: t.Optional[float] = Field(ge=0, le=1, default=None)
+
+
+class AllOptionalSubModel(AllOptionalModel):
+    pass
+
+
+class InheritedAllOptionalModel(ClassicModel, metaclass=AllOptionalMetaclass):
+    pass
+
+
+class TestAllOptionalModel:
+    """
+    Test that AllOptionalMetaclass works with base classes.
+    """
+
+    @pytest.mark.parametrize("cls", [AllOptionalModel, AllOptionalSubModel, InheritedAllOptionalModel])
+    def test_classes(self, cls: t.Type[BaseModel]) -> None:
+        assert cls.__fields__["mandatory"].required is False
+        assert cls.__fields__["mandatory"].allow_none is True
+        assert cls.__fields__["mandatory"].default is None
+        assert cls.__fields__["mandatory"].default_factory is None  # undefined
+
+        assert cls.__fields__["mandatory_with_default"].required is False
+        assert cls.__fields__["mandatory_with_default"].allow_none is True
+        assert cls.__fields__["mandatory_with_default"].default == 0.2
+        assert cls.__fields__["mandatory_with_default"].default_factory is None  # undefined
+
+        assert cls.__fields__["mandatory_with_none"].required is False
+        assert cls.__fields__["mandatory_with_none"].allow_none is True
+        assert cls.__fields__["mandatory_with_none"].default is None
+        assert cls.__fields__["mandatory_with_none"].default_factory is None  # undefined
+
+        assert cls.__fields__["optional"].required is False
+        assert cls.__fields__["optional"].allow_none is True
+        assert cls.__fields__["optional"].default is None
+        assert cls.__fields__["optional"].default_factory is None  # undefined
+
+        assert cls.__fields__["optional_with_default"].required is False
+        assert cls.__fields__["optional_with_default"].allow_none is True
+        assert cls.__fields__["optional_with_default"].default == 0.2
+        assert cls.__fields__["optional_with_default"].default_factory is None  # undefined
+
+        assert cls.__fields__["optional_with_none"].required is False
+        assert cls.__fields__["optional_with_none"].allow_none is True
+        assert cls.__fields__["optional_with_none"].default is None
+        assert cls.__fields__["optional_with_none"].default_factory is None  # undefined
+
+    @pytest.mark.parametrize("cls", [AllOptionalModel, AllOptionalSubModel, InheritedAllOptionalModel])
+    def test_initialization(self, cls: t.Type[AllOptionalModel]) -> None:
+        # We can build a model without providing values.
+        # The initialized value will be the default value or `None` for optional values.
+        # Note that the mandatory fields are not required anymore, and can be `None`.
+        obj = cls()
+        assert obj.mandatory is None
+        assert obj.mandatory_with_default == 0.2
+        assert obj.mandatory_with_none is None
+        assert obj.optional is None
+        assert obj.optional_with_default == 0.2
+        assert obj.optional_with_none is None
+
+        # If we convert the model to a dictionary, without `None` values,
+        # we should have a dictionary with default values only.
+        actual = obj.dict(exclude_none=True)
+        expected = {
+            "mandatory_with_default": 0.2,
+            "optional_with_default": 0.2,
+        }
+        assert actual == expected
+
+    @pytest.mark.parametrize("cls", [AllOptionalModel, AllOptionalSubModel, InheritedAllOptionalModel])
+    def test_validation(self, cls: t.Type[AllOptionalModel]) -> None:
+        # We can use `None` as a value for all fields.
+        cls(mandatory=None)
+        cls(mandatory_with_default=None)
+        cls(mandatory_with_none=None)
+        cls(optional=None)
+        cls(optional_with_default=None)
+        cls(optional_with_none=None)
+
+        # We can validate a model with valid values.
+        cls(
+            mandatory=0.5,
+            mandatory_with_default=0.2,
+            mandatory_with_none=0.2,
+            optional=0.5,
+            optional_with_default=0.2,
+            optional_with_none=0.2,
+        )
+
+        # We CANNOT validate a model with invalid values.
+        with pytest.raises(ValidationError):
+            cls(mandatory=2)
+
+        with pytest.raises(ValidationError):
+            cls(mandatory_with_default=2)
+
+        with pytest.raises(ValidationError):
+            cls(mandatory_with_none=2)
+
+        with pytest.raises(ValidationError):
+            cls(optional=2)
+
+        with pytest.raises(ValidationError):
+            cls(optional_with_default=2)
+
+        with pytest.raises(ValidationError):
+            cls(optional_with_none=2)
+
+
+# The `use_none` keyword argument is set to `True` to allow the use of `None`
+# as a default value for the fields of the model.
+
+
+class UseNoneModel(BaseModel, metaclass=AllOptionalMetaclass, use_none=True):
+    mandatory: float = Field(ge=0, le=1)
+    mandatory_with_default: float = Field(ge=0, le=1, default=0.2)
+    mandatory_with_none: float = Field(ge=0, le=1, default=None)
+    optional: t.Optional[float] = Field(ge=0, le=1)
+    optional_with_default: t.Optional[float] = Field(ge=0, le=1, default=0.2)
+    optional_with_none: t.Optional[float] = Field(ge=0, le=1, default=None)
+
+
+class UseNoneSubModel(UseNoneModel):
+    pass
+
+
+class InheritedUseNoneModel(ClassicModel, metaclass=AllOptionalMetaclass, use_none=True):
+    pass
+
+
+class TestUseNoneModel:
+    @pytest.mark.parametrize("cls", [UseNoneModel, UseNoneSubModel, InheritedUseNoneModel])
+    def test_classes(self, cls: t.Type[BaseModel]) -> None:
+        assert cls.__fields__["mandatory"].required is False
+        assert cls.__fields__["mandatory"].allow_none is True
+        assert cls.__fields__["mandatory"].default is None
+        assert cls.__fields__["mandatory"].default_factory is None  # undefined
+
+        assert cls.__fields__["mandatory_with_default"].required is False
+        assert cls.__fields__["mandatory_with_default"].allow_none is True
+        assert cls.__fields__["mandatory_with_default"].default is None
+        assert cls.__fields__["mandatory_with_default"].default_factory is None  # undefined
+
+        assert cls.__fields__["mandatory_with_none"].required is False
+        assert cls.__fields__["mandatory_with_none"].allow_none is True
+        assert cls.__fields__["mandatory_with_none"].default is None
+        assert cls.__fields__["mandatory_with_none"].default_factory is None  # undefined
+
+        assert cls.__fields__["optional"].required is False
+        assert cls.__fields__["optional"].allow_none is True
+        assert cls.__fields__["optional"].default is None
+        assert cls.__fields__["optional"].default_factory is None  # undefined
+
+        assert cls.__fields__["optional_with_default"].required is False
+        assert cls.__fields__["optional_with_default"].allow_none is True
+        assert cls.__fields__["optional_with_default"].default is None
+        assert cls.__fields__["optional_with_default"].default_factory is None  # undefined
+
+        assert cls.__fields__["optional_with_none"].required is False
+        assert cls.__fields__["optional_with_none"].allow_none is True
+        assert cls.__fields__["optional_with_none"].default is None
+        assert cls.__fields__["optional_with_none"].default_factory is None  # undefined
+
+    @pytest.mark.parametrize("cls", [UseNoneModel, UseNoneSubModel, InheritedUseNoneModel])
+    def test_initialization(self, cls: t.Type[UseNoneModel]) -> None:
+        # We can build a model without providing values.
+        # The initialized value will be the default value or `None` for optional values.
+        # Note that the mandatory fields are not required anymore, and can be `None`.
+        obj = cls()
+        assert obj.mandatory is None
+        assert obj.mandatory_with_default is None
+        assert obj.mandatory_with_none is None
+        assert obj.optional is None
+        assert obj.optional_with_default is None
+        assert obj.optional_with_none is None
+
+        # If we convert the model to a dictionary, without `None` values,
+        # we should have an empty dictionary.
+        actual = obj.dict(exclude_none=True)
+        expected = {}
+        assert actual == expected
+
+    @pytest.mark.parametrize("cls", [UseNoneModel, UseNoneSubModel, InheritedUseNoneModel])
+    def test_validation(self, cls: t.Type[UseNoneModel]) -> None:
+        # We can use `None` as a value for all fields.
+        cls(mandatory=None)
+        cls(mandatory_with_default=None)
+        cls(mandatory_with_none=None)
+        cls(optional=None)
+        cls(optional_with_default=None)
+        cls(optional_with_none=None)
+
+        # We can validate a model with valid values.
+        cls(
+            mandatory=0.5,
+            mandatory_with_default=0.2,
+            mandatory_with_none=0.2,
+            optional=0.5,
+            optional_with_default=0.2,
+            optional_with_none=0.2,
+        )
+
+        # We CANNOT validate a model with invalid values.
+        with pytest.raises(ValidationError):
+            cls(mandatory=2)
+
+        with pytest.raises(ValidationError):
+            cls(mandatory_with_default=2)
+
+        with pytest.raises(ValidationError):
+            cls(mandatory_with_none=2)
+
+        with pytest.raises(ValidationError):
+            cls(optional=2)
+
+        with pytest.raises(ValidationError):
+            cls(optional_with_default=2)
+
+        with pytest.raises(ValidationError):
+            cls(optional_with_none=2)

--- a/tests/variantstudy/model/command/test_create_st_storage.py
+++ b/tests/variantstudy/model/command/test_create_st_storage.py
@@ -311,7 +311,7 @@ class TestCreateSTStorage:
             "storage1": {
                 "efficiency": 0.94,
                 "group": "Battery",
-                # "initiallevel": 0,  # default value is 0
+                "initiallevel": 0.5,
                 "initialleveloptim": True,
                 "injectionnominalcapacity": 1500,
                 "name": "Storage1",


### PR DESCRIPTION
The goal of this PR is to correct the implementation of the `AllOptionalMetaclass` metaclass used to implement Pydantic models for reading and updating configuration data (short-term storage, thermal clusters, renewable resources clusters, etc.).

The metaclass has been fixed to allow field validation when they come from an ancestor class to the model (using inheritance).

The `use_none` option has been added to the metaclass parameters to indicate that we want to use the `None` value instead of the default values. This is necessary, for example, to update certain fields of a model while leaving other fields unchanged: the `None` value is used to indicate the fields that we wants to preserve.

Unit tests have been corrected to take into consideration the form field validation (previously, validation was not occurring).

Minor changes have been made to correct the documentation and reorganize/fix module imports.