### PR TITLE
refactor(ui-matrix): encode query string parameters in matrix endpoint calls

### DIFF
--- a/webapp/src/services/api/matrix.ts
+++ b/webapp/src/services/api/matrix.ts
@@ -15,9 +15,9 @@ export const getMatrixList = async (
   name = "",
   filterOwn = false,
 ): Promise<MatrixDataSetDTO[]> => {
-  const res = await client.get(
-    `/v1/matrixdataset/_search?name=${encodeURI(name)}&filter_own=${filterOwn}`,
-  );
+  const res = await client.get(`/v1/matrixdataset/_search`, {
+    params: { name: name, filter_own: filterOwn },
+  });
   return res.data;
 };
 
@@ -28,7 +28,7 @@ export const getMatrix = async (id: string): Promise<MatrixDTO> => {
 
 export const getExportMatrixUrl = (matrixId: string): string =>
   `${
-    getConfig().downloadHostUrl ||
+    getConfig().downloadHostUrl ??
     getConfig().baseUrl + getConfig().restEndpoint
   }/v1/matrix/${matrixId}/download`;
 
@@ -48,24 +48,21 @@ export const createMatrixByImportation = async (
   if (onProgress) {
     options.onUploadProgress = (progressEvent): void => {
       const percentCompleted = Math.round(
-        (progressEvent.loaded * 100) / (progressEvent.total || 1),
+        (progressEvent.loaded * 100) / (progressEvent.total ?? 1),
       );
       onProgress(percentCompleted);
     };
   }
   const formData = new FormData();
   formData.append("file", file);
-  const restconfig = {
+  const restConfig = {
     ...options,
     headers: {
       "content-type": "multipart/form-data",
     },
+    params: { json: json },
   };
-  const res = await client.post(
-    `/v1/matrix/_import?json=${json}`,
-    formData,
-    restconfig,
-  );
+  const res = await client.post(`/v1/matrix/_import`, formData, restConfig);
   return res.data;
 };
 
@@ -96,10 +93,9 @@ export const editMatrix = async (
   path: string,
   matrixEdit: MatrixEditDTO[],
 ): Promise<void> => {
-  const res = await client.put(
-    `/v1/studies/${sid}/matrix?path=${path}`,
-    matrixEdit,
-  );
+  const res = await client.put(`/v1/studies/${sid}/matrix`, matrixEdit, {
+    params: { path: path },
+  });
   return res.data;
 };
 
@@ -107,7 +103,7 @@ export const getStudyMatrixIndex = async (
   sid: string,
   path?: string,
 ): Promise<MatrixIndex> => {
-  const query = path ? `?path=${encodeURIComponent(path)}` : "";
-  const res = await client.get(`/v1/studies/${sid}/matrixindex${query}`);
+  const restConfig = path ? { params: { path: path } } : {};
+  const res = await client.get(`/v1/studies/${sid}/matrixindex`, restConfig);
   return res.data;
 };


### PR DESCRIPTION
## Description

L'objectif de cette PR est de refactoriser les appels aux endpoints de l'API pour les matrices (dans un premier temps)
afin d'encoder systématiquement les paramètres des chaînes de requête (query-string) pour éviter les erreurs.

Cette modification nécessite des tests d'intégration décrits ci-dessous. Pour observer les paramètres envoyés au serveur
web, il convient de cliquer sur l'onglet "Réseau" du panneau des **Outils de développement web** dans FireFox / Chrome.

> Note: les tests unitaires ne couvrent pas ces changements

## Tests d'intégration

### Liste des matrices du Matrix Dataset

- Dans le menu latéral de gauche, cliquer sur "Data" / "Données" pour afficher la liste des datasets
- On doit observer la requête `GET /v1/matrixdataset/_search?name=&filter_own=false`

### Import d'un dataset

Deux scénarios sont possibles pour l'import d'un dataset :

1. Import d'un dataset depuis un fichier au format TSV (fichier `.txt`) (voir pièce jointe [^1])
2. Import d'un dataset depuis un fichier au format JSON (voir pièce jointe [^2])

- Depuis le menu latéral de gauche, cliquer sur "Data",
- Cliquer sur le bouton "+" (add),
- Fournir un nom de dataset et sélectionner un fichier au format TSV ou JSON,
- Cliquer sur le bouton "Importer"
- On doit observer la requête `POST /v1/matrixdataset/import?json=true` (ou `json=false`).

### Téléchargement d'une matrice sur son poste

- Depuis le menu latéral de gauche, cliquer sur "Data",
- Sélectionner un dataset dans la liste
- Cliquer sur le bouton "↓" (download),
- On doit observer la requête `GET /v1/matrix/{uuid}/download`, où `uuid` est l'identifiant unique d'une matrice du
  dataset

> Note : cette URL ne possède pas de paramètres de type query-string

### Lecture des dimensions et métadonnées d'une matrice

- Sélectionner une étude dans la liste des études,
- Ouvrir l'étude et sélectionner une zone,
- Choisir un onglet comportant une matrice à éditer (par exemple l'onglet "Load"),
- On doit observer la requête `GET /v1/studies/{uuid}/matrixindex?path={path}` où `path` est un chemin vers la matrice.

### Édition d'une matrice

- Sélectionner une étude dans la liste des études,
- Ouvrir l'étude et sélectionner une zone,
- Choisir un onglet comportant une matrice à éditer (par exemple l'onglet "Load"),
- Modifier une ou plusieurs cellules de la matrice,
- On doit observer la requête `PUT /v1/studies/{uuid}/matrix?path={path}` où `path` est un chemin vers la matrice.

[^1]: Pièce jointe pour tester le téléversement d'une matrice au format TSV : [matrix-example-ror.txt](https://github.com/AntaresSimulatorTeam/AntaREST/files/14361092/matrix-example-ror.txt)

[^2]: Pièce jointe pour tester le téléversement d'une matrice au format JSON : [matrix-example-ror.json](https://github.com/AntaresSimulatorTeam/AntaREST/files/14360999/matrix-example-ror.json)
