### PR TITLE
feat(api): do not allow areas, links or thermals deletion when referenced in a binding constraint

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -325,7 +325,7 @@ class StudyVariantUpgradeError(HTTPException):
             super().__init__(HTTPStatus.EXPECTATION_FAILED, "Upgrade not supported for parent of variants")
 
 
-class BindingConstraintDeletionNotAllowed(HTTPException):
+class ReferencedObjectDeletionNotAllowed(HTTPException):
     """
     Exception raised when a binding constraint is not allowed to be deleted because it references
     other objects: areas, links or thermal clusters.

--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -4,6 +4,8 @@ from http import HTTPStatus
 
 from fastapi.exceptions import HTTPException
 
+MAX_BINDING_CONSTRAINTS_TO_DISPLAY = 10
+
 
 class ShouldNotHappenException(Exception):
     pass
@@ -326,10 +328,12 @@ class StudyVariantUpgradeError(HTTPException):
 
 
 class AreaDeletionNotAllowed(HTTPException):
-    def __init__(self, uuid: str, message: t.Optional[str] = None) -> None:
-        msg = f"Area {uuid} is not allowed to be deleted"
-        if message:
-            msg += f"\n{message}"
+    def __init__(self, uuid: str, binding_constraints_ids: t.List[str]) -> None:
+        first_bcs_ids = ""
+        for i, bc in enumerate(binding_constraints_ids[:MAX_BINDING_CONSTRAINTS_TO_DISPLAY]):
+            first_bcs_ids += f"{i+1}- {bc}\n"
+        message = "Area is referenced in the following binding constraints:\n" + first_bcs_ids
+        msg = f"Area {uuid} is not allowed to be deleted\n{message}"
         super().__init__(
             HTTPStatus.FORBIDDEN,
             msg,
@@ -337,10 +341,12 @@ class AreaDeletionNotAllowed(HTTPException):
 
 
 class LinkDeletionNotAllowed(HTTPException):
-    def __init__(self, uuid: str, message: t.Optional[str] = None) -> None:
-        msg = f"Link {uuid} is not allowed to be deleted"
-        if message:
-            msg += f"\n{message}"
+    def __init__(self, uuid: str, binding_constraints_ids: t.List[str]) -> None:
+        first_bcs_ids = ""
+        for i, bc in enumerate(binding_constraints_ids[:MAX_BINDING_CONSTRAINTS_TO_DISPLAY]):
+            first_bcs_ids += f"{i+1}- {bc}\n"
+        message = "Link is referenced in the following binding constraints:\n" + first_bcs_ids
+        msg = f"Link {uuid} is not allowed to be deleted\n{message}"
         super().__init__(
             HTTPStatus.FORBIDDEN,
             msg,
@@ -348,10 +354,12 @@ class LinkDeletionNotAllowed(HTTPException):
 
 
 class ClusterDeletionNotAllowed(HTTPException):
-    def __init__(self, uuid: str, message: t.Optional[str] = None) -> None:
-        msg = f"Cluster {uuid} is not allowed to be deleted"
-        if message:
-            msg += f"\n{message}"
+    def __init__(self, uuid: str, binding_constraints_ids: t.List[str]) -> None:
+        first_bcs_ids = ""
+        for i, bc in enumerate(binding_constraints_ids[:MAX_BINDING_CONSTRAINTS_TO_DISPLAY]):
+            first_bcs_ids += f"{i+1}- {bc}\n"
+        message = "Cluster is referenced in the following binding constraints:\n" + first_bcs_ids
+        msg = f"Cluster {uuid} is not allowed to be deleted\n{message}"
         super().__init__(
             HTTPStatus.FORBIDDEN,
             msg,

--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -325,6 +325,39 @@ class StudyVariantUpgradeError(HTTPException):
             super().__init__(HTTPStatus.EXPECTATION_FAILED, "Upgrade not supported for parent of variants")
 
 
+class AreaDeletionNotAllowed(HTTPException):
+    def __init__(self, uuid: str, message: t.Optional[str] = None) -> None:
+        msg = f"Area {uuid} is not allowed to be deleted"
+        if message:
+            msg += f"\n{message}"
+        super().__init__(
+            HTTPStatus.FORBIDDEN,
+            msg,
+        )
+
+
+class LinkDeletionNotAllowed(HTTPException):
+    def __init__(self, uuid: str, message: t.Optional[str] = None) -> None:
+        msg = f"Link {uuid} is not allowed to be deleted"
+        if message:
+            msg += f"\n{message}"
+        super().__init__(
+            HTTPStatus.FORBIDDEN,
+            msg,
+        )
+
+
+class ClusterDeletionNotAllowed(HTTPException):
+    def __init__(self, uuid: str, message: t.Optional[str] = None) -> None:
+        msg = f"Cluster {uuid} is not allowed to be deleted"
+        if message:
+            msg += f"\n{message}"
+        super().__init__(
+            HTTPStatus.FORBIDDEN,
+            msg,
+        )
+
+
 class UnsupportedStudyVersion(HTTPException):
     def __init__(self, version: str) -> None:
         super().__init__(

--- a/antarest/study/business/binding_constraint_management.py
+++ b/antarest/study/business/binding_constraint_management.py
@@ -501,13 +501,12 @@ class BindingConstraintManager:
         :return: A dictionary of term IDs mapped to a list of their coefficients.
         """
         coeffs = {}
