### PR TITLE
fix(ui-results): correct weekly data formatting to support 53-week years

### DIFF
--- a/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
@@ -160,11 +160,16 @@ function ResultDetails() {
       return ["Annual"];
     }
 
+    // Directly use API's week index (handles 53 weeks) as no formatting is required.
+    // !NOTE: Suboptimal: Assumes API consistency, lacks flexibility.
+    if (timestep === Timestep.Weekly) {
+      return matrixRes.data.index.map((weekNumber) => weekNumber.toString());
+    }
+
     // Original date/time format mapping for moment parsing
     const parseFormat = {
       [Timestep.Hourly]: "MM/DD HH:mm",
       [Timestep.Daily]: "MM/DD",
-      [Timestep.Weekly]: "WW",
       [Timestep.Monthly]: "MM",
     }[timestep];
 
@@ -172,7 +177,6 @@ function ResultDetails() {
     const outputFormat = {
       [Timestep.Hourly]: "DD MMM HH:mm  I",
       [Timestep.Daily]: "DD MMM  I",
-      [Timestep.Weekly]: "WW",
       [Timestep.Monthly]: "MMM",
     }[timestep];
 


### PR DESCRIPTION
Related to: https://gopro-tickets.rte-france.com/browse/ANT-1368

### Description

In results matrices configured for 'Weekly' temporality, an 'Invalid date' appears for week 53, due to the fact that the year sometimes has 53 weeks, or 52.n instead of 52.

![image](https://github.com/AntaresSimulatorTeam/AntaREST/assets/33469289/be7edf79-c133-46c3-a41b-faef36c66c9e)
