### PR TITLE
fix(tags): resolve issue with `study.additional_data.patch` attribute reading

### DIFF
--- a/antarest/study/storage/patch_service.py
+++ b/antarest/study/storage/patch_service.py
@@ -1,27 +1,32 @@
-import logging
+import json
+import typing as t
 from pathlib import Path
-from typing import Optional, Union
 
 from antarest.study.model import Patch, PatchOutputs, RawStudy, StudyAdditionalData
 from antarest.study.repository import StudyMetadataRepository
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
 
-logger = logging.getLogger(__name__)
+PATCH_JSON = "patch.json"
 
 
 class PatchService:
-    def __init__(self, repository: Optional[StudyMetadataRepository] = None):
+    """
+    Handle patch file ("patch.json") for a RawStudy or VariantStudy
+    """
+
+    def __init__(self, repository: t.Optional[StudyMetadataRepository] = None):
         self.repository = repository
 
-    def get(self, study: Union[RawStudy, VariantStudy], get_from_file: bool = False) -> Patch:
-        if not get_from_file:
+    def get(self, study: t.Union[RawStudy, VariantStudy], get_from_file: bool = False) -> Patch:
+        if not get_from_file and study.additional_data is not None:
             # the `study.additional_data.patch` field is optional
-            if patch_data := study.additional_data.patch:
-                return Patch.parse_raw(patch_data)
+            if study.additional_data.patch:
+                patch_obj = json.loads(study.additional_data.patch or "{}")
+                return Patch.parse_obj(patch_obj)
 
         patch = Patch()
-        patch_path = Path(study.path) / "patch.json"
+        patch_path = Path(study.path) / PATCH_JSON
         if patch_path.exists():
             patch = Patch.parse_file(patch_path)
 
@@ -29,14 +34,14 @@ class PatchService:
 
     def get_from_filestudy(self, file_study: FileStudy) -> Patch:
         patch = Patch()
-        patch_path = (Path(file_study.config.study_path)) / "patch.json"
+        patch_path = (Path(file_study.config.study_path)) / PATCH_JSON
         if patch_path.exists():
             patch = Patch.parse_file(patch_path)
         return patch
 
     def set_reference_output(
         self,
-        study: Union[RawStudy, VariantStudy],
+        study: t.Union[RawStudy, VariantStudy],
         output_id: str,
         status: bool = True,
     ) -> None:
@@ -47,12 +52,12 @@ class PatchService:
             patch.outputs = PatchOutputs(reference=output_id)
         self.save(study, patch)
 
-    def save(self, study: Union[RawStudy, VariantStudy], patch: Patch) -> None:
+    def save(self, study: t.Union[RawStudy, VariantStudy], patch: Patch) -> None:
         if self.repository:
             study.additional_data = study.additional_data or StudyAdditionalData()
             study.additional_data.patch = patch.json()
             self.repository.save(study)
 
-        patch_path = (Path(study.path)) / "patch.json"
+        patch_path = (Path(study.path)) / PATCH_JSON
         patch_path.parent.mkdir(parents=True, exist_ok=True)
         patch_path.write_text(patch.json())

--- a/antarest/study/storage/rawstudy/raw_study_service.py
+++ b/antarest/study/storage/rawstudy/raw_study_service.py
@@ -1,10 +1,10 @@
 import logging
 import shutil
 import time
+import typing as t
 from datetime import datetime
 from pathlib import Path
 from threading import Thread
-from typing import BinaryIO, List, Optional, Sequence
 from uuid import uuid4
 from zipfile import ZipFile
 
@@ -61,7 +61,7 @@ class RawStudyService(AbstractStorageService[RawStudy]):
         )
         self.cleanup_thread.start()
 
-    def update_from_raw_meta(self, metadata: RawStudy, fallback_on_default: Optional[bool] = False) -> None:
+    def update_from_raw_meta(self, metadata: RawStudy, fallback_on_default: t.Optional[bool] = False) -> None:
         """
         Update metadata from study raw metadata
         Args:
@@ -90,7 +90,7 @@ class RawStudyService(AbstractStorageService[RawStudy]):
                 metadata.version = metadata.version or 0
                 metadata.created_at = metadata.created_at or datetime.utcnow()
                 metadata.updated_at = metadata.updated_at or datetime.utcnow()
-                if not metadata.additional_data:
+                if metadata.additional_data is None:
                     metadata.additional_data = StudyAdditionalData()
                 metadata.additional_data.patch = metadata.additional_data.patch or Patch().json()
                 metadata.additional_data.author = metadata.additional_data.author or "Unknown"
@@ -148,7 +148,7 @@ class RawStudyService(AbstractStorageService[RawStudy]):
         self,
         metadata: RawStudy,
         use_cache: bool = True,
-        output_dir: Optional[Path] = None,
+        output_dir: t.Optional[Path] = None,
     ) -> FileStudy:
         """
         Fetch a study object and its config
