### PR TITLE
fix(tablemode): hide `adequacy_patch_mode` column from table-mode before v8.3

### DIFF
--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -218,11 +218,7 @@ class AreaOutput(_BaseAreaDTO, metaclass=AllOptionalMetaclass, use_none=True):
             **area_folder.optimization.filtering.dict(by_alias=False),
             **area_folder.optimization.nodal_optimization.dict(by_alias=False),
             # adequacy_patch is only available if study version >= 830.
-            **(
-                area_folder.adequacy_patch.adequacy_patch.dict(by_alias=False)
-                if area_folder.adequacy_patch
-                else {"adequacy_patch_mode": "outside"}
-            ),
+            **(area_folder.adequacy_patch.adequacy_patch.dict(by_alias=False) if area_folder.adequacy_patch else {}),
         }
         return cls(**obj)
 

--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -218,7 +218,11 @@ class AreaOutput(_BaseAreaDTO, metaclass=AllOptionalMetaclass, use_none=True):
             **area_folder.optimization.filtering.dict(by_alias=False),
             **area_folder.optimization.nodal_optimization.dict(by_alias=False),
             # adequacy_patch is only available if study version >= 830.
-            **(area_folder.adequacy_patch.adequacy_patch.dict(by_alias=False) if area_folder.adequacy_patch else {}),
+            **(
+                area_folder.adequacy_patch.adequacy_patch.dict(by_alias=False)
+                if area_folder.adequacy_patch
+                else {"adequacy_patch_mode": "outside"}
+            ),
         }
         return cls(**obj)
 

--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -232,8 +232,11 @@ class AreaOutput(_BaseAreaDTO, metaclass=AllOptionalMetaclass, use_none=True):
             nodal_optimization=nodal_optimization_section,
         )
 
-    def _to_adequacy_patch(self) -> AdequacyPathProperties:
+    def _to_adequacy_patch(self) -> t.Optional[AdequacyPathProperties]:
         obj = {name: getattr(self, name) for name in AdequacyPathProperties.AdequacyPathSection.__fields__}
+        # If all fields are `None`, the object is empty.
+        if all(value is None for value in obj.values()):
+            return None
         adequacy_path_section = AdequacyPathProperties.AdequacyPathSection(**obj)
         return AdequacyPathProperties(adequacy_patch=adequacy_path_section)
 

--- a/antarest/study/business/table_mode_management.py
+++ b/antarest/study/business/table_mode_management.py
@@ -174,10 +174,10 @@ class TableModeManager:
             The updated properties of the objects including the old ones.
         """
         if table_type == TableModeType.AREA:
-            # Use AreaOutput to update properties of areas
+            # Use AreaOutput to update properties of areas, which may include `None` values
             area_props_by_ids = {key: AreaOutput(**values) for key, values in data.items()}
             areas_map = self._area_manager.update_areas_props(study, area_props_by_ids)
-            data = {area_id: area.dict(by_alias=True) for area_id, area in areas_map.items()}
+            data = {area_id: area.dict(by_alias=True, exclude_none=True) for area_id, area in areas_map.items()}
             return data
         elif table_type == TableModeType.LINK:
             links_map = {tuple(key.split(" / ")): LinkOutput(**values) for key, values in data.items()}

--- a/antarest/study/business/table_mode_management.py
+++ b/antarest/study/business/table_mode_management.py
@@ -83,7 +83,11 @@ class TableModeManager:
     def _get_table_data_unsafe(self, study: RawStudy, table_type: TableModeType) -> TableDataDTO:
         if table_type == TableModeType.AREA:
             areas_map = self._area_manager.get_all_area_props(study)
-            data = {area_id: area.dict(by_alias=True) for area_id, area in areas_map.items()}
+            study_version = int(study.version)
+            data = {
+                area_id: area.dict(by_alias=True, exclude={"adequacy_patch_mode"} if study_version < 830 else {})
+                for area_id, area in areas_map.items()
+            }
         elif table_type == TableModeType.LINK:
             links_map = self._link_manager.get_all_links_props(study)
             data = {
@@ -177,8 +181,11 @@ class TableModeManager:
             # Use AreaOutput to update properties of areas
             area_props_by_ids = {key: AreaOutput(**values) for key, values in data.items()}
             areas_map = self._area_manager.update_areas_props(study, area_props_by_ids)
-            data = {area_id: area.dict(by_alias=True) for area_id, area in areas_map.items()}
-            return data
+            study_version = int(study.version)
+            data = {
+                area_id: area.dict(by_alias=True, exclude={"adequacy_patch_mode"} if study_version < 830 else {})
+                for area_id, area in areas_map.items()
+            }
         elif table_type == TableModeType.LINK:
             links_map = {tuple(key.split(" / ")): LinkOutput(**values) for key, values in data.items()}
             updated_map = self._link_manager.update_links_props(study, links_map)  # type: ignore
@@ -186,7 +193,6 @@ class TableModeManager:
                 f"{area1_id} / {area2_id}": link.dict(by_alias=True)
                 for (area1_id, area2_id), link in updated_map.items()
             }
-            return data
         elif table_type == TableModeType.THERMAL:
             thermals_by_areas: t.MutableMapping[str, t.MutableMapping[str, ThermalClusterInput]]
             thermals_by_areas = collections.defaultdict(dict)
@@ -199,7 +205,6 @@ class TableModeManager:
                 for area_id, thermals_by_ids in thermals_map.items()
                 for cluster_id, cluster in thermals_by_ids.items()
             }
-            return data
         elif table_type == TableModeType.RENEWABLE:
             renewables_by_areas: t.MutableMapping[str, t.MutableMapping[str, RenewableClusterInput]]
             renewables_by_areas = collections.defaultdict(dict)
@@ -212,7 +217,6 @@ class TableModeManager:
                 for area_id, renewables_by_ids in renewables_map.items()
                 for cluster_id, cluster in renewables_by_ids.items()
             }
-            return data
         elif table_type == TableModeType.ST_STORAGE:
             storages_by_areas: t.MutableMapping[str, t.MutableMapping[str, STStorageInput]]
             storages_by_areas = collections.defaultdict(dict)
@@ -225,13 +229,13 @@ class TableModeManager:
                 for area_id, storages_by_ids in storages_map.items()
                 for cluster_id, cluster in storages_by_ids.items()
             }
-            return data
         elif table_type == TableModeType.BINDING_CONSTRAINT:
             bcs_by_ids = {key: ConstraintInput(**values) for key, values in data.items()}
             bcs_map = self._binding_constraint_manager.update_binding_constraints(study, bcs_by_ids)
-            return {bc_id: bc.dict(by_alias=True, exclude={"id", "name", "terms"}) for bc_id, bc in bcs_map.items()}
+            data = {bc_id: bc.dict(by_alias=True, exclude={"id", "name", "terms"}) for bc_id, bc in bcs_map.items()}
         else:  # pragma: no cover
             raise NotImplementedError(f"Table type {table_type} not implemented")
+        return data
 
     def get_table_schema(self, table_type: TableModeType) -> JSON:
         """


### PR DESCRIPTION
## Description

This PR addresses an issue with the editing of Area properties in table mode. Specifically, it corrects the behavior of the `AreaOutput` model, which is used to group all properties of an area. 

Previously, the `adequacy-patch-mode` column was being populated even when it contained an empty value. This PR corrects this behavior to ensure that the `adequacy-patch-mode` column is not populated when its value is empty. That way, this column is hidden in the Table Mode view, in the UI.

In addition, this PR improves the unit tests to account for study versions 8.1, 8.3, 8.6, 8.7, and 8.8. Each of these versions adds one or more fields, with default values. The improved unit tests ensure that new fields are properly hidden for earlier versions.
