### PR TITLE
feat: enhancements for areas and binding constraints management

### DIFF
--- a/antarest/study/storage/variantstudy/model/command/update_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/update_binding_constraint.py
@@ -79,10 +79,12 @@ class UpdateBindingConstraint(AbstractBindingConstraintCommand):
         updated_cfg = binding_constraints[index]
         updated_cfg.update(obj)
 
-        if self.coeffs:
-            # Remove terms which IDs contain a "%" or a "." in their name
-            term_ids = {k for k in updated_cfg if "%" in k or "." in k}
-            binding_constraints[index] = {k: v for k, v in updated_cfg.items() if k not in term_ids}
+        updated_terms = set(self.coeffs.keys()) if self.coeffs else set()
+
+        # Remove the terms not in the current update but existing in the config
+        terms_to_remove = {key for key in updated_cfg if ("%" in key or "." in key) and key not in updated_terms}
+        for term_id in terms_to_remove:
+            updated_cfg.pop(term_id, None)
 
         return super().apply_binding_constraint(study_data, binding_constraints, index, self.id, old_groups=old_groups)
 

--- a/antarest/study/storage/variantstudy/model/command/update_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/update_binding_constraint.py
@@ -79,7 +79,7 @@ class UpdateBindingConstraint(AbstractBindingConstraintCommand):
         updated_cfg = binding_constraints[index]
         updated_cfg.update(obj)
 
-        updated_terms = set(self.coeffs.keys()) if self.coeffs else set()
+        updated_terms = set(self.coeffs) if self.coeffs else set()
 
         # Remove the terms not in the current update but existing in the config
         terms_to_remove = {key for key in updated_cfg if ("%" in key or "." in key) and key not in updated_terms}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/AddConstraintTermDialog/AddConstraintTermForm/OptionsList.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/AddConstraintTermDialog/AddConstraintTermForm/OptionsList.tsx
