### PR TITLE
fix(api-aggregation): raise 404 HTTP exception for unfound output names

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -335,6 +335,20 @@ class BadOutputError(HTTPException):
         super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, message)
 
 
+class OutputNotFound(HTTPException):
+    """
+    Exception raised when an output is not found in the study results directory.
+    """
+
+    def __init__(self, output_id: str) -> None:
+        message = f"Output '{output_id}' not found"
+        super().__init__(HTTPStatus.NOT_FOUND, message)
+
+    def __str__(self) -> str:
+        """Return a string representation of the exception."""
+        return self.detail
+
+
 class BadZipBinary(HTTPException):
     def __init__(self, message: str) -> None:
         super().__init__(HTTPStatus.UNSUPPORTED_MEDIA_TYPE, message)

--- a/antarest/study/business/aggregator_management.py
+++ b/antarest/study/business/aggregator_management.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from antarest.core.exceptions import FileTooLargeError
+from antarest.core.exceptions import BadOutputError, FileTooLargeError
 from antarest.study.storage.rawstudy.ini_reader import IniReader
 from antarest.study.storage.rawstudy.model.filesystem.matrix.date_serializer import (
     FactoryDateSerializer,
@@ -198,7 +198,7 @@ class AggregatorManager:
 
         # Checks if mc-ind results exist
         if not self.mc_ind_path.exists():
-            return pd.DataFrame()
+            raise BadOutputError(f"Output data not found in {self.mc_ind_path}")
 
         # Retrieves the horizon from the study output
         horizon_path = self.study_path / HORIZON_TEMPLATE.format(sim_id=self.output_id)

--- a/antarest/study/business/aggregator_management.py
+++ b/antarest/study/business/aggregator_management.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from antarest.core.exceptions import BadOutputError, FileTooLargeError
+from antarest.core.exceptions import FileTooLargeError, OutputNotFound
 from antarest.study.storage.rawstudy.ini_reader import IniReader
 from antarest.study.storage.rawstudy.model.filesystem.matrix.date_serializer import (
     FactoryDateSerializer,
@@ -198,7 +198,7 @@ class AggregatorManager:
 
         # Checks if mc-ind results exist
         if not self.mc_ind_path.exists():
-            raise BadOutputError(f"Output data not found in {self.mc_ind_path}")
+            raise OutputNotFound(self.output_id)
 
         # Retrieves the horizon from the study output
         horizon_path = self.study_path / HORIZON_TEMPLATE.format(sim_id=self.output_id)

--- a/antarest/study/web/raw_studies_blueprint.py
+++ b/antarest/study/web/raw_studies_blueprint.py
@@ -175,7 +175,7 @@ def create_raw_study_routes(
         return Response(content=json_response, media_type="application/json")
 
     @bp.get(
-        "/studies/{uuid}/areas/aggregate",
+        "/studies/{uuid}/areas/aggregate/{output_id}",
         tags=[APITag.study_raw_data],
         summary="Retrieve Aggregated Areas Raw Data from Study Output",
     )
@@ -244,7 +244,7 @@ def create_raw_study_routes(
         )
 
     @bp.get(
-        "/studies/{uuid}/links/aggregate",
+        "/studies/{uuid}/links/aggregate/{output_id}",
         tags=[APITag.study_raw_data],
         summary="Retrieve Aggregated Links Raw Data from Study Output",
     )

--- a/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
@@ -144,11 +144,6 @@ SAME_REQUEST_DIFFERENT_FORMATS = [
 
 INCOHERENT_REQUESTS_BODIES = [
     {
-        "output_id": "fake_output_id",
-        "query_file": LinksQueryFile.VALUES,
-        "frequency": MatrixFrequency.HOURLY,
-    },
-    {
         "output_id": "20201014-1425eco-goodbye",
         "query_file": AreasQueryFile.VALUES,
         "frequency": MatrixFrequency.HOURLY,
@@ -311,3 +306,33 @@ class TestRawDataAggregation:
             )
             assert res.status_code == 422
             assert res.json()["exception"] == "RequestValidationError"
+
+    def test_aggregation_with_wrong_output(self, client: TestClient, user_access_token: str, study_id: str):
+        """
+        Asserts that requests with wrong output send an HTTP 422 Exception
+        """
+        client.headers = {"Authorization": f"Bearer {user_access_token}"}
+
+        # test for areas
+        res = client.get(
+            f"/v1/studies/{study_id}/areas/aggregate",
+            params={
+                "output_id": "fake_output_id",
+                "query_file": AreasQueryFile.VALUES,
+                "frequency": MatrixFrequency.HOURLY,
+            },
+        )
+        assert res.status_code == 422
+        assert res.json()["exception"] == "BadOutputError"
+
+        # test for links
+        res = client.get(
+            f"/v1/studies/{study_id}/links/aggregate",
+            params={
+                "output_id": "fake_output_id",
+                "query_file": LinksQueryFile.VALUES,
+                "frequency": MatrixFrequency.HOURLY,
+            },
+        )
+        assert res.status_code == 422
+        assert res.json()["exception"] == "BadOutputError"


### PR DESCRIPTION
Context:
Actually when a wrong output name is submitted, the aggregation gives back an empty data frame. 

Issue:
The users in the case of an in-existing output name may get confused (not knowing the origin of problem).

Solution:
Notify the user with an 404 HTTP exception. 