-        if terms is not None:
-            for term in terms:
-                if term.id and term.weight is not None:
-                    coeffs[term.id] = [term.weight]
-                    if term.offset:
-                        coeffs[term.id].append(term.offset)
-            return coeffs
+        for term in terms:
+            if term.id and term.weight is not None:
+                coeffs[term.id] = [term.weight]
+                if term.offset:
+                    coeffs[term.id].append(term.offset)
+        return coeffs
 
     def get_binding_constraint(self, study: Study, bc_id: str) -> ConstraintOutput:
         """

--- a/antarest/study/model.py
+++ b/antarest/study/model.py
@@ -426,13 +426,37 @@ class ExportFormat(str, enum.Enum):
     TAR_GZ = "application/tar+gz"
     JSON = "application/json"
 
-    @staticmethod
-    def from_dto(data: str) -> "ExportFormat":
-        if data == "application/zip":
-            return ExportFormat.ZIP
-        if data == "application/tar+gz":
-            return ExportFormat.TAR_GZ
-        return ExportFormat.JSON
+    @classmethod
+    def from_dto(cls, accept_header: str) -> "ExportFormat":
+        """
+        Convert the "Accept" header to the corresponding content type.
+
+        Args:
+            accept_header: Value of the "Accept" header.
+
+        Returns:
+            The corresponding content type: ZIP, TAR_GZ or JSON.
+            By default, JSON is returned if the format is not recognized.
+            For instance, if the "Accept" header is "*/*", JSON is returned.
+        """
+        mapping = {
+            "application/zip": ExportFormat.ZIP,
+            "application/tar+gz": ExportFormat.TAR_GZ,
+            "application/json": ExportFormat.JSON,
+        }
+        return mapping.get(accept_header, ExportFormat.JSON)
+
+    @property
+    def suffix(self) -> str:
+        """
+        Returns the file suffix associated with the format: ".zip", ".tar.gz" or ".json".
+        """
+        mapping = {
+            ExportFormat.ZIP: ".zip",
+            ExportFormat.TAR_GZ: ".tar.gz",
+            ExportFormat.JSON: ".json",
+        }
+        return mapping[self]
 
 
 class StudyDownloadDTO(BaseModel):

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -9,7 +9,6 @@ import os
 import time
 import typing as t
 from datetime import datetime, timedelta
-from os.path import abspath
 from pathlib import Path, PurePosixPath
 from uuid import uuid4
 
@@ -1189,12 +1188,12 @@ class StudyService:
         """
         Download outputs
         Args:
-            study_id: study ID
-            output_id: output ID
+            study_id: study Id
+            output_id: output id
             data: Json parameters
             use_task: use task or not
             filetype: type of returning file,
-            tmp_export_file: temporary file (if `use_task` is false),
+            tmp_export_file: temporary file (if use_task is false),
             params: request parameters
 
         Returns: CSV content file
@@ -1277,7 +1276,7 @@ class StudyService:
                 else:  # pragma: no cover
                     raise NotImplementedError(f"Export format {filetype} is not supported")
 
