### PR TITLE
fix(db): correct conversion to `CommandDTO` when the version isn't provided in the database

### DIFF
--- a/antarest/study/storage/variantstudy/model/dbmodel.py
+++ b/antarest/study/storage/variantstudy/model/dbmodel.py
@@ -55,7 +55,9 @@ class CommandBlock(Base):  # type: ignore
     args: str = Column(String())
 
     def to_dto(self) -> CommandDTO:
-        return CommandDTO(id=self.id, action=self.command, args=json.loads(self.args), version=self.version)
+        # Database may lack a version number, defaulting to 1 if so.
+        version = self.version or 1
+        return CommandDTO(id=self.id, action=self.command, args=json.loads(self.args), version=version)
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
This PR fixes the crash accounted when generating a variant of a study.

Trace back:
```python
Traceback (most recent call last):
  ...
  File "/antarest/study/storage/variantstudy/model/dbmodel.py", line 58, in to_dto
    return CommandDTO(id=self.id, action=self.command, args=json.loads(self.args), version=self.version)
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for CommandDTO
version
  none is not an allowed value (type=type_error.none.not_allowed)
```

In databases, the `version` field is optional, whereas it isn't in the `CommandDTO` class. I therefore modified the `to_dto` conversion function to use the default value of 1 when this field is empty.

## Integration Tests

We can check the behavior with the following scenario:

- use `GET /v1/studies/{uuid}/commands` to download the commands list of a variant in JSON format;
- edit the JSON file to remove the version attribute is some places;
- use `PUT /v1/studies/{uuid}/commands` to replace the command list with the modified JSON file;
- use `GET /v1/studies/{uuid}/commands` again to check that the version number is set to the default value of 1.
