### PR TITLE
fix(xpansion): catch Exception when no sensitvity folder in xpansion

### DIFF
--- a/antarest/study/business/xpansion_management.py
+++ b/antarest/study/business/xpansion_management.py
@@ -365,7 +365,7 @@ class XpansionManager:
         logger.info(f"Getting xpansion settings for study '{study.id}'")
         file_study = self.study_storage_service.get_storage(study).get_raw(study)
         config_obj = file_study.tree.get(["user", "expansion", "settings"])
-        with contextlib.suppress(KeyError):
+        with contextlib.suppress(ChildNotFoundError):
             config_obj["sensitivity_config"] = file_study.tree.get(
                 ["user", "expansion", "sensitivity", "sensitivity_in"]
             )

--- a/antarest/study/storage/rawstudy/ini_reader.py
+++ b/antarest/study/storage/rawstudy/ini_reader.py
@@ -109,7 +109,7 @@ class IniReader(IReader):
                     sections = self._parse_ini_file(f)
             except FileNotFoundError:
                 # If the file is missing, an empty dictionary is returned.
-                # This is required tp mimic the behavior of `configparser.ConfigParser`.
+                # This is required to mimic the behavior of `configparser.ConfigParser`.
                 return {}
 
         elif hasattr(path, "read"):

--- a/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
@@ -1,7 +1,7 @@
 import shutil
+import typing as t
 from abc import ABC, abstractmethod
 from http import HTTPStatus
-from typing import List, Optional, Tuple, Union
 
 from fastapi import HTTPException
 
@@ -38,7 +38,7 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
         self,
         context: ContextServer,
         config: FileStudyTreeConfig,
-        children_glob_exceptions: Optional[List[str]] = None,
+        children_glob_exceptions: t.Optional[t.List[str]] = None,
     ) -> None:
         super().__init__(config)
         self.context = context
@@ -50,11 +50,11 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
 
     def _forward_get(
         self,
-        url: List[str],
+        url: t.List[str],
         depth: int = -1,
         formatted: bool = True,
         get_node: bool = False,
-    ) -> Union[JSON, INode[JSON, SUB_JSON, JSON]]:
+    ) -> t.Union[JSON, INode[JSON, SUB_JSON, JSON]]:
         children = self.build()
         names, sub_url = self.extract_child(children, url)
 
@@ -84,7 +84,7 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
 
     def _expand_get(
         self, depth: int = -1, formatted: bool = True, get_node: bool = False
-    ) -> Union[JSON, INode[JSON, SUB_JSON, JSON]]:
+    ) -> t.Union[JSON, INode[JSON, SUB_JSON, JSON]]:
         if get_node:
             return self
 
@@ -99,11 +99,11 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
 
     def _get(
         self,
-        url: Optional[List[str]] = None,
+        url: t.Optional[t.List[str]] = None,
         depth: int = -1,
         formatted: bool = True,
         get_node: bool = False,
-    ) -> Union[JSON, INode[JSON, SUB_JSON, JSON]]:
+    ) -> t.Union[JSON, INode[JSON, SUB_JSON, JSON]]:
         if url and url != [""]:
             return self._forward_get(url, depth, formatted, get_node)
         else:
@@ -111,7 +111,7 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
 
     def get(
         self,
-        url: Optional[List[str]] = None,
+        url: t.Optional[t.List[str]] = None,
         depth: int = -1,
         expanded: bool = False,
         formatted: bool = True,
@@ -122,7 +122,7 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
 
     def get_node(
         self,
-        url: Optional[List[str]] = None,
+        url: t.Optional[t.List[str]] = None,
     ) -> INode[JSON, SUB_JSON, JSON]:
         output = self._get(url=url, get_node=True)
         assert isinstance(output, INode)
@@ -131,7 +131,7 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
     def save(
         self,
         data: SUB_JSON,
-        url: Optional[List[str]] = None,
+        url: t.Optional[t.List[str]] = None,
     ) -> None:
         self._assert_not_in_zipped_file()
         children = self.build()
@@ -146,7 +146,7 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
             for key in data:
                 children[key].save(data[key])
 
-    def delete(self, url: Optional[List[str]] = None) -> None:
+    def delete(self, url: t.Optional[t.List[str]] = None) -> None:
         if url and url != [""]:
             children = self.build()
             names, sub_url = self.extract_child(children, url)
@@ -158,16 +158,16 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
     def check_errors(
         self,
         data: JSON,
-        url: Optional[List[str]] = None,
+        url: t.Optional[t.List[str]] = None,
         raising: bool = False,
-    ) -> List[str]:
+    ) -> t.List[str]:
         children = self.build()
 
         if url and url != [""]:
             (name,), sub_url = self.extract_child(children, url)
             return children[name].check_errors(data, sub_url, raising)
         else:
