### PR TITLE
feat(commands): add command ID in variant generation job results

### DIFF
--- a/antarest/core/configdata/model.py
+++ b/antarest/core/configdata/model.py
@@ -2,8 +2,7 @@ from enum import Enum
 from typing import Any, Optional
 
 from pydantic import BaseModel
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, Sequence, String  # type: ignore
-from sqlalchemy.orm import relationship  # type: ignore
+from sqlalchemy import Column, Integer, String  # type: ignore
 
 from antarest.core.persistence import Base
 

--- a/antarest/core/filesystem_blueprint.py
+++ b/antarest/core/filesystem_blueprint.py
@@ -15,7 +15,6 @@ from pydantic import BaseModel, Extra, Field
 from starlette.responses import PlainTextResponse, StreamingResponse
 
 from antarest.core.config import Config
-from antarest.core.jwt import JWTUser
 from antarest.core.utils.web import APITag
 from antarest.login.auth import Auth
 

--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -231,7 +231,7 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
                     "value": "local",
                 },
             },
-        )
+        ),
     ) -> List[str]:
         """
         Get list of supported solver versions defined in the configuration.
@@ -268,7 +268,7 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
                     "value": "local",
                 },
             },
-        )
+        ),
     ) -> Dict[str, int]:
         """
         Retrieve the numer of cores of the launcher.

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -61,7 +61,7 @@ class PathType:
         from antarest.main import PathType
 
         parser = argparse.ArgumentParser()
-        parser.add_argument('--input', type=PathType(file_ok=True, exists=True))
+        parser.add_argument("--input", type=PathType(file_ok=True, exists=True))
         args = parser.parse_args()
 
         print(args.input)

--- a/antarest/matrixstore/main.py
+++ b/antarest/matrixstore/main.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from fastapi import FastAPI
-from fastapi_jwt_auth.exceptions import AuthJWTException  # type: ignore
 
 from antarest.core.config import Config
 from antarest.core.filetransfer.service import FileTransferManager

--- a/antarest/matrixstore/repository.py
+++ b/antarest/matrixstore/repository.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import numpy as np
 from filelock import FileLock
 from numpy import typing as npt
-from sqlalchemy import and_, exists  # type: ignore
-from sqlalchemy.orm import Session, aliased  # type: ignore
+from sqlalchemy import exists  # type: ignore
+from sqlalchemy.orm import Session  # type: ignore
 
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.matrixstore.model import Matrix, MatrixContent, MatrixData, MatrixDataSet

--- a/antarest/study/business/areas/properties_management.py
+++ b/antarest/study/business/areas/properties_management.py
@@ -2,7 +2,7 @@ import re
 from builtins import sorted
 from typing import Any, Dict, Iterable, List, Optional, Set, cast
 
-from pydantic import Field, root_validator
+from pydantic import root_validator
 
 from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.business.utils import FieldInfo, FormFieldsBaseModel, execute_or_add_commands

--- a/antarest/study/business/table_mode_management.py
+++ b/antarest/study/business/table_mode_management.py
@@ -436,17 +436,13 @@ class TableModeManager:
 
         if table_type == TableTemplateType.AREA:
             return {
-                area_id: columns_model.construct(
-                    **{col: get_column_value(col, data) for col in columns}
-                )  # type: ignore
+                area_id: columns_model.construct(**{col: get_column_value(col, data) for col in columns})  # type: ignore
                 for area_id, data in glob_object.items()
             }
 
         if table_type == TableTemplateType.BINDING_CONSTRAINT:
             return {
-                data["id"]: columns_model.construct(
-                    **{col: get_column_value(col, data) for col in columns}
-                )  # type: ignore
+                data["id"]: columns_model.construct(**{col: get_column_value(col, data) for col in columns})  # type: ignore
                 for data in glob_object.values()
             }
 

--- a/antarest/study/repository.py
+++ b/antarest/study/repository.py
@@ -23,9 +23,7 @@ def escape_like(string: str, escape_char: str = "\\") -> str:
 
         from sqlalchemy_utils import escape_like
 
-        query = session.query(User).filter(
-            User.name.ilike(escape_like('John'))
-        )
+        query = session.query(User).filter(User.name.ilike(escape_like("John")))
 
     Args:
         string: a string to escape