@@ -163,7 +163,7 @@ class RawStudyService(AbstractStorageService[RawStudy]):
         study_path = self.get_study_path(metadata)
         return self.study_factory.create_from_fs(study_path, metadata.id, output_dir, use_cache=use_cache)
 
-    def get_synthesis(self, metadata: RawStudy, params: Optional[RequestParameters] = None) -> FileStudyTreeConfigDTO:
+    def get_synthesis(self, metadata: RawStudy, params: t.Optional[RequestParameters] = None) -> FileStudyTreeConfigDTO:
         self._check_study_exists(metadata)
         study_path = self.get_study_path(metadata)
         study = self.study_factory.create_from_fs(study_path, metadata.id)
@@ -206,7 +206,7 @@ class RawStudyService(AbstractStorageService[RawStudy]):
         self,
         src_meta: RawStudy,
         dest_name: str,
-        groups: Sequence[str],
+        groups: t.Sequence[str],
         with_outputs: bool = False,
     ) -> RawStudy:
         """
@@ -223,7 +223,7 @@ class RawStudyService(AbstractStorageService[RawStudy]):
         """
         self._check_study_exists(src_meta)
 
-        if not src_meta.additional_data:
+        if src_meta.additional_data is None:
             additional_data = StudyAdditionalData()
         else:
             additional_data = StudyAdditionalData(
@@ -295,7 +295,7 @@ class RawStudyService(AbstractStorageService[RawStudy]):
             output_path.unlink(missing_ok=True)
         remove_from_cache(self.cache, metadata.id)
 
-    def import_study(self, metadata: RawStudy, stream: BinaryIO) -> Study:
+    def import_study(self, metadata: RawStudy, stream: t.BinaryIO) -> Study:
         """
         Import study in the directory of the study.
 
@@ -329,7 +329,7 @@ class RawStudyService(AbstractStorageService[RawStudy]):
         metadata: RawStudy,
         dst_path: Path,
         outputs: bool = True,
-        output_list_filter: Optional[List[str]] = None,
+        output_list_filter: t.Optional[t.List[str]] = None,
         denormalize: bool = True,
     ) -> None:
         try:
@@ -352,7 +352,7 @@ class RawStudyService(AbstractStorageService[RawStudy]):
     def check_errors(
         self,
         metadata: RawStudy,
-    ) -> List[str]:
+    ) -> t.List[str]:
         """
         Check study antares data integrity
         Args:

--- a/tests/storage/business/test_patch_service.py
+++ b/tests/storage/business/test_patch_service.py
@@ -51,7 +51,7 @@ class TestPatchService:
     @with_db_context
     @pytest.mark.parametrize("get_from_file", [True, False])
     @pytest.mark.parametrize("file_data", ["", PATCH_CONTENT])
-    @pytest.mark.parametrize("patch_data", ["", PATCH_CONTENT])
+    @pytest.mark.parametrize("patch_data", [None, "", PATCH_CONTENT])
     def test_get(
         self,
         tmp_path: Path,
@@ -67,7 +67,15 @@ class TestPatchService:
             patch_json.write_text(file_data, encoding="utf-8")
 
         # Prepare a RAW study
-        # noinspection PyArgumentList
+        additional_data = (
+            None
+            if patch_data is None
+            else StudyAdditionalData(
+                author="john.doe",
+                horizon="foo-horizon",
+                patch=patch_data,
+            )
+        )
         raw_study = RawStudy(
             id=study_id,
             name="my_study",
@@ -76,11 +84,7 @@ class TestPatchService:
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
             version="840",
-            additional_data=StudyAdditionalData(
-                author="john.doe",
-                horizon="foo-horizon",
-                patch=patch_data,
-            ),
+            additional_data=additional_data,
             archived=False,
             owner=None,
             groups=[],


### PR DESCRIPTION
# Pull Request Description

This pull request resolves an issue encountered when reading the `study.additional_data.patch` attribute in cases where
the study lacks an `additional_data` instance.
The `additional_data` attribute is designed to be optional, but an error occurred when attempting to access it without
ensuring its presence.

## Problem Origin

The anomaly originated during the implementation phase of managing tags within the database,
instead of retrieving the list of tags from a designated file "patch.json".

## Solution

The code now appropriately checks for the existence of the `additional_data` instance before attempting to access its
attributes.

- Now, the "patch.json" file is read if the `additional_data` attribute is missing.
- If `additional_data` is present, the `study.additional_data.patch` attribute is read as expected.

## Testing

Comprehensive testing has been performed to validate the effectiveness of the implemented solution.

## Related pull requests

- [x] #1929
- [x] #1934
- [x] #1937
