### PR TITLE
fix(variants): display variants in reverse chronological order in the variants tree

### DIFF
--- a/antarest/study/storage/variantstudy/repository.py
+++ b/antarest/study/storage/variantstudy/repository.py
@@ -50,7 +50,7 @@ class VariantStudyRepository(StudyMetadataRepository):
             List of `VariantStudy` objects, ordered by creation date.
         """
         q = self.session.query(VariantStudy).filter(Study.parent_id == parent_id)
-        q = q.order_by(Study.created_at.asc())
+        q = q.order_by(Study.created_at.desc())
         studies = t.cast(t.List[VariantStudy], q.all())
         return studies
 

--- a/tests/integration/variant_blueprint/test_variant_manager.py
+++ b/tests/integration/variant_blueprint/test_variant_manager.py
@@ -57,8 +57,9 @@ def test_variant_manager(
         assert len(children["children"]) == 1
         assert children["children"][0]["node"]["name"] == "Variant1"
         assert len(children["children"][0]["children"]) == 2
-        assert children["children"][0]["children"][0]["node"]["name"] == "bar"
-        assert children["children"][0]["children"][1]["node"]["name"] == "baz"
+        # Variant children are sorted by creation date in reverse order
+        assert children["children"][0]["children"][0]["node"]["name"] == "baz"
+        assert children["children"][0]["children"][1]["node"]["name"] == "bar"
 
         # George creates a base study
         # He creates a variant from this study : assert that no command is created

--- a/tests/storage/business/test_repository.py
+++ b/tests/storage/business/test_repository.py
@@ -14,7 +14,7 @@ class TestVariantStudyRepository:
         """
         Given a root study with children and a grandchild
         When getting the children of the root study
-        Then the children are returned in chronological order
+        Then the children are returned in reverse chronological order
         """
         repository = VariantStudyRepository(cache_service=Mock(spec=ICache), session=db_session)
 
@@ -41,8 +41,8 @@ class TestVariantStudyRepository:
 
         # Ensure the root study has 2 children
         children = repository.get_children(parent_id=raw_study.id)
-        assert children == [variant1, variant2]
-        assert children[0].created_at < children[1].created_at
+        assert children == [variant2, variant1]
+        assert children[0].created_at > children[1].created_at
 
         # Ensure variants have no children
         children = repository.get_children(parent_id=variant1.id)
@@ -50,15 +50,15 @@ class TestVariantStudyRepository:
         children = repository.get_children(parent_id=variant2.id)
         assert children == []
 
-        # Add a variant study between the two existing ones (in chronological order)
+        # Add a variant study between the two existing ones (in reverse chronological order)
         variant3 = VariantStudy(name="My Variant 3", parent_id=raw_study.id, created_at=day2)
         db_session.add(variant3)
         db_session.commit()
 
         # Ensure the root study has 3 children in chronological order
         children = repository.get_children(parent_id=raw_study.id)
-        assert children == [variant1, variant3, variant2]
-        assert children[0].created_at < children[1].created_at < children[2].created_at
+        assert children == [variant2, variant3, variant1]
+        assert children[0].created_at > children[1].created_at > children[2].created_at
 
         # Add a variant of a variant
         variant3a = VariantStudy(name="My Variant 3a", parent_id=variant3.id, created_at=day4)
@@ -67,4 +67,4 @@ class TestVariantStudyRepository:
 
         # Ensure the root study has the 3 same children
         children = repository.get_children(parent_id=raw_study.id)
-        assert children == [variant1, variant3, variant2]
+        assert children == [variant2, variant3, variant1]


### PR DESCRIPTION
[ANT-1797](https://gopro-tickets.rte-france.com/browse/ANT-1797)

This PR addresses the issue of variant display order in the variants tree. Previously, the variants were displayed in chronological order, which was not intuitive for users who expected to see the most recent variants first.

This PR completes #2049