### PR TITLE
fix(upgrade): raise an HTTP 417 exception when an upgrade has unmet requirements

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -314,6 +314,20 @@ class StudyDeletionNotAllowed(HTTPException):
         )
 
 
+class StudyUpgradeRequirementsNotMet(HTTPException):
+    def __init__(self, is_variant: bool, study_id: str) -> None:
+        if is_variant:
+            super().__init__(
+                HTTPStatus.EXPECTATION_FAILED,
+                f"Variant study {study_id} cannot be upgraded",
+            )
+        else:
+            super().__init__(
+                HTTPStatus.EXPECTATION_FAILED,
+                f"Raw Study {study_id} cannot be upgraded: it has children studies",
+            )
+
+
 class UnsupportedStudyVersion(HTTPException):
     def __init__(self, version: str) -> None:
         super().__init__(

--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -314,18 +314,15 @@ class StudyDeletionNotAllowed(HTTPException):
         )
 
 
-class StudyUpgradeRequirementsNotMet(HTTPException):
-    def __init__(self, is_variant: bool, study_id: str) -> None:
+class StudyVariantUpgradeError(HTTPException):
+    def __init__(self, is_variant: bool) -> None:
         if is_variant:
             super().__init__(
                 HTTPStatus.EXPECTATION_FAILED,
-                f"Variant study {study_id} cannot be upgraded",
+                "Upgrade not supported for variant study",
             )
         else:
-            super().__init__(
-                HTTPStatus.EXPECTATION_FAILED,
-                f"Raw Study {study_id} cannot be upgraded: it has children studies",
-            )
+            super().__init__(HTTPStatus.EXPECTATION_FAILED, "Upgrade not supported for parent of variants")
 
 
 class UnsupportedStudyVersion(HTTPException):

--- a/antarest/study/repository.py
+++ b/antarest/study/repository.py
@@ -416,3 +416,16 @@ class StudyMetadataRepository:
         subquery = session.query(Study.path).group_by(Study.path).having(func.count() > 1).subquery()
         query = session.query(Study.id, Study.path).filter(Study.path.in_(subquery))
         return t.cast(t.List[t.Tuple[str, str]], query.all())
+
+    def has_children(self, uuid: str) -> bool:
+        """
+        Check if a study has children.
+
+        Args:
+            uuid: The `uuid` of the study to check.
+
+        Returns:
+            True if the study has children, False otherwise.
+        """
+
+        return bool(self.session.query(Study).filter(and_(Study.parent_id == uuid, Study.id != uuid)).count())

--- a/antarest/study/repository.py
+++ b/antarest/study/repository.py
@@ -428,4 +428,4 @@ class StudyMetadataRepository:
             True if the study has children, False otherwise.
         """
 
-        return bool(self.session.query(Study).filter(and_(Study.parent_id == uuid, Study.id != uuid)).count())
+        return self.session.query(Study).filter(Study.parent_id == uuid).first() is not None

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -27,6 +27,7 @@ from antarest.core.exceptions import (
     StudyDeletionNotAllowed,
     StudyNotFoundError,
     StudyTypeUnsupported,
+    StudyUpgradeRequirementsNotMet,
     TaskAlreadyRunning,
     UnsupportedOperationOnArchivedStudy,
     UnsupportedStudyVersion,
@@ -2383,6 +2384,10 @@ class StudyService:
         study = self.get_study(study_id)
         assert_permission(params.user, study, StudyPermissionType.WRITE)
         self._assert_study_unarchived(study)
+
+        # If the study is raw study with variants or a variant study throw an Expectation Failed error
+        if isinstance(study, VariantStudy) or self.repository.has_children(study_id):
+            raise StudyUpgradeRequirementsNotMet(isinstance(study, VariantStudy), study.id)
 
         target_version = target_version or find_next_version(study.version)
         if not target_version:

--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -377,7 +377,7 @@ class VariantStudyService(AbstractStorageService[VariantStudy]):
         shutil.rmtree(self.get_study_path(variant_study), ignore_errors=True)
 
     def has_children(self, study: VariantStudy) -> bool:
-        return len(self.repository.get_children(parent_id=study.id)) > 0
+        return self.repository.has_children(study.id)
 
     def get_all_variants_children(
         self,

--- a/tests/integration/test_studies_upgrade.py
+++ b/tests/integration/test_studies_upgrade.py
@@ -52,3 +52,61 @@ class TestStudyUpgrade:
         task = wait_task_completion(client, user_access_token, task_id)
         assert task.status == TaskStatus.FAILED
         assert target_version in task.result.message, f"Version not in {task.result.message=}"
+
+    @pytest.mark.skipif(RUN_ON_WINDOWS, reason="This test runs randomly on Windows")
+    def test_upgrade_study__unmet_requirements(self, client: TestClient, admin_access_token: str):
+        """
+        Test that an upgrade with unmet requirements fails, corresponding to the two following cases:
+            - the study is a raw study with at least one child study
+            - the study is a variant study
+
+        Args:
+            client:
+            admin_access_token
+
+        Returns:
+        """
+
+        # create a raw study
+        res = client.post(
+            "/v1/studies",
+            headers={"Authorization": f"Bearer {admin_access_token}"},
+            params={"name": "test_upgrade_study__unmet_requirements__raw_study"},
+        )
+        assert res.status_code == 201
+        uuid = res.json()
+
+        # create a child variant study
+        res = client.post(
+            f"/v1/studies/{uuid}/variants",
+            headers={"Authorization": f"Bearer {admin_access_token}"},
+            params={"name": "test_upgrade_study__unmet_requirements__variant_study"},
+        )
+        assert res.status_code == 200
+        child_uuid = res.json()
+
+        # upgrade the raw study
+        res = client.put(
+            f"/v1/studies/{uuid}/upgrade",
+            headers={"Authorization": f"Bearer {admin_access_token}"},
+        )
+
+        # check that the upgrade failed (HttpException:417, with the expected message)
+        assert res.status_code == 417
+        assert res.json() == {
+            "description": f"Raw Study {uuid} cannot be upgraded: it has children studies",
+            "exception": "StudyUpgradeRequirementsNotMet",
+        }
+
+        # upgrade the variant study
+        res = client.put(
+            f"/v1/studies/{child_uuid}/upgrade",
+            headers={"Authorization": f"Bearer {admin_access_token}"},
+        )
+
+        # check that the upgrade failed (HttpException:417, with the expected message)
+        assert res.status_code == 417
+        assert res.json() == {
+            "description": f"Variant study {child_uuid} cannot be upgraded",
+            "exception": "StudyUpgradeRequirementsNotMet",
+        }

--- a/tests/integration/test_studies_upgrade.py
+++ b/tests/integration/test_studies_upgrade.py
@@ -53,60 +53,52 @@ class TestStudyUpgrade:
         assert task.status == TaskStatus.FAILED
         assert target_version in task.result.message, f"Version not in {task.result.message=}"
 
-    @pytest.mark.skipif(RUN_ON_WINDOWS, reason="This test runs randomly on Windows")
     def test_upgrade_study__unmet_requirements(self, client: TestClient, admin_access_token: str):
         """
         Test that an upgrade with unmet requirements fails, corresponding to the two following cases:
             - the study is a raw study with at least one child study
             - the study is a variant study