--- a/antarest/study/storage/variantstudy/business/utils_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/business/utils_binding_constraint.py
@@ -8,7 +8,7 @@ from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint 
 )
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-from antarest.study.storage.variantstudy.model.command.common import BindingConstraintOperator, CommandOutput
+from antarest.study.storage.variantstudy.model.command.common import BindingConstraintOperator
 
 
 def apply_binding_constraint(
@@ -29,7 +29,7 @@ def apply_binding_constraint(
     filter_year_by_year: t.Optional[str] = None,
     filter_synthesis: t.Optional[str] = None,
     group: t.Optional[str] = None,
-) -> CommandOutput:
+) -> str:
     version = study_data.config.version
     binding_constraints[new_key] = {
         "name": name,
@@ -52,19 +52,13 @@ def apply_binding_constraint(
         if "%" in link_or_cluster:
             area_1, area_2 = link_or_cluster.split("%")
             if area_1 not in study_data.config.areas or area_2 not in study_data.config.areas[area_1].links:
-                return CommandOutput(
-                    status=False,
-                    message=f"Link '{link_or_cluster}' does not exist in binding constraint '{bd_id}'",
-                )
+                return f"Link '{link_or_cluster}' does not exist in binding constraint '{bd_id}'"
         elif "." in link_or_cluster:
             # Cluster IDs are stored in lower case in the binding constraints file.
             area, cluster_id = link_or_cluster.split(".")
             thermal_ids = {thermal.id.lower() for thermal in study_data.config.areas[area].thermals}
             if area not in study_data.config.areas or cluster_id.lower() not in thermal_ids:
-                return CommandOutput(
-                    status=False,
-                    message=f"Cluster '{link_or_cluster}' does not exist in binding constraint '{bd_id}'",
-                )
+                return f"Cluster '{link_or_cluster}' does not exist in binding constraint '{bd_id}'"
         else:
             raise NotImplementedError(f"Invalid link or thermal ID: {link_or_cluster}")
 
@@ -95,7 +89,7 @@ def apply_binding_constraint(
                 raise TypeError(repr(matrix_term))
             if version >= 870:
                 study_data.tree.save(matrix_term, ["input", "bindingconstraints", f"{bd_id}_{matrix_alias}"])
-    return CommandOutput(status=True)
+    return ""  # success
 
 
 def parse_bindings_coeffs_and_save_into_config(

--- a/antarest/study/storage/variantstudy/command_factory.py
+++ b/antarest/study/storage/variantstudy/command_factory.py
@@ -74,7 +74,7 @@ class CommandFactory:
             patch_service=patch_service,
         )
 
-    def _to_single_command(self, command_id: t.Optional[str], action: str, args: JSON, version: int) -> ICommand:
+    def _to_single_command(self, action: str, args: JSON, version: int, command_id: t.Optional[str]) -> ICommand:
         """Convert a single CommandDTO to ICommand."""
         if action in COMMAND_MAPPING:
             command_class = COMMAND_MAPPING[action]
@@ -101,10 +101,10 @@ class CommandFactory:
         """
         args = command_dto.args
         if isinstance(args, dict):
-            return [self._to_single_command(command_dto.id, command_dto.action, args, command_dto.version)]
+            return [self._to_single_command(command_dto.action, args, command_dto.version, command_dto.id)]
         elif isinstance(args, list):
             return [
-                self._to_single_command(command_dto.id, command_dto.action, argument, command_dto.version)
+                self._to_single_command(command_dto.action, argument, command_dto.version, command_dto.id)
                 for argument in args
             ]
         raise NotImplementedError()

--- a/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
@@ -241,7 +241,7 @@ class CreateBindingConstraint(AbstractBindingConstraintCommand):
         bd_id = transform_name_to_id(self.name)
         self.validates_and_fills_matrices(specific_matrices=None, version=study_data.config.version, create=True)
 
-        return apply_binding_constraint(
+        err_msg = apply_binding_constraint(
             study_data,
             binding_constraints,
             str(new_key),
@@ -260,6 +260,7 @@ class CreateBindingConstraint(AbstractBindingConstraintCommand):
             self.filter_synthesis,
             self.group,
         )
+        return CommandOutput(status=not err_msg, message=err_msg)
 
     def to_dto(self) -> CommandDTO:
         dto = super().to_dto()

--- a/antarest/study/storage/variantstudy/model/command/icommand.py
+++ b/antarest/study/storage/variantstudy/model/command/icommand.py
@@ -1,6 +1,7 @@
 import logging
+import typing as t
+import uuid
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 from pydantic import BaseModel, Extra
 
@@ -11,7 +12,7 @@ from antarest.study.storage.variantstudy.model.command.common import CommandName
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.model.model import CommandDTO
 
-if TYPE_CHECKING:  # False at runtime, for mypy
+if t.TYPE_CHECKING:  # False at runtime, for mypy
     from antarest.study.storage.variantstudy.business.command_extractor import CommandExtractor
 
 MATCH_SIGNATURE_SEPARATOR = "%"
@@ -19,12 +20,23 @@ logger = logging.getLogger(__name__)
 
 
 class ICommand(ABC, BaseModel, extra=Extra.forbid, arbitrary_types_allowed=True):
+    """
+    Interface for all commands that can be applied to a study.
+
+    Attributes:
+        command_id: The ID of the command extracted from the database, if any.
+        command_name: The name of the command.
+        version: The version of the command (currently always equal to 1).
+        command_context: The context of the command.
+    """
+
+    command_id: t.Optional[uuid.UUID] = None
     command_name: CommandName
     version: int
     command_context: CommandContext
 
     @abstractmethod
-    def _apply_config(self, study_data: FileStudyTreeConfig) -> Tuple[CommandOutput, Dict[str, Any]]:
+    def _apply_config(self, study_data: FileStudyTreeConfig) -> t.Tuple[CommandOutput, t.Dict[str, t.Any]]:
         """
         Applies configuration changes to the study data.
 
@@ -112,7 +124,7 @@ class ICommand(ABC, BaseModel, extra=Extra.forbid, arbitrary_types_allowed=True)
         raise NotImplementedError()
 
     @abstractmethod
-    def _create_diff(self, other: "ICommand") -> List["ICommand"]:
+    def _create_diff(self, other: "ICommand") -> t.List["ICommand"]:
         """
         Creates a list of commands representing the differences between
         the current instance and another `ICommand` object.
@@ -126,7 +138,7 @@ class ICommand(ABC, BaseModel, extra=Extra.forbid, arbitrary_types_allowed=True)
         """
         raise NotImplementedError()
 
-    def create_diff(self, other: "ICommand") -> List["ICommand"]:
+    def create_diff(self, other: "ICommand") -> t.List["ICommand"]:
         """
         Creates a list of commands representing the differences between
         the current instance and another `ICommand` object.
@@ -142,7 +154,7 @@ class ICommand(ABC, BaseModel, extra=Extra.forbid, arbitrary_types_allowed=True)
         return self._create_diff(other)
 
     @abstractmethod
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> t.List[str]:
         """
         Retrieves the list of matrix IDs.
         """

--- a/antarest/study/storage/variantstudy/model/command/remove_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_binding_constraint.py
@@ -26,7 +26,7 @@ class RemoveBindingConstraint(ICommand):
                 dict(),
             )
         study_data.bindings.remove(next(iter([bind for bind in study_data.bindings if bind.id == self.id])))
-        return CommandOutput(status=True), dict()
+        return CommandOutput(status=True), {}
 
     def _apply(self, study_data: FileStudy) -> CommandOutput:
         if self.id not in [bind.id for bind in study_data.config.bindings]:

--- a/antarest/study/storage/variantstudy/model/command/update_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/update_binding_constraint.py
@@ -56,7 +56,7 @@ class UpdateBindingConstraint(AbstractBindingConstraintCommand):
         self.validates_and_fills_matrices(specific_matrices=updated_matrices or None, version=study_data.config.version, create=False)
         # fmt: on
 
-        return apply_binding_constraint(
+        err_msg = apply_binding_constraint(
             study_data,
             binding_constraints,
             new_key,
@@ -75,6 +75,7 @@ class UpdateBindingConstraint(AbstractBindingConstraintCommand):
             self.filter_synthesis,
             self.group,
         )
+        return CommandOutput(status=not err_msg, message=err_msg)
 
     def to_dto(self) -> CommandDTO:
         dto = super().to_dto()

--- a/antarest/study/storage/variantstudy/model/command/update_config.py
+++ b/antarest/study/storage/variantstudy/model/command/update_config.py
@@ -27,7 +27,7 @@ class UpdateConfig(ICommand):
     data: Union[str, int, float, bool, JSON, None]
 
     def _apply_config(self, study_data: FileStudyTreeConfig) -> Tuple[CommandOutput, Dict[str, Any]]:
-        return CommandOutput(status=True, message="ok"), dict()
+        return CommandOutput(status=True, message="ok"), {}
 
     def _apply(self, study_data: FileStudy) -> CommandOutput:
         url = self.target.split("/")

--- a/antarest/study/storage/variantstudy/model/model.py
+++ b/antarest/study/storage/variantstudy/model/model.py
@@ -2,7 +2,6 @@ import typing as t
 import uuid
 
 import typing_extensions as te
-
 from pydantic import BaseModel
 
 from antarest.core.model import JSON
@@ -25,7 +24,7 @@ class NewDetailsDTO(te.TypedDict):
         msg: message de la génération de la commande ou message d'erreur (si le statut est false).
     """
 
-    id: uuid.UUID
+    id: t.Optional[uuid.UUID]
     name: str
     status: bool
     msg: str

--- a/antarest/study/storage/variantstudy/model/model.py
+++ b/antarest/study/storage/variantstudy/model/model.py
@@ -12,7 +12,8 @@ class GenerationResultInfoDTO(BaseModel):
 
     Attributes:
         success: A boolean indicating whether the generation process was successful.
-        details: A list of tuples containing detailed information about the generation process.
+        details: A list of tuples containing detailed information about the generation process:
+            (``name``, ``output_status``, ``output_message``).
     """
 
     success: bool

--- a/antarest/study/storage/variantstudy/model/model.py
+++ b/antarest/study/storage/variantstudy/model/model.py
@@ -1,9 +1,37 @@
 import typing as t
+import uuid
+
+import typing_extensions as te
 
 from pydantic import BaseModel
 
 from antarest.core.model import JSON
 from antarest.study.model import StudyMetadataDTO
+
+LegacyDetailsDTO = t.Tuple[str, bool, str]
+"""
+Legacy details DTO: triplet of name, output status and output message.
+"""
+
+
+class NewDetailsDTO(te.TypedDict):
+    """
+    New details DTO: dictionary with keys 'id', 'name', 'status' and 'msg'.
+
+    Attributes:
+        id: identifiant de la commande (UUID),
+        name: nom de la commande,
+        status: statut de la commande (true ou false),
+        msg: message de la génération de la commande ou message d'erreur (si le statut est false).
+    """
+
+    id: uuid.UUID
+    name: str
+    status: bool
+    msg: str
+
+
+DetailsDTO = t.Union[LegacyDetailsDTO, NewDetailsDTO]
 
 
 class GenerationResultInfoDTO(BaseModel):
@@ -12,12 +40,11 @@ class GenerationResultInfoDTO(BaseModel):
 
     Attributes:
         success: A boolean indicating whether the generation process was successful.
-        details: A list of tuples containing detailed information about the generation process:
-            (``name``, ``output_status``, ``output_message``).
+        details: Objects containing detailed information about the generation process.
     """
 
     success: bool
-    details: t.MutableSequence[t.Tuple[str, bool, str]]
+    details: t.MutableSequence[DetailsDTO]
 
 
 class CommandDTO(BaseModel):

--- a/antarest/study/storage/variantstudy/model/model.py
+++ b/antarest/study/storage/variantstudy/model/model.py
@@ -18,13 +18,13 @@ class NewDetailsDTO(te.TypedDict):
     New details DTO: dictionary with keys 'id', 'name', 'status' and 'msg'.
 
     Attributes:
-        id: identifiant de la commande (UUID),
-        name: nom de la commande,
-        status: statut de la commande (true ou false),
-        msg: message de la génération de la commande ou message d'erreur (si le statut est false).
+        id: command identifier (UUID) if it exists.
+        name: command name.
+        status: command status (true or false).
+        msg: command generation message or error message (if the status is false).
     """
 
-    id: t.Optional[uuid.UUID]
+    id: uuid.UUID
     name: str
     status: bool
     msg: str

--- a/antarest/study/storage/variantstudy/repository.py
+++ b/antarest/study/storage/variantstudy/repository.py
@@ -1,6 +1,6 @@
 import typing as t
 
-from sqlalchemy.orm import Session, joinedload, subqueryload  # type: ignore
+from sqlalchemy.orm import Session, joinedload  # type: ignore
 
 from antarest.core.interfaces.cache import ICache
 from antarest.core.utils.fastapi_sqlalchemy import db

--- a/antarest/study/storage/variantstudy/snapshot_generator.py
+++ b/antarest/study/storage/variantstudy/snapshot_generator.py
@@ -175,8 +175,15 @@ class SnapshotGenerator:
         if not results.success:
             message = f"Failed to generate variant study {variant_study.id}"
             if results.details:
-                detail: t.Tuple[str, bool, str] = results.details[-1]
-                message += f": {detail[2]}"
+                detail = results.details[-1]
+                if isinstance(detail, (tuple, list)):
+                    # old format: LegacyDetailsDTO
+                    message += f": {detail[2]}"
+                elif isinstance(detail, dict):
+                    # new format since v2.17: NewDetailsDTO
+                    message += f": {detail['msg']}"
+                else:  # pragma: no cover
+                    raise NotImplementedError(f"Unexpected detail type: {type(detail)}")
             raise VariantGenerationError(message)
         return results
 

--- a/antarest/study/storage/variantstudy/variant_command_generator.py
+++ b/antarest/study/storage/variantstudy/variant_command_generator.py
@@ -1,5 +1,6 @@
 import logging
 import shutil
+import uuid
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple, Union, cast
 
@@ -65,8 +66,9 @@ class VariantCommandGenerator:
                 )
                 logger.error(output.message, exc_info=e)
 
+            # noinspection PyTypeChecker
             detail: NewDetailsDTO = {
-                "id": cmd.command_id,
+                "id": uuid.UUID(int=0) if cmd.command_id is None else cmd.command_id,
                 "name": cmd.command_name.value,
                 "status": output.status,
                 "msg": output.message,

--- a/antarest/study/storage/variantstudy/variant_command_generator.py
+++ b/antarest/study/storage/variantstudy/variant_command_generator.py
@@ -10,11 +10,21 @@ from antarest.study.storage.utils import update_antares_info
 from antarest.study.storage.variantstudy.model.command.common import CommandOutput
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
-from antarest.study.storage.variantstudy.model.model import GenerationResultInfoDTO
+from antarest.study.storage.variantstudy.model.model import GenerationResultInfoDTO, NewDetailsDTO
 
 logger = logging.getLogger(__name__)
 
 APPLY_CALLBACK = Callable[[ICommand, Union[FileStudyTreeConfig, FileStudy]], CommandOutput]
+
+
+class CmdNotifier:
+    def __init__(self, study_id: str, total_count: int) -> None:
+        self.index = 0
+        self.study_id = study_id
+        self.total_count = total_count
+
+    def __call__(self, x: float) -> None:
+        logger.info(f"Command {self.index}/{self.total_count} [{self.study_id}] applied in {x}s")
 
 
 class VariantCommandGenerator:
@@ -33,53 +43,44 @@ class VariantCommandGenerator:
         # Apply commands
         results: GenerationResultInfoDTO = GenerationResultInfoDTO(success=True, details=[])
 
-        stopwatch.reset_current()
         logger.info("Applying commands")
-        command_index = 0
-        total_commands = len(commands)
-        study_id = metadata.id if metadata is not None else "-"
-        for command_batch in commands:
-            command_output_status = True
-            command_output_message = ""
-            command_name = command_batch[0].command_name.value if len(command_batch) > 0 else ""
-            try:
-                command_index += 1
-                command_output_messages: List[str] = []
-                for command in command_batch:
-                    output = applier(command, data)
-                    command_output_messages.append(output.message)
-                    command_output_status = command_output_status and output.status
-                    if not command_output_status:
-                        break
-                command_output_message = "\n".join(command_output_messages)
-            except Exception as e:
-                command_output_status = False
-                command_output_message = f"Error while applying command {command_name}"
-                logger.error(command_output_message, exc_info=e)
-                break
-            finally:
-                results.details.append(
-                    (
-                        command_name,
-                        command_output_status,
-                        command_output_message,
-                    )
-                )
-                results.success = command_output_status
-                if notifier:
-                    notifier(
-                        command_index - 1,
-                        command_output_status,
-                        command_output_message,
-                    )
-                stopwatch.log_elapsed(
-                    lambda x: logger.info(
-                        f"Command {command_index}/{total_commands} [{study_id}] {command.match_signature()} applied in {x}s"
-                    )
-                )
+        study_id = "-" if metadata is None else metadata.id
 
-            if not results.success:
-                break
+        # flatten the list of commands
+        all_commands = [command for command_batch in commands for command in command_batch]
+
+        # Prepare the stopwatch
+        cmd_notifier = CmdNotifier(study_id, len(all_commands))
+        stopwatch.reset_current()
+
+        # Store all the outputs
+        for index, cmd in enumerate(all_commands, 1):
+            try:
+                output = applier(cmd, data)
+            except Exception as e:
+                # Unhandled exception
+                output = CommandOutput(
+                    status=False,
+                    message=f"Error while applying command {cmd.command_name}",
+                )
+                logger.error(output.message, exc_info=e)
+
+            detail: NewDetailsDTO = {
+                "id": cmd.command_id,
+                "name": cmd.command_name.value,
+                "status": output.status,
+                "msg": output.message,
+            }
+            results.details.append(detail)
+
+            if notifier:
+                notifier(index - 1, output.status, output.message)
+
+            cmd_notifier.index = index
+            stopwatch.log_elapsed(cmd_notifier)
+
+        results.success = all(detail["status"] for detail in results.details)  # type: ignore
+
         data_type = isinstance(data, FileStudy)
         stopwatch.log_elapsed(
             lambda x: logger.info(

--- a/antarest/utils.py
+++ b/antarest/utils.py
@@ -101,9 +101,7 @@ def init_db_engine(
     return engine
 
 
-def create_event_bus(
-    application: Optional[FastAPI], config: Config
-) -> Tuple[IEventBus, Optional[redis.Redis]]:  # type: ignore
+def create_event_bus(application: Optional[FastAPI], config: Config) -> Tuple[IEventBus, Optional[redis.Redis]]:  # type: ignore
     redis_client = new_redis_instance(config.redis) if config.redis is not None else None
     return (
         build_eventbus(application, config, True, redis_client),

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 from typing import Any, Callable, Dict, List, cast
@@ -76,3 +77,26 @@ def auto_retry_assert(predicate: Callable[..., bool], timeout: int = 2, delay: f
             return
         time.sleep(delay)
     raise AssertionError()
+
+
+class AnyUUID:
+    """Mock object to match any UUID."""
+
+    def __init__(self, as_string: bool = False):
+        self.as_string = as_string
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, AnyUUID):
+            return True
+        if isinstance(other, str):
+            if self.as_string:
+                try:
+                    uuid.UUID(other)
+                    return True
+                except ValueError:
+                    return False
+            return False
+        return isinstance(other, uuid.UUID)
+
+    def __ne__(self, other: object) -> bool:
+        return not self.__eq__(other)

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -24,9 +24,8 @@ from antarest.study.storage.variantstudy.model.dbmodel import CommandBlock, Vari
 from antarest.study.storage.variantstudy.model.model import CommandDTO
 from antarest.study.storage.variantstudy.snapshot_generator import SnapshotGenerator, search_ref_study
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from helpers import AnyUUID
 from tests.db_statement_recorder import DBStatementRecorder
-from tests.helpers import with_db_context
+from tests.helpers import AnyUUID, with_db_context
 
 
 def _create_variant(

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -21,11 +21,27 @@ from antarest.login.model import Group, Role, User
 from antarest.study.model import RawStudy, Study, StudyAdditionalData
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
 from antarest.study.storage.variantstudy.model.dbmodel import CommandBlock, VariantStudy, VariantStudySnapshot
-from antarest.study.storage.variantstudy.model.model import CommandDTO, GenerationResultInfoDTO
+from antarest.study.storage.variantstudy.model.model import CommandDTO
 from antarest.study.storage.variantstudy.snapshot_generator import SnapshotGenerator, search_ref_study
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 from tests.db_statement_recorder import DBStatementRecorder
 from tests.helpers import with_db_context
+
+
+class AnyUUID:
+    """Mock object to match any UUID."""
+
+    def __init__(self, as_string: bool = False):
+        self.as_string = as_string
+
+    def __eq__(self, other):
+        if self.as_string:
+            try:
+                uuid.UUID(other)
+                return True
+            except ValueError:
+                return False
+        return isinstance(other, uuid.UUID)
 
 
 def _create_variant(
@@ -851,15 +867,35 @@ class TestSnapshotGenerator:
         assert len(db_recorder.sql_statements) == 5, str(db_recorder)
 
         # Check: the variant generation must succeed.
-        assert results == GenerationResultInfoDTO(
-            success=True,
-            details=[
-                ("create_area", True, "Area 'North' created"),
-                ("create_area", True, "Area 'South' created"),
-                ("create_link", True, "Link between 'north' and 'south' created"),
-                ("create_cluster", True, "Thermal cluster 'gas_cluster' added to area 'south'."),
+        assert results.dict() == {
+            "success": True,
+            "details": [
+                {
+                    "id": AnyUUID(),
+                    "name": "create_area",
+                    "status": True,
+                    "msg": "Area 'North' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_area",
+                    "status": True,
+                    "msg": "Area 'South' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_link",
+                    "status": True,
+                    "msg": "Link between 'north' and 'south' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_cluster",
+                    "status": True,
+                    "msg": "Thermal cluster 'gas_cluster' added to area 'south'.",
+                },
             ],
-        )
+        }
 
         # Check: the variant is correctly generated and all commands are applied.
         snapshot_dir = variant_study.snapshot_dir
@@ -907,13 +943,33 @@ class TestSnapshotGenerator:
         assert list(snapshot_dir.parent.iterdir()) == [snapshot_dir]
 
         # Check: the notifications are correctly registered.
-        assert notifier.notifications == [  # type: ignore
+        assert notifier.notifications == [
             {
                 "details": [
-                    ["create_area", True, "Area 'North' created"],
-                    ["create_area", True, "Area 'South' created"],
-                    ["create_link", True, "Link between 'north' and 'south' created"],
-                    ["create_cluster", True, "Thermal cluster 'gas_cluster' added to area 'south'."],
+                    {
+                        "id": AnyUUID(as_string=True),
+                        "msg": "Area 'North' created",
+                        "name": "create_area",
+                        "status": True,
+                    },
+                    {
+                        "id": AnyUUID(as_string=True),
+                        "msg": "Area 'South' created",
+                        "name": "create_area",
+                        "status": True,
+                    },
+                    {
+                        "id": AnyUUID(as_string=True),
+                        "msg": "Link between 'north' and 'south' created",
+                        "name": "create_link",
+                        "status": True,
+                    },
+                    {
+                        "id": AnyUUID(as_string=True),
+                        "msg": "Thermal cluster 'gas_cluster' added to area 'south'.",
+                        "name": "create_cluster",
+                        "status": True,
+                    },
                 ],
                 "success": True,
             }
@@ -996,15 +1052,35 @@ class TestSnapshotGenerator:
         )
 
         # Check the results
-        assert results == GenerationResultInfoDTO(
-            success=True,
-            details=[
-                ("create_area", True, "Area 'North' created"),
-                ("create_area", True, "Area 'South' created"),
-                ("create_link", True, "Link between 'north' and 'south' created"),
-                ("create_cluster", True, "Thermal cluster 'gas_cluster' added to area 'south'."),
+        assert results.dict() == {
+            "success": True,
+            "details": [
+                {
+                    "id": AnyUUID(),
+                    "name": "create_area",
+                    "status": True,
+                    "msg": "Area 'North' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_area",
+                    "status": True,
+                    "msg": "Area 'South' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_link",
+                    "status": True,
+                    "msg": "Link between 'north' and 'south' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_cluster",
+                    "status": True,
+                    "msg": "Thermal cluster 'gas_cluster' added to area 'south'.",
+                },
             ],
-        )
+        }
 
         # Check: the matrices are denormalized (we should have TSV files).
         snapshot_dir = variant_study.snapshot_dir
@@ -1099,15 +1175,35 @@ class TestSnapshotGenerator:
             )
 
         # Check the results
-        assert results == GenerationResultInfoDTO(
-            success=True,
-            details=[
-                ("create_area", True, "Area 'North' created"),
-                ("create_area", True, "Area 'South' created"),
-                ("create_link", True, "Link between 'north' and 'south' created"),
-                ("create_cluster", True, "Thermal cluster 'gas_cluster' added to area 'south'."),
+        assert results.dict() == {
+            "success": True,
+            "details": [
+                {
+                    "id": AnyUUID(),
+                    "name": "create_area",
+                    "status": True,
+                    "msg": "Area 'North' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_area",
+                    "status": True,
+                    "msg": "Area 'South' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_link",
+                    "status": True,
+                    "msg": "Link between 'north' and 'south' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_cluster",
+                    "status": True,
+                    "msg": "Thermal cluster 'gas_cluster' added to area 'south'.",
+                },
             ],
-        )
+        }
 
         # Check th logs
         assert "Something went wrong" in caplog.text
@@ -1161,4 +1257,14 @@ class TestSnapshotGenerator:
         )
 
         # Check the results
-        assert results == GenerationResultInfoDTO(success=True, details=[("create_area", True, "Area 'East' created")])
+        assert results.dict() == {
+            "success": True,
+            "details": [
+                {
+                    "id": AnyUUID(),
+                    "name": "create_area",
+                    "status": True,
+                    "msg": "Area 'East' created",
+                },
+            ],
+        }

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -24,24 +24,9 @@ from antarest.study.storage.variantstudy.model.dbmodel import CommandBlock, Vari
 from antarest.study.storage.variantstudy.model.model import CommandDTO
 from antarest.study.storage.variantstudy.snapshot_generator import SnapshotGenerator, search_ref_study
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
+from helpers import AnyUUID
 from tests.db_statement_recorder import DBStatementRecorder
 from tests.helpers import with_db_context
-
-
-class AnyUUID:
-    """Mock object to match any UUID."""
-
-    def __init__(self, as_string: bool = False):
-        self.as_string = as_string
-
-    def __eq__(self, other):
-        if self.as_string:
-            try:
-                uuid.UUID(other)
-                return True
-            except ValueError:
-                return False
-        return isinstance(other, uuid.UUID)
 
 
 def _create_variant(

--- a/tests/variantstudy/model/test_variant_model.py
+++ b/tests/variantstudy/model/test_variant_model.py
@@ -15,14 +15,7 @@ from antarest.study.storage.variantstudy.business.matrix_constants_generator imp
 from antarest.study.storage.variantstudy.model.model import CommandDTO
 from antarest.study.storage.variantstudy.snapshot_generator import SnapshotGenerator
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.helpers import with_db_context
-
-
-class AnyUUID:
-    """Mock object to match any UUID."""
-
-    def __eq__(self, other):
-        return isinstance(other, uuid.UUID)
+from tests.helpers import AnyUUID, with_db_context
 
 
 class TestVariantStudyService:

--- a/tests/variantstudy/model/test_variant_model.py
+++ b/tests/variantstudy/model/test_variant_model.py
@@ -12,10 +12,17 @@ from antarest.login.model import Group, Role, User
 from antarest.study.model import RawStudy, StudyAdditionalData
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
-from antarest.study.storage.variantstudy.model.model import CommandDTO, GenerationResultInfoDTO
+from antarest.study.storage.variantstudy.model.model import CommandDTO
 from antarest.study.storage.variantstudy.snapshot_generator import SnapshotGenerator
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 from tests.helpers import with_db_context
+
+
+class AnyUUID:
+    """Mock object to match any UUID."""
+
+    def __eq__(self, other):
+        return isinstance(other, uuid.UUID)
 
 
 class TestVariantStudyService:
@@ -141,13 +148,33 @@ class TestVariantStudyService:
             repository=variant_study_service.repository,
         )
         results = generator.generate_snapshot(saved_id, jwt_user, denormalize=False)
-        assert results == GenerationResultInfoDTO(
-            success=True,
-            details=[
-                ("create_area", True, "Area 'Yes' created"),
-                ("create_area", True, "Area 'No' created"),
-                ("create_link", True, "Link between 'no' and 'yes' created"),
-                ("create_cluster", True, "Thermal cluster 'cl1' added to area 'yes'."),
+        assert results.dict() == {
+            "success": True,
+            "details": [
+                {
+                    "id": AnyUUID(),
+                    "name": "create_area",
+                    "status": True,
+                    "msg": "Area 'Yes' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_area",
+                    "status": True,
+                    "msg": "Area 'No' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_link",
+                    "status": True,
+                    "msg": "Link between 'no' and 'yes' created",
+                },
+                {
+                    "id": AnyUUID(),
+                    "name": "create_cluster",
+                    "status": True,
+                    "msg": "Thermal cluster 'cl1' added to area 'yes'.",
+                },
             ],
-        )
+        }
         assert study.snapshot.id == study.id


### PR DESCRIPTION
L'objectif de cette PR est de modifier le processus de génération des variants afin d'inclure l'identifiant des commandes dans les résultats du Job.

Actuellement, lorsqu'un snapshot d'une variante d'étude est généré, une tâche de génération asynchrone est utilisée. À la fin de cette génération, le résultat de la tâche est analysé pour obtenir un message utilisateur, le statut de la tâche (réussite ou échec), ainsi qu'un détail au format JSON, indiquant la liste des commandes appliquées lors de la génération du variant.

Voici un exemple de génération de variant qui a nécessité d'appliquer plusieurs commandes :

```json
{
  "success": true,
  "details": [
    ["update_config", true, "ok"],
    ["create_area", true, "Area 'North' created"],
    ["update_config", true, "ok"],
    ["update_file", true, "ok"],
    ["update_file", true, "ok"],
    ["create_cluster", true, "Thermal cluster 'Cl1' added to area 'west'."]
  ]
}
```

Le détail est une liste de triplet (`name`, `status`,  `msg`) qui renseigne sur le nom et le statut de chaque commande mais ne donne aucune information concernant l'ID de la commande appliquée. Connaître l'identifiant de chaque commande appliquée permettrait de faciliter le diagnostique et la correction des variants en cas d'erreur : la dernière commande en erreur pourrait être supprimée plus facilement.

La proposition consiste à remplacer ce format actuel par un objet JSON plus structuré, contenant les attributs suivants :

- `id`: identifiant de la commande (UUID),
- `name`: nom de la commande,
- `status`: statut de la commande (`true` ou `false`),
- `msg`: message de la génération de la commande ou message d'erreur (si le statut est `false`).

Exemple de résultat attendu :

```json
{
  "success": true,
  "details": [
    {
      "id": "bae4edc4-ebe8-4108-9a58-ffcb9bf1451a",
      "name": "update_config",
      "status": true,
      "msg": "ok"
    },
    {
      "id": "17b4bef7-306d-41ef-9a5f-1028f9b28bbd",
      "name": "create_area",
      "status": true,
      "msg": "Area 'North' created"
    },
    {
      "id": "b8d688ca-c08f-45cd-b7e9-32411d63b826",
      "name": "update_config",
      "status": true,
      "msg": "ok"
    },
    {
      "id": "4f4114fa-8c15-4ed1-9a88-54c507eb56bf",
      "name": "update_file",
      "status": true,
      "msg": "ok"
    },
    {
      "id": "ac584997-4580-46e9-b4f5-dd42cfe823cd",
      "name": "update_file",
      "status": true,
      "msg": "ok"
    },
    {
      "id": "77077651-d71f-4d82-b394-afa9ae45c238",
      "name": "create_cluster",
      "status": true,
      "msg": "Thermal cluster 'Cl1' added to area 'west'."
    }
  ]
}
```

**ATTENTION :** Il est important de noter que le support de l'ancien format de détails (`name`, `status`,  `msg`) sera maintenu pour les variantes déjà générées, afin de garantir la compatibilité avec les données existantes. Aucune migration de données ne sera effectuée dans cette PR.