-                return FileResponse(Path(abspath(tmp_export_file)), headers=headers, media_type=filetype)
+                return FileResponse(tmp_export_file, headers=headers, media_type=filetype)
 
             else:
                 json_response = json.dumps(

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -21,10 +21,10 @@ from starlette.responses import FileResponse, Response
 from antarest.core.config import Config
 from antarest.core.exceptions import (
     BadEditInstructionException,
-    BindingConstraintDeletionNotAllowed,
     CommandApplicationError,
     IncorrectPathError,
     NotAManagedStudyException,
+    ReferencedObjectDeletionNotAllowed,
     StudyDeletionNotAllowed,
     StudyNotFoundError,
     StudyTypeUnsupported,
@@ -1861,7 +1861,7 @@ class StudyService:
             params: The request parameters used to check user permissions.
 
         Raises:
-            BindingConstraintDeletionNotAllowed: If the area is referenced by a binding constraint.
+            ReferencedObjectDeletionNotAllowed: If the area is referenced by a binding constraint.
         """
         study = self.get_study(uuid)
         assert_permission(params.user, study, StudyPermissionType.WRITE)
@@ -1871,7 +1871,7 @@ class StudyService:
         )
         if referencing_binding_constraints:
             binding_ids = [bc.id for bc in referencing_binding_constraints]
-            raise BindingConstraintDeletionNotAllowed(area_id, binding_ids, object_type="Area")
+            raise ReferencedObjectDeletionNotAllowed(area_id, binding_ids, object_type="Area")
         self.areas.delete_area(study, area_id)
         self.event_bus.push(
             Event(
@@ -1899,7 +1899,7 @@ class StudyService:
             params: The request parameters used to check user permissions.
 
         Raises:
-            BindingConstraintDeletionNotAllowed: If the link is referenced by a binding constraint.
+            ReferencedObjectDeletionNotAllowed: If the link is referenced by a binding constraint.
         """
         study = self.get_study(uuid)
         assert_permission(params.user, study, StudyPermissionType.WRITE)
@@ -1910,7 +1910,7 @@ class StudyService:
         )
         if referencing_binding_constraints:
             binding_ids = [bc.id for bc in referencing_binding_constraints]
-            raise BindingConstraintDeletionNotAllowed(link_id, binding_ids, object_type="Link")
+            raise ReferencedObjectDeletionNotAllowed(link_id, binding_ids, object_type="Link")
         self.links.delete_link(study, area_from, area_to)
         self.event_bus.push(
             Event(
@@ -2565,7 +2565,7 @@ class StudyService:
             cluster_ids: IDs of the thermal clusters to be checked
 
         Raises:
-            BindingConstraintDeletionNotAllowed: if a cluster is referenced in a binding constraint
+            ReferencedObjectDeletionNotAllowed: if a cluster is referenced in a binding constraint
         """
 
         for cluster_id in cluster_ids:
@@ -2574,4 +2574,4 @@ class StudyService:
             )
             if ref_bcs:
                 binding_ids = [bc.id for bc in ref_bcs]
-                raise BindingConstraintDeletionNotAllowed(cluster_id, binding_ids, object_type="Cluster")
+                raise ReferencedObjectDeletionNotAllowed(cluster_id, binding_ids, object_type="Cluster")

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -9,6 +9,7 @@ import os
 import time
 import typing as t
 from datetime import datetime, timedelta
+from os.path import abspath
 from pathlib import Path, PurePosixPath
 from uuid import uuid4
 
@@ -1188,12 +1189,12 @@ class StudyService:
         """
         Download outputs
         Args:
-            study_id: study Id
-            output_id: output id
+            study_id: study ID
+            output_id: output ID
             data: Json parameters
             use_task: use task or not
             filetype: type of returning file,
-            tmp_export_file: temporary file (if use_task is false),
+            tmp_export_file: temporary file (if `use_task` is false),
             params: request parameters
 
         Returns: CSV content file
@@ -1276,7 +1277,7 @@ class StudyService:
                 else:  # pragma: no cover
                     raise NotImplementedError(f"Export format {filetype} is not supported")
 
-                return FileResponse(tmp_export_file, headers=headers, media_type=filetype)
+                return FileResponse(Path(abspath(tmp_export_file)), headers=headers, media_type=filetype)
 
             else:
                 json_response = json.dumps(

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -2544,12 +2544,13 @@ class StudyService:
 
         return df_matrix
 
-    def assert_no_cluster_referenced_in_bcs(self, study: Study, cluster_ids: t.Sequence[str]) -> None:
+    def assert_no_cluster_referenced_in_bcs(self, study: Study, area_id: str, cluster_ids: t.Sequence[str]) -> None:
         """
         Check that no cluster is referenced in a binding constraint otherwise raise an ClusterDeletionNotAllowed Exception
 
         Args:
             study: input study
+            area_id: area ID to be checked
             cluster_ids: cluster IDs to be checked
 
         Returns:
@@ -2558,7 +2559,7 @@ class StudyService:
 
         for cluster_id in cluster_ids:
             referencing_binding_constraints = self.binding_constraint_manager.get_binding_constraints(
-                study, ConstraintFilters(cluster_id=cluster_id)
+                study, ConstraintFilters(cluster_id=f"{area_id}.{cluster_id}")
             )[:MAX_BINDING_CONSTRAINTS_TO_DISPLAY]
             if referencing_binding_constraints:
                 first_bcs_ids = ""

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -2185,7 +2185,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         )
         request_params = RequestParameters(user=current_user)
         study = study_service.check_study_access(uuid, StudyPermissionType.WRITE, request_params)
-        study_service.assert_no_cluster_referenced_in_bcs(study, area_id, cluster_ids)
+        study_service.asserts_no_thermal_in_binding_constraints(study, area_id, cluster_ids)
         study_service.thermal_manager.delete_clusters(study, area_id, cluster_ids)
 
     @bp.get(

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -2185,6 +2185,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         )
         request_params = RequestParameters(user=current_user)
         study = study_service.check_study_access(uuid, StudyPermissionType.WRITE, request_params)
+        study_service.assert_no_cluster_referenced_in_bcs(study, cluster_ids)
         study_service.thermal_manager.delete_clusters(study, area_id, cluster_ids)
 
     @bp.get(

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -2185,7 +2185,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         )
         request_params = RequestParameters(user=current_user)
         study = study_service.check_study_access(uuid, StudyPermissionType.WRITE, request_params)
-        study_service.assert_no_cluster_referenced_in_bcs(study, cluster_ids)
+        study_service.assert_no_cluster_referenced_in_bcs(study, area_id, cluster_ids)
         study_service.thermal_manager.delete_clusters(study, area_id, cluster_ids)
 
     @bp.get(

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -1,0 +1,25 @@
+from antarest.core.exceptions import BindingConstraintDeletionNotAllowed
+
+
+class TestBindingConstraintDeletionNotAllowed:
+    def test_few_binding_constraints(self) -> None:
+        object_id = "france"
+        binding_ids = ["bc1", "bc2"]
+        object_type = "Area"
+        exception = BindingConstraintDeletionNotAllowed(object_id, binding_ids, object_type=object_type)
+        message = str(exception)
+        assert f"{object_type} '{object_id}'" in message
+        assert "bc1" in message
+        assert "bc2" in message
+        assert "more..." not in message
+
+    def test_many_binding_constraints(self) -> None:
+        object_id = "france"
+        binding_ids = [f"bc{i}" for i in range(1, 50)]
+        object_type = "Area"
+        exception = BindingConstraintDeletionNotAllowed(object_id, binding_ids, object_type=object_type)
+        message = str(exception)
+        assert f"{object_type} '{object_id}'" in message
+        assert "bc1" in message
+        assert "bc2" in message
+        assert "more..." in message

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -1,12 +1,12 @@
-from antarest.core.exceptions import BindingConstraintDeletionNotAllowed
+from antarest.core.exceptions import ReferencedObjectDeletionNotAllowed
 
 
-class TestBindingConstraintDeletionNotAllowed:
+class TestReferencedObjectDeletionNotAllowed:
     def test_few_binding_constraints(self) -> None:
         object_id = "france"
         binding_ids = ["bc1", "bc2"]
         object_type = "Area"
-        exception = BindingConstraintDeletionNotAllowed(object_id, binding_ids, object_type=object_type)
+        exception = ReferencedObjectDeletionNotAllowed(object_id, binding_ids, object_type=object_type)
         message = str(exception)
         assert f"{object_type} '{object_id}'" in message
         assert "bc1" in message
@@ -17,7 +17,7 @@ class TestBindingConstraintDeletionNotAllowed:
         object_id = "france"
         binding_ids = [f"bc{i}" for i in range(1, 50)]
         object_type = "Area"
-        exception = BindingConstraintDeletionNotAllowed(object_id, binding_ids, object_type=object_type)
+        exception = ReferencedObjectDeletionNotAllowed(object_id, binding_ids, object_type=object_type)
         message = str(exception)
         assert f"{object_type} '{object_id}'" in message
         assert "bc1" in message

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -654,12 +654,9 @@ class TestThermal:
             json=[fr_gas_conventional_id],
         )
         assert res.status_code == 403, res.json()
-        assert res.json() == {
-            "description": "Cluster FR_Gas conventional is not allowed to be deleted\n"
-            "Cluster is referenced in the following binding constraints:"
-            "\n1- binding constraint\n",
-            "exception": "ClusterDeletionNotAllowed",
-        }
+        description = res.json()["description"]
+        assert all([elm in description for elm in [fr_gas_conventional, "binding constraint"]])
+        assert res.json()["exception"] == "ClusterDeletionNotAllowed"
 
         # delete the binding constraint
         res = client.delete(
@@ -1051,20 +1048,12 @@ class TestThermal:
             "remove_cluster",
         ]
 
-    def test_thermal_cluster_deletion(self, client: TestClient, user_access_token: str) -> None:
+    def test_thermal_cluster_deletion(self, client: TestClient, user_access_token: str, study_id: str) -> None:
         """
         Test that creating a thermal cluster with invalid properties raises a validation error.
         """
 
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
-
-        # Create a new study
-        res = client.post(
-            f"/v1/studies",
-            params={"name": "My Study"},
-        )
-        assert res.status_code in {200, 201}, res.json()
-        study_id = res.json()
 
         # Create an area "area_1" in the study
         res = client.post(

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -40,6 +40,7 @@ from starlette.testclient import TestClient
 from antarest.core.utils.string import to_camel_case
 from antarest.study.storage.rawstudy.model.filesystem.config.model import transform_name_to_id
 from antarest.study.storage.rawstudy.model.filesystem.config.thermal import ThermalProperties
+from antarest.study.storage.variantstudy.model.command.common import CommandName
 from tests.integration.utils import wait_task_completion
 
 DEFAULT_PROPERTIES = json.loads(ThermalProperties(name="Dummy").json())
@@ -1002,6 +1003,25 @@ class TestThermal:
         )
         assert res.status_code == 200
         assert res.json()["data"] == matrix
+
+        # # create a binding constraint for
+        # res = client.post(
+        #     f"/v1/studies/{variant_id}/commands",
+        #     headers={"Authorization": f"Bearer {user_access_token}"},
+        #     json=[
+        #         {
+        #             "action": CommandName.CREATE_BINDING_CONSTRAINT.value,
+        #             "args": {
+        #                 "name": "binding constraint 1",
+        #                 "enabled": True,
+        #                 "time_step": "hourly",
+        #                 "operator": "less",
+        #                 "coeffs": {f"{area_id}.{cluster_id}": [2.0, 4]},
+        #             },
+        #         }
+        #     ],
+        # )
+        # res.raise_for_status()
 
         # Delete the thermal cluster
         res = client.delete(

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -656,7 +656,7 @@ class TestThermal:
         assert res.status_code == 403, res.json()
         description = res.json()["description"]
         assert all([elm in description for elm in [fr_gas_conventional, "binding constraint"]])
-        assert res.json()["exception"] == "ClusterDeletionNotAllowed"
+        assert res.json()["exception"] == "BindingConstraintDeletionNotAllowed"
 
         # delete the binding constraint
         res = client.delete(

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -656,7 +656,7 @@ class TestThermal:
         assert res.status_code == 403, res.json()
         description = res.json()["description"]
         assert all([elm in description for elm in [fr_gas_conventional, "binding constraint"]])
-        assert res.json()["exception"] == "BindingConstraintDeletionNotAllowed"
+        assert res.json()["exception"] == "ReferencedObjectDeletionNotAllowed"
 
         # delete the binding constraint
         res = client.delete(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1434,7 +1434,7 @@ def test_area_management(client: TestClient, admin_access_token: str) -> None:
     description = result.json()["description"]
     assert all([elm in description for elm in ["area 1", "binding constraint 1"]])
     # check the exception
-    assert result.json()["exception"] == "BindingConstraintDeletionNotAllowed"
+    assert result.json()["exception"] == "ReferencedObjectDeletionNotAllowed"
 
     # delete binding constraint 1
     client.delete(f"/v1/studies/{study_id}/bindingconstraints/binding%20constraint%201")
@@ -1801,7 +1801,7 @@ def test_areas_deletion_with_binding_constraints(client: TestClient, user_access
             assert res.status_code == 403, res.json()
             description = res.json()["description"]
             assert all([elm in description for elm in [area_id, bc_id]])
-            assert res.json()["exception"] == "BindingConstraintDeletionNotAllowed"
+            assert res.json()["exception"] == "ReferencedObjectDeletionNotAllowed"
 
         # delete the binding constraint
         res = client.delete(f"/v1/studies/{study_id}/bindingconstraints/{bc_id}")
@@ -1872,7 +1872,7 @@ def test_links_deletion_with_binding_constraints(client: TestClient, user_access
     assert res.status_code == 403, res.json()
     description = res.json()["description"]
     assert all([elm in description for elm in ["area_1%area_2", "bc_1"]])
-    assert res.json()["exception"] == "BindingConstraintDeletionNotAllowed"
+    assert res.json()["exception"] == "ReferencedObjectDeletionNotAllowed"
 
     # delete the binding constraint
     res = client.delete(f"/v1/studies/{study_id}/bindingconstraints/bc_1")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1434,7 +1434,7 @@ def test_area_management(client: TestClient, admin_access_token: str) -> None:
     description = result.json()["description"]
     assert all([elm in description for elm in ["area 1", "binding constraint 1"]])
     # check the exception
-    assert result.json()["exception"] == "AreaDeletionNotAllowed"
+    assert result.json()["exception"] == "BindingConstraintDeletionNotAllowed"
 
     # delete binding constraint 1
     client.delete(f"/v1/studies/{study_id}/bindingconstraints/binding%20constraint%201")
@@ -1715,9 +1715,107 @@ def test_copy(client: TestClient, admin_access_token: str, study_id: str) -> Non
     assert res["public_mode"] == "READ"
 
 
-def test_links_deletion(client: TestClient, user_access_token: str, study_id: str) -> None:
+def test_areas_deletion_with_binding_constraints(client: TestClient, user_access_token: str, study_id: str) -> None:
     """
-    Test the deletion of links between areas.
+    Test the deletion of areas that are referenced in binding constraints.
+    """
+
+    # set client headers to user access token
+    client.headers = {"Authorization": f"Bearer {user_access_token}"}
+
+    area1_id = "france"
+    area2_id = "germany"
+    cluster_id = "nuclear power plant"
+
+    constraint_terms = [
+        {
+            # Link between two areas
+            "data": {"area1": area1_id, "area2": area2_id},
+            "id": f"{area1_id}%{area2_id}",
+            "offset": 2,
+            "weight": 1.0,
+        },
+        {
+            # Cluster in an area
+            "data": {"area": area1_id, "cluster": cluster_id.lower()},
+            "id": f"{area1_id}.{cluster_id.lower()}",
+            "offset": 2,
+            "weight": 1.0,
+        },
+    ]
+
+    for constraint_term in constraint_terms:
+        # Create an area "area_1" in the study
+        res = client.post(
+            f"/v1/studies/{study_id}/areas",
+            json={"name": area1_id.title(), "type": "AREA", "metadata": {"country": "FR"}},
+        )
+        res.raise_for_status()
+
+        if set(constraint_term["data"]) == {"area1", "area2"}:
+            # Create a second area and a link between the two areas
+            res = client.post(
+                f"/v1/studies/{study_id}/areas",
+                json={"name": area2_id.title(), "type": "AREA", "metadata": {"country": "DE"}},
+            )
+            res.raise_for_status()
+            res = client.post(
+                f"/v1/studies/{study_id}/links",
+                json={"area1": area1_id, "area2": area2_id},
+            )
+            res.raise_for_status()
+
+        elif set(constraint_term["data"]) == {"area", "cluster"}:
+            # Create a cluster in the first area
+            res = client.post(
+                f"/v1/studies/{study_id}/areas/{area1_id}/clusters/thermal",
+                json={"name": cluster_id.title(), "group": "Nuclear"},
+            )
+            res.raise_for_status()
+
+        else:
+            raise NotImplementedError(f"Unsupported constraint term: {constraint_term}")
+
+        # create a binding constraint that references the link
+        bc_id = "bc_1"
+        bc_obj = {
+            "name": bc_id,
+            "enabled": True,
+            "time_step": "daily",
+            "operator": "less",
+            "terms": [constraint_term],
+        }
+        res = client.post(f"/v1/studies/{study_id}/bindingconstraints", json=bc_obj)
+        res.raise_for_status()
+
+        if set(constraint_term["data"]) == {"area1", "area2"}:
+            areas_to_delete = [area1_id, area2_id]
+        elif set(constraint_term["data"]) == {"area", "cluster"}:
+            areas_to_delete = [area1_id]
+        else:
+            raise NotImplementedError(f"Unsupported constraint term: {constraint_term}")
+
+        for area_id in areas_to_delete:
+            # try to delete the areas
+            res = client.delete(f"/v1/studies/{study_id}/areas/{area_id}")
+            assert res.status_code == 403, res.json()
+            description = res.json()["description"]
+            assert all([elm in description for elm in [area_id, bc_id]])
+            assert res.json()["exception"] == "BindingConstraintDeletionNotAllowed"
+
+        # delete the binding constraint
+        res = client.delete(f"/v1/studies/{study_id}/bindingconstraints/{bc_id}")
+        assert res.status_code == 200, res.json()
+
+        for area_id in areas_to_delete:
+            # delete the area
+            res = client.delete(f"/v1/studies/{study_id}/areas/{area_id}")
+            assert res.status_code == 200, res.json()
+
+
+def test_links_deletion_with_binding_constraints(client: TestClient, user_access_token: str, study_id: str) -> None:
+    """
+    Test the deletion of links that are referenced in binding constraints.
     """
 
     # set client headers to user access token
@@ -1748,10 +1846,7 @@ def test_links_deletion(client: TestClient, user_access_token: str, study_id: st
     # create a link between the two areas
     res = client.post(
         f"/v1/studies/{study_id}/links",
-        json={
-            "area1": "area_1",
-            "area2": "area_2",
-        },
+        json={"area1": "area_1", "area2": "area_2"},
     )
     assert res.status_code == 200, res.json()
 
@@ -1769,10 +1864,7 @@ def test_links_deletion(client: TestClient, user_access_token: str, study_id: st
             }
         ],
     }
-    res = client.post(
-        f"/v1/studies/{study_id}/bindingconstraints",
-        json=bc_obj,
-    )
+    res = client.post(f"/v1/studies/{study_id}/bindingconstraints", json=bc_obj)
     assert res.status_code == 200, res.json()
 
     # try to delete the link before deleting the binding constraint
@@ -1780,7 +1872,7 @@ def test_links_deletion(client: TestClient, user_access_token: str, study_id: st
     assert res.status_code == 403, res.json()
     description = res.json()["description"]
     assert all([elm in description for elm in ["area_1%area_2", "bc_1"]])
-    assert res.json()["exception"] == "LinkDeletionNotAllowed"
+    assert res.json()["exception"] == "BindingConstraintDeletionNotAllowed"
 
     # delete the binding constraint
     res = client.delete(f"/v1/studies/{study_id}/bindingconstraints/bc_1")


### PR DESCRIPTION
context:
When an object is deleted while being referenced in a binding constraint, this may cause the study to become corrupt.

## Acceptance tests

List of endpoints affected by the changes and to be tested:

- PUT `/v1/studies/{uuid}/table-mode/binding-constraints`: Update binding constraints from Table Mode,
- PUT `/v1/studies/{uuid}/bindingconstraints/{binding_constraint_id}`: Update binding constraint,
- POST `/v1/studies/{uuid}/bindingconstraints`: Create a binding constraint,
- DELETE `/v1/studies/{uuid}/areas/{area_id}/clusters/thermal`: Remove thermal clusters for a given area,
- DELETE `/v1//studies/{uuid}/links/{area_from}/{area_to}`: Delete a link,
- DELETE `/v1/studies/{uuid}/areas/{area_id}`: Delete an area.