-            errors: List[str] = []
+            errors: t.List[str] = []
             for key in data:
                 if key not in children:
                     msg = f"key={key} not in {list(children.keys())} for {self.__class__.__name__}"
@@ -186,7 +186,7 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
         for child in self.build().values():
             child.denormalize()
 
-    def extract_child(self, children: TREE, url: List[str]) -> Tuple[List[str], List[str]]:
+    def extract_child(self, children: TREE, url: t.List[str]) -> t.Tuple[t.List[str], t.List[str]]:
         names, sub_url = url[0].split(","), url[1:]
         names = (
             list(

--- a/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
@@ -1,7 +1,7 @@
 import shutil
 from abc import ABC, abstractmethod
 from http import HTTPStatus
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from fastapi import HTTPException
 
@@ -208,6 +208,6 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
         for name in names:
             if name not in children:
                 raise ChildNotFoundError(f"'{name}' not a child of {self.__class__.__name__}")
-            if type(children[name]) != child_class:
+            if not isinstance(children[name], child_class):
                 raise FilterError("Filter selection has different classes")
         return names, sub_url

--- a/antarest/study/storage/rawstudy/model/filesystem/json_file_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/json_file_node.py
@@ -1,6 +1,6 @@
 import json
-from pathlib import Path
 import typing as t
+from pathlib import Path
 
 from antarest.core.model import JSON
 from antarest.study.storage.rawstudy.ini_reader import IReader

--- a/antarest/study/storage/rawstudy/model/filesystem/root/user/expansion/expansion.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/user/expansion/expansion.py
@@ -14,11 +14,7 @@ from antarest.study.storage.rawstudy.model.filesystem.root.user.expansion.settin
 
 class Expansion(BucketNode):
     registered_files = [
-        RegisteredFile(
-            key="candidates",
-            node=ExpansionCandidates,
-            filename="candidates.ini",
-        ),
+        RegisteredFile(key="candidates", node=ExpansionCandidates, filename="candidates.ini"),
         RegisteredFile(key="settings", node=ExpansionSettings, filename="settings.ini"),
         RegisteredFile(key="capa", node=ExpansionMatrixResources),
         RegisteredFile(key="weights", node=ExpansionMatrixResources),

--- a/antarest/study/storage/study_upgrader/__init__.py
+++ b/antarest/study/storage/study_upgrader/__init__.py
@@ -3,10 +3,10 @@ import re
 import shutil
 import tempfile
 import time
+import typing as t
 from http import HTTPStatus
 from http.client import HTTPException
 from pathlib import Path
-from typing import Callable, List, NamedTuple
 
 from antarest.core.exceptions import StudyValidationError
 
@@ -23,40 +23,27 @@ from .upgrader_860 import upgrade_860
 logger = logging.getLogger(__name__)
 
 
-class UpgradeMethod(NamedTuple):
+class UpgradeMethod(t.NamedTuple):
     """Raw study upgrade method (old version, new version, upgrade function)."""
 
     old: str
     new: str
-    method: Callable[[Path], None]
-    files: List[Path]
+    method: t.Callable[[Path], None]
+    files: t.List[Path]
 
+
+_GENERAL_DATA_PATH = Path("settings/generaldata.ini")
 
 UPGRADE_METHODS = [
-    UpgradeMethod("700", "710", upgrade_710, [Path("settings/generaldata.ini")]),
+    UpgradeMethod("700", "710", upgrade_710, [_GENERAL_DATA_PATH]),
     UpgradeMethod("710", "720", upgrade_720, []),
-    UpgradeMethod("720", "800", upgrade_800, [Path("settings/generaldata.ini")]),
-    UpgradeMethod(
-        "800",
-        "810",
-        upgrade_810,
-        [Path("settings/generaldata.ini"), Path("input")],
-    ),
+    UpgradeMethod("720", "800", upgrade_800, [_GENERAL_DATA_PATH]),
+    UpgradeMethod("800", "810", upgrade_810, [_GENERAL_DATA_PATH, Path("input")]),
     UpgradeMethod("810", "820", upgrade_820, [Path("input/links")]),
-    UpgradeMethod(
-        "820",
-        "830",
-        upgrade_830,
-        [Path("settings/generaldata.ini"), Path("input/areas")],
-    ),
-    UpgradeMethod("830", "840", upgrade_840, [Path("settings/generaldata.ini")]),
-    UpgradeMethod("840", "850", upgrade_850, [Path("settings/generaldata.ini")]),
-    UpgradeMethod(
-        "850",
-        "860",
-        upgrade_860,
-        [Path("input"), Path("settings/generaldata.ini")],
-    ),
+    UpgradeMethod("820", "830", upgrade_830, [_GENERAL_DATA_PATH, Path("input/areas")]),
+    UpgradeMethod("830", "840", upgrade_840, [_GENERAL_DATA_PATH]),
+    UpgradeMethod("840", "850", upgrade_850, [_GENERAL_DATA_PATH]),
+    UpgradeMethod("850", "860", upgrade_860, [Path("input"), _GENERAL_DATA_PATH]),
 ]
 
 
@@ -127,7 +114,7 @@ def get_current_version(study_path: Path) -> str:
     )
 
 
-def can_upgrade_version(from_version: str, to_version: str) -> List[Path]:
+def can_upgrade_version(from_version: str, to_version: str) -> t.List[Path]:
     """
     Checks if upgrading from one version to another is possible.
 
@@ -190,7 +177,7 @@ def _update_study_antares_file(target_version: str, study_path: Path) -> None:
     file.write_text(content, encoding="utf-8")
 
 
-def _copies_only_necessary_files(files_to_upgrade: List[Path], study_path: Path, tmp_path: Path) -> List[Path]:
+def _copies_only_necessary_files(files_to_upgrade: t.List[Path], study_path: Path, tmp_path: Path) -> t.List[Path]:
     """
     Copies files concerned by the version upgrader into a temporary directory.
     Args:
@@ -221,7 +208,7 @@ def _copies_only_necessary_files(files_to_upgrade: List[Path], study_path: Path,
     return files_to_retrieve
 
 
-def _filters_out_children_files(files_to_upgrade: List[Path]) -> List[Path]:
+def _filters_out_children_files(files_to_upgrade: t.List[Path]) -> t.List[Path]:
     """
     Filters out children paths of "input" if "input" is already in the list.
     Args:
@@ -237,7 +224,7 @@ def _filters_out_children_files(files_to_upgrade: List[Path]) -> List[Path]:
     return files_to_upgrade
 
 
-def _replace_safely_original_files(files_to_replace: List[Path], study_path: Path, tmp_path: Path) -> None:
+def _replace_safely_original_files(files_to_replace: t.List[Path], study_path: Path, tmp_path: Path) -> None:
     """
     Replace files/folders of the study that should be upgraded by their copy already upgraded in the tmp directory.
     It uses Path.rename() and an intermediary tmp directory to swap the folders safely.

--- a/tests/storage/business/test_xpansion_manager.py
+++ b/tests/storage/business/test_xpansion_manager.py
@@ -81,6 +81,14 @@ def make_link_and_areas(empty_study: FileStudy) -> None:
     make_link(empty_study)
 
 
+def set_up_xpansion_manager(tmp_path: Path) -> t.Tuple[FileStudy, RawStudy, XpansionManager]:
+    empty_study = make_empty_study(tmp_path, 810)
+    study = RawStudy(id="1", path=str(empty_study.config.study_path), version="810")
+    xpansion_manager = make_xpansion_manager(empty_study)
+    xpansion_manager.create_xpansion_configuration(study)
+    return empty_study, study, xpansion_manager
+
+
 @pytest.mark.unit_test
 @pytest.mark.parametrize(
     "version, expected_output",
@@ -117,7 +125,7 @@ def test_create_configuration(tmp_path: Path, version: int, expected_output: JSO
     Test the creation of a configuration.
     """
     empty_study = make_empty_study(tmp_path, version)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=version)
+    study = RawStudy(id="1", path=str(empty_study.config.study_path), version=str(version))
     xpansion_manager = make_xpansion_manager(empty_study)
 
     with pytest.raises(ChildNotFoundError):
@@ -135,7 +143,7 @@ def test_delete_xpansion_configuration(tmp_path: Path) -> None:
     Test the deletion of a configuration.
     """
     empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
+    study = RawStudy(id="1", path=str(empty_study.config.study_path), version="810")
     xpansion_manager = make_xpansion_manager(empty_study)
 
     with pytest.raises(ChildNotFoundError):
@@ -183,7 +191,7 @@ def test_get_xpansion_settings(tmp_path: Path, version: int, expected_output: JS
     """
 
     empty_study = make_empty_study(tmp_path, version)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=version)
+    study = RawStudy(id="1", path=str(empty_study.config.study_path), version=str(version))
     xpansion_manager = make_xpansion_manager(empty_study)
 
     xpansion_manager.create_xpansion_configuration(study)
@@ -197,12 +205,7 @@ def test_update_xpansion_settings(tmp_path: Path) -> None:
     """
     Test the retrieval of the xpansion settings.
     """
-
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-
-    xpansion_manager.create_xpansion_configuration(study)
+    _, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     new_settings_obj = {
         "optimality_gap": 4.0,
@@ -246,10 +249,7 @@ def test_update_xpansion_settings(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_add_candidate(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     actual = empty_study.tree.get(["user", "expansion", "candidates"])
     assert actual == {}
@@ -298,10 +298,7 @@ def test_add_candidate(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_get_candidate(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     assert empty_study.tree.get(["user", "expansion", "candidates"]) == {}
 
@@ -334,10 +331,7 @@ def test_get_candidate(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_get_candidates(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     assert empty_study.tree.get(["user", "expansion", "candidates"]) == {}
 
@@ -372,10 +366,7 @@ def test_get_candidates(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_update_candidates(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     assert empty_study.tree.get(["user", "expansion", "candidates"]) == {}
 
@@ -406,10 +397,7 @@ def test_update_candidates(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_delete_candidate(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     assert empty_study.tree.get(["user", "expansion", "candidates"]) == {}
 
@@ -442,10 +430,7 @@ def test_delete_candidate(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_update_constraints(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     with pytest.raises(XpansionFileNotFoundError):
         xpansion_manager.update_xpansion_constraints_settings(study=study, constraints_file_name="non_existent_file")
@@ -464,10 +449,7 @@ def test_update_constraints(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_add_resources(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     filename1 = "constraints1.txt"
     filename2 = "constraints2.txt"
@@ -520,10 +502,8 @@ def test_add_resources(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_list_root_resources(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
+
     constraints_file_content = b"0"
     constraints_file_name = "unknownfile.txt"
 
@@ -533,10 +513,7 @@ def test_list_root_resources(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_get_single_constraints(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     constraints_file_content = b"0"
     constraints_file_name = "constraints.txt"
@@ -550,11 +527,17 @@ def test_get_single_constraints(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit_test
+def test_get_settings_without_sensitivity(tmp_path: Path) -> None:
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
+
+    empty_study.tree.delete(["user", "expansion", "sensitivity"])
+    # should not fail even if the folder doesn't exist as it's optional
+    xpansion_manager.get_xpansion_settings(study)
+
+
+@pytest.mark.unit_test
 def test_get_all_constraints(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    _, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     filename1 = "constraints1.txt"
     filename2 = "constraints2.txt"
@@ -576,10 +559,7 @@ def test_get_all_constraints(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_add_capa(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     filename1 = "capa1.txt"
     filename2 = "capa2.txt"
@@ -610,10 +590,7 @@ def test_add_capa(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_delete_capa(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    empty_study, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     filename1 = "capa1.txt"
     filename2 = "capa2.txt"
@@ -636,10 +613,7 @@ def test_delete_capa(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_get_single_capa(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    _, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     filename1 = "capa1.txt"
     filename2 = "capa2.txt"
@@ -664,10 +638,7 @@ def test_get_single_capa(tmp_path: Path) -> None:
 
 @pytest.mark.unit_test
 def test_get_all_capa(tmp_path: Path) -> None:
-    empty_study = make_empty_study(tmp_path, 810)
-    study = RawStudy(id="1", path=empty_study.config.study_path, version=810)
-    xpansion_manager = make_xpansion_manager(empty_study)
-    xpansion_manager.create_xpansion_configuration(study)
+    _, study, xpansion_manager = set_up_xpansion_manager(tmp_path)
 
     filename1 = "capa1.txt"
     filename2 = "capa2.txt"

--- a/tests/storage/repository/filesystem/test_folder_node.py
+++ b/tests/storage/repository/filesystem/test_folder_node.py
@@ -121,9 +121,8 @@ def test_get_user_expansion_sensitivity_sensitivity_in(tmp_path: Path) -> None:
 
     # Add the "sensitivity" directory
     tmp_path.joinpath("user/expansion/sensitivity").mkdir()
-    # fixme: we should have `{}`
-    with pytest.raises(FileNotFoundError, match=r"No such file or directory"):
-        file_study.tree.get(url)
+    actual = file_study.tree.get(url)
+    assert actual == {}
 
     # Add the "sensitivity_in.json" file
     sensitivity_obj = {"epsilon": 10000.0, "projection": ["pv", "battery"], "capex": True}


### PR DESCRIPTION
Resolves [ANT-1216] 

Cette PR règle un problème d'affichage et d'édition des paramètres d'Xpansion alors que la configuration existe bien dans l'étude.
C'est le cas, en particulier, lorsqu'il n'y a pas de configuration pour l'analyse de sensibilité (absence du dossier `sensitvity`)
