### PR TITLE
fix(variants): display variants in chronological order in the variants tree

### DIFF
--- a/antarest/study/storage/variantstudy/repository.py
+++ b/antarest/study/storage/variantstudy/repository.py
@@ -41,17 +41,17 @@ class VariantStudyRepository(StudyMetadataRepository):
 
     def get_children(self, parent_id: str) -> t.List[VariantStudy]:
         """
-        Get the children of a variant study.
+        Get the children of a variant study in chronological order.
 
         Args:
             parent_id: Identifier of the parent study.
 
         Returns:
-            List of `VariantStudy` objects.
+            List of `VariantStudy` objects, ordered by creation date.
         """
-        studies: t.List[VariantStudy] = (
-            self.session.query(VariantStudy).filter(VariantStudy.parent_id == parent_id).all()
-        )
+        q = self.session.query(VariantStudy).filter(Study.parent_id == parent_id)
+        q = q.order_by(Study.created_at.asc())
+        studies = t.cast(t.List[VariantStudy], q.all())
         return studies
 
     def get_ancestor_or_self_ids(self, variant_id: str) -> t.Sequence[str]:

--- a/tests/storage/business/test_repository.py
+++ b/tests/storage/business/test_repository.py
@@ -1,0 +1,70 @@
+import datetime
+from unittest.mock import Mock
+
+from sqlalchemy.orm import Session  # type: ignore
+
+from antarest.core.interfaces.cache import ICache
+from antarest.study.model import RawStudy
+from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
+from antarest.study.storage.variantstudy.repository import VariantStudyRepository
+
+
+class TestVariantStudyRepository:
+    def test_get_children(self, db_session: Session) -> None:
+        """
+        Given a root study with children and a grandchild
+        When getting the children of the root study
+        Then the children are returned in chronological order
+        """
+        repository = VariantStudyRepository(cache_service=Mock(spec=ICache), session=db_session)
+
+        # Create a root study
+        raw_study = RawStudy(name="My Root")
+        db_session.add(raw_study)
+        db_session.commit()
+
+        # Ensure the root study has no children
+        children = repository.get_children(parent_id=raw_study.id)
+        assert children == []
+
+        # Prepare some dates for the children
+        day1 = datetime.datetime(2023, 1, 1)
+        day2 = datetime.datetime(2023, 1, 2)
+        day3 = datetime.datetime(2023, 1, 3)
+        day4 = datetime.datetime(2023, 1, 4)
+
+        # Create two variant studies of the same parent
+        variant1 = VariantStudy(name="My Variant 1", parent_id=raw_study.id, created_at=day1)
+        variant2 = VariantStudy(name="My Variant 2", parent_id=raw_study.id, created_at=day3)
+        db_session.add_all([variant1, variant2])
+        db_session.commit()
+
+        # Ensure the root study has 2 children
+        children = repository.get_children(parent_id=raw_study.id)
+        assert children == [variant1, variant2]
+        assert children[0].created_at < children[1].created_at
+
+        # Ensure variants have no children
+        children = repository.get_children(parent_id=variant1.id)
+        assert children == []
+        children = repository.get_children(parent_id=variant2.id)
+        assert children == []
+
+        # Add a variant study between the two existing ones (in chronological order)
+        variant3 = VariantStudy(name="My Variant 3", parent_id=raw_study.id, created_at=day2)
+        db_session.add(variant3)
+        db_session.commit()
+
+        # Ensure the root study has 3 children in chronological order
+        children = repository.get_children(parent_id=raw_study.id)
+        assert children == [variant1, variant3, variant2]
+        assert children[0].created_at < children[1].created_at < children[2].created_at
+
+        # Add a variant of a variant
+        variant3a = VariantStudy(name="My Variant 3a", parent_id=variant3.id, created_at=day4)
+        db_session.add(variant3a)
+        db_session.commit()
+
+        # Ensure the root study has the 3 same children
+        children = repository.get_children(parent_id=raw_study.id)
+        assert children == [variant1, variant3, variant2]


### PR DESCRIPTION
This PR fixes [ANT-1797](https://gopro-tickets.rte-france.com/browse/ANT-1797)

The database query was changed to query the children in chronological order.