### PR TITLE
fix(api-study): check area duplicates on creation

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -253,6 +253,14 @@ class AreaNotFound(HTTPException):
         super().__init__(HTTPStatus.NOT_FOUND, msg)
 
 
+class DuplicateAreaName(HTTPException):
+    """Exception raised when trying to create an area with an already existing name."""
+
+    def __init__(self, area_name: str) -> None:
+        msg = f"Area '{area_name}' already exists and could not be created"
+        super().__init__(HTTPStatus.CONFLICT, msg)
+
+
 class DistrictNotFound(HTTPException):
     def __init__(self, *district_ids: str) -> None:
         count = len(district_ids)

--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -320,9 +320,8 @@ class AreaManager:
         file_study = self.storage_service.get_storage(study).get_raw(study)
 
         # check if area already exists
-        existing_area_ids = set(file_study.config.areas)
         area_id = transform_name_to_id(area_creation_info.name)
-        if area_id in existing_area_ids:
+        if area_id in set(file_study.config.areas):
             raise DuplicateAreaName(area_creation_info.name)
 
         # Create area and apply changes in the study

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -9,7 +9,7 @@ from starlette.testclient import TestClient
 from antarest.core.model import PublicMode
 from antarest.launcher.model import LauncherLoadDTO
 from antarest.study.business.adequacy_patch_management import PriceTakingOrder
-from antarest.study.business.area_management import AreaType, LayerInfoDTO
+from antarest.study.business.area_management import LayerInfoDTO
 from antarest.study.business.areas.properties_management import AdequacyPatchMode
 from antarest.study.business.areas.renewable_management import TimeSeriesInterpretation
 from antarest.study.business.general_management import Mode
@@ -420,23 +420,26 @@ def test_area_management(client: TestClient, admin_access_token: str, study_id: 
         headers=admin_headers,
         json={
             "name": "area 1",
-            "type": AreaType.AREA.value,
+            "type": "AREA",
             "metadata": {"country": "FR", "tags": ["a"]},
         },
     )
+    assert res.status_code == 200, res.json()
+
+    # Test area creation with duplicate name
     res = client.post(
         f"/v1/studies/{study_id}/areas",
         headers=admin_headers,
         json={
-            "name": "area 1",
-            "type": AreaType.AREA.value,
+            "name": "Area 1",  # Same name but with different case
+            "type": "AREA",
             "metadata": {"country": "FR"},
         },
     )
-    assert res.status_code == 500
+    assert res.status_code == 409, res.json()
     assert res.json() == {
-        "description": "Area 'area 1' already exists and could not be created",
-        "exception": "CommandApplicationError",
+        "description": "Area 'Area 1' already exists and could not be created",
+        "exception": "DuplicateAreaName",
     }
 
     client.post(
@@ -444,7 +447,7 @@ def test_area_management(client: TestClient, admin_access_token: str, study_id: 
         headers=admin_headers,
         json={
             "name": "area 2",
-            "type": AreaType.AREA.value,
+            "type": "AREA",
             "metadata": {"country": "DE"},
         },
     )


### PR DESCRIPTION
Lorsque l'on crée une zone et que l'on met comme nom le même que celui d'une zone déjà existante (même mot, insensibilité à la case) aucune erreur n'est renvoyée lorsqu'on clique sur sauvegarder. Cependant, aucune zone n'est créée.

Le variant est corrompu après cette action. Il renvoi une erreur 417. Une commande de variant a été créée et elle essaye de modifier l'étude en voulant créer une nouvelle zone avec un nom existant. D'où l'erreur 417. De plus le message d'erreur n'est pas parlant.