### PR TITLE
feat(outputs): remove useless folder `updated_links`

### DIFF
--- a/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
+++ b/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
@@ -285,7 +285,7 @@ class SlurmLauncher(AbstractLauncher):
         xpansion_mode: t.Optional[str] = None,
         log_dir: t.Optional[str] = None,
     ) -> t.Optional[str]:
-        if xpansion_mode is not None:
+        if xpansion_mode:
             self._import_xpansion_result(job_id, xpansion_mode)
 
         launcher_logs: t.Dict[str, t.List[Path]] = {}
@@ -331,14 +331,6 @@ class SlurmLauncher(AbstractLauncher):
                 )
                 output_path = unzipped_output_path
 
-            if (output_path / "updated_links").exists():
-                logger.warning("Skipping updated links")
-                self.callbacks.append_after_log(job_id, "Skipping updated links")
-            else:
-                shutil.copytree(
-                    self.local_workspace / STUDIES_OUTPUT_DIR_NAME / job_id / "input" / "links",
-                    output_path / "updated_links",
-                )
             if xpansion_mode == "r":
                 shutil.copytree(
                     self.local_workspace / STUDIES_OUTPUT_DIR_NAME / job_id / "user" / "expansion",

--- a/tests/launcher/test_slurm_launcher.py
+++ b/tests/launcher/test_slurm_launcher.py
@@ -1,6 +1,5 @@
 import os
 import random
-import shutil
 import textwrap
 import uuid
 from argparse import Namespace
@@ -400,13 +399,6 @@ def test_import_study_output(launcher_config, tmp_path) -> None:
     xpansion_test_file.write_text("world")
     output_dir = launcher_config.launcher.slurm.local_workspace / "OUTPUT" / "1" / "output" / "output_name"
     output_dir.mkdir(parents=True)
-    assert not (output_dir / "updated_links" / "something").exists()
-    assert not (output_dir / "updated_links" / "something").exists()
-
-    slurm_launcher._import_study_output("1", "cpp")
-    assert (output_dir / "updated_links" / "something").exists()
-    assert (output_dir / "updated_links" / "something").read_text() == "hello"
-    shutil.rmtree(output_dir / "updated_links")
 
     slurm_launcher._import_study_output("1", "r")
     assert (output_dir / "results" / "something_else").exists()


### PR DESCRIPTION
**Current situation:**
The folder `updated_links` is created at the root of each output folder. But it is useless (seen with Thomas Bittar).
Furthermore, due to a little code error, we always create it (`xpansion_mode` is now `""` and not `None`)
**So it's useless AND time consuming !!**

**After this PR:**
AntaresWeb never builds this folder.
