### PR TITLE
fix(ui-map): reload map data on study revisit

### DIFF
--- a/webapp/src/redux/ducks/studies.ts
+++ b/webapp/src/redux/ducks/studies.ts
@@ -47,6 +47,7 @@ export interface StudiesSortConf {
 
 export interface StudiesState extends AsyncEntityState<StudyMetadata> {
   current: string;
+  prevStudyId: string;
   scrollPosition: number;
   versionList: string[];
   favorites: Array<StudyMetadata["id"]>;
@@ -73,6 +74,7 @@ const initialState = studiesAdapter.getInitialState({
   status: FetchStatus.Idle,
   error: null as string | null,
   current: "",
+  prevStudyId: "",
   scrollPosition: 0,
   versionList: [] as string[],
   favorites: [],
@@ -297,6 +299,7 @@ export default createReducer(initialState, (builder) => {
       draftState.versionList = action.payload;
     })
     .addCase(setCurrentStudy, (draftState, action) => {
+      draftState.prevStudyId = draftState.current;
       draftState.current = action.payload;
     })
     .addCase(setStudyScrollPosition, (draftState, action) => {


### PR DESCRIPTION
## Description:

We encounter a bug related to how study map data is fetched and displayed. 
The current logic checks for the existence of map data based on the `studyId` or the absence of data in the state for the given study. 
This approach works well when navigating within the same study; map data loads from the state, utilizing previously persisted Redux store data. However, an issue arises when a user exits a study, visits a different study, and then returns to the first study. Despite the expectation for the map to reload, it fails to do so. 
This behavior is due to the `isMapsExis`t condition evaluating to `true` the `studyId` exists in the store from the previous visit, preventing the map from reloading.

### Cause:

The core of the issue lies in the reliance on the mere presence of study map data in the Redux store (isMapsExist) to determine whether to fetch map data. This condition fails to account for user navigations away from and back to a study within the same session, where a fresh fetch of map data may be necessary to ensure accurate and updated displays.

### Fix:

To address this, we are introducing a more robust check that not only considers the existence of map data but also accounts for user navigations that necessitate refreshing map data. 
This involves adjusting the logic to trigger a data fetch not just based on the absence of data but also under circumstances where a revisit to a study requires fresh data to ensure the map reflects the most current information.

