### PR TITLE
feat(tags-db): populate `tag` and `study_tag` tables using pre-existing patch data in `study_additional_data` table

### DIFF
--- a/alembic/versions/dae93f1d9110_populate_tag_and_study_tag_tables_with_.py
+++ b/alembic/versions/dae93f1d9110_populate_tag_and_study_tag_tables_with_.py
@@ -1,19 +1,18 @@
-"""This code is implemented manually to populate the `tag` and `study_tag` tables using
-    pre-existing patch data in `study_additional_data` table.
+"""
+Populate `tag` and `study_tag` tables from `patch` field in `study_additional_data` table
 
 Revision ID: dae93f1d9110
 Revises: 3c70366b10ea
 Create Date: 2024-02-08 10:30:20.590919
-
 """
 import collections
 import itertools
 import json
 import secrets
 
+import sqlalchemy as sa  # type: ignore
 from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.engine import Connection
+from sqlalchemy.engine import Connection  # type: ignore
 
 from antarest.study.css4_colors import COLOR_NAMES
 
@@ -24,9 +23,10 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
+def upgrade() -> None:
     """
-    This code is implemented manually to populate the `tag` and `study_tag` tables.\n
+    Populate `tag` and `study_tag` tables from `patch` field in `study_additional_data` table
+
     Four steps to proceed:
         - Retrieve study-tags pairs from patches in `study_additional_data`.
         - Delete all rows in `tag` and `study_tag`, as tag updates between revised 3c70366b10ea and this version,
@@ -65,7 +65,8 @@ def upgrade():
 
 def downgrade() -> None:
     """
-    This code is implemented manually to downgrade to revised version of the db (3c70366b10ea).
+    Restore `patch` field in `study_additional_data` from `tag` and `study_tag` tables
+
     Three steps to proceed:
         - Retrieve study-tags pairs from `study_tag` table.
         - Update patches study-tags in `study_additional_data` using these pairs.

--- a/alembic/versions/dae93f1d9110_populate_tag_and_study_tag_tables_with_.py
+++ b/alembic/versions/dae93f1d9110_populate_tag_and_study_tag_tables_with_.py
@@ -1,0 +1,60 @@
+"""This code is implemented manually to populate the `tag` and `study_tag` tables using
+    pre-existing patch data in `study_additional_data` table.
+
+Revision ID: dae93f1d9110
+Revises: 3c70366b10ea
+Create Date: 2024-02-08 10:30:20.590919
+
+"""
+import itertools
+import json
+import secrets
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection
+
+from antarest.study.css4_colors import COLOR_NAMES
+
+# revision identifiers, used by Alembic.
+revision = "dae93f1d9110"
+down_revision = "3c70366b10ea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ### This code is implemented manually to populate the `tag` and `study_tag` tables ###
+
+    # create connexion to the db
+    connexion: Connection = op.get_bind()
+
+    # retrieve the tags and the study-tag pairs from the db
+    study_tags = connexion.execute("SELECT study_id,patch FROM study_additional_data")
+    tags_by_ids = {}
+    for study_id, patch in study_tags:
+        obj = json.loads(patch or "{}")
+        tags = frozenset(obj.get("study", {}).get("tags", ()))
+        tags_by_ids[study_id] = tags
+    labels = set(itertools.chain.from_iterable(tags_by_ids.values()))
+    tags = {label: secrets.choice(COLOR_NAMES) for label in labels}
+
+    for label, color in tags.items():
+        connexion.execute(
+            sa.text("INSERT INTO tag (label, color) VALUES (:label, :color)"), {"label": label, "color": color}
+        )
+
+    # Create relationships between studies and tags in the `study_tag` table
+    study_tag_data = {(study_id, label) for study_id, tags in tags_by_ids.items() for label in tags}
+    for study_id, label in study_tag_data:
+        connexion.execute(
+            sa.text("INSERT INTO study_tag (study_id, tag_label) VALUES (:study_id, :tag_label)"),
+            {"study_id": study_id, "tag_label": label},
+        )
+
+
+def downgrade():
+    # ### Unfortunately there is no way to distinguish between the tags that have been added from additional data
+    # and those that have will be added following the data migration, using the current database scheme. Thus, we may
+    # perform no action in the downgrade and leave the `tag` and `study_tag` tables unchanged.###
+    pass

--- a/alembic/versions/dae93f1d9110_populate_tag_and_study_tag_tables_with_.py
+++ b/alembic/versions/dae93f1d9110_populate_tag_and_study_tag_tables_with_.py
@@ -25,7 +25,15 @@ depends_on = None
 
 
 def upgrade():
-    # ### This code is implemented manually to populate the `tag` and `study_tag` tables ###
+    """
+    This code is implemented manually to populate the `tag` and `study_tag` tables.\n
+    Four steps to proceed:
+        - Retrieve study-tags pairs from patches in `study_additional_data`.
+        - Delete all rows in `tag` and `study_tag`, as tag updates between revised 3c70366b10ea and this version,
+          do modify the data in patches alongside the two previous tables.
+        - Populate `tag` table using unique tag-labels and by randomly generating their associated colors.
+        - Populate `study_tag` using study-tags pairs.
+    """
 
     # create connexion to the db
     connexion: Connection = op.get_bind()
@@ -35,7 +43,8 @@ def upgrade():
     tags_by_ids = {}
     for study_id, patch in study_tags:
         obj = json.loads(patch or "{}")
-        tags = frozenset(obj.get("study", {}).get("tags", ()))
+        study = obj.get("study") or {}
+        tags = frozenset(study.get("tags") or ())
         tags_by_ids[study_id] = tags
 
     # delete rows in tables `tag` and `study_tag`
@@ -55,8 +64,13 @@ def upgrade():
 
 
 def downgrade() -> None:
-    # ### repopulate the patches tags in `study_additional_data` from `study_tag` ###
-
+    """
+    This code is implemented manually to downgrade to revised version of the db (3c70366b10ea).
+    Three steps to proceed:
+        - Retrieve study-tags pairs from `study_tag` table.
+        - Update patches study-tags in `study_additional_data` using these pairs.
+        - Delete all rows from `tag` and `study_tag`.
+    """
     # create a connection to the db
     connexion: Connection = op.get_bind()
 

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -12,5 +12,5 @@ CUR_DIR=$(cd "$(dirname "$0")" && pwd)
 BASE_DIR=$(dirname "$CUR_DIR")
 
 cd "$BASE_DIR"
-alembic downgrade 1f5db5dfad80
+alembic downgrade 3c70366b10ea
 cd -


### PR DESCRIPTION
Context:
Currently, tags do not have a specific table but are directly retrieved from Patches using Python code.

Issue:
This coding paradigm results in filtering that cannot occur at the database level but rather post-query (posing a problem for pagination). It can also potentially slightly slow down API queries.

Solution in following steps:
- Create two tables, `tag` and `study_tag`, to manage the many-to-many relationships between studies and tags. This step requires data migration.
- Update endpoints and services
- Create an update script to populate the newly created tables with pre-existing data.

Note:
This PR deals with the last step