@@ -76,6 +76,7 @@ export default function OptionsList({ list, isLink, constraintTerms }: Props) {
         options={areaOptions}
         control={control}
         sx={{ width: 250 }}
+        rules={{ required: true }}
       />
       <SelectFE
         variant="outlined"
@@ -84,6 +85,7 @@ export default function OptionsList({ list, isLink, constraintTerms }: Props) {
         options={areaOrClusterOptions}
         control={control}
         sx={{ width: 250, ml: 1, mr: 3 }}
+        rules={{ required: true }}
       />
     </>
   );

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintTerm/OptionsList.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintTerm/OptionsList.tsx
@@ -119,7 +119,7 @@ export default function OptionsList({
         list={areaOptions}
         handleChange={(key, value) => handleAreaChange(value as string)}
         sx={{
-          width: 200,
+          maxWidth: 200,
           mr: 1,
         }}
       />
@@ -134,7 +134,7 @@ export default function OptionsList({
           handleClusterOrAreaChange(value as string)
         }
         sx={{
-          width: 200,
+          maxWidth: 200,
         }}
       />
     </>

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintTerm/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintTerm/index.tsx
@@ -149,7 +149,7 @@ function ConstraintTermItem({
             type="number"
             value={weight}
             onChange={handleWeightChange}
-            sx={{ maxWidth: 150, mr: 0 }}
+            sx={{ maxWidth: 150 }}
           />
         }
         right={

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/constraintviews/style.ts
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/constraintviews/style.ts
@@ -3,7 +3,7 @@ import { Box, Paper, styled } from "@mui/material";
 export const ConstraintElementRoot = styled(Paper)(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
-  padding: theme.spacing(0.8),
+  padding: theme.spacing(1),
   borderRadius: 5,
   backgroundImage:
     "linear-gradient(rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05))",

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/index.tsx
@@ -1,11 +1,12 @@
 import { BindingConstraint } from "./utils";
-import { Box, Button, Paper } from "@mui/material";
+import { Box, Button, Paper, Skeleton } from "@mui/material";
 import Form from "../../../../../../common/Form";
 import UsePromiseCond, {
   mergeResponses,
 } from "../../../../../../common/utils/UsePromiseCond";
 import {
   getBindingConstraint,
+  getBindingConstraintList,
   updateBindingConstraint,
 } from "../../../../../../../services/api/studydata";
 import { useOutletContext } from "react-router";
@@ -83,8 +84,12 @@ function BindingConstView({ constraintId }: Props) {
         },
       ]);
 
-      // Trigger a reload redirecting to the first constraint
-      dispatch(setCurrentBindingConst(""));
+      const updatedConstraints = await getBindingConstraintList(study.id);
+
+      if (updatedConstraints && updatedConstraints.length > 0) {
+        // Trigger a reload redirecting to the first constraint
+        dispatch(setCurrentBindingConst(updatedConstraints[0].id));
+      }
 
       enqueueSnackbar(t("study.success.deleteConstraint"), {
         variant: "success",
@@ -149,6 +154,7 @@ function BindingConstView({ constraintId }: Props) {
             </Box>
           </>
         )}
+        ifPending={() => <Skeleton sx={{ height: 1, transform: "none" }} />}
       />
 
       {deleteConstraintDialogOpen && (

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
@@ -72,7 +72,7 @@ function BindingConstraints() {
             />
           </Box>
           <Box>
-            {data && data.length > 0 && currentConstraintId ? (
+            {data.length > 0 && currentConstraintId ? (
               <BindingConstView constraintId={currentConstraintId} />
             ) : (
               <SimpleContent title="No Binding Constraints" />

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
@@ -72,8 +72,10 @@ function BindingConstraints() {
             />
           </Box>
           <Box>
-            {currentConstraintId && (
+            {data && data.length > 0 && currentConstraintId ? (
               <BindingConstView constraintId={currentConstraintId} />
+            ) : (
+              <SimpleContent title="No Binding Constraints" />
             )}
           </Box>
         </SplitView>

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/index.tsx
@@ -5,7 +5,11 @@ import { useTranslation } from "react-i18next";
 import { StudyMetadata } from "../../../../../common/types";
 import TabWrapper from "../TabWrapper";
 import useAppSelector from "../../../../../redux/hooks/useAppSelector";
-import { getAreas, getCurrentAreaId } from "../../../../../redux/selectors";
+import {
+  getAreas,
+  getCurrentAreaId,
+  getLinks,
+} from "../../../../../redux/selectors";
 import useAppDispatch from "../../../../../redux/hooks/useAppDispatch";
 import { setCurrentArea } from "../../../../../redux/ducks/studySyntheses";
 
@@ -16,6 +20,7 @@ function Modelization() {
   const navigate = useNavigate();
   const { areaId: paramAreaId } = useParams();
   const areas = useAppSelector((state) => getAreas(state, study.id));
+  const links = useAppSelector((state) => getLinks(state, study.id));
   const areaId = useAppSelector(getCurrentAreaId);
 
   useEffect(() => {
@@ -49,17 +54,19 @@ function Modelization() {
         label: t("study.areas"),
         path: `${basePath}/area/${encodeURI(areaId)}`,
         onClick: handleAreasClick,
+        disabled: areas.length === 0,
       },
       {
         label: t("study.links"),
         path: `${basePath}/links`,
+        disabled: links.length === 0,
       },
       {
         label: t("study.bindingconstraints"),
         path: `${basePath}/bindingcontraint`,
       },
     ];
-  }, [areaId, areas, dispatch, navigate, study?.id, t]);
+  }, [areaId, areas, dispatch, links, navigate, study.id, t]);
 
   return (
     <Box

--- a/webapp/src/components/App/Singlestudy/explore/TabWrapper.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/TabWrapper.tsx
@@ -31,6 +31,7 @@ interface TabItem {
   label: string;
   path: string;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
 interface Props {
@@ -101,7 +102,11 @@ function TabWrapper({
         }}
       >
         {tabList.map((tab) => (
-          <Tab key={tab.path} label={tab.label} />
+          <Tab
+            key={tab.path}
+            label={tab.label}
+            disabled={tab.disabled ?? false}
+          />
         ))}
       </StyledTab>
       <Outlet context={{ study }} />


### PR DESCRIPTION
### Changes 

#### 1. **Disable 'Areas' Tab When No Areas are Present (`fix/ui`)**
   - **Issue**: Previously, the 'Areas' tab incorrectly displayed the map component when no area data were available.
   - **Fix**: Disabled the 'Areas' tab if no areas are present. This change forces users to create areas before accessing this tab, thus ensuring UI consistency and preventing incorrect displays.

#### 2. **Add Empty Screen for Binding Constraints (`feat/ui-bc`)**
   - **Enhancement**: Implemented an empty message screen that appears when no binding constraints exist, replacing what was previously a blank or erroneous 404 screen. This provides clearer feedback to users about the absence of data.

#### 3. **Ensure Removal of the Last Term in Binding Constraints (`fix/api-bc`)**
   - **Issue**: A bug prevented the deletion of the last term in a binding constraint, without raising any execption.
   - **Fix**: Updated API logic to allow the complete removal of terms, ensuring data integrity and user control over constraint terms.

#### 4. **Minor Style Adjustments on Terms Component (`feat/ui-bc`)**
   - **Enhancement**: Adjusted padding and spacing in the terms component to improve visual alignment and user interface consistency.

#### 5. **Prevent Submitting Empty 'SelectFE' Fields (`fix/ui-bc`)**
   - **Issue**: The dialog for adding constraint terms allowed submissions with empty selects, leading to server errors.
   - **Fix**: Introduced validation to require users to select options from both dropdowns before submission, enhancing form handling and preventing unnecessary server errors.

#### 6. **Prevent '404' Error After Deletion of the Current or Last Constraint (`fix/ui-bc`)**
   - **Issue**: Deleting the currently selected or the last binding constraint led to a '404' error screen.
   - **Fix**: Implemented a post-deletion refresh of the constraints list and adjusted the UI to redirect to the first available constraint if any remain, or handle the absence of constraints more gracefully.