### PR TITLE
fix(table-mode): correct the update of the `average_spilled_energy_cost` field in table mode

### DIFF
--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -381,7 +381,7 @@ class AreaManager:
             if old_area.average_spilled_energy_cost != new_area.average_spilled_energy_cost:
                 commands.append(
                     UpdateConfig(
-                        target=f"input/thermal/areas/spilledenergycost:{area_id}",
+                        target=f"input/thermal/areas/spilledenergycost/{area_id}",
                         data=new_area.average_spilled_energy_cost,
                         command_context=command_context,
                     )

--- a/tests/integration/study_data_blueprint/test_table_mode.py
+++ b/tests/integration/study_data_blueprint/test_table_mode.py
@@ -25,7 +25,7 @@ class TestTableMode:
     def test_lifecycle__nominal(
         self, client: TestClient, user_access_token: str, study_id: str, study_version: int
     ) -> None:
-        user_headers = {"Authorization": f"Bearer {user_access_token}"}
+        client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
         # In order to test the table mode for renewable clusters and short-term storage,
         # it is required that the study is either in version 8.1 for renewable energies
@@ -36,7 +36,6 @@ class TestTableMode:
         if study_version:
             res = client.put(
                 f"/v1/studies/{study_id}/upgrade",
-                headers={"Authorization": f"Bearer {user_access_token}"},
                 params={"target_version": study_version},
             )
             assert res.status_code == 200, res.json()
@@ -53,10 +52,7 @@ class TestTableMode:
         # =================
 
         # Get the schema of the areas table
-        res = client.get(
-            "/v1/table-schema/areas",
-            headers=user_headers,
-        )
+        res = client.get("/v1/table-schema/areas")
         assert res.status_code == 200, res.json()
         actual = res.json()
         assert set(actual["properties"]) == {
@@ -88,7 +84,6 @@ class TestTableMode:
 
         res = client.put(
             f"/v1/studies/{study_id}/table-mode/areas",
-            headers=user_headers,
             json={
                 "de": _de_values,
                 "es": _es_values,
@@ -152,7 +147,7 @@ class TestTableMode:
         actual = res.json()
         assert actual == expected_areas
 
-        res = client.get(f"/v1/studies/{study_id}/table-mode/areas", headers=user_headers)
+        res = client.get(f"/v1/studies/{study_id}/table-mode/areas")
         assert res.status_code == 200, res.json()
         actual = res.json()
         assert actual == expected_areas
@@ -163,7 +158,6 @@ class TestTableMode:
         # Get the schema of the links table
         res = client.get(
             "/v1/table-schema/links",
-            headers=user_headers,
         )
         assert res.status_code == 200, res.json()
         actual = res.json()
@@ -184,7 +178,6 @@ class TestTableMode:
 
         res = client.put(
             f"/v1/studies/{study_id}/table-mode/links",
-            headers=user_headers,
             json={
                 "de / fr": {
                     "colorRgb": "#FFA500",
@@ -280,7 +273,7 @@ class TestTableMode:
         del expected_result["de / it"]
         assert actual == expected_result
 
-        res = client.get(f"/v1/studies/{study_id}/table-mode/links", headers=user_headers)
+        res = client.get(f"/v1/studies/{study_id}/table-mode/links")
         assert res.status_code == 200, res.json()
         actual = res.json()
         # asserts the `de / it` link is not removed.
@@ -292,7 +285,6 @@ class TestTableMode:
         # Get the schema of the thermals table
         res = client.get(
             "/v1/table-schema/thermals",
-            headers=user_headers,
         )
         assert res.status_code == 200, res.json()
         actual = res.json()
@@ -349,7 +341,6 @@ class TestTableMode:
 
         res = client.put(
             f"/v1/studies/{study_id}/table-mode/thermals",
-            headers=user_headers,
             json={
                 "de / 01_solar": _solar_values,
                 "de / 02_wind_on": _wind_on_values,
@@ -433,7 +424,6 @@ class TestTableMode:
 
         res = client.get(
             f"/v1/studies/{study_id}/table-mode/thermals",
-            headers=user_headers,
             params={"columns": ",".join(["group", "unitCount", "nominalCapacity", "so2"])},
         )
         assert res.status_code == 200, res.json()
@@ -497,7 +487,6 @@ class TestTableMode:
             }
             res = client.post(
                 f"/v1/studies/{study_id}/commands",
-                headers={"Authorization": f"Bearer {user_access_token}"},
                 json=[{"action": "update_config", "args": args}],
             )
             assert res.status_code == 200, res.json()
@@ -557,7 +546,6 @@ class TestTableMode:
                 for generator_id, generator in generators.items():
                     res = client.post(
                         f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
-                        headers=user_headers,
                         json=generator,
                     )
                     res.raise_for_status()
@@ -565,7 +553,6 @@ class TestTableMode:
             # Get the schema of the renewables table
             res = client.get(
                 "/v1/table-schema/renewables",
-                headers=user_headers,
             )
             assert res.status_code == 200, res.json()
             actual = res.json()
@@ -584,7 +571,6 @@ class TestTableMode:
             # Update some generators using the table mode
             res = client.put(
                 f"/v1/studies/{study_id}/table-mode/renewables",
-                headers=user_headers,
                 json={
                     "fr / Dieppe": {"enabled": False},
                     "fr / La Rochelle": {"enabled": True, "nominalCapacity": 3.1, "unitCount": 2},
@@ -595,7 +581,6 @@ class TestTableMode:
 
             res = client.get(
                 f"/v1/studies/{study_id}/table-mode/renewables",
-                headers=user_headers,
                 params={"columns": ",".join(["group", "enabled", "unitCount", "nominalCapacity"])},
             )
             assert res.status_code == 200, res.json()
@@ -618,7 +603,6 @@ class TestTableMode:
             # Get the schema of the short-term storages table
             res = client.get(
                 "/v1/table-schema/st-storages",
-                headers=user_headers,
             )
             assert res.status_code == 200, res.json()
             actual = res.json()
@@ -682,7 +666,6 @@ class TestTableMode:
                 for storage_id, storage in storages.items():
                     res = client.post(
                         f"/v1/studies/{study_id}/areas/{area_id}/storages",
-                        headers=user_headers,
                         json=storage,
                     )
                     res.raise_for_status()
@@ -696,7 +679,6 @@ class TestTableMode:
 
             res = client.put(
                 f"/v1/studies/{study_id}/table-mode/st-storages",
-                headers=user_headers,
                 json={
                     "fr / siemens": _fr_siemes_values,
                     "fr / tesla": _fr_tesla_values,
@@ -765,7 +747,6 @@ class TestTableMode:
 
             res = client.get(
                 f"/v1/studies/{study_id}/table-mode/st-storages",
-                headers=user_headers,
                 params={
                     "columns": ",".join(
                         [
@@ -816,7 +797,6 @@ class TestTableMode:
         fr_id = "fr"
         res = client.post(
             f"/v1/studies/{study_id}/areas/{fr_id}/clusters/thermal",
-            headers=user_headers,
             json={
                 "name": "Cluster 1",
                 "group": "Nuclear",
@@ -835,7 +815,6 @@ class TestTableMode:
                 "time_step": "hourly",
                 "operator": "less",
             },
-            headers=user_headers,
         )
         assert res.status_code == 200, res.json()
 
@@ -849,14 +828,12 @@ class TestTableMode:
                 "comments": "This is a binding constraint",
                 "filter_synthesis": "hourly, daily, weekly",
             },
-            headers=user_headers,
         )
         assert res.status_code == 200, res.json()
 
         # Get the schema of the binding constraints table
         res = client.get(
             "/v1/table-schema/binding-constraints",
-            headers=user_headers,
         )
         assert res.status_code == 200, res.json()
         actual = res.json()
@@ -884,7 +861,6 @@ class TestTableMode:
 
         res = client.put(
             f"/v1/studies/{study_id}/table-mode/binding-constraints",
-            headers=user_headers,
             json={
                 "binding constraint 1": _bc1_values,
                 "binding constraint 2": _bc2_values,
@@ -920,7 +896,6 @@ class TestTableMode:
 
         res = client.get(
             f"/v1/studies/{study_id}/table-mode/binding-constraints",
-            headers=user_headers,
             params={"columns": ""},
         )
         assert res.status_code == 200, res.json()
@@ -933,8 +908,8 @@ def test_table_type_aliases(client: TestClient, user_access_token: str) -> None:
     """
     Ensure that we can use the old table type aliases to get the schema of the tables.
     """
-    user_headers = {"Authorization": f"Bearer {user_access_token}"}
+    client.headers = {"Authorization": f"Bearer {user_access_token}"}
     # do not use `pytest.mark.parametrize`, because it is too slow
     for table_type in ["area", "link", "cluster", "renewable", "binding constraint"]:
-        res = client.get(f"/v1/table-schema/{table_type}", headers=user_headers)
+        res = client.get(f"/v1/table-schema/{table_type}")
         assert res.status_code == 200, f"Failed to get schema for {table_type}: {res.json()}"

--- a/tests/integration/study_data_blueprint/test_table_mode.py
+++ b/tests/integration/study_data_blueprint/test_table_mode.py
@@ -152,6 +152,20 @@ class TestTableMode:
         actual = res.json()
         assert actual == expected_areas
 
+        # Specific tests for averageSpilledEnergyCost and averageUnsuppliedEnergyCost
+        _de_values = {
+            "averageSpilledEnergyCost": 123,
+            "averageUnsuppliedEnergyCost": 456,
+        }
+        res = client.put(
+            f"/v1/studies/{study_id}/table-mode/areas",
+            json={"de": _de_values},
+        )
+        assert res.status_code == 200, res.json()
+        actual = res.json()["de"]
+        assert actual["averageSpilledEnergyCost"] == 123
+        assert actual["averageUnsuppliedEnergyCost"] == 456
+
         # Table Mode - Links
         # ==================
 


### PR DESCRIPTION
[ANT-1764](https://gopro-tickets.rte-france.com/browse/ANT-1764)

This PR corrects the problem of updating the `averageSpilledEnergyCost` field in the Table Mode editor and in the "CONFIGURATION" / "Economic Options" view.

Unit tests have been added to check that both the `averageSpilledEnergyCost` and `averageUnsuppliedEnergyCost` fields update correctly.