### PR TITLE
fix(variants): correct the generation of variant when a snapshot is removed

### DIFF
--- a/antarest/study/model.py
+++ b/antarest/study/model.py
@@ -188,8 +188,9 @@ class Study(Base):  # type: ignore
     __mapper_args__ = {"polymorphic_identity": "study", "polymorphic_on": type}
 
     def __str__(self) -> str:
+        cls = self.__class__.__name__
         return (
-            f"[Study]"
+            f"[{cls}]"
             f" id={self.id},"
             f" type={self.type},"
             f" name={self.name},"

--- a/antarest/study/storage/variantstudy/model/dbmodel.py
+++ b/antarest/study/storage/variantstudy/model/dbmodel.py
@@ -112,3 +112,7 @@ class VariantStudy(Study):
             and (self.snapshot.created_at >= self.updated_at)
             and (self.snapshot_dir / "study.antares").is_file()
         )
+
+    def has_snapshot(self) -> bool:
+        """Check if the snapshot exists."""
+        return (self.snapshot is not None) and (self.snapshot_dir / "study.antares").is_file()

--- a/antarest/study/storage/variantstudy/snapshot_generator.py
+++ b/antarest/study/storage/variantstudy/snapshot_generator.py
@@ -246,7 +246,7 @@ def search_ref_study(
     # To reuse the snapshot of the current variant, the last executed command
     # must be one of the commands of the current variant.
     curr_variant = descendants[-1]
-    if curr_variant.snapshot:
+    if curr_variant.has_snapshot():
         last_exec_cmd = curr_variant.snapshot.last_executed_command
         command_ids = [c.id for c in curr_variant.commands]
         # If the variant has no command, we can reuse the snapshot if it is recent

--- a/tests/study/storage/variantstudy/model/test_dbmodel.py
+++ b/tests/study/storage/variantstudy/model/test_dbmodel.py
@@ -188,7 +188,7 @@ class TestVariantStudy:
         obj: VariantStudy = db_session.query(VariantStudy).filter(VariantStudy.id == variant_study_id).one()
 
         # check Study representation
-        assert str(obj).startswith(f"[Study] id={variant_study_id}")
+        assert str(obj).startswith(f"[VariantStudy] id={variant_study_id}")
 
         # check Study fields
         assert obj.id == variant_study_id


### PR DESCRIPTION
Ajout de la méthode `has_snapshot` dans le modèle `VariantStudy` afin de s'assurer que le `snapshot` existe bien avant de la mettre à jour.