### PR TITLE
fix(ui-api-bc): v8.7 binding constraints fix

### DIFF
--- a/antarest/study/business/binding_constraint_management.py
+++ b/antarest/study/business/binding_constraint_management.py
@@ -423,6 +423,7 @@ class BindingConstraintManager:
             "terms": constraint.get("terms", []),
         }
 
+        # TODO: Implement a model for version-specific fields. Output filters are sent regardless of the version.
         if version >= 840:
             constraint_output["filter_year_by_year"] = constraint.get("filter_year_by_year") or constraint.get(
                 "filter-year-by-year", ""

--- a/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
@@ -75,13 +75,13 @@ class BindingConstraintProperties(BaseModel, extra=Extra.forbid, allow_populatio
     enabled: bool = True
     time_step: BindingConstraintFrequency = BindingConstraintFrequency.HOURLY
     operator: BindingConstraintOperator = BindingConstraintOperator.EQUAL
-    comments: t.Optional[str] = None
-    filter_year_by_year: t.Optional[str] = None
-    filter_synthesis: t.Optional[str] = None
+    comments: t.Optional[str] = ""
+    filter_year_by_year: t.Optional[str] = ""
+    filter_synthesis: t.Optional[str] = ""
 
 
 class BindingConstraintProperties870(BindingConstraintProperties):
-    group: t.Optional[str] = None
+    group: t.Optional[str] = ""
 
 
 class BindingConstraintMatrices(BaseModel, extra=Extra.forbid, allow_population_by_field_name=True):

--- a/tests/variantstudy/model/command/test_manage_binding_constraints.py
+++ b/tests/variantstudy/model/command/test_manage_binding_constraints.py
@@ -92,6 +92,7 @@ def test_manage_binding_constraint(empty_study: FileStudy, command_context: Comm
         "name": "BD 2",
         "id": "bd 2",
         "enabled": False,
+        "comments": "",
         "area1.cluster": 50.0,
         "operator": "both",
         "type": "daily",
@@ -127,6 +128,7 @@ def test_manage_binding_constraint(empty_study: FileStudy, command_context: Comm
         "id": "bd 1",
         "enabled": False,
         "area1%area2": "800.0%30",
+        "comments": "",
         "operator": "both",
         "type": "weekly",
     }
@@ -151,6 +153,7 @@ def test_manage_binding_constraint(empty_study: FileStudy, command_context: Comm
         "id": "bd 2",
         "enabled": False,
         "area1.cluster": 50.0,
+        "comments": "",
         "operator": "both",
         "type": "daily",
     }
@@ -338,7 +341,7 @@ def test_revert(command_context: CommandContext):
             operator=BindingConstraintOperator.EQUAL,
             coeffs={"a": [0.3]},
             values=hourly_matrix_id,
-            comments=None,
+            comments="",
             command_context=command_context,
         )
     ]

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/AddDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/AddDialog.tsx
@@ -30,15 +30,6 @@ interface Props {
   reloadConstraintsList: VoidFunction;
 }
 
-const defaultValues = {
-  name: "",
-  group: "default",
-  enabled: true,
-  timeStep: TimeStep.HOURLY,
-  operator: BindingConstraintOperator.LESS,
-  comments: "",
-};
-
 // TODO rename AddConstraintDialog
 function AddDialog({
   open,
@@ -50,6 +41,16 @@ function AddDialog({
   const { enqueueSnackbar } = useSnackbar();
   const dispatch = useAppDispatch();
   const [t] = useTranslation();
+  const studyVersion = Number(study.version);
+
+  const defaultValues = {
+    name: "",
+    group: studyVersion >= 870 ? "default" : "",
+    enabled: true,
+    timeStep: TimeStep.HOURLY,
+    operator: BindingConstraintOperator.LESS,
+    comments: "",
+  };
 
   const operatorOptions = useMemo(
     () =>
@@ -145,7 +146,7 @@ function AddDialog({
                 validateString(v, { existingValues: existingConstraints }),
             }}
           />
-          {Number(study.version) >= 870 && (
+          {studyVersion >= 870 && (
             <StringFE
               name="group"
               label={t("global.group")}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/AddDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/AddDialog.tsx
@@ -143,7 +143,10 @@ function AddDialog({
             control={control}
             rules={{
               validate: (v) =>
-                validateString(v, { existingValues: existingConstraints }),
+                validateString(v, {
+                  existingValues: existingConstraints,
+                  specialChars: "@&_-()",
+                }),
             }}
           />
           {studyVersion >= 870 && (

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
@@ -35,10 +35,14 @@ function BindingConstraints() {
   );
 
   useEffect(() => {
-    if (constraints.data && !currentConstraintId) {
-      const firstConstraintId = constraints.data[0].id;
-      dispatch(setCurrentBindingConst(firstConstraintId));
+    const { data } = constraints;
+
+    if (!data || data.length === 0 || currentConstraintId) {
+      return;
     }
+
+    const firstConstraintId = data[0].id;
+    dispatch(setCurrentBindingConst(firstConstraintId));
   }, [constraints, currentConstraintId, dispatch]);
 
   ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Fix a UI issue when no binding constraint data exists.
- Fix default values for optional strings to prevent null default values that triggers a UI error.
- Group default value is now displayed only for v8.7 without causing an error for versions below.
- Add broader special chars set