### PR TITLE
feat(archive-output): add `.7z` archiving and unarchiving support for study outputs

### DIFF
--- a/antarest/core/utils/archives.py
+++ b/antarest/core/utils/archives.py
@@ -34,6 +34,12 @@ def is_archive_format(suffix: str) -> bool:
     return suffix in {ArchiveFormat.ZIP, ArchiveFormat.SEVEN_ZIP}
 
 
+def is_output_archived(path_output: Path) -> bool:
+    # Returns True it the given path is archived or if adding a suffix to the path points to an existing path
+    suffixes = [".zip", ".7z"]
+    return path_output.suffix in suffixes or any(path_output.with_suffix(suffix).exists() for suffix in suffixes)
+
+
 def archive_dir(
     src_dir_path: Path,
     target_archive_path: Path,

--- a/antarest/study/common/studystorage.py
+++ b/antarest/study/common/studystorage.py
@@ -264,10 +264,25 @@ class IStudyStorageService(ABC, t.Generic[T]):
         """Initialize additional data for a study."""
 
     @abstractmethod
-    def archive_study_output(self, study: T, output_id: str) -> bool:
-        """Archive a study output."""
+    def archive_study_output(self, study: T, output_id: str) -> None:
+        """
+        Archive study output in a 7z file and remove the output folder.
+
+        Args:
+            study: Study to archive the output from.
+            output_id: Output to archive.
+        """
 
     # noinspection SpellCheckingInspection
     @abstractmethod
-    def unarchive_study_output(self, study: T, output_id: str, keep_src_zip: bool) -> bool:
-        """Un-archive a study output."""
+    def unarchive_study_output(self, study: T, output_id: str, keep_src_archive: bool) -> None:
+        """
+        Unarchive a study output archive and remove the archive file if needed.
+
+        The output archive file could be a 7z file or a zip file.
+
+        Args:
+            study: Study to unarchive the output from.
+            output_id: Output to unarchive.
+            keep_src_archive: Whether to keep the source archive file.
+        """

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -58,7 +58,7 @@ from antarest.core.requests import RequestParameters, UserHasNotPermissionError
 from antarest.core.serialization import to_json
 from antarest.core.tasks.model import TaskListFilter, TaskResult, TaskStatus, TaskType
 from antarest.core.tasks.service import ITaskService, TaskUpdateNotifier, noop_notifier
-from antarest.core.utils.archives import ArchiveFormat, is_archive_format
+from antarest.core.utils.archives import ArchiveFormat, is_archive_format, is_output_archived
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import StopWatch
 from antarest.login.model import Group
@@ -140,13 +140,7 @@ from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
 from antarest.study.storage.storage_service import StudyStorageService
 from antarest.study.storage.study_download_utils import StudyDownloader, get_output_variables_information
 from antarest.study.storage.study_upgrader import StudyUpgrader, check_versions_coherence, find_next_version
-from antarest.study.storage.utils import (
-    assert_permission,
-    get_start_date,
-    is_managed,
-    is_output_archived,
-    remove_from_cache,
-)
+from antarest.study.storage.utils import assert_permission, get_start_date, is_managed, remove_from_cache
 from antarest.study.storage.variantstudy.business.utils import transform_command_to_dto
 from antarest.study.storage.variantstudy.model.command.generate_thermal_cluster_timeseries import (
     GenerateThermalClusterTimeSeries,

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -2360,24 +2360,22 @@ class StudyService:
             if len(list(filter(lambda t: t.name in archive_task_names, study_tasks))):
                 raise TaskAlreadyRunning()
 
-        def archive_output_task(
-            notifier: TaskUpdateNotifier,
-        ) -> TaskResult:
+        def archive_output_task(_: TaskUpdateNotifier) -> TaskResult:
             try:
-                study = self.get_study(study_id)
-                stopwatch = StopWatch()
-                self.storage_service.get_storage(study).archive_study_output(study, output_id)
-                stopwatch.log_elapsed(lambda x: logger.info(f"Output {output_id} of study {study_id} archived in {x}s"))
+                _study = self.get_study(study_id)
+                _stopwatch = StopWatch()
+                self.storage_service.get_storage(_study).archive_study_output(_study, output_id)
+                _stopwatch.log_elapsed(
+                    lambda x: logger.info(f"Output {output_id} of study {study_id} archived in {x}s")
+                )
                 return TaskResult(
                     success=True,
                     message=f"Study output {study_id}/{output_id} successfully archived",
                 )
             except Exception as e:
-                logger.warning(
-                    f"Could not archive the output {study_id}/{output_id}",
-                    exc_info=e,
-                )
-                raise e
+                _err_msg = f"Could not archive the output {study_id}/{output_id}"
+                logger.warning(_err_msg, exc_info=e)
+                return TaskResult(success=False, message=f"Unhandled exception: {_err_msg}: {e}")
 
         task_id = self.task_service.add_task(
             archive_output_task,
@@ -2422,14 +2420,12 @@ class StudyService:
         if len(list(filter(lambda t: t.name in archive_task_names, study_tasks))):
             raise TaskAlreadyRunning()
 
-        def unarchive_output_task(
-            notifier: TaskUpdateNotifier,
-        ) -> TaskResult:
+        def unarchive_output_task(_: TaskUpdateNotifier) -> TaskResult:
             try:
-                study = self.get_study(study_id)
-                stopwatch = StopWatch()
-                self.storage_service.get_storage(study).unarchive_study_output(study, output_id, keep_src_zip)
-                stopwatch.log_elapsed(
+                _study = self.get_study(study_id)
+                _stopwatch = StopWatch()
+                self.storage_service.get_storage(_study).unarchive_study_output(_study, output_id, keep_src_zip)
+                _stopwatch.log_elapsed(
                     lambda x: logger.info(f"Output {output_id} of study {study_id} unarchived in {x}s")
                 )
                 return TaskResult(
@@ -2437,11 +2433,9 @@ class StudyService:
                     message=f"Study output {study_id}/{output_id} successfully unarchived",
                 )
             except Exception as e:
-                logger.warning(
-                    f"Could not unarchive the output {study_id}/{output_id}",
-                    exc_info=e,
-                )
-                raise e
+                _err_msg = f"Could not unarchive the output {study_id}/{output_id}"
+                logger.warning(_err_msg, exc_info=e)
+                return TaskResult(success=False, message=f"Unhandled exception: {_err_msg}: {e}")
 
         task_id: t.Optional[str] = None
         workspace = getattr(study, "workspace", DEFAULT_WORKSPACE_NAME)

--- a/antarest/study/storage/abstract_storage_service.py
+++ b/antarest/study/storage/abstract_storage_service.py
@@ -51,12 +51,13 @@ from antarest.study.storage.utils import extract_output_name, fix_study_root, re
 logger = logging.getLogger(__name__)
 
 
-def find_output_archive(study: T, output_id: str) -> t.Optional[Path]:
-    if (Path(study.path) / "output" / f"{output_id}.7z").exists():
-        return Path(study.path) / "output" / f"{output_id}.7z"
-    elif (Path(study.path) / "output" / f"{output_id}.zip").exists():
-        return Path(study.path) / "output" / f"{output_id}.zip"
-    return None
+def _search_output_archive(study_path: str, output_id: str) -> t.Optional[Path]:
+    """Search for an output archive file in the study path, return ``None`` if not found."""
+    locations = [
+        Path(study_path) / "output" / f"{output_id}.7z",
+        Path(study_path) / "output" / f"{output_id}.zip",
+    ]
+    return next(iter(path for path in locations if path.exists()), None)
 
 
 class AbstractStorageService(IStudyStorageService[T], ABC):
@@ -364,7 +365,7 @@ class AbstractStorageService(IStudyStorageService[T], ABC):
             return False
 
     def unarchive_study_output(self, study: T, output_id: str, keep_src_archive: bool) -> bool:
-        archive_path = find_output_archive(study, output_id)
+        archive_path = _search_output_archive(study.path, output_id)
         if archive_path is None:
             logger.warning(
                 f"Failed to archive study {study.name} output {output_id}. Maybe it's already unarchived",

--- a/antarest/study/storage/abstract_storage_service.py
+++ b/antarest/study/storage/abstract_storage_service.py
@@ -263,7 +263,7 @@ class AbstractStorageService(IStudyStorageService[T], ABC):
             stopwatch.log_elapsed(lambda elapsed_time: logger.info(f"Copied output for {study_id} in {elapsed_time}s"))
             fix_study_root(path_output)
             output_full_name = extract_output_name(path_output, output_name)
-            extension = f"{ArchiveFormat.ZIP}" if is_zipped else ""
+            extension = f"{ArchiveFormat.SEVEN_ZIP}" if is_archived else ""
             path_output = path_output.rename(Path(path_output.parent, output_full_name + extension))
 
             data = self.get(metadata, f"output/{output_full_name}", 1, use_cache=False)

--- a/antarest/study/storage/abstract_storage_service.py
+++ b/antarest/study/storage/abstract_storage_service.py
@@ -44,7 +44,6 @@ from antarest.study.model import (
 )
 from antarest.study.storage.patch_service import PatchService
 from antarest.study.storage.rawstudy.model.filesystem.config.files import get_playlist
-from antarest.study.storage.rawstudy.model.filesystem.config.model import Simulation
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy, StudyFactory
 from antarest.study.storage.rawstudy.model.helpers import FileStudyHelpers
 from antarest.study.storage.utils import extract_output_name, fix_study_root, remove_from_cache
@@ -187,10 +186,10 @@ class AbstractStorageService(IStudyStorageService[T], ABC):
         results: t.List[StudySimResultDTO] = []
         if study_data.config.outputs is not None:
             reference = (patch_metadata.outputs or PatchOutputs()).reference
-            for output in study_data.config.outputs:
-                output_data: Simulation = study_data.config.outputs[output]
+            for output, output_data in study_data.config.outputs.items():
                 try:
-                    file_metadata = FileStudyHelpers.get_config(study_data, output_data.get_file())
+                    output_file = output_data.get_file()
+                    file_metadata = FileStudyHelpers.get_config(study_data, output_file)
                     settings = StudySimSettingsDTO(
                         general=file_metadata["general"],
                         input=file_metadata["input"],
@@ -204,7 +203,7 @@ class AbstractStorageService(IStudyStorageService[T], ABC):
 
                     results.append(
                         StudySimResultDTO(
-                            name=output_data.get_file(),
+                            name=output_file,
                             type=output_data.mode,
                             settings=settings,
                             completionDate="",

--- a/antarest/study/storage/rawstudy/model/filesystem/config/files.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/files.py
@@ -25,11 +25,7 @@ from antares.study.version import StudyVersion
 
 from antarest.core.model import JSON
 from antarest.core.serialization import from_json
-from antarest.core.utils.archives import (
-    extract_lines_from_archive,
-    is_archive_format,
-    read_file_from_archive,
-)
+from antarest.core.utils.archives import extract_lines_from_archive, is_archive_format, read_file_from_archive
 from antarest.study.model import STUDY_VERSION_8_1, STUDY_VERSION_8_6
 from antarest.study.storage.rawstudy.ini_reader import IniReader
 from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint import (

--- a/antarest/study/storage/rawstudy/model/filesystem/config/files.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/files.py
@@ -23,12 +23,9 @@ from pathlib import Path
 import py7zr
 from antares.study.version import StudyVersion
 
-import py7zr
-
 from antarest.core.model import JSON
 from antarest.core.serialization import from_json
 from antarest.core.utils.archives import (
-    ArchiveFormat,
     extract_lines_from_archive,
     is_archive_format,
     read_file_from_archive,

--- a/antarest/study/storage/rawstudy/model/filesystem/config/model.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/model.py
@@ -194,7 +194,7 @@ class FileStudyTreeConfig(DTO):
     def next_file(self, name: str, is_output: bool = False) -> "FileStudyTreeConfig":
         if is_output and name in self.outputs and self.outputs[name].archived:
             locations = [self.path / f"{name}.7z", self.path / f"{name}.zip"]
-            archive_path = next((p for p in locations if p.exists()))
+            archive_path: t.Optional[Path] = next((p for p in locations if p.exists()))
         else:
             archive_path = self.archive_path
 

--- a/antarest/study/storage/rawstudy/model/filesystem/config/model.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/model.py
@@ -193,7 +193,8 @@ class FileStudyTreeConfig(DTO):
 
     def next_file(self, name: str, is_output: bool = False) -> "FileStudyTreeConfig":
         if is_output and name in self.outputs and self.outputs[name].archived:
-            archive_path: t.Optional[Path] = self.path / f"{name}.zip"
+            locations = [self.path / f"{name}.7z", self.path / f"{name}.zip"]
+            archive_path = next((p for p in locations if p.exists()))
         else:
             archive_path = self.archive_path
 

--- a/antarest/study/storage/rawstudy/raw_study_service.py
+++ b/antarest/study/storage/rawstudy/raw_study_service.py
@@ -304,6 +304,8 @@ class RawStudyService(AbstractStorageService[RawStudy]):
         output_path = study_path / "output" / output_name
         if output_path.exists() and output_path.is_dir():
             shutil.rmtree(output_path, ignore_errors=True)
+        elif (output_path.parent / f"{output_name}.7z").exists():
+            (output_path.parent / f"{output_name}.7z").unlink(missing_ok=True)
         else:
             output_path = output_path.parent / f"{output_name}.zip"
             output_path.unlink(missing_ok=True)

--- a/antarest/study/storage/rawstudy/raw_study_service.py
+++ b/antarest/study/storage/rawstudy/raw_study_service.py
@@ -292,23 +292,20 @@ class RawStudyService(AbstractStorageService[RawStudy]):
 
     def delete_output(self, metadata: RawStudy, output_name: str) -> None:
         """
-        Delete output folder
+        Delete output folder or archive (zip or 7z) of a study.
+
         Args:
-            metadata: study
-            output_name: output simulation
-
-        Returns:
-
+            metadata: The study metadata.
+            output_name: Output name to be deleted.
         """
         study_path = self.get_study_path(metadata)
         output_path = study_path / "output" / output_name
-        if output_path.exists() and output_path.is_dir():
+        if output_path.is_dir():
             shutil.rmtree(output_path, ignore_errors=True)
-        elif (output_path.parent / f"{output_name}.7z").exists():
-            (output_path.parent / f"{output_name}.7z").unlink(missing_ok=True)
         else:
-            output_path = output_path.parent / f"{output_name}.zip"
-            output_path.unlink(missing_ok=True)
+            locations = [output_path.with_suffix(".7z"), output_path.with_suffix(".zip")]
+            for path in locations:
+                path.unlink(missing_ok=True)
         remove_from_cache(self.cache, metadata.id)
 
     def import_study(self, metadata: RawStudy, stream: t.BinaryIO) -> Study:

--- a/antarest/study/storage/utils.py
+++ b/antarest/study/storage/utils.py
@@ -24,7 +24,6 @@ from uuid import uuid4
 from zipfile import ZipFile
 
 import py7zr
-
 from antares.study.version import StudyVersion
 
 from antarest.core.exceptions import StudyValidationError, UnsupportedStudyVersion

--- a/antarest/study/storage/utils.py
+++ b/antarest/study/storage/utils.py
@@ -152,7 +152,7 @@ def extract_output_name(path_output: Path, new_suffix_name: t.Optional[str] = No
     if new_suffix_name:
         suffix_name = new_suffix_name
         general_info["name"] = suffix_name
-        if not archived:
+        if not is_output_archived:
             ini_writer = IniWriter()
             ini_writer.write(info_antares_output, path_output / info_filename)
         else:

--- a/antarest/study/storage/utils.py
+++ b/antarest/study/storage/utils.py
@@ -32,7 +32,6 @@ from antarest.core.jwt import JWTUser
 from antarest.core.model import PermissionInfo, StudyPermissionType
 from antarest.core.permissions import check_permission
 from antarest.core.requests import UserHasNotPermissionError
-from antarest.core.utils.archives import is_archive_format
 from antarest.core.utils.utils import StopWatch
 from antarest.study.model import (
     DEFAULT_WORKSPACE_NAME,
@@ -116,50 +115,6 @@ def find_single_output_path(all_output_path: Path) -> Path:
             return all_output_path / children[0]
         return find_single_output_path(all_output_path / children[0])
     return all_output_path
-
-
-def is_output_archived(path_output: Path) -> bool:
-    # Returns True it the given path is archived or if adding a suffix to the path points to an existing path
-    suffixes = [".zip"]
-    return path_output.suffix in suffixes or any(path_output.with_suffix(suffix).exists() for suffix in suffixes)
-
-
-def extract_output_name(path_output: Path, new_suffix_name: t.Optional[str] = None) -> str:
-    ini_reader = IniReader()
-    is_output_archived = path_output.suffix in {".zip", ".7z"}
-    info_filename = "info.antares-output"
-    if is_output_archived:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            s = StopWatch()
-            if path_output.suffix == ".zip":
-                with ZipFile(path_output, mode="r") as zip_obj:
-                    zip_obj.extract(info_filename, temp_dir)
-            else:
-                with py7zr.SevenZipFile(path_output, mode="r") as archive:
-                    archive.extract(targets=[info_filename], path=temp_dir)
-            info_antares_output = ini_reader.read(Path(temp_dir) / info_filename)
-            s.log_elapsed(lambda x: logger.info(f"'{info_filename}' has been read in {x}s"))
-
-    else:
-        info_antares_output = ini_reader.read(path_output / info_filename)
-
-    general_info = info_antares_output["general"]
-
-    date = datetime.fromtimestamp(int(general_info["timestamp"])).strftime("%Y%m%d-%H%M")
-
-    mode = "eco" if general_info["mode"] == "Economy" else "adq"
-    suffix_name = general_info["name"] or ""
-    if new_suffix_name:
-        suffix_name = new_suffix_name
-        general_info["name"] = suffix_name
-        if not is_output_archived:
-            ini_writer = IniWriter()
-            ini_writer.write(info_antares_output, path_output / info_filename)
-        else:
-            logger.warning("Could not rewrite the new name inside the output: the output is archived")
-
-    name = f"-{suffix_name}" if suffix_name else ""
-    return f"{date}{mode}{name}"
 
 
 def is_managed(study: Study) -> bool:
@@ -395,3 +350,41 @@ def export_study_flat(
         study.tree.denormalize()
         duration = "{:.3f}".format(time.time() - stop_time)
         logger.info(f"Study '{study_dir}' denormalized in {duration}s")
+
+
+def extract_output_name(path_output: Path, new_suffix_name: t.Optional[str] = None) -> str:
+    ini_reader = IniReader()
+    is_output_archived = path_output.suffix in {".zip", ".7z"}
+    info_filename = "info.antares-output"
+    if is_output_archived:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            s = StopWatch()
+            if path_output.suffix == ".zip":
+                with ZipFile(path_output, mode="r") as zip_obj:
+                    zip_obj.extract(info_filename, temp_dir)
+            else:
+                with py7zr.SevenZipFile(path_output, mode="r") as archive:
+                    archive.extract(targets=[info_filename], path=temp_dir)
+            info_antares_output = ini_reader.read(Path(temp_dir) / info_filename)
+            s.log_elapsed(lambda x: logger.info(f"'{info_filename}' has been read in {x}s"))
+
+    else:
+        info_antares_output = ini_reader.read(path_output / info_filename)
+
+    general_info = info_antares_output["general"]
+
+    date = datetime.fromtimestamp(int(general_info["timestamp"])).strftime("%Y%m%d-%H%M")
+
+    mode = "eco" if general_info["mode"] == "Economy" else "adq"
+    suffix_name = general_info["name"] or ""
+    if new_suffix_name:
+        suffix_name = new_suffix_name
+        general_info["name"] = suffix_name
+        if not is_output_archived:
+            ini_writer = IniWriter()
+            ini_writer.write(info_antares_output, path_output / info_filename)
+        else:
+            logger.warning("Could not rewrite the new name inside the output: the output is archived")
+
+    name = f"-{suffix_name}" if suffix_name else ""
+    return f"{date}{mode}{name}"

--- a/tests/core/utils/test_extract_zip.py
+++ b/tests/core/utils/test_extract_zip.py
@@ -20,6 +20,7 @@ import pytest
 from antarest.core.exceptions import BadArchiveContent
 from antarest.core.utils.archives import extract_archive
 
+
 class TestExtractArchive:
     """
     Test the `extract_zip` function.

--- a/tests/core/utils/test_extract_zip.py
+++ b/tests/core/utils/test_extract_zip.py
@@ -20,7 +20,6 @@ import pytest
 from antarest.core.exceptions import BadArchiveContent
 from antarest.core.utils.archives import extract_archive
 
-
 class TestExtractArchive:
     """
     Test the `extract_zip` function.

--- a/tests/storage/business/test_raw_study_service.py
+++ b/tests/storage/business/test_raw_study_service.py
@@ -18,7 +18,6 @@ import time
 from pathlib import Path
 from typing import Callable
 from unittest.mock import Mock
-from zipfile import ZIP_DEFLATED, ZipFile
 
 import py7zr
 import pytest

--- a/tests/storage/repository/filesystem/config/test_files.py
+++ b/tests/storage/repository/filesystem/config/test_files.py
@@ -14,17 +14,18 @@ import zipfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import py7zr
 import pytest
 
 from antarest.study.storage.rawstudy.model.filesystem.config.exceptions import SimulationParsingError
-from antarest.study.storage.rawstudy.model.filesystem.config.files import parse_simulation_zip
+from antarest.study.storage.rawstudy.model.filesystem.config.files import parse_simulation_archive
 from antarest.study.storage.rawstudy.model.filesystem.config.model import Simulation
 
 PARSE_SIMULATION_NAME = "antarest.study.storage.rawstudy.model.filesystem.config.files.parse_simulation"
 
 
 class TestParseSimulationZip:
-    def test_parse_simulation_zip__nominal(self, tmp_path: Path):
+    def test_parse_simulation_archive__nominal_zip(self, tmp_path: Path):
         # prepare a ZIP file with the following files
         archived_files = [
             "about-the-study/parameters.ini",
@@ -49,14 +50,46 @@ class TestParseSimulationZip:
                 assert uncompressed.is_file(), f"Missing {name_}"
             return Mock(spec=Simulation)
 
-        # Call the `parse_simulation_zip` but using `my_parse_simulation`
+        # Call the `parse_simulation_archive` but using `my_parse_simulation`
         with patch(PARSE_SIMULATION_NAME, new=my_parse_simulation):
-            actual = parse_simulation_zip(zip_path)
+            actual = parse_simulation_archive(zip_path)
 
         # check the result
         assert actual.archived is True
 
-    def test_parse_simulation_zip__missing_required_files(self, tmp_path: Path):
+    def test_parse_simulation_archive__nominal_7z(self, tmp_path: Path):
+        # prepare a ZIP file with the following files
+        archived_files = [
+            "about-the-study/parameters.ini",
+            "expansion/out.json",
+            "checkIntegrity.txt",
+        ]
+        archive_path = tmp_path.joinpath("dummy.7z")
+        with py7zr.SevenZipFile(archive_path, mode="w") as zf:
+            for name in archived_files:
+                zf.writestr(b"dummy data", name)
+
+        def my_parse_simulation(path: Path, canonical_name: str) -> Simulation:
+            """
+            Mock function of the function `parse_simulation`, which is used to:
+            - avoid calling the original function which do a lot of stuff,
+            - check that the required files exist in a temporary directory.
+            """
+            assert path.is_dir()
+            assert canonical_name == archive_path.stem
+            for name_ in archived_files:
+                uncompressed = path.joinpath(name_)
+                assert uncompressed.is_file(), f"Missing {name_}"
+            return Mock(spec=Simulation)
+
+        # Call the `parse_simulation_archive` but using `my_parse_simulation`
+        with patch(PARSE_SIMULATION_NAME, new=my_parse_simulation):
+            actual = parse_simulation_archive(archive_path)
+
+        # check the result
+        assert actual.archived is True
+
+    def test_parse_simulation_archive__missing_required_files(self, tmp_path: Path):
         # prepare a ZIP file with the following files
         archived_files = [
             # "about-the-study/parameters.ini",  # <- required
@@ -68,17 +101,17 @@ class TestParseSimulationZip:
             for name in archived_files:
                 zf.writestr(name, b"dummy data")
 
-        # Call the `parse_simulation_zip` but using `my_parse_simulation`
+        # Call the `parse_simulation_archive` but using `my_parse_simulation`
         with patch(PARSE_SIMULATION_NAME):
             with pytest.raises(SimulationParsingError):
-                parse_simulation_zip(zip_path)
+                parse_simulation_archive(zip_path)
 
-    def test_parse_simulation_zip__bad_zip_file(self, tmp_path: Path):
+    def test_parse_simulation_archive__bad_zip_file(self, tmp_path: Path):
         # prepare a bad ZIP file
         zip_path = tmp_path.joinpath("dummy.zip")
         zip_path.write_bytes(b"PK")
 
-        # Call the `parse_simulation_zip` but using `my_parse_simulation`
+        # Call the `parse_simulation_archive` but using `my_parse_simulation`
         with patch(PARSE_SIMULATION_NAME):
             with pytest.raises(SimulationParsingError):
-                parse_simulation_zip(zip_path)
+                parse_simulation_archive(zip_path)


### PR DESCRIPTION
## Context

In the continuity of ANT1549 and 1551 to use ".7z" format to archive studies, it is planned to do the same with simulations outputs. 

## Description

Ajout du support pour archiver les sorties de simulation au format "7z" (au lieu de "zip") et les désarchiver au format "7z" (en plus de "zip")

Cette PR modifie le format d'archivage des sorties afin d'utiliser le format "7z" au lieu du format "zip".
Pour l'archivage, on supporte à la fois le format "zip" et "7z" dans le but d'être rétrocompatible.

## API

D'un point de vue de l'utilisateur de l'API, les endpoints impactés par cette PR sont les suivants :

- `POST /v1/studies/{uuid}/output` : import d'une sortie dans l'étude.
  L'utilisateur peut utiliser le format "zip" ou "7z" pour l'import.
- `DELETE /v1/studies/{study_id}/outputs/{output_id}`: suppression d'une sortie de l'étude.
  La suppression fonctionne maintenant pour les sorties archivées en "7z" en plus de celles archivées en "zip".
- `POST /v1/studies/{study_id}/outputs/{output_id}/_archive`: archivage d'une sortie.
  Ce endpoint permet de démarrer une tâche d'archivage pour une sortie donnée.
  L'archivage se fait maintenant en "7z" au lieu de "zip".
- `POST /v1/studies/{study_id}/outputs/{output_id}/_unarchive`: désarchivage d'une sortie.
  Ce endpoint permet de démarrer une tâche de désarchivage pour une sortie donnée.
  Le désarchivage fonctionne pour les sorties archivées en "7z" en plus de celles archivées en "zip".
- `POST /v1/launcher/run/{study_id}` : lacement d'une simulation d'étude.
  La récupération de la sortie est actuellement au format ZIP.
  À l'avenir, il faudra prendre aussi en compte le format 7z (en attende d'une évolution du solver).

## IHM frontend

Cette PR a un impact sur l'IHM frontend. Les changements suivants ont été effectués au niveau
de la liste des résultats :

- Le bouton "Archiver" permet maintenant d'archiver une sortie en "7z" au lieu de "zip".
- Le bouton "Désarchiver" permet de désarchiver une sortie archivée en "7z" en plus de celles archivées en "zip".

![archive_unarchive_output](https://github.com/AntaresSimulatorTeam/AntaREST/assets/43534797/5dcd8e2f-5831-495c-af99-f553279475b0)


## Services

Le service d'archivage automatique des études effectue également un archivage automatique des sorties au format "7z"
pour les variantes d'études.
