### PR TITLE
fix(ui): prevent `CreateVariantDialog` fields overflow

### DIFF
--- a/webapp/src/components/App/Singlestudy/HomeView/InformationView/CreateVariantDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/HomeView/InformationView/CreateVariantDialog.tsx
@@ -44,7 +44,7 @@ function CreateVariantDialog(props: Props) {
     return createVariant(sourceId, name);
   };
 
-  const handleSubmitSuccessful = async (
+  const handleSubmitSuccessful = (
     data: SubmitHandlerPlus<typeof defaultValues>,
     variantId: string,
   ) => {
@@ -58,6 +58,7 @@ function CreateVariantDialog(props: Props) {
 
   return (
     <FormDialog
+      maxWidth="sm"
       title={t("studies.createNewStudy")}
       titleIcon={AddCircleIcon}
       open={open}
@@ -67,7 +68,7 @@ function CreateVariantDialog(props: Props) {
       config={{ defaultValues }}
     >
       {({ control }) => (
-        <Fieldset fullFieldWidth>
+        <Fieldset fieldWidth={550}>
           <StringFE
             label={t("variants.newVariant")}
             name="name"
@@ -79,6 +80,7 @@ function CreateVariantDialog(props: Props) {
           />
           <SelectFE
             label={t("study.versionSource")}
+            variant="outlined"
             options={sourceList.map((ver) => ({
               label: ver.name,
               value: ver.id,


### PR DESCRIPTION
## Before:
![Screenshot 2024-05-30 at 18-00-19 Antares Web Test variant long nameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee (b75ee60f-60db-4e5a-87f9-c41c26d7976b)](https://github.com/AntaresSimulatorTeam/AntaREST/assets/33469289/cd58d6fd-138a-4326-9d5e-dd103dbbf270)

## After:
![Screenshot 2024-05-30 at 18-00-42 Antares Web Test variant long nameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee (b75ee60f-60db-4e5a-87f9-c41c26d7976b)](https://github.com/AntaresSimulatorTeam/AntaREST/assets/33469289/7a29ef86-206b-4200-b8d8-49e47d5716f3)