-
-        Args:
-            client:
-            admin_access_token
-
-        Returns:
         """
+
+        # set the admin access token in the client headers
+        client.headers = {"Authorization": f"Bearer {admin_access_token}"}
 
         # create a raw study
         res = client.post(
             "/v1/studies",
-            headers={"Authorization": f"Bearer {admin_access_token}"},
-            params={"name": "test_upgrade_study__unmet_requirements__raw_study"},
+            params={"name": "My Study"},
         )
-        assert res.status_code == 201
+        assert res.status_code == 201, res.json()
         uuid = res.json()
 
         # create a child variant study
         res = client.post(
             f"/v1/studies/{uuid}/variants",
-            headers={"Authorization": f"Bearer {admin_access_token}"},
-            params={"name": "test_upgrade_study__unmet_requirements__variant_study"},
+            params={"name": "foo"},
         )
-        assert res.status_code == 200
+        assert res.status_code == 200, res.json()
         child_uuid = res.json()
 
         # upgrade the raw study
         res = client.put(
             f"/v1/studies/{uuid}/upgrade",
-            headers={"Authorization": f"Bearer {admin_access_token}"},
         )
 
         # check that the upgrade failed (HttpException:417, with the expected message)
-        assert res.status_code == 417
+        assert res.status_code == 417, res.json()
         assert res.json() == {
-            "description": f"Raw Study {uuid} cannot be upgraded: it has children studies",
-            "exception": "StudyUpgradeRequirementsNotMet",
+            "description": "Upgrade not supported for parent of variants",
+            "exception": "StudyVariantUpgradeError",
         }
 
         # upgrade the variant study
         res = client.put(
             f"/v1/studies/{child_uuid}/upgrade",
-            headers={"Authorization": f"Bearer {admin_access_token}"},
         )
 
         # check that the upgrade failed (HttpException:417, with the expected message)
-        assert res.status_code == 417
+        assert res.status_code == 417, res.json()
         assert res.json() == {
-            "description": f"Variant study {child_uuid} cannot be upgraded",
-            "exception": "StudyUpgradeRequirementsNotMet",
+            "description": "Upgrade not supported for variant study",
+            "exception": "StudyVariantUpgradeError",
         }


### PR DESCRIPTION
Context: 
This PR addresses two potential issues that can occur when upgrading studies:  
- Upgrading a variant study could potentially corrupt it.
- Upgrading a parent study that has variant children could potentially corrupt those children.

Issue: 
At present, our system does not support the upgrade of commands, which complicates the resolution of these issues. Until we develop a solution for upgrading commands, this PR implements measures to prevent the two situations mentioned above.

Solution: 
The modifications in this PR will trigger a 417 HTTP ERROR if an attempt is made to upgrade a study that either has children or is a variant. This is a temporary measure until we implement a solution for upgrading commands.