### PR TITLE
test: rename 'study_id' fixture to 'internal_study_id' to avoid confusion with `study_id` variable

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -120,7 +120,7 @@ def user_access_token_fixture(
     return t.cast(str, credentials["access_token"])
 
 
-@pytest.fixture(name="internal_study")
+@pytest.fixture(name="internal_study_id")
 def internal_study_fixture(
     client: TestClient,
     user_access_token: str,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -120,12 +120,12 @@ def user_access_token_fixture(
     return t.cast(str, credentials["access_token"])
 
 
-@pytest.fixture(name="study_id")
-def study_id_fixture(
+@pytest.fixture(name="internal_study")
+def internal_study_fixture(
     client: TestClient,
     user_access_token: str,
 ) -> str:
-    """Get the ID of the study stored in database"""
+    """Get the ID of the internal study which is scanned by the watcher"""
     res = client.get(
         "/v1/studies",
         headers={"Authorization": f"Bearer {user_access_token}"},

--- a/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
@@ -193,7 +193,7 @@ class TestRawDataAggregation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """
         Test the aggregation of areas data
@@ -202,7 +202,7 @@ class TestRawDataAggregation:
 
         for params, expected_result_filename in AREAS_REQUESTS:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{study_id}/areas/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study}/areas/aggregate/{output_id}", params=params)
             assert res.status_code == 200, res.json()
             content = io.BytesIO(res.content)
             df = pd.read_csv(content, index_col=0, sep=",")
@@ -222,7 +222,7 @@ class TestRawDataAggregation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """
         Test the aggregation of links data
@@ -231,7 +231,7 @@ class TestRawDataAggregation:
 
         for params, expected_result_filename in LINKS_REQUESTS:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{study_id}/links/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study}/links/aggregate/{output_id}", params=params)
             assert res.status_code == 200, res.json()
             content = io.BytesIO(res.content)
             df = pd.read_csv(content, index_col=0, sep=",")
@@ -251,7 +251,7 @@ class TestRawDataAggregation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """
         Tests that all formats work and produce the same result
@@ -260,7 +260,7 @@ class TestRawDataAggregation:
 
         for params, expected_result_filename in SAME_REQUEST_DIFFERENT_FORMATS:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{study_id}/links/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study}/links/aggregate/{output_id}", params=params)
             assert res.status_code == 200, res.json()
             content = io.BytesIO(res.content)
             export_format = params["format"]
@@ -282,31 +282,31 @@ class TestRawDataAggregation:
                 expected_df[col] = expected_df[col].astype(df[col].dtype)
             pd.testing.assert_frame_equal(df, expected_df)
 
-    def test_aggregation_with_incoherent_bodies(self, client: TestClient, user_access_token: str, study_id: str):
+    def test_aggregation_with_incoherent_bodies(self, client: TestClient, user_access_token: str, internal_study: str):
         """
         Asserts that requests with incoherent bodies don't crash but send empty dataframes
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
         for params in INCOHERENT_REQUESTS_BODIES:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{study_id}/links/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study}/links/aggregate/{output_id}", params=params)
             assert res.status_code == 200, res.json()
             content = io.BytesIO(res.content)
             df = pd.read_csv(content, index_col=0, sep=",")
             assert df.empty
 
-    def test_wrongly_typed_request(self, client: TestClient, user_access_token: str, study_id: str):
+    def test_wrongly_typed_request(self, client: TestClient, user_access_token: str, internal_study: str):
         """
         Asserts that wrongly typed requests send an HTTP 422 Exception
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
         for params in WRONGLY_TYPED_REQUESTS:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{study_id}/links/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study}/links/aggregate/{output_id}", params=params)
             assert res.status_code == 422
             assert res.json()["exception"] == "RequestValidationError"
 
-    def test_aggregation_with_wrong_output(self, client: TestClient, user_access_token: str, study_id: str):
+    def test_aggregation_with_wrong_output(self, client: TestClient, user_access_token: str, internal_study: str):
         """
         Asserts that requests with wrong output send an HTTP 422 Exception
         """
@@ -314,7 +314,7 @@ class TestRawDataAggregation:
 
         # test for areas
         res = client.get(
-            f"/v1/studies/{study_id}/areas/aggregate/unknown_id",
+            f"/v1/studies/{internal_study}/areas/aggregate/unknown_id",
             params={
                 "query_file": AreasQueryFile.VALUES,
                 "frequency": MatrixFrequency.HOURLY,
@@ -326,7 +326,7 @@ class TestRawDataAggregation:
 
         # test for links
         res = client.get(
-            f"/v1/studies/{study_id}/links/aggregate/unknown_id",
+            f"/v1/studies/{internal_study}/links/aggregate/unknown_id",
             params={
                 "query_file": LinksQueryFile.VALUES,
                 "frequency": MatrixFrequency.HOURLY,

--- a/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
@@ -193,7 +193,7 @@ class TestRawDataAggregation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """
         Test the aggregation of areas data
@@ -202,7 +202,7 @@ class TestRawDataAggregation:
 
         for params, expected_result_filename in AREAS_REQUESTS:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{internal_study}/areas/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study_id}/areas/aggregate/{output_id}", params=params)
             assert res.status_code == 200, res.json()
             content = io.BytesIO(res.content)
             df = pd.read_csv(content, index_col=0, sep=",")
@@ -222,7 +222,7 @@ class TestRawDataAggregation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """
         Test the aggregation of links data
@@ -231,7 +231,7 @@ class TestRawDataAggregation:
 
         for params, expected_result_filename in LINKS_REQUESTS:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{internal_study}/links/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/{output_id}", params=params)
             assert res.status_code == 200, res.json()
             content = io.BytesIO(res.content)
             df = pd.read_csv(content, index_col=0, sep=",")
@@ -251,7 +251,7 @@ class TestRawDataAggregation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """
         Tests that all formats work and produce the same result
@@ -260,7 +260,7 @@ class TestRawDataAggregation:
 
         for params, expected_result_filename in SAME_REQUEST_DIFFERENT_FORMATS:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{internal_study}/links/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/{output_id}", params=params)
             assert res.status_code == 200, res.json()
             content = io.BytesIO(res.content)
             export_format = params["format"]
@@ -282,31 +282,33 @@ class TestRawDataAggregation:
                 expected_df[col] = expected_df[col].astype(df[col].dtype)
             pd.testing.assert_frame_equal(df, expected_df)
 
-    def test_aggregation_with_incoherent_bodies(self, client: TestClient, user_access_token: str, internal_study: str):
+    def test_aggregation_with_incoherent_bodies(
+        self, client: TestClient, user_access_token: str, internal_study_id: str
+    ):
         """
         Asserts that requests with incoherent bodies don't crash but send empty dataframes
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
         for params in INCOHERENT_REQUESTS_BODIES:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{internal_study}/links/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/{output_id}", params=params)
             assert res.status_code == 200, res.json()
             content = io.BytesIO(res.content)
             df = pd.read_csv(content, index_col=0, sep=",")
             assert df.empty
 
-    def test_wrongly_typed_request(self, client: TestClient, user_access_token: str, internal_study: str):
+    def test_wrongly_typed_request(self, client: TestClient, user_access_token: str, internal_study_id: str):
         """
         Asserts that wrongly typed requests send an HTTP 422 Exception
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
         for params in WRONGLY_TYPED_REQUESTS:
             output_id = params.pop("output_id")
-            res = client.get(f"/v1/studies/{internal_study}/links/aggregate/{output_id}", params=params)
+            res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/{output_id}", params=params)
             assert res.status_code == 422
             assert res.json()["exception"] == "RequestValidationError"
 
-    def test_aggregation_with_wrong_output(self, client: TestClient, user_access_token: str, internal_study: str):
+    def test_aggregation_with_wrong_output(self, client: TestClient, user_access_token: str, internal_study_id: str):
         """
         Asserts that requests with wrong output send an HTTP 422 Exception
         """
@@ -314,7 +316,7 @@ class TestRawDataAggregation:
 
         # test for areas
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/aggregate/unknown_id",
+            f"/v1/studies/{internal_study_id}/areas/aggregate/unknown_id",
             params={
                 "query_file": AreasQueryFile.VALUES,
                 "frequency": MatrixFrequency.HOURLY,
@@ -326,7 +328,7 @@ class TestRawDataAggregation:
 
         # test for links
         res = client.get(
-            f"/v1/studies/{internal_study}/links/aggregate/unknown_id",
+            f"/v1/studies/{internal_study_id}/links/aggregate/unknown_id",
             params={
                 "query_file": LinksQueryFile.VALUES,
                 "frequency": MatrixFrequency.HOURLY,

--- a/tests/integration/raw_studies_blueprint/test_download_matrices.py
+++ b/tests/integration/raw_studies_blueprint/test_download_matrices.py
@@ -45,13 +45,13 @@ class PreparerProxy(Proxy):
         assert task.status == TaskStatus.COMPLETED
         return study_820_id
 
-    def upload_matrix(self, study_id: str, matrix_path: str, df: pd.DataFrame) -> None:
+    def upload_matrix(self, internal_study: str, matrix_path: str, df: pd.DataFrame) -> None:
         tsv = io.BytesIO()
         df.to_csv(tsv, sep="\t", index=False, header=False)
         tsv.seek(0)
         # noinspection SpellCheckingInspection
         res = self.client.put(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": matrix_path, "create_missing": True},
             headers=self.headers,
             files={"file": tsv, "create_missing": "true"},
@@ -92,9 +92,9 @@ class PreparerProxy(Proxy):
         area_id = res.json()["id"]
         return area_id
 
-    def update_general_data(self, study_id: str, **data: t.Any):
+    def update_general_data(self, internal_study: str, **data: t.Any):
         res = self.client.put(
-            f"/v1/studies/{study_id}/config/general/form",
+            f"/v1/studies/{internal_study}/config/general/form",
             json=data,
             headers=self.headers,
         )
@@ -107,7 +107,7 @@ class TestDownloadMatrices:
     Checks the retrieval of matrices with the endpoint GET studies/uuid/raw/download
     """
 
-    def test_download_matrices(self, client: TestClient, user_access_token: str, study_id: str) -> None:
+    def test_download_matrices(self, client: TestClient, user_access_token: str, internal_study: str) -> None:
         user_headers = {"Authorization": f"Bearer {user_access_token}"}
 
         # =====================
@@ -116,7 +116,7 @@ class TestDownloadMatrices:
 
         preparer = PreparerProxy(client, user_access_token)
 
-        study_820_id = preparer.copy_upgrade_study(study_id, target_version=820)
+        study_820_id = preparer.copy_upgrade_study(internal_study, target_version=820)
 
         # Create Variant
         variant_id = preparer.create_variant(study_820_id, name="New Variant")
@@ -131,7 +131,7 @@ class TestDownloadMatrices:
         preparer.generate_snapshot(variant_id)
 
         # Prepare a managed study to test specific matrices for version 8.6
-        study_860_id = preparer.copy_upgrade_study(study_id, target_version=860)
+        study_860_id = preparer.copy_upgrade_study(internal_study, target_version=860)
 
         # Import a Min Gen. matrix: shape=(8760, 3), with random integers between 0 and 1000
         generator = np.random.default_rng(11)
@@ -226,7 +226,7 @@ class TestDownloadMatrices:
 
         # tests links headers before v8.2
         res = client.get(
-            f"/v1/studies/{study_id}/raw/download",
+            f"/v1/studies/{internal_study}/raw/download",
             params={"path": "input/links/de/fr", "format": "tsv", "index": False},
             headers=user_headers,
         )
@@ -275,7 +275,7 @@ class TestDownloadMatrices:
 
         # test for empty matrix
         res = client.get(
-            f"/v1/studies/{study_id}/raw/download",
+            f"/v1/studies/{internal_study}/raw/download",
             params={"path": "input/hydro/common/capacity/waterValues_de", "format": "tsv"},
             headers=user_headers,
         )
@@ -305,7 +305,7 @@ class TestDownloadMatrices:
 
         # asserts endpoint returns the right columns for output matrix
         res = client.get(
-            f"/v1/studies/{study_id}/raw/download",
+            f"/v1/studies/{internal_study}/raw/download",
             params={
                 "path": "output/20201014-1422eco-hello/economy/mc-ind/00001/links/de/fr/values-hourly",
                 "format": "tsv",
@@ -331,7 +331,7 @@ class TestDownloadMatrices:
 
         # test energy matrix to test the regex
         res = client.get(
-            f"/v1/studies/{study_id}/raw/download",
+            f"/v1/studies/{internal_study}/raw/download",
             params={"path": "input/hydro/prepro/de/energy", "format": "tsv"},
             headers=user_headers,
         )

--- a/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
@@ -25,7 +25,7 @@ class TestFetchRawData:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """
         Test the `get_study` endpoint for fetching raw data from a study.
@@ -42,7 +42,7 @@ class TestFetchRawData:
         """
         # First copy the user resources in the Study directory
         with db():
-            study: RawStudy = db.session.get(Study, study_id)
+            study: RawStudy = db.session.get(Study, internal_study)
             study_dir = pathlib.Path(study.path)
         headers = {"Authorization": f"Bearer {user_access_token}"}
 
@@ -57,7 +57,7 @@ class TestFetchRawData:
         for file_path in user_folder_dir.glob("*.*"):
             rel_path = file_path.relative_to(study_dir).as_posix()
             res = client.get(
-                f"/v1/studies/{study_id}/raw",
+                f"/v1/studies/{internal_study}/raw",
                 params={"path": rel_path, "depth": 1},
                 headers=headers,
             )
@@ -83,7 +83,7 @@ class TestFetchRawData:
         for file_path in user_folder_dir.glob("*.*"):
             rel_path = file_path.relative_to(study_dir)
             res = client.get(
-                f"/v1/studies/{study_id}/raw",
+                f"/v1/studies/{internal_study}/raw",
                 params={"path": f"/{rel_path.as_posix()}", "depth": 1},
                 headers=headers,
             )
@@ -94,7 +94,7 @@ class TestFetchRawData:
 
         # If you try to retrieve a file that doesn't exist, we should have a 404 error
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": "user/somewhere/something.txt"},
             headers=headers,
         )
@@ -107,7 +107,7 @@ class TestFetchRawData:
         # If you want to update an existing resource, you can use PUT method.
         # But, if the resource doesn't exist, you should have a 404 Not Found error.
         res = client.put(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": "user/somewhere/something.txt"},
             headers=headers,
             files={"file": io.BytesIO(b"Goodbye World!")},
@@ -121,7 +121,7 @@ class TestFetchRawData:
         # To create a resource, you can use PUT method and the `create_missing` flag.
         # The expected status code should be 204 No Content.
         res = client.put(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": "user/somewhere/something.txt", "create_missing": True},
             headers=headers,
             files={"file": io.BytesIO(b"Goodbye Cruel World!")},
@@ -131,7 +131,7 @@ class TestFetchRawData:
         # To update a resource, you can use PUT method, with or without the `create_missing` flag.
         # The expected status code should be 204 No Content.
         res = client.put(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": "user/somewhere/something.txt", "create_missing": True},
             headers=headers,
             files={"file": io.BytesIO(b"This is the end!")},
@@ -140,7 +140,7 @@ class TestFetchRawData:
 
         # You can check that the resource has been created or updated.
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": "user/somewhere/something.txt"},
             headers=headers,
         )
@@ -150,7 +150,7 @@ class TestFetchRawData:
         # If we ask for properties, we should have a JSON content
         rel_path = "/input/links/de/properties/fr"
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": rel_path, "depth": 2},
             headers=headers,
         )
@@ -175,7 +175,7 @@ class TestFetchRawData:
         # If we ask for a matrix, we should have a JSON content if formatted is True
         rel_path = "/input/links/de/fr"
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": rel_path, "formatted": True},
             headers=headers,
         )
@@ -186,7 +186,7 @@ class TestFetchRawData:
         # If we ask for a matrix, we should have a CSV content if formatted is False
         rel_path = "/input/links/de/fr"
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": rel_path, "formatted": False},
             headers=headers,
         )
@@ -198,7 +198,7 @@ class TestFetchRawData:
 
         # If ask for an empty matrix, we should have an empty binary content
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": "input/thermal/prepro/de/01_solar/data", "formatted": False},
             headers=headers,
         )
@@ -207,7 +207,7 @@ class TestFetchRawData:
 
         # But, if we use formatted = True, we should have a JSON objet representing and empty matrix
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": "input/thermal/prepro/de/01_solar/data", "formatted": True},
             headers=headers,
         )
@@ -219,7 +219,7 @@ class TestFetchRawData:
         for file_path in user_folder_dir.glob("*.*"):
             rel_path = file_path.relative_to(study_dir)
             res = client.get(
-                f"/v1/studies/{study_id}/raw",
+                f"/v1/studies/{internal_study}/raw",
                 params={"path": f"/{rel_path.as_posix()}", "depth": 1},
                 headers=headers,
             )
@@ -228,7 +228,7 @@ class TestFetchRawData:
         # We can access to the configuration the classic way,
         # for instance, we can get the list of areas:
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": "/input/areas/list", "depth": 1},
             headers=headers,
         )
@@ -237,7 +237,7 @@ class TestFetchRawData:
 
         # asserts that the GET /raw endpoint is able to read matrix containing NaN values
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": "output/20201014-1427eco/economy/mc-all/areas/de/id-monthly"},
             headers=headers,
         )
@@ -247,7 +247,7 @@ class TestFetchRawData:
         # Iterate over all possible combinations of path and depth
         for path, depth in itertools.product([None, "", "/"], [0, 1, 2]):
             res = client.get(
-                f"/v1/studies/{study_id}/raw",
+                f"/v1/studies/{internal_study}/raw",
                 params={"path": path, "depth": depth},
                 headers=headers,
             )

--- a/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
@@ -25,7 +25,7 @@ class TestFetchRawData:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """
         Test the `get_study` endpoint for fetching raw data from a study.
@@ -42,7 +42,7 @@ class TestFetchRawData:
         """
         # First copy the user resources in the Study directory
         with db():
-            study: RawStudy = db.session.get(Study, internal_study)
+            study: RawStudy = db.session.get(Study, internal_study_id)
             study_dir = pathlib.Path(study.path)
         headers = {"Authorization": f"Bearer {user_access_token}"}
 
@@ -57,7 +57,7 @@ class TestFetchRawData:
         for file_path in user_folder_dir.glob("*.*"):
             rel_path = file_path.relative_to(study_dir).as_posix()
             res = client.get(
-                f"/v1/studies/{internal_study}/raw",
+                f"/v1/studies/{internal_study_id}/raw",
                 params={"path": rel_path, "depth": 1},
                 headers=headers,
             )
@@ -83,7 +83,7 @@ class TestFetchRawData:
         for file_path in user_folder_dir.glob("*.*"):
             rel_path = file_path.relative_to(study_dir)
             res = client.get(
-                f"/v1/studies/{internal_study}/raw",
+                f"/v1/studies/{internal_study_id}/raw",
                 params={"path": f"/{rel_path.as_posix()}", "depth": 1},
                 headers=headers,
             )
@@ -94,7 +94,7 @@ class TestFetchRawData:
 
         # If you try to retrieve a file that doesn't exist, we should have a 404 error
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": "user/somewhere/something.txt"},
             headers=headers,
         )
@@ -107,7 +107,7 @@ class TestFetchRawData:
         # If you want to update an existing resource, you can use PUT method.
         # But, if the resource doesn't exist, you should have a 404 Not Found error.
         res = client.put(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": "user/somewhere/something.txt"},
             headers=headers,
             files={"file": io.BytesIO(b"Goodbye World!")},
@@ -121,7 +121,7 @@ class TestFetchRawData:
         # To create a resource, you can use PUT method and the `create_missing` flag.
         # The expected status code should be 204 No Content.
         res = client.put(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": "user/somewhere/something.txt", "create_missing": True},
             headers=headers,
             files={"file": io.BytesIO(b"Goodbye Cruel World!")},
@@ -131,7 +131,7 @@ class TestFetchRawData:
         # To update a resource, you can use PUT method, with or without the `create_missing` flag.
         # The expected status code should be 204 No Content.
         res = client.put(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": "user/somewhere/something.txt", "create_missing": True},
             headers=headers,
             files={"file": io.BytesIO(b"This is the end!")},
@@ -140,7 +140,7 @@ class TestFetchRawData:
 
         # You can check that the resource has been created or updated.
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": "user/somewhere/something.txt"},
             headers=headers,
         )
@@ -150,7 +150,7 @@ class TestFetchRawData:
         # If we ask for properties, we should have a JSON content
         rel_path = "/input/links/de/properties/fr"
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": rel_path, "depth": 2},
             headers=headers,
         )
@@ -175,7 +175,7 @@ class TestFetchRawData:
         # If we ask for a matrix, we should have a JSON content if formatted is True
         rel_path = "/input/links/de/fr"
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": rel_path, "formatted": True},
             headers=headers,
         )
@@ -186,7 +186,7 @@ class TestFetchRawData:
         # If we ask for a matrix, we should have a CSV content if formatted is False
         rel_path = "/input/links/de/fr"
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": rel_path, "formatted": False},
             headers=headers,
         )
@@ -198,7 +198,7 @@ class TestFetchRawData:
 
         # If ask for an empty matrix, we should have an empty binary content
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": "input/thermal/prepro/de/01_solar/data", "formatted": False},
             headers=headers,
         )
@@ -207,7 +207,7 @@ class TestFetchRawData:
 
         # But, if we use formatted = True, we should have a JSON objet representing and empty matrix
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": "input/thermal/prepro/de/01_solar/data", "formatted": True},
             headers=headers,
         )
@@ -219,7 +219,7 @@ class TestFetchRawData:
         for file_path in user_folder_dir.glob("*.*"):
             rel_path = file_path.relative_to(study_dir)
             res = client.get(
-                f"/v1/studies/{internal_study}/raw",
+                f"/v1/studies/{internal_study_id}/raw",
                 params={"path": f"/{rel_path.as_posix()}", "depth": 1},
                 headers=headers,
             )
@@ -228,7 +228,7 @@ class TestFetchRawData:
         # We can access to the configuration the classic way,
         # for instance, we can get the list of areas:
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": "/input/areas/list", "depth": 1},
             headers=headers,
         )
@@ -237,7 +237,7 @@ class TestFetchRawData:
 
         # asserts that the GET /raw endpoint is able to read matrix containing NaN values
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": "output/20201014-1427eco/economy/mc-all/areas/de/id-monthly"},
             headers=headers,
         )
@@ -247,7 +247,7 @@ class TestFetchRawData:
         # Iterate over all possible combinations of path and depth
         for path, depth in itertools.product([None, "", "/"], [0, 1, 2]):
             res = client.get(
-                f"/v1/studies/{internal_study}/raw",
+                f"/v1/studies/{internal_study_id}/raw",
                 params={"path": path, "depth": depth},
                 headers=headers,
             )

--- a/tests/integration/studies_blueprint/test_comments.py
+++ b/tests/integration/studies_blueprint/test_comments.py
@@ -20,7 +20,7 @@ class TestStudyComments:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         """
         This test verifies that we can retrieve and modify the comments of a study.
@@ -29,7 +29,7 @@ class TestStudyComments:
 
         # Get the comments of the study and compare with the expected file
         res = client.get(
-            f"/v1/studies/{study_id}/comments",
+            f"/v1/studies/{internal_study}/comments",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -41,7 +41,7 @@ class TestStudyComments:
         # Ensure the duration is relatively short
         start = time.time()
         res = client.get(
-            f"/v1/studies/{study_id}/comments",
+            f"/v1/studies/{internal_study}/comments",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -50,7 +50,7 @@ class TestStudyComments:
 
         # Update the comments of the study
         res = client.put(
-            f"/v1/studies/{study_id}/comments",
+            f"/v1/studies/{internal_study}/comments",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"comments": "<text>Ceci est un commentaire en français.</text>"},
         )
@@ -58,7 +58,7 @@ class TestStudyComments:
 
         # Get the comments of the study and compare with the expected file
         res = client.get(
-            f"/v1/studies/{study_id}/comments",
+            f"/v1/studies/{internal_study}/comments",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -68,7 +68,7 @@ class TestStudyComments:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         """
         This test verifies that we can retrieve and modify the comments of a VARIANT study.
@@ -76,7 +76,7 @@ class TestStudyComments:
         """
         # First, we create a copy of the study, and we convert it to a managed study.
         res = client.post(
-            f"/v1/studies/{study_id}/copy",
+            f"/v1/studies/{internal_study}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "default", "with_outputs": False, "use_task": False},  # type: ignore
         )

--- a/tests/integration/studies_blueprint/test_comments.py
+++ b/tests/integration/studies_blueprint/test_comments.py
@@ -20,7 +20,7 @@ class TestStudyComments:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         """
         This test verifies that we can retrieve and modify the comments of a study.
@@ -29,7 +29,7 @@ class TestStudyComments:
 
         # Get the comments of the study and compare with the expected file
         res = client.get(
-            f"/v1/studies/{internal_study}/comments",
+            f"/v1/studies/{internal_study_id}/comments",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -41,7 +41,7 @@ class TestStudyComments:
         # Ensure the duration is relatively short
         start = time.time()
         res = client.get(
-            f"/v1/studies/{internal_study}/comments",
+            f"/v1/studies/{internal_study_id}/comments",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -50,7 +50,7 @@ class TestStudyComments:
 
         # Update the comments of the study
         res = client.put(
-            f"/v1/studies/{internal_study}/comments",
+            f"/v1/studies/{internal_study_id}/comments",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"comments": "<text>Ceci est un commentaire en français.</text>"},
         )
@@ -58,7 +58,7 @@ class TestStudyComments:
 
         # Get the comments of the study and compare with the expected file
         res = client.get(
-            f"/v1/studies/{internal_study}/comments",
+            f"/v1/studies/{internal_study_id}/comments",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -68,7 +68,7 @@ class TestStudyComments:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         """
         This test verifies that we can retrieve and modify the comments of a VARIANT study.
@@ -76,7 +76,7 @@ class TestStudyComments:
         """
         # First, we create a copy of the study, and we convert it to a managed study.
         res = client.post(
-            f"/v1/studies/{internal_study}/copy",
+            f"/v1/studies/{internal_study_id}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "default", "with_outputs": False, "use_task": False},  # type: ignore
         )

--- a/tests/integration/studies_blueprint/test_disk_usage.py
+++ b/tests/integration/studies_blueprint/test_disk_usage.py
@@ -10,7 +10,7 @@ class TestDiskUsage:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
         tmp_path: Path,
     ) -> None:
         """
@@ -23,7 +23,7 @@ class TestDiskUsage:
 
         user_headers = {"Authorization": f"Bearer {user_access_token}"}
         res = client.get(
-            f"/v1/studies/{study_id}/disk-usage",
+            f"/v1/studies/{internal_study}/disk-usage",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -32,7 +32,7 @@ class TestDiskUsage:
 
         # Copy the study in managed workspace in order to create a variant
         res = client.post(
-            f"/v1/studies/{study_id}/copy",
+            f"/v1/studies/{internal_study}/copy",
             headers=user_headers,
             params={"dest": "somewhere", "use_task": "false"},
         )

--- a/tests/integration/studies_blueprint/test_disk_usage.py
+++ b/tests/integration/studies_blueprint/test_disk_usage.py
@@ -10,7 +10,7 @@ class TestDiskUsage:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
         tmp_path: Path,
     ) -> None:
         """
@@ -23,7 +23,7 @@ class TestDiskUsage:
 
         user_headers = {"Authorization": f"Bearer {user_access_token}"}
         res = client.get(
-            f"/v1/studies/{internal_study}/disk-usage",
+            f"/v1/studies/{internal_study_id}/disk-usage",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -32,7 +32,7 @@ class TestDiskUsage:
 
         # Copy the study in managed workspace in order to create a variant
         res = client.post(
-            f"/v1/studies/{internal_study}/copy",
+            f"/v1/studies/{internal_study_id}/copy",
             headers=user_headers,
             params={"dest": "somewhere", "use_task": "false"},
         )

--- a/tests/integration/studies_blueprint/test_study_matrix_index.py
+++ b/tests/integration/studies_blueprint/test_study_matrix_index.py
@@ -14,7 +14,7 @@ class TestStudyMatrixIndex:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         user_access_token = {"Authorization": f"Bearer {user_access_token}"}
 
@@ -23,7 +23,7 @@ class TestStudyMatrixIndex:
 
         # Check the Common matrix index
         res = client.get(
-            f"/v1/studies/{study_id}/matrixindex",
+            f"/v1/studies/{internal_study}/matrixindex",
             headers=user_access_token,
             params={"path": "input/thermal/prepro/fr/01_solar/modulation"},
         )
@@ -40,7 +40,7 @@ class TestStudyMatrixIndex:
 
         # Check the TS Generator matrix index
         res = client.get(
-            f"/v1/studies/{study_id}/matrixindex",
+            f"/v1/studies/{internal_study}/matrixindex",
             headers=user_access_token,
             params={"path": "input/thermal/prepro/fr/01_solar/data"},
         )
@@ -57,7 +57,7 @@ class TestStudyMatrixIndex:
 
         # Check the time series
         res = client.get(
-            f"/v1/studies/{study_id}/matrixindex",
+            f"/v1/studies/{internal_study}/matrixindex",
             headers=user_access_token,
             params={"path": "input/thermal/series/fr/01_solar/series"},
         )
@@ -75,7 +75,7 @@ class TestStudyMatrixIndex:
         # Check the default matrix index
         # ==============================
 
-        res = client.get(f"/v1/studies/{study_id}/matrixindex", headers=user_access_token)
+        res = client.get(f"/v1/studies/{internal_study}/matrixindex", headers=user_access_token)
         assert res.status_code == 200
         actual = res.json()
         expected = {
@@ -90,7 +90,7 @@ class TestStudyMatrixIndex:
         # =========================================================================
 
         res = client.get(
-            f"/v1/studies/{study_id}/matrixindex",
+            f"/v1/studies/{internal_study}/matrixindex",
             headers=user_access_token,
             params={"path": "output/20201014-1427eco/economy/mc-all/areas/es/details-daily"},
         )

--- a/tests/integration/studies_blueprint/test_study_matrix_index.py
+++ b/tests/integration/studies_blueprint/test_study_matrix_index.py
@@ -14,7 +14,7 @@ class TestStudyMatrixIndex:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         user_access_token = {"Authorization": f"Bearer {user_access_token}"}
 
@@ -23,7 +23,7 @@ class TestStudyMatrixIndex:
 
         # Check the Common matrix index
         res = client.get(
-            f"/v1/studies/{internal_study}/matrixindex",
+            f"/v1/studies/{internal_study_id}/matrixindex",
             headers=user_access_token,
             params={"path": "input/thermal/prepro/fr/01_solar/modulation"},
         )
@@ -40,7 +40,7 @@ class TestStudyMatrixIndex:
 
         # Check the TS Generator matrix index
         res = client.get(
-            f"/v1/studies/{internal_study}/matrixindex",
+            f"/v1/studies/{internal_study_id}/matrixindex",
             headers=user_access_token,
             params={"path": "input/thermal/prepro/fr/01_solar/data"},
         )
@@ -57,7 +57,7 @@ class TestStudyMatrixIndex:
 
         # Check the time series
         res = client.get(
-            f"/v1/studies/{internal_study}/matrixindex",
+            f"/v1/studies/{internal_study_id}/matrixindex",
             headers=user_access_token,
             params={"path": "input/thermal/series/fr/01_solar/series"},
         )
@@ -75,7 +75,7 @@ class TestStudyMatrixIndex:
         # Check the default matrix index
         # ==============================
 
-        res = client.get(f"/v1/studies/{internal_study}/matrixindex", headers=user_access_token)
+        res = client.get(f"/v1/studies/{internal_study_id}/matrixindex", headers=user_access_token)
         assert res.status_code == 200
         actual = res.json()
         expected = {
@@ -90,7 +90,7 @@ class TestStudyMatrixIndex:
         # =========================================================================
 
         res = client.get(
-            f"/v1/studies/{internal_study}/matrixindex",
+            f"/v1/studies/{internal_study_id}/matrixindex",
             headers=user_access_token,
             params={"path": "output/20201014-1427eco/economy/mc-all/areas/es/details-daily"},
         )

--- a/tests/integration/studies_blueprint/test_synthesis.py
+++ b/tests/integration/studies_blueprint/test_synthesis.py
@@ -33,7 +33,7 @@ class TestStudySynthesis:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         """
         This test verifies that we can retrieve the synthesis of a study.
@@ -42,7 +42,7 @@ class TestStudySynthesis:
 
         # Get the synthesis of the study and compare with the expected file
         res = client.get(
-            f"/v1/studies/{study_id}/synthesis",
+            f"/v1/studies/{internal_study}/synthesis",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -53,7 +53,7 @@ class TestStudySynthesis:
         # Ensure the duration is relatively short
         start = time.time()
         res = client.get(
-            f"/v1/studies/{study_id}/synthesis",
+            f"/v1/studies/{internal_study}/synthesis",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -64,7 +64,7 @@ class TestStudySynthesis:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         """
         This test verifies that we can retrieve and modify the synthesis of a VARIANT study.
@@ -72,7 +72,7 @@ class TestStudySynthesis:
         """
         # First, we create a copy of the study, and we convert it to a managed study.
         res = client.post(
-            f"/v1/studies/{study_id}/copy",
+            f"/v1/studies/{internal_study}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "default", "with_outputs": False, "use_task": False},  # type: ignore
         )

--- a/tests/integration/studies_blueprint/test_synthesis.py
+++ b/tests/integration/studies_blueprint/test_synthesis.py
@@ -33,7 +33,7 @@ class TestStudySynthesis:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         """
         This test verifies that we can retrieve the synthesis of a study.
@@ -42,7 +42,7 @@ class TestStudySynthesis:
 
         # Get the synthesis of the study and compare with the expected file
         res = client.get(
-            f"/v1/studies/{internal_study}/synthesis",
+            f"/v1/studies/{internal_study_id}/synthesis",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -53,7 +53,7 @@ class TestStudySynthesis:
         # Ensure the duration is relatively short
         start = time.time()
         res = client.get(
-            f"/v1/studies/{internal_study}/synthesis",
+            f"/v1/studies/{internal_study_id}/synthesis",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -64,7 +64,7 @@ class TestStudySynthesis:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         """
         This test verifies that we can retrieve and modify the synthesis of a VARIANT study.
@@ -72,7 +72,7 @@ class TestStudySynthesis:
         """
         # First, we create a copy of the study, and we convert it to a managed study.
         res = client.post(
-            f"/v1/studies/{internal_study}/copy",
+            f"/v1/studies/{internal_study_id}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "default", "with_outputs": False, "use_task": False},  # type: ignore
         )

--- a/tests/integration/studies_blueprint/test_update_tags.py
+++ b/tests/integration/studies_blueprint/test_update_tags.py
@@ -10,7 +10,7 @@ class TestupdateStudyMetadata:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         """
         This test verifies that we can update the tags of a study.
@@ -20,7 +20,7 @@ class TestupdateStudyMetadata:
         # Classic usage: set some tags to a study
         study_tags = ["Tag1", "Tag2"]
         res = client.put(
-            f"/v1/studies/{internal_study}",
+            f"/v1/studies/{internal_study_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -33,7 +33,7 @@ class TestupdateStudyMetadata:
         # - "Tag2" is replaced by "Tag3".
         study_tags = ["tag1", "Tag3"]
         res = client.put(
-            f"/v1/studies/{internal_study}",
+            f"/v1/studies/{internal_study_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -46,7 +46,7 @@ class TestupdateStudyMetadata:
         # consecutive whitespaces are replaced by a single one.
         study_tags = [" \xa0Foo  \t  Bar  \n  ", "  \t  Baz\xa0\xa0"]
         res = client.put(
-            f"/v1/studies/{internal_study}",
+            f"/v1/studies/{internal_study_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -57,7 +57,7 @@ class TestupdateStudyMetadata:
         # We can have symbols in the tags
         study_tags = ["Foo-Bar", ":Baz%"]
         res = client.put(
-            f"/v1/studies/{internal_study}",
+            f"/v1/studies/{internal_study_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -69,12 +69,12 @@ class TestupdateStudyMetadata:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         # We cannot have empty tags
         study_tags = [""]
         res = client.put(
-            f"/v1/studies/{internal_study}",
+            f"/v1/studies/{internal_study_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -86,7 +86,7 @@ class TestupdateStudyMetadata:
         study_tags = ["very long tags, very long tags, very long tags"]
         assert len(study_tags[0]) > 40
         res = client.put(
-            f"/v1/studies/{internal_study}",
+            f"/v1/studies/{internal_study_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )

--- a/tests/integration/studies_blueprint/test_update_tags.py
+++ b/tests/integration/studies_blueprint/test_update_tags.py
@@ -10,7 +10,7 @@ class TestupdateStudyMetadata:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         """
         This test verifies that we can update the tags of a study.
@@ -20,7 +20,7 @@ class TestupdateStudyMetadata:
         # Classic usage: set some tags to a study
         study_tags = ["Tag1", "Tag2"]
         res = client.put(
-            f"/v1/studies/{study_id}",
+            f"/v1/studies/{internal_study}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -33,7 +33,7 @@ class TestupdateStudyMetadata:
         # - "Tag2" is replaced by "Tag3".
         study_tags = ["tag1", "Tag3"]
         res = client.put(
-            f"/v1/studies/{study_id}",
+            f"/v1/studies/{internal_study}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -46,7 +46,7 @@ class TestupdateStudyMetadata:
         # consecutive whitespaces are replaced by a single one.
         study_tags = [" \xa0Foo  \t  Bar  \n  ", "  \t  Baz\xa0\xa0"]
         res = client.put(
-            f"/v1/studies/{study_id}",
+            f"/v1/studies/{internal_study}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -57,7 +57,7 @@ class TestupdateStudyMetadata:
         # We can have symbols in the tags
         study_tags = ["Foo-Bar", ":Baz%"]
         res = client.put(
-            f"/v1/studies/{study_id}",
+            f"/v1/studies/{internal_study}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -69,12 +69,12 @@ class TestupdateStudyMetadata:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         # We cannot have empty tags
         study_tags = [""]
         res = client.put(
-            f"/v1/studies/{study_id}",
+            f"/v1/studies/{internal_study}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )
@@ -86,7 +86,7 @@ class TestupdateStudyMetadata:
         study_tags = ["very long tags, very long tags, very long tags"]
         assert len(study_tags[0]) > 40
         res = client.put(
-            f"/v1/studies/{study_id}",
+            f"/v1/studies/{internal_study}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"tags": study_tags},
         )

--- a/tests/integration/study_data_blueprint/test_advanced_parameters.py
+++ b/tests/integration/study_data_blueprint/test_advanced_parameters.py
@@ -19,11 +19,11 @@ class TestAdvancedParametersForm:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """Check `get_advanced_parameters_form_values` end point"""
         res = client.get(
-            f"/v1/studies/{internal_study}/config/advancedparameters/form",
+            f"/v1/studies/{internal_study_id}/config/advancedparameters/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -55,12 +55,12 @@ class TestAdvancedParametersForm:
 
     @pytest.mark.parametrize("study_version", [0, 880])
     def test_set_advanced_parameters_values(
-        self, client: TestClient, user_access_token: str, internal_study: str, study_version: int
+        self, client: TestClient, user_access_token: str, internal_study_id: str, study_version: int
     ):
         """Check `set_advanced_parameters_values` end point"""
         obj = {"initialReservoirLevels": "hot start"}
         res = client.put(
-            f"/v1/studies/{internal_study}/config/advancedparameters/form",
+            f"/v1/studies/{internal_study_id}/config/advancedparameters/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )
@@ -70,7 +70,7 @@ class TestAdvancedParametersForm:
 
         if study_version:
             res = client.put(
-                f"/v1/studies/{internal_study}/upgrade",
+                f"/v1/studies/{internal_study_id}/upgrade",
                 headers={"Authorization": f"Bearer {user_access_token}"},
                 params={"target_version": study_version},
             )
@@ -82,7 +82,7 @@ class TestAdvancedParametersForm:
 
         obj = {"unitCommitmentMode": "milp"}
         res = client.put(
-            f"/v1/studies/{internal_study}/config/advancedparameters/form",
+            f"/v1/studies/{internal_study_id}/config/advancedparameters/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )

--- a/tests/integration/study_data_blueprint/test_advanced_parameters.py
+++ b/tests/integration/study_data_blueprint/test_advanced_parameters.py
@@ -19,11 +19,11 @@ class TestAdvancedParametersForm:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """Check `get_advanced_parameters_form_values` end point"""
         res = client.get(
-            f"/v1/studies/{study_id}/config/advancedparameters/form",
+            f"/v1/studies/{internal_study}/config/advancedparameters/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -55,12 +55,12 @@ class TestAdvancedParametersForm:
 
     @pytest.mark.parametrize("study_version", [0, 880])
     def test_set_advanced_parameters_values(
-        self, client: TestClient, user_access_token: str, study_id: str, study_version: int
+        self, client: TestClient, user_access_token: str, internal_study: str, study_version: int
     ):
         """Check `set_advanced_parameters_values` end point"""
         obj = {"initialReservoirLevels": "hot start"}
         res = client.put(
-            f"/v1/studies/{study_id}/config/advancedparameters/form",
+            f"/v1/studies/{internal_study}/config/advancedparameters/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )
@@ -70,7 +70,7 @@ class TestAdvancedParametersForm:
 
         if study_version:
             res = client.put(
-                f"/v1/studies/{study_id}/upgrade",
+                f"/v1/studies/{internal_study}/upgrade",
                 headers={"Authorization": f"Bearer {user_access_token}"},
                 params={"target_version": study_version},
             )
@@ -82,7 +82,7 @@ class TestAdvancedParametersForm:
 
         obj = {"unitCommitmentMode": "milp"}
         res = client.put(
-            f"/v1/studies/{study_id}/config/advancedparameters/form",
+            f"/v1/studies/{internal_study}/config/advancedparameters/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )

--- a/tests/integration/study_data_blueprint/test_config_general.py
+++ b/tests/integration/study_data_blueprint/test_config_general.py
@@ -17,11 +17,11 @@ class TestConfigGeneralForm:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """Check `set_general_form_values` end point"""
         res = client.get(
-            f"/v1/studies/{study_id}/config/general/form",
+            f"/v1/studies/{internal_study}/config/general/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -49,12 +49,12 @@ class TestConfigGeneralForm:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """Check `set_general_form_values` end point"""
         obj = {"horizon": 2020}
         res = client.put(
-            f"/v1/studies/{study_id}/config/general/form",
+            f"/v1/studies/{internal_study}/config/general/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )

--- a/tests/integration/study_data_blueprint/test_config_general.py
+++ b/tests/integration/study_data_blueprint/test_config_general.py
@@ -17,11 +17,11 @@ class TestConfigGeneralForm:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """Check `set_general_form_values` end point"""
         res = client.get(
-            f"/v1/studies/{internal_study}/config/general/form",
+            f"/v1/studies/{internal_study_id}/config/general/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -49,12 +49,12 @@ class TestConfigGeneralForm:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """Check `set_general_form_values` end point"""
         obj = {"horizon": 2020}
         res = client.put(
-            f"/v1/studies/{internal_study}/config/general/form",
+            f"/v1/studies/{internal_study_id}/config/general/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )

--- a/tests/integration/study_data_blueprint/test_edit_matrix.py
+++ b/tests/integration/study_data_blueprint/test_edit_matrix.py
@@ -241,7 +241,7 @@ class TestEditMatrix:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         # Given the following Area
         area_id = "fr"
@@ -249,7 +249,7 @@ class TestEditMatrix:
         # Create a cluster
         cluster_id = "cluster 1"
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[
                 {
@@ -273,7 +273,7 @@ class TestEditMatrix:
             }
         ]
         res = client.put(
-            f"/v1/studies/{internal_study}/matrix?path=input/thermal/series/{area_id}/{cluster_id}/series",
+            f"/v1/studies/{internal_study_id}/matrix?path=input/thermal/series/{area_id}/{cluster_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )
@@ -281,7 +281,7 @@ class TestEditMatrix:
 
         # We can check the modified matrix
         res = client.get(
-            f"/v1/studies/{internal_study}/raw?path=input/thermal/series/{area_id}/{cluster_id}/series",
+            f"/v1/studies/{internal_study_id}/raw?path=input/thermal/series/{area_id}/{cluster_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()

--- a/tests/integration/study_data_blueprint/test_edit_matrix.py
+++ b/tests/integration/study_data_blueprint/test_edit_matrix.py
@@ -241,7 +241,7 @@ class TestEditMatrix:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         # Given the following Area
         area_id = "fr"
@@ -249,7 +249,7 @@ class TestEditMatrix:
         # Create a cluster
         cluster_id = "cluster 1"
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[
                 {
@@ -273,7 +273,7 @@ class TestEditMatrix:
             }
         ]
         res = client.put(
-            f"/v1/studies/{study_id}/matrix?path=input/thermal/series/{area_id}/{cluster_id}/series",
+            f"/v1/studies/{internal_study}/matrix?path=input/thermal/series/{area_id}/{cluster_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )
@@ -281,7 +281,7 @@ class TestEditMatrix:
 
         # We can check the modified matrix
         res = client.get(
-            f"/v1/studies/{study_id}/raw?path=input/thermal/series/{area_id}/{cluster_id}/series",
+            f"/v1/studies/{internal_study}/raw?path=input/thermal/series/{area_id}/{cluster_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()

--- a/tests/integration/study_data_blueprint/test_hydro_allocation.py
+++ b/tests/integration/study_data_blueprint/test_hydro_allocation.py
@@ -20,12 +20,12 @@ class TestHydroAllocation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         """Check `get_allocation_form_values` end point"""
         area_id = "de"
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/allocation/form",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/allocation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()
@@ -37,7 +37,7 @@ class TestHydroAllocation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         """
         The purpose of this test is to check that we can get the form parameters from a study variant.
@@ -46,7 +46,7 @@ class TestHydroAllocation:
         """
         # Create a managed study from the RAW study.
         res = client.post(
-            f"/v1/studies/{internal_study}/copy",
+            f"/v1/studies/{internal_study_id}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "Clone", "with_outputs": False, "use_task": False},
         )
@@ -109,13 +109,13 @@ class TestHydroAllocation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
         area_id: str,
         expected: t.List[t.List[float]],
     ) -> None:
         """Check `get_allocation_matrix` end point"""
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/hydro/allocation/matrix",
+            f"/v1/studies/{internal_study_id}/areas/hydro/allocation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()
@@ -126,7 +126,7 @@ class TestHydroAllocation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         """Check `set_allocation_form_values` end point"""
         area_id = "de"
@@ -137,7 +137,7 @@ class TestHydroAllocation:
             ]
         }
         res = client.put(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/allocation/form",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/allocation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=expected,
         )
@@ -147,7 +147,7 @@ class TestHydroAllocation:
 
         # check that the values are updated
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"path": "input/hydro/allocation", "depth": 3},
         )
@@ -161,7 +161,7 @@ class TestHydroAllocation:
         }
         assert actual == expected
 
-    def test_create_area(self, client: TestClient, user_access_token: str, internal_study: str) -> None:
+    def test_create_area(self, client: TestClient, user_access_token: str, internal_study_id: str) -> None:
         """
         Given a study, when an area is created, the hydraulic allocation
         column for this area must be updated with the following values:
@@ -171,14 +171,14 @@ class TestHydroAllocation:
         """
         area_info = AreaInfoDTO(id="north", name="NORTH", type=AreaType.AREA)
         res = client.post(
-            f"/v1/studies/{internal_study}/areas",
+            f"/v1/studies/{internal_study_id}/areas",
             headers={"Authorization": f"Bearer {user_access_token}"},
             data=area_info.json(),
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()
 
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/hydro/allocation/matrix",
+            f"/v1/studies/{internal_study_id}/areas/hydro/allocation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK
@@ -196,7 +196,7 @@ class TestHydroAllocation:
         }
         assert actual == expected
 
-    def test_delete_area(self, client: TestClient, user_access_token: str, internal_study: str) -> None:
+    def test_delete_area(self, client: TestClient, user_access_token: str, internal_study_id: str) -> None:
         """
         Given a study, when an area is deleted, the hydraulic allocation
         column for this area must be removed.
@@ -211,7 +211,7 @@ class TestHydroAllocation:
         }
         for prod_area, allocation_cfg in obj.items():
             res = client.post(
-                f"/v1/studies/{internal_study}/raw",
+                f"/v1/studies/{internal_study_id}/raw",
                 headers={"Authorization": f"Bearer {user_access_token}"},
                 params={"path": f"input/hydro/allocation/{prod_area}"},
                 json=allocation_cfg,
@@ -221,7 +221,7 @@ class TestHydroAllocation:
         # Then we remove the "fr" zone.
         # The deletion should update the allocation matrix of all other zones.
         res = client.delete(
-            f"/v1/studies/{internal_study}/areas/fr",
+            f"/v1/studies/{internal_study_id}/areas/fr",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()
@@ -229,7 +229,7 @@ class TestHydroAllocation:
         # Check that the "fr" column is removed from the hydraulic allocation matrix.
         # The row corresponding to "fr" must also be deleted.
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/hydro/allocation/matrix",
+            f"/v1/studies/{internal_study_id}/areas/hydro/allocation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()

--- a/tests/integration/study_data_blueprint/test_hydro_allocation.py
+++ b/tests/integration/study_data_blueprint/test_hydro_allocation.py
@@ -20,12 +20,12 @@ class TestHydroAllocation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         """Check `get_allocation_form_values` end point"""
         area_id = "de"
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/allocation/form",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/allocation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()
@@ -37,7 +37,7 @@ class TestHydroAllocation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         """
         The purpose of this test is to check that we can get the form parameters from a study variant.
@@ -46,7 +46,7 @@ class TestHydroAllocation:
         """
         # Create a managed study from the RAW study.
         res = client.post(
-            f"/v1/studies/{study_id}/copy",
+            f"/v1/studies/{internal_study}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "Clone", "with_outputs": False, "use_task": False},
         )
@@ -109,13 +109,13 @@ class TestHydroAllocation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
         area_id: str,
         expected: t.List[t.List[float]],
     ) -> None:
         """Check `get_allocation_matrix` end point"""
         res = client.get(
-            f"/v1/studies/{study_id}/areas/hydro/allocation/matrix",
+            f"/v1/studies/{internal_study}/areas/hydro/allocation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()
@@ -126,7 +126,7 @@ class TestHydroAllocation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         """Check `set_allocation_form_values` end point"""
         area_id = "de"
@@ -137,7 +137,7 @@ class TestHydroAllocation:
             ]
         }
         res = client.put(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/allocation/form",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/allocation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=expected,
         )
@@ -147,7 +147,7 @@ class TestHydroAllocation:
 
         # check that the values are updated
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"path": "input/hydro/allocation", "depth": 3},
         )
@@ -161,7 +161,7 @@ class TestHydroAllocation:
         }
         assert actual == expected
 
-    def test_create_area(self, client: TestClient, user_access_token: str, study_id: str) -> None:
+    def test_create_area(self, client: TestClient, user_access_token: str, internal_study: str) -> None:
         """
         Given a study, when an area is created, the hydraulic allocation
         column for this area must be updated with the following values:
@@ -171,14 +171,14 @@ class TestHydroAllocation:
         """
         area_info = AreaInfoDTO(id="north", name="NORTH", type=AreaType.AREA)
         res = client.post(
-            f"/v1/studies/{study_id}/areas",
+            f"/v1/studies/{internal_study}/areas",
             headers={"Authorization": f"Bearer {user_access_token}"},
             data=area_info.json(),
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()
 
         res = client.get(
-            f"/v1/studies/{study_id}/areas/hydro/allocation/matrix",
+            f"/v1/studies/{internal_study}/areas/hydro/allocation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK
@@ -196,7 +196,7 @@ class TestHydroAllocation:
         }
         assert actual == expected
 
-    def test_delete_area(self, client: TestClient, user_access_token: str, study_id: str) -> None:
+    def test_delete_area(self, client: TestClient, user_access_token: str, internal_study: str) -> None:
         """
         Given a study, when an area is deleted, the hydraulic allocation
         column for this area must be removed.
@@ -211,7 +211,7 @@ class TestHydroAllocation:
         }
         for prod_area, allocation_cfg in obj.items():
             res = client.post(
-                f"/v1/studies/{study_id}/raw",
+                f"/v1/studies/{internal_study}/raw",
                 headers={"Authorization": f"Bearer {user_access_token}"},
                 params={"path": f"input/hydro/allocation/{prod_area}"},
                 json=allocation_cfg,
@@ -221,7 +221,7 @@ class TestHydroAllocation:
         # Then we remove the "fr" zone.
         # The deletion should update the allocation matrix of all other zones.
         res = client.delete(
-            f"/v1/studies/{study_id}/areas/fr",
+            f"/v1/studies/{internal_study}/areas/fr",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()
@@ -229,7 +229,7 @@ class TestHydroAllocation:
         # Check that the "fr" column is removed from the hydraulic allocation matrix.
         # The row corresponding to "fr" must also be deleted.
         res = client.get(
-            f"/v1/studies/{study_id}/areas/hydro/allocation/matrix",
+            f"/v1/studies/{internal_study}/areas/hydro/allocation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == http.HTTPStatus.OK, res.json()

--- a/tests/integration/study_data_blueprint/test_hydro_correlation.py
+++ b/tests/integration/study_data_blueprint/test_hydro_correlation.py
@@ -20,12 +20,12 @@ class TestHydroCorrelation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """Check `get_correlation_form_values` end point"""
         area_id = "fr"
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/correlation/form",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/correlation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -44,7 +44,7 @@ class TestHydroCorrelation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """Check `set_correlation_form_values` end point"""
         area_id = "fr"
@@ -57,7 +57,7 @@ class TestHydroCorrelation:
             ]
         }
         res = client.put(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/correlation/form",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/correlation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )
@@ -74,7 +74,7 @@ class TestHydroCorrelation:
 
         # check that the form is updated correctly
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/correlation/form",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/correlation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -90,7 +90,7 @@ class TestHydroCorrelation:
 
         # check that the matrix is symmetric
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study_id}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -158,14 +158,14 @@ class TestHydroCorrelation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
         columns: str,
         expected: List[List[float]],
     ):
         """Check `get_correlation_matrix` end point"""
         query = f"columns={columns}" if columns else ""
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix?{query}",
+            f"/v1/studies/{internal_study_id}/areas/hydro/correlation/matrix?{query}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -176,7 +176,7 @@ class TestHydroCorrelation:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         """Check `set_correlation_matrix` end point"""
         obj = {
@@ -190,7 +190,7 @@ class TestHydroCorrelation:
             "index": ["de", "es", "fr", "it"],
         }
         res = client.put(
-            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study_id}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )
@@ -200,7 +200,7 @@ class TestHydroCorrelation:
         assert actual == expected
 
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study_id}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -217,7 +217,7 @@ class TestHydroCorrelation:
         }
         assert actual == expected
 
-    def test_create_area(self, client: TestClient, user_access_token: str, internal_study: str):
+    def test_create_area(self, client: TestClient, user_access_token: str, internal_study_id: str):
         """
         Given a study, when an area is created, the hydraulic correlation
         column for this area must be updated with the following values:
@@ -227,14 +227,14 @@ class TestHydroCorrelation:
         """
         area_info = AreaInfoDTO(id="north", name="NORTH", type="AREA")
         res = client.post(
-            f"/v1/studies/{internal_study}/areas",
+            f"/v1/studies/{internal_study_id}/areas",
             headers={"Authorization": f"Bearer {user_access_token}"},
             data=area_info.json(),
         )
         assert res.status_code == HTTPStatus.OK, res.json()
 
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study_id}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK
@@ -252,7 +252,7 @@ class TestHydroCorrelation:
         }
         assert actual == expected
 
-    def test_delete_area(self, client: TestClient, user_access_token: str, internal_study: str):
+    def test_delete_area(self, client: TestClient, user_access_token: str, internal_study_id: str):
         """
         Given a study, when an area is deleted, the hydraulic correlation
         column for this area must be removed.
@@ -270,7 +270,7 @@ class TestHydroCorrelation:
             }
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/raw?path=input/hydro/prepro/correlation",
+            f"/v1/studies/{internal_study_id}/raw?path=input/hydro/prepro/correlation",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=correlation_cfg,
         )
@@ -279,7 +279,7 @@ class TestHydroCorrelation:
         # Then we remove the "fr" zone.
         # The deletion should update the correlation matrix of all other zones.
         res = client.delete(
-            f"/v1/studies/{internal_study}/areas/fr",
+            f"/v1/studies/{internal_study_id}/areas/fr",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -287,7 +287,7 @@ class TestHydroCorrelation:
         # Check that the "fr" column is removed from the hydraulic correlation matrix.
         # The row corresponding to "fr" must also be deleted.
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study_id}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()

--- a/tests/integration/study_data_blueprint/test_hydro_correlation.py
+++ b/tests/integration/study_data_blueprint/test_hydro_correlation.py
@@ -20,12 +20,12 @@ class TestHydroCorrelation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """Check `get_correlation_form_values` end point"""
         area_id = "fr"
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/correlation/form",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/correlation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -44,7 +44,7 @@ class TestHydroCorrelation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """Check `set_correlation_form_values` end point"""
         area_id = "fr"
@@ -57,7 +57,7 @@ class TestHydroCorrelation:
             ]
         }
         res = client.put(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/correlation/form",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/correlation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )
@@ -74,7 +74,7 @@ class TestHydroCorrelation:
 
         # check that the form is updated correctly
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/correlation/form",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/correlation/form",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -90,7 +90,7 @@ class TestHydroCorrelation:
 
         # check that the matrix is symmetric
         res = client.get(
-            f"/v1/studies/{study_id}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -158,14 +158,14 @@ class TestHydroCorrelation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
         columns: str,
         expected: List[List[float]],
     ):
         """Check `get_correlation_matrix` end point"""
         query = f"columns={columns}" if columns else ""
         res = client.get(
-            f"/v1/studies/{study_id}/areas/hydro/correlation/matrix?{query}",
+            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix?{query}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -176,7 +176,7 @@ class TestHydroCorrelation:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         """Check `set_correlation_matrix` end point"""
         obj = {
@@ -190,7 +190,7 @@ class TestHydroCorrelation:
             "index": ["de", "es", "fr", "it"],
         }
         res = client.put(
-            f"/v1/studies/{study_id}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=obj,
         )
@@ -200,7 +200,7 @@ class TestHydroCorrelation:
         assert actual == expected
 
         res = client.get(
-            f"/v1/studies/{study_id}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -217,7 +217,7 @@ class TestHydroCorrelation:
         }
         assert actual == expected
 
-    def test_create_area(self, client: TestClient, user_access_token: str, study_id: str):
+    def test_create_area(self, client: TestClient, user_access_token: str, internal_study: str):
         """
         Given a study, when an area is created, the hydraulic correlation
         column for this area must be updated with the following values:
@@ -227,14 +227,14 @@ class TestHydroCorrelation:
         """
         area_info = AreaInfoDTO(id="north", name="NORTH", type="AREA")
         res = client.post(
-            f"/v1/studies/{study_id}/areas",
+            f"/v1/studies/{internal_study}/areas",
             headers={"Authorization": f"Bearer {user_access_token}"},
             data=area_info.json(),
         )
         assert res.status_code == HTTPStatus.OK, res.json()
 
         res = client.get(
-            f"/v1/studies/{study_id}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK
@@ -252,7 +252,7 @@ class TestHydroCorrelation:
         }
         assert actual == expected
 
-    def test_delete_area(self, client: TestClient, user_access_token: str, study_id: str):
+    def test_delete_area(self, client: TestClient, user_access_token: str, internal_study: str):
         """
         Given a study, when an area is deleted, the hydraulic correlation
         column for this area must be removed.
@@ -270,7 +270,7 @@ class TestHydroCorrelation:
             }
         }
         res = client.post(
-            f"/v1/studies/{study_id}/raw?path=input/hydro/prepro/correlation",
+            f"/v1/studies/{internal_study}/raw?path=input/hydro/prepro/correlation",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=correlation_cfg,
         )
@@ -279,7 +279,7 @@ class TestHydroCorrelation:
         # Then we remove the "fr" zone.
         # The deletion should update the correlation matrix of all other zones.
         res = client.delete(
-            f"/v1/studies/{study_id}/areas/fr",
+            f"/v1/studies/{internal_study}/areas/fr",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -287,7 +287,7 @@ class TestHydroCorrelation:
         # Check that the "fr" column is removed from the hydraulic correlation matrix.
         # The row corresponding to "fr" must also be deleted.
         res = client.get(
-            f"/v1/studies/{study_id}/areas/hydro/correlation/matrix",
+            f"/v1/studies/{internal_study}/areas/hydro/correlation/matrix",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == HTTPStatus.OK, res.json()

--- a/tests/integration/study_data_blueprint/test_hydro_inflow_structure.py
+++ b/tests/integration/study_data_blueprint/test_hydro_inflow_structure.py
@@ -18,7 +18,7 @@ class TestHydroInflowStructure:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         user_header = {"Authorization": f"Bearer {user_access_token}"}
         area_id = "fr"
@@ -29,7 +29,7 @@ class TestHydroInflowStructure:
 
         # Check that the default values are returned
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -40,7 +40,7 @@ class TestHydroInflowStructure:
         # Update the values
         obj = {"interMonthlyCorrelation": 0.8}
         res = client.put(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
             json=obj,
         )
@@ -48,7 +48,7 @@ class TestHydroInflowStructure:
 
         # Check that the right values are returned
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -62,7 +62,7 @@ class TestHydroInflowStructure:
 
         # Create a managed study from the RAW study.
         res = client.post(
-            f"/v1/studies/{internal_study}/copy",
+            f"/v1/studies/{internal_study_id}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "Clone", "with_outputs": False, "use_task": False},
         )
@@ -132,7 +132,7 @@ class TestHydroInflowStructure:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         user_header = {"Authorization": f"Bearer {user_access_token}"}
         area_id = "fr"
@@ -140,7 +140,7 @@ class TestHydroInflowStructure:
         # Update the values with invalid values
         obj = {"interMonthlyCorrelation": 1.1}
         res = client.put(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
             json=obj,
         )
@@ -148,7 +148,7 @@ class TestHydroInflowStructure:
 
         obj = {"interMonthlyCorrelation": -0.1}
         res = client.put(
-            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
             json=obj,
         )

--- a/tests/integration/study_data_blueprint/test_hydro_inflow_structure.py
+++ b/tests/integration/study_data_blueprint/test_hydro_inflow_structure.py
@@ -18,7 +18,7 @@ class TestHydroInflowStructure:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         user_header = {"Authorization": f"Bearer {user_access_token}"}
         area_id = "fr"
@@ -29,7 +29,7 @@ class TestHydroInflowStructure:
 
         # Check that the default values are returned
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -40,7 +40,7 @@ class TestHydroInflowStructure:
         # Update the values
         obj = {"interMonthlyCorrelation": 0.8}
         res = client.put(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
             json=obj,
         )
@@ -48,7 +48,7 @@ class TestHydroInflowStructure:
 
         # Check that the right values are returned
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
         )
         assert res.status_code == HTTPStatus.OK, res.json()
@@ -62,7 +62,7 @@ class TestHydroInflowStructure:
 
         # Create a managed study from the RAW study.
         res = client.post(
-            f"/v1/studies/{study_id}/copy",
+            f"/v1/studies/{internal_study}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "Clone", "with_outputs": False, "use_task": False},
         )
@@ -132,7 +132,7 @@ class TestHydroInflowStructure:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         user_header = {"Authorization": f"Bearer {user_access_token}"}
         area_id = "fr"
@@ -140,7 +140,7 @@ class TestHydroInflowStructure:
         # Update the values with invalid values
         obj = {"interMonthlyCorrelation": 1.1}
         res = client.put(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
             json=obj,
         )
@@ -148,7 +148,7 @@ class TestHydroInflowStructure:
 
         obj = {"interMonthlyCorrelation": -0.1}
         res = client.put(
-            f"/v1/studies/{study_id}/areas/{area_id}/hydro/inflow-structure",
+            f"/v1/studies/{internal_study}/areas/{area_id}/hydro/inflow-structure",
             headers=user_header,
             json=obj,
         )

--- a/tests/integration/study_data_blueprint/test_renewable.py
+++ b/tests/integration/study_data_blueprint/test_renewable.py
@@ -51,11 +51,11 @@ class TestRenewable:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         # Upgrade study to version 810
         res = client.put(
-            f"/v1/studies/{study_id}/upgrade",
+            f"/v1/studies/{internal_study}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": 810},
         )
@@ -75,7 +75,7 @@ class TestRenewable:
             "data": {"renewable-generation-modelling": "clusters"},
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "update_config", "args": args}],
         )
@@ -95,7 +95,7 @@ class TestRenewable:
         attempts = [{}, {"name": ""}, {"name": "!??"}]
         for attempt in attempts:
             res = client.post(
-                f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+                f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
                 headers={"Authorization": f"Bearer {user_access_token}"},
                 json=attempt,
             )
@@ -112,7 +112,7 @@ class TestRenewable:
             "tsInterpretation": "production-factor",
         }
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=fr_solar_pv_props,
         )
@@ -125,7 +125,7 @@ class TestRenewable:
 
         # reading the properties of a renewable cluster
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -139,14 +139,14 @@ class TestRenewable:
         matrix_path = f"input/renewables/series/{area_id}/{fr_solar_pv_id.lower()}/series"
         args = {"target": matrix_path, "matrix": matrix}
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             json=[{"action": "replace_matrix", "args": args}],
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code in {200, 201}, res.json()
 
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": matrix_path},
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -159,7 +159,7 @@ class TestRenewable:
 
         # Reading the list of renewable clusters
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -167,7 +167,7 @@ class TestRenewable:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "name": "FR Solar pv old 1",
@@ -183,7 +183,7 @@ class TestRenewable:
         assert res.json() == fr_solar_pv_cfg
 
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -195,7 +195,7 @@ class TestRenewable:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "nominalCapacity": 2260,
@@ -215,7 +215,7 @@ class TestRenewable:
         # The `unitCount` property must be an integer greater than 0.
         bad_properties = {"unitCount": 0}
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=bad_properties,
         )
@@ -224,7 +224,7 @@ class TestRenewable:
 
         # The renewable cluster properties should not have been updated.
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -236,7 +236,7 @@ class TestRenewable:
 
         new_name = "Duplicate of SolarPV"
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/renewables/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/renewables/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": new_name},
         )
@@ -251,7 +251,7 @@ class TestRenewable:
         # asserts the matrix has also been duplicated
         new_cluster_matrix_path = f"input/renewables/series/{area_id}/{duplicated_id.lower()}/series"
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": new_cluster_matrix_path},
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -265,7 +265,7 @@ class TestRenewable:
         # To delete a renewable cluster, we need to provide its ID.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_solar_pv_id],
         )
@@ -275,7 +275,7 @@ class TestRenewable:
         # If the renewable cluster list is empty, the deletion should be a no-op.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[],
         )
@@ -286,7 +286,7 @@ class TestRenewable:
         # Create two clusters
         other_cluster_name = "Other Cluster 1"
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"name": other_cluster_name},
         )
@@ -294,7 +294,7 @@ class TestRenewable:
         other_cluster_id1 = res.json()["id"]
 
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"name": "Other Cluster 2"},
         )
@@ -304,7 +304,7 @@ class TestRenewable:
         # We can delete two renewable clusters at once.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[other_cluster_id2, duplicated_id],
         )
@@ -313,7 +313,7 @@ class TestRenewable:
 
         # There should only be one remaining cluster
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200
@@ -328,7 +328,7 @@ class TestRenewable:
         bad_area_id = "bad_area"
         res = client.request(
             "DELETE",
-            f"/v1/studies/{study_id}/areas/{bad_area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_solar_pv_id],
         )
@@ -357,7 +357,7 @@ class TestRenewable:
 
         # Check GET with wrong `area_id`
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{bad_area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         obj = res.json()
@@ -388,7 +388,7 @@ class TestRenewable:
 
         # Check POST with wrong `area_id`
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{bad_area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "name": fr_solar_pv,
@@ -407,7 +407,7 @@ class TestRenewable:
 
         # Check POST with wrong `group`
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"name": fr_solar_pv, "group": "GroupFoo"},
         )
@@ -418,7 +418,7 @@ class TestRenewable:
 
         # Check PATCH with the wrong `area_id`
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{bad_area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "group": "Wind Onshore",
@@ -436,7 +436,7 @@ class TestRenewable:
         # Check PATCH with the wrong `cluster_id`
         bad_cluster_id = "bad_cluster"
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable/{bad_cluster_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{bad_cluster_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "group": "Wind Onshore",
@@ -470,7 +470,7 @@ class TestRenewable:
         # Cannot duplicate a fake cluster
         unknown_id = "unknown"
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/renewables/{unknown_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/renewables/{unknown_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": "duplicata"},
         )
@@ -481,7 +481,7 @@ class TestRenewable:
 
         # Cannot duplicate with an existing id
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/renewables/{other_cluster_id1}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/renewables/{other_cluster_id1}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": other_cluster_name.upper()},  # different case, but same ID
         )

--- a/tests/integration/study_data_blueprint/test_renewable.py
+++ b/tests/integration/study_data_blueprint/test_renewable.py
@@ -51,11 +51,11 @@ class TestRenewable:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         # Upgrade study to version 810
         res = client.put(
-            f"/v1/studies/{internal_study}/upgrade",
+            f"/v1/studies/{internal_study_id}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": 810},
         )
@@ -75,7 +75,7 @@ class TestRenewable:
             "data": {"renewable-generation-modelling": "clusters"},
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "update_config", "args": args}],
         )
@@ -95,7 +95,7 @@ class TestRenewable:
         attempts = [{}, {"name": ""}, {"name": "!??"}]
         for attempt in attempts:
             res = client.post(
-                f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+                f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
                 headers={"Authorization": f"Bearer {user_access_token}"},
                 json=attempt,
             )
@@ -112,7 +112,7 @@ class TestRenewable:
             "tsInterpretation": "production-factor",
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=fr_solar_pv_props,
         )
@@ -125,7 +125,7 @@ class TestRenewable:
 
         # reading the properties of a renewable cluster
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -139,14 +139,14 @@ class TestRenewable:
         matrix_path = f"input/renewables/series/{area_id}/{fr_solar_pv_id.lower()}/series"
         args = {"target": matrix_path, "matrix": matrix}
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             json=[{"action": "replace_matrix", "args": args}],
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code in {200, 201}, res.json()
 
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": matrix_path},
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -159,7 +159,7 @@ class TestRenewable:
 
         # Reading the list of renewable clusters
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -167,7 +167,7 @@ class TestRenewable:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "name": "FR Solar pv old 1",
@@ -183,7 +183,7 @@ class TestRenewable:
         assert res.json() == fr_solar_pv_cfg
 
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -195,7 +195,7 @@ class TestRenewable:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "nominalCapacity": 2260,
@@ -215,7 +215,7 @@ class TestRenewable:
         # The `unitCount` property must be an integer greater than 0.
         bad_properties = {"unitCount": 0}
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=bad_properties,
         )
@@ -224,7 +224,7 @@ class TestRenewable:
 
         # The renewable cluster properties should not have been updated.
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -236,7 +236,7 @@ class TestRenewable:
 
         new_name = "Duplicate of SolarPV"
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/renewables/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/renewables/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": new_name},
         )
@@ -251,7 +251,7 @@ class TestRenewable:
         # asserts the matrix has also been duplicated
         new_cluster_matrix_path = f"input/renewables/series/{area_id}/{duplicated_id.lower()}/series"
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": new_cluster_matrix_path},
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -265,7 +265,7 @@ class TestRenewable:
         # To delete a renewable cluster, we need to provide its ID.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_solar_pv_id],
         )
@@ -275,7 +275,7 @@ class TestRenewable:
         # If the renewable cluster list is empty, the deletion should be a no-op.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[],
         )
@@ -286,7 +286,7 @@ class TestRenewable:
         # Create two clusters
         other_cluster_name = "Other Cluster 1"
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"name": other_cluster_name},
         )
@@ -294,7 +294,7 @@ class TestRenewable:
         other_cluster_id1 = res.json()["id"]
 
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"name": "Other Cluster 2"},
         )
@@ -304,7 +304,7 @@ class TestRenewable:
         # We can delete two renewable clusters at once.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[other_cluster_id2, duplicated_id],
         )
@@ -313,7 +313,7 @@ class TestRenewable:
 
         # There should only be one remaining cluster
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200
@@ -328,7 +328,7 @@ class TestRenewable:
         bad_area_id = "bad_area"
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_solar_pv_id],
         )
@@ -357,7 +357,7 @@ class TestRenewable:
 
         # Check GET with wrong `area_id`
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         obj = res.json()
@@ -388,7 +388,7 @@ class TestRenewable:
 
         # Check POST with wrong `area_id`
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "name": fr_solar_pv,
@@ -407,7 +407,7 @@ class TestRenewable:
 
         # Check POST with wrong `group`
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"name": fr_solar_pv, "group": "GroupFoo"},
         )
@@ -418,7 +418,7 @@ class TestRenewable:
 
         # Check PATCH with the wrong `area_id`
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/renewable/{fr_solar_pv_id}",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/clusters/renewable/{fr_solar_pv_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "group": "Wind Onshore",
@@ -436,7 +436,7 @@ class TestRenewable:
         # Check PATCH with the wrong `cluster_id`
         bad_cluster_id = "bad_cluster"
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable/{bad_cluster_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable/{bad_cluster_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "group": "Wind Onshore",
@@ -470,7 +470,7 @@ class TestRenewable:
         # Cannot duplicate a fake cluster
         unknown_id = "unknown"
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/renewables/{unknown_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/renewables/{unknown_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": "duplicata"},
         )
@@ -481,7 +481,7 @@ class TestRenewable:
 
         # Cannot duplicate with an existing id
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/renewables/{other_cluster_id1}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/renewables/{other_cluster_id1}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": other_cluster_name.upper()},  # different case, but same ID
         )

--- a/tests/integration/study_data_blueprint/test_st_storage.py
+++ b/tests/integration/study_data_blueprint/test_st_storage.py
@@ -49,7 +49,7 @@ class TestSTStorage:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
         study_type: str,
         study_version: int,
         default_output: t.Dict[str, t.Any],
@@ -85,7 +85,7 @@ class TestSTStorage:
 
         # Upgrade study to version 860 or above
         res = client.put(
-            f"/v1/studies/{internal_study}/upgrade",
+            f"/v1/studies/{internal_study_id}/upgrade",
             headers=user_headers,
             params={"target_version": study_version},
         )
@@ -96,22 +96,22 @@ class TestSTStorage:
 
         # Copies the study, to convert it into a managed one.
         res = client.post(
-            f"/v1/studies/{internal_study}/copy",
+            f"/v1/studies/{internal_study_id}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "default", "with_outputs": False, "use_task": False},  # type: ignore
         )
         assert res.status_code == 201, res.json()
-        internal_study = res.json()
+        internal_study_id = res.json()
 
         if study_type == "variant":
             # Create Variant
             res = client.post(
-                f"/v1/studies/{internal_study}/variants",
+                f"/v1/studies/{internal_study_id}/variants",
                 headers=user_headers,
                 params={"name": "Variant 1"},
             )
             assert res.status_code in {200, 201}, res.json()
-            internal_study = res.json()
+            internal_study_id = res.json()
 
         # =============================
         #  SHORT-TERM STORAGE CREATION
@@ -126,7 +126,7 @@ class TestSTStorage:
         attempts = [{}, {"name": ""}, {"name": "!??"}]
         for attempt in attempts:
             res = client.post(
-                f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+                f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
                 headers=user_headers,
                 json=attempt,
             )
@@ -143,7 +143,7 @@ class TestSTStorage:
             "reservoirCapacity": 1500,
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
             json=siemens_properties,
         )
@@ -155,7 +155,7 @@ class TestSTStorage:
 
         # reading the properties of a short-term storage
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -169,7 +169,7 @@ class TestSTStorage:
         array = np.random.randint(0, 1000, size=(8760, 1))
         array_list = array.tolist()
         res = client.put(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}/series/inflows",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}/series/inflows",
             headers=user_headers,
             json={
                 "index": list(range(array.shape[0])),
@@ -182,7 +182,7 @@ class TestSTStorage:
 
         # reading the matrix of a short-term storage
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}/series/inflows",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}/series/inflows",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -192,7 +192,7 @@ class TestSTStorage:
 
         # validating the matrices of a short-term storage
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}/validate",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}/validate",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -204,7 +204,7 @@ class TestSTStorage:
 
         # Reading the list of short-term storages
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -212,7 +212,7 @@ class TestSTStorage:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
             headers=user_headers,
             json={
                 "name": "New Siemens Battery",
@@ -228,7 +228,7 @@ class TestSTStorage:
         assert res.json() == siemens_output
 
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -240,7 +240,7 @@ class TestSTStorage:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
             headers=user_headers,
             json={
                 "initialLevel": 0.59,
@@ -260,7 +260,7 @@ class TestSTStorage:
         # The `efficiency` property must be a float between 0 and 1.
         bad_properties = {"efficiency": 2.0}
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
             headers=user_headers,
             json=bad_properties,
         )
@@ -269,7 +269,7 @@ class TestSTStorage:
 
         # The short-term storage properties should not have been updated.
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -281,7 +281,7 @@ class TestSTStorage:
 
         new_name = "Duplicate of Siemens"
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": new_name},
         )
@@ -295,7 +295,7 @@ class TestSTStorage:
 
         # asserts the matrix has also been duplicated
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{duplicated_id}/series/inflows",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{duplicated_id}/series/inflows",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200
@@ -308,7 +308,7 @@ class TestSTStorage:
         # To delete a short-term storage, we need to provide its ID.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
             json=[siemens_battery_id],
         )
@@ -318,7 +318,7 @@ class TestSTStorage:
         # If the short-term storage list is empty, the deletion should be a no-op.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
             json=[],
         )
@@ -338,7 +338,7 @@ class TestSTStorage:
             "initialLevelOptim": False,
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
             json=siemens_properties,
         )
@@ -357,7 +357,7 @@ class TestSTStorage:
             "initialLevel": 1,
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
             json=grand_maison_properties,
         )
@@ -367,7 +367,7 @@ class TestSTStorage:
         # We can check that we have 2 short-term storages in the list.
         # Reading the list of short-term storages
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -378,7 +378,7 @@ class TestSTStorage:
         # We can delete the three short-term storages at once.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
             json=[grand_maison_id, duplicated_output["id"]],
         )
@@ -387,7 +387,7 @@ class TestSTStorage:
 
         # Only one st-storage should remain.
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
@@ -401,7 +401,7 @@ class TestSTStorage:
         bad_area_id = "bad_area"
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/storages",
             headers=user_headers,
             json=[siemens_battery_id],
         )
@@ -426,7 +426,7 @@ class TestSTStorage:
 
         # Check get with wrong `area_id`
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/storages/{siemens_battery_id}",
             headers=user_headers,
         )
         obj = res.json()
@@ -457,7 +457,7 @@ class TestSTStorage:
 
         # Check POST with wrong `area_id`
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/storages",
             headers=user_headers,
             json={"name": siemens_battery, "group": "Battery"},
         )
@@ -468,7 +468,7 @@ class TestSTStorage:
 
         # Check POST with wrong `group`
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
             json={"name": siemens_battery, "group": "GroupFoo"},
         )
@@ -479,7 +479,7 @@ class TestSTStorage:
 
         # Check PATCH with the wrong `area_id`
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/storages/{siemens_battery_id}",
             headers=user_headers,
             json={"efficiency": 1.0},
         )
@@ -491,7 +491,7 @@ class TestSTStorage:
         # Check PATCH with the wrong `storage_id`
         bad_storage_id = "bad_storage"
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{bad_storage_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{bad_storage_id}",
             headers=user_headers,
             json={"efficiency": 1.0},
         )
@@ -516,7 +516,7 @@ class TestSTStorage:
         # Cannot duplicate a unknown st-storage
         unknown_id = "unknown"
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{unknown_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{unknown_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": "duplicata"},
         )
@@ -527,7 +527,7 @@ class TestSTStorage:
 
         # Cannot duplicate with an existing id
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages/{siemens_battery_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages/{siemens_battery_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": siemens_battery.upper()},  # different case, but same ID
         )
@@ -540,7 +540,7 @@ class TestSTStorage:
         # Cannot specify the field 'enabled' before v8.8
         properties = {"enabled": False, "name": "fake_name", "group": "Battery"}
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
             headers=user_headers,
             json=properties,
         )

--- a/tests/integration/study_data_blueprint/test_table_mode.py
+++ b/tests/integration/study_data_blueprint/test_table_mode.py
@@ -23,7 +23,7 @@ class TestTableMode:
 
     @pytest.mark.parametrize("study_version", [0, 810, 830, 860, 870, 880])
     def test_lifecycle__nominal(
-        self, client: TestClient, user_access_token: str, internal_study: str, study_version: int
+        self, client: TestClient, user_access_token: str, internal_study_id: str, study_version: int
     ) -> None:
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
@@ -35,7 +35,7 @@ class TestTableMode:
         # Upgrade the study to the desired version
         if study_version:
             res = client.put(
-                f"/v1/studies/{internal_study}/upgrade",
+                f"/v1/studies/{internal_study_id}/upgrade",
                 params={"target_version": study_version},
             )
             assert res.status_code == 200, res.json()
@@ -45,7 +45,7 @@ class TestTableMode:
             assert task.status == TaskStatus.COMPLETED, task
 
         # Create another link to test specific bug.
-        res = client.post(f"/v1/studies/{internal_study}/links", json={"area1": "de", "area2": "it"})
+        res = client.post(f"/v1/studies/{internal_study_id}/links", json={"area1": "de", "area2": "it"})
         assert res.status_code in [200, 201], res.json()
 
         # Table Mode - Area
@@ -83,7 +83,7 @@ class TestTableMode:
             _es_values["adequacyPatchMode"] = "inside"
 
         res = client.put(
-            f"/v1/studies/{internal_study}/table-mode/areas",
+            f"/v1/studies/{internal_study_id}/table-mode/areas",
             json={
                 "de": _de_values,
                 "es": _es_values,
@@ -147,7 +147,7 @@ class TestTableMode:
         actual = res.json()
         assert actual == expected_areas
 
-        res = client.get(f"/v1/studies/{internal_study}/table-mode/areas")
+        res = client.get(f"/v1/studies/{internal_study_id}/table-mode/areas")
         assert res.status_code == 200, res.json()
         actual = res.json()
         assert actual == expected_areas
@@ -158,7 +158,7 @@ class TestTableMode:
             "averageUnsuppliedEnergyCost": 456,
         }
         res = client.put(
-            f"/v1/studies/{internal_study}/table-mode/areas",
+            f"/v1/studies/{internal_study_id}/table-mode/areas",
             json={"de": _de_values},
         )
         assert res.status_code == 200, res.json()
@@ -191,7 +191,7 @@ class TestTableMode:
         }
 
         res = client.put(
-            f"/v1/studies/{internal_study}/table-mode/links",
+            f"/v1/studies/{internal_study_id}/table-mode/links",
             json={
                 "de / fr": {
                     "colorRgb": "#FFA500",
@@ -287,7 +287,7 @@ class TestTableMode:
         del expected_result["de / it"]
         assert actual == expected_result
 
-        res = client.get(f"/v1/studies/{internal_study}/table-mode/links")
+        res = client.get(f"/v1/studies/{internal_study_id}/table-mode/links")
         assert res.status_code == 200, res.json()
         actual = res.json()
         # asserts the `de / it` link is not removed.
@@ -354,7 +354,7 @@ class TestTableMode:
             _solar_values.update({"costGeneration": "useCostTimeseries", "efficiency": 87, "variableOMCost": -12.5})
 
         res = client.put(
-            f"/v1/studies/{internal_study}/table-mode/thermals",
+            f"/v1/studies/{internal_study_id}/table-mode/thermals",
             json={
                 "de / 01_solar": _solar_values,
                 "de / 02_wind_on": _wind_on_values,
@@ -437,7 +437,7 @@ class TestTableMode:
         assert res.json()["de / 02_wind_on"] == expected_thermals["de / 02_wind_on"]
 
         res = client.get(
-            f"/v1/studies/{internal_study}/table-mode/thermals",
+            f"/v1/studies/{internal_study_id}/table-mode/thermals",
             params={"columns": ",".join(["group", "unitCount", "nominalCapacity", "so2"])},
         )
         assert res.status_code == 200, res.json()
@@ -500,7 +500,7 @@ class TestTableMode:
                 "data": {"renewable-generation-modelling": "clusters"},
             }
             res = client.post(
-                f"/v1/studies/{internal_study}/commands",
+                f"/v1/studies/{internal_study_id}/commands",
                 json=[{"action": "update_config", "args": args}],
             )
             assert res.status_code == 200, res.json()
@@ -559,7 +559,7 @@ class TestTableMode:
             for area_id, generators in generators_by_country.items():
                 for generator_id, generator in generators.items():
                     res = client.post(
-                        f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
+                        f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/renewable",
                         json=generator,
                     )
                     res.raise_for_status()
@@ -584,7 +584,7 @@ class TestTableMode:
 
             # Update some generators using the table mode
             res = client.put(
-                f"/v1/studies/{internal_study}/table-mode/renewables",
+                f"/v1/studies/{internal_study_id}/table-mode/renewables",
                 json={
                     "fr / Dieppe": {"enabled": False},
                     "fr / La Rochelle": {"enabled": True, "nominalCapacity": 3.1, "unitCount": 2},
@@ -594,7 +594,7 @@ class TestTableMode:
             assert res.status_code == 200, res.json()
 
             res = client.get(
-                f"/v1/studies/{internal_study}/table-mode/renewables",
+                f"/v1/studies/{internal_study_id}/table-mode/renewables",
                 params={"columns": ",".join(["group", "enabled", "unitCount", "nominalCapacity"])},
             )
             assert res.status_code == 200, res.json()
@@ -679,7 +679,7 @@ class TestTableMode:
             for area_id, storages in storage_by_country.items():
                 for storage_id, storage in storages.items():
                     res = client.post(
-                        f"/v1/studies/{internal_study}/areas/{area_id}/storages",
+                        f"/v1/studies/{internal_study_id}/areas/{area_id}/storages",
                         json=storage,
                     )
                     res.raise_for_status()
@@ -692,7 +692,7 @@ class TestTableMode:
                 _it_storage3_values["enabled"] = False
 
             res = client.put(
-                f"/v1/studies/{internal_study}/table-mode/st-storages",
+                f"/v1/studies/{internal_study_id}/table-mode/st-storages",
                 json={
                     "fr / siemens": _fr_siemes_values,
                     "fr / tesla": _fr_tesla_values,
@@ -760,7 +760,7 @@ class TestTableMode:
             assert actual == expected
 
             res = client.get(
-                f"/v1/studies/{internal_study}/table-mode/st-storages",
+                f"/v1/studies/{internal_study_id}/table-mode/st-storages",
                 params={
                     "columns": ",".join(
                         [
@@ -810,7 +810,7 @@ class TestTableMode:
         # Create a cluster in fr
         fr_id = "fr"
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{fr_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{fr_id}/clusters/thermal",
             json={
                 "name": "Cluster 1",
                 "group": "Nuclear",
@@ -822,7 +822,7 @@ class TestTableMode:
 
         # Create Binding Constraints
         res = client.post(
-            f"/v1/studies/{internal_study}/bindingconstraints",
+            f"/v1/studies/{internal_study_id}/bindingconstraints",
             json={
                 "name": "Binding Constraint 1",
                 "enabled": True,
@@ -833,7 +833,7 @@ class TestTableMode:
         assert res.status_code == 200, res.json()
 
         res = client.post(
-            f"/v1/studies/{internal_study}/bindingconstraints",
+            f"/v1/studies/{internal_study_id}/bindingconstraints",
             json={
                 "name": "Binding Constraint 2",
                 "enabled": False,
@@ -874,7 +874,7 @@ class TestTableMode:
             _bc2_values["group"] = "My BC Group"
 
         res = client.put(
-            f"/v1/studies/{internal_study}/table-mode/binding-constraints",
+            f"/v1/studies/{internal_study_id}/table-mode/binding-constraints",
             json={
                 "binding constraint 1": _bc1_values,
                 "binding constraint 2": _bc2_values,
@@ -909,7 +909,7 @@ class TestTableMode:
         assert actual == expected_binding
 
         res = client.get(
-            f"/v1/studies/{internal_study}/table-mode/binding-constraints",
+            f"/v1/studies/{internal_study_id}/table-mode/binding-constraints",
             params={"columns": ""},
         )
         assert res.status_code == 200, res.json()

--- a/tests/integration/study_data_blueprint/test_table_mode.py
+++ b/tests/integration/study_data_blueprint/test_table_mode.py
@@ -23,7 +23,7 @@ class TestTableMode:
 
     @pytest.mark.parametrize("study_version", [0, 810, 830, 860, 870, 880])
     def test_lifecycle__nominal(
-        self, client: TestClient, user_access_token: str, study_id: str, study_version: int
+        self, client: TestClient, user_access_token: str, internal_study: str, study_version: int
     ) -> None:
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
@@ -35,7 +35,7 @@ class TestTableMode:
         # Upgrade the study to the desired version
         if study_version:
             res = client.put(
-                f"/v1/studies/{study_id}/upgrade",
+                f"/v1/studies/{internal_study}/upgrade",
                 params={"target_version": study_version},
             )
             assert res.status_code == 200, res.json()
@@ -45,7 +45,7 @@ class TestTableMode:
             assert task.status == TaskStatus.COMPLETED, task
 
         # Create another link to test specific bug.
-        res = client.post(f"/v1/studies/{study_id}/links", json={"area1": "de", "area2": "it"})
+        res = client.post(f"/v1/studies/{internal_study}/links", json={"area1": "de", "area2": "it"})
         assert res.status_code in [200, 201], res.json()
 
         # Table Mode - Area
@@ -83,7 +83,7 @@ class TestTableMode:
             _es_values["adequacyPatchMode"] = "inside"
 
         res = client.put(
-            f"/v1/studies/{study_id}/table-mode/areas",
+            f"/v1/studies/{internal_study}/table-mode/areas",
             json={
                 "de": _de_values,
                 "es": _es_values,
@@ -147,7 +147,7 @@ class TestTableMode:
         actual = res.json()
         assert actual == expected_areas
 
-        res = client.get(f"/v1/studies/{study_id}/table-mode/areas")
+        res = client.get(f"/v1/studies/{internal_study}/table-mode/areas")
         assert res.status_code == 200, res.json()
         actual = res.json()
         assert actual == expected_areas
@@ -158,7 +158,7 @@ class TestTableMode:
             "averageUnsuppliedEnergyCost": 456,
         }
         res = client.put(
-            f"/v1/studies/{study_id}/table-mode/areas",
+            f"/v1/studies/{internal_study}/table-mode/areas",
             json={"de": _de_values},
         )
         assert res.status_code == 200, res.json()
@@ -191,7 +191,7 @@ class TestTableMode:
         }
 
         res = client.put(
-            f"/v1/studies/{study_id}/table-mode/links",
+            f"/v1/studies/{internal_study}/table-mode/links",
             json={
                 "de / fr": {
                     "colorRgb": "#FFA500",
@@ -287,7 +287,7 @@ class TestTableMode:
         del expected_result["de / it"]
         assert actual == expected_result
 
-        res = client.get(f"/v1/studies/{study_id}/table-mode/links")
+        res = client.get(f"/v1/studies/{internal_study}/table-mode/links")
         assert res.status_code == 200, res.json()
         actual = res.json()
         # asserts the `de / it` link is not removed.
@@ -354,7 +354,7 @@ class TestTableMode:
             _solar_values.update({"costGeneration": "useCostTimeseries", "efficiency": 87, "variableOMCost": -12.5})
 
         res = client.put(
-            f"/v1/studies/{study_id}/table-mode/thermals",
+            f"/v1/studies/{internal_study}/table-mode/thermals",
             json={
                 "de / 01_solar": _solar_values,
                 "de / 02_wind_on": _wind_on_values,
@@ -437,7 +437,7 @@ class TestTableMode:
         assert res.json()["de / 02_wind_on"] == expected_thermals["de / 02_wind_on"]
 
         res = client.get(
-            f"/v1/studies/{study_id}/table-mode/thermals",
+            f"/v1/studies/{internal_study}/table-mode/thermals",
             params={"columns": ",".join(["group", "unitCount", "nominalCapacity", "so2"])},
         )
         assert res.status_code == 200, res.json()
@@ -500,7 +500,7 @@ class TestTableMode:
                 "data": {"renewable-generation-modelling": "clusters"},
             }
             res = client.post(
-                f"/v1/studies/{study_id}/commands",
+                f"/v1/studies/{internal_study}/commands",
                 json=[{"action": "update_config", "args": args}],
             )
             assert res.status_code == 200, res.json()
@@ -559,7 +559,7 @@ class TestTableMode:
             for area_id, generators in generators_by_country.items():
                 for generator_id, generator in generators.items():
                     res = client.post(
-                        f"/v1/studies/{study_id}/areas/{area_id}/clusters/renewable",
+                        f"/v1/studies/{internal_study}/areas/{area_id}/clusters/renewable",
                         json=generator,
                     )
                     res.raise_for_status()
@@ -584,7 +584,7 @@ class TestTableMode:
 
             # Update some generators using the table mode
             res = client.put(
-                f"/v1/studies/{study_id}/table-mode/renewables",
+                f"/v1/studies/{internal_study}/table-mode/renewables",
                 json={
                     "fr / Dieppe": {"enabled": False},
                     "fr / La Rochelle": {"enabled": True, "nominalCapacity": 3.1, "unitCount": 2},
@@ -594,7 +594,7 @@ class TestTableMode:
             assert res.status_code == 200, res.json()
 
             res = client.get(
-                f"/v1/studies/{study_id}/table-mode/renewables",
+                f"/v1/studies/{internal_study}/table-mode/renewables",
                 params={"columns": ",".join(["group", "enabled", "unitCount", "nominalCapacity"])},
             )
             assert res.status_code == 200, res.json()
@@ -679,7 +679,7 @@ class TestTableMode:
             for area_id, storages in storage_by_country.items():
                 for storage_id, storage in storages.items():
                     res = client.post(
-                        f"/v1/studies/{study_id}/areas/{area_id}/storages",
+                        f"/v1/studies/{internal_study}/areas/{area_id}/storages",
                         json=storage,
                     )
                     res.raise_for_status()
@@ -692,7 +692,7 @@ class TestTableMode:
                 _it_storage3_values["enabled"] = False
 
             res = client.put(
-                f"/v1/studies/{study_id}/table-mode/st-storages",
+                f"/v1/studies/{internal_study}/table-mode/st-storages",
                 json={
                     "fr / siemens": _fr_siemes_values,
                     "fr / tesla": _fr_tesla_values,
@@ -760,7 +760,7 @@ class TestTableMode:
             assert actual == expected
 
             res = client.get(
-                f"/v1/studies/{study_id}/table-mode/st-storages",
+                f"/v1/studies/{internal_study}/table-mode/st-storages",
                 params={
                     "columns": ",".join(
                         [
@@ -810,7 +810,7 @@ class TestTableMode:
         # Create a cluster in fr
         fr_id = "fr"
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{fr_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{fr_id}/clusters/thermal",
             json={
                 "name": "Cluster 1",
                 "group": "Nuclear",
@@ -822,7 +822,7 @@ class TestTableMode:
 
         # Create Binding Constraints
         res = client.post(
-            f"/v1/studies/{study_id}/bindingconstraints",
+            f"/v1/studies/{internal_study}/bindingconstraints",
             json={
                 "name": "Binding Constraint 1",
                 "enabled": True,
@@ -833,7 +833,7 @@ class TestTableMode:
         assert res.status_code == 200, res.json()
 
         res = client.post(
-            f"/v1/studies/{study_id}/bindingconstraints",
+            f"/v1/studies/{internal_study}/bindingconstraints",
             json={
                 "name": "Binding Constraint 2",
                 "enabled": False,
@@ -874,7 +874,7 @@ class TestTableMode:
             _bc2_values["group"] = "My BC Group"
 
         res = client.put(
-            f"/v1/studies/{study_id}/table-mode/binding-constraints",
+            f"/v1/studies/{internal_study}/table-mode/binding-constraints",
             json={
                 "binding constraint 1": _bc1_values,
                 "binding constraint 2": _bc2_values,
@@ -909,7 +909,7 @@ class TestTableMode:
         assert actual == expected_binding
 
         res = client.get(
-            f"/v1/studies/{study_id}/table-mode/binding-constraints",
+            f"/v1/studies/{internal_study}/table-mode/binding-constraints",
             params={"columns": ""},
         )
         assert res.status_code == 200, res.json()

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -287,7 +287,7 @@ class TestThermal:
         "version", [pytest.param(0, id="No Upgrade"), pytest.param(860, id="v8.6"), pytest.param(870, id="v8.7")]
     )
     def test_lifecycle(
-        self, client: TestClient, user_access_token: str, internal_study: str, admin_access_token: str, version: int
+        self, client: TestClient, user_access_token: str, internal_study_id: str, admin_access_token: str, version: int
     ) -> None:
         # =============================
         #  STUDY UPGRADE
@@ -295,7 +295,7 @@ class TestThermal:
 
         if version != 0:
             res = client.put(
-                f"/v1/studies/{internal_study}/upgrade",
+                f"/v1/studies/{internal_study_id}/upgrade",
                 headers={"Authorization": f"Bearer {admin_access_token}"},
                 params={"target_version": version},
             )
@@ -337,7 +337,7 @@ class TestThermal:
         attempts = [{}, {"name": ""}, {"name": "!??"}]
         for attempt in attempts:
             res = client.post(
-                f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
+                f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal",
                 headers={"Authorization": f"Bearer {user_access_token}"},
                 json=attempt,
             )
@@ -360,7 +360,7 @@ class TestThermal:
             "marketBidCost": 181.267,
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=fr_gas_conventional_props,
         )
@@ -385,7 +385,7 @@ class TestThermal:
 
         # reading the properties of a thermal cluster
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -399,14 +399,14 @@ class TestThermal:
         matrix_path = f"input/thermal/prepro/{area_id}/{fr_gas_conventional_id.lower()}/data"
         args = {"target": matrix_path, "matrix": matrix}
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             json=[{"action": "replace_matrix", "args": args}],
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code in {200, 201}, res.json()
 
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": matrix_path},
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -419,7 +419,7 @@ class TestThermal:
 
         # Reading the list of thermal clusters
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -427,7 +427,7 @@ class TestThermal:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "name": "FR_Gas conventional old 1",
@@ -443,7 +443,7 @@ class TestThermal:
         assert res.json() == fr_gas_conventional_cfg
 
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -455,7 +455,7 @@ class TestThermal:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "marginalCost": 182.456,
@@ -477,7 +477,7 @@ class TestThermal:
         # The `unitCount` property must be an integer greater than 0.
         bad_properties = {"unitCount": 0}
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=bad_properties,
         )
@@ -486,7 +486,7 @@ class TestThermal:
 
         # The thermal cluster properties should not have been updated.
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -494,7 +494,7 @@ class TestThermal:
 
         # Update with a pollutant. Should succeed even with versions prior to v8.6
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"nox": 10.0},
         )
@@ -503,7 +503,7 @@ class TestThermal:
 
         # Update with the field `efficiency`. Should succeed even with versions prior to v8.7
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"efficiency": 97.0},
         )
@@ -516,7 +516,7 @@ class TestThermal:
 
         new_name = "Duplicate of Fr_Gas_Conventional"
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/thermals/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/thermals/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": new_name},
         )
@@ -536,7 +536,7 @@ class TestThermal:
         # asserts the matrix has also been duplicated
         new_cluster_matrix_path = f"input/thermal/prepro/{area_id}/{duplicated_id.lower()}/data"
         res = client.get(
-            f"/v1/studies/{internal_study}/raw",
+            f"/v1/studies/{internal_study_id}/raw",
             params={"path": new_cluster_matrix_path},
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -549,7 +549,7 @@ class TestThermal:
 
         # Everything is fine at the beginning
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200
@@ -559,14 +559,14 @@ class TestThermal:
         _upload_matrix(
             client,
             user_access_token,
-            internal_study,
+            internal_study_id,
             f"input/thermal/series/{area_id}/{fr_gas_conventional_id.lower()}/series",
             pd.DataFrame(np.random.randint(0, 10, size=(4, 1))),
         )
 
         # Validation should fail
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 422
@@ -578,14 +578,14 @@ class TestThermal:
         _upload_matrix(
             client,
             user_access_token,
-            internal_study,
+            internal_study_id,
             f"input/thermal/series/{area_id}/{fr_gas_conventional_id.lower()}/series",
             pd.DataFrame(np.random.randint(0, 10, size=(8760, 4))),
         )
 
         # Validation should succeed again
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200
@@ -596,14 +596,14 @@ class TestThermal:
             _upload_matrix(
                 client,
                 user_access_token,
-                internal_study,
+                internal_study_id,
                 f"input/thermal/series/{area_id}/{fr_gas_conventional_id.lower()}/CO2Cost",
                 pd.DataFrame(np.random.randint(0, 10, size=(8760, 3))),
             )
 
             # Validation should fail
             res = client.get(
-                f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
+                f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
                 headers={"Authorization": f"Bearer {user_access_token}"},
             )
             assert res.status_code == 422
@@ -640,7 +640,7 @@ class TestThermal:
 
         # noinspection SpellCheckingInspection
         res = client.post(
-            f"/v1/studies/{internal_study}/bindingconstraints",
+            f"/v1/studies/{internal_study_id}/bindingconstraints",
             json=bc_obj,
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -649,7 +649,7 @@ class TestThermal:
         # verify that we can't delete the thermal cluster because it is referenced in a binding constraint
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_gas_conventional_id],
         )
@@ -660,7 +660,7 @@ class TestThermal:
 
         # delete the binding constraint
         res = client.delete(
-            f"/v1/studies/{internal_study}/bindingconstraints/{bc_obj['name']}",
+            f"/v1/studies/{internal_study_id}/bindingconstraints/{bc_obj['name']}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -668,7 +668,7 @@ class TestThermal:
         # Now we can delete the thermal cluster
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_gas_conventional_id],
         )
@@ -677,7 +677,7 @@ class TestThermal:
         # check that the binding constraint has been deleted
         # noinspection SpellCheckingInspection
         res = client.get(
-            f"/v1/studies/{internal_study}/bindingconstraints",
+            f"/v1/studies/{internal_study_id}/bindingconstraints",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -686,7 +686,7 @@ class TestThermal:
         # If the thermal cluster list is empty, the deletion should be a no-op.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[],
         )
@@ -699,7 +699,7 @@ class TestThermal:
         other_cluster_id2 = "02_wind_on"
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[other_cluster_id1, other_cluster_id2],
         )
@@ -708,7 +708,7 @@ class TestThermal:
 
         # The list of thermal clusters should not contain the deleted ones.
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -724,7 +724,7 @@ class TestThermal:
         bad_area_id = "bad_area"
         res = client.request(
             "DELETE",
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_gas_conventional_id],
         )
@@ -753,7 +753,7 @@ class TestThermal:
 
         # Check GET with wrong `area_id`
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         obj = res.json()
@@ -784,7 +784,7 @@ class TestThermal:
 
         # Check POST with wrong `area_id`
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "name": fr_gas_conventional,
@@ -807,7 +807,7 @@ class TestThermal:
 
         # Check POST with wrong `group`
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"name": fr_gas_conventional, "group": "GroupFoo"},
         )
@@ -818,7 +818,7 @@ class TestThermal:
 
         # Check PATCH with the wrong `area_id`
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study_id}/areas/{bad_area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "group": "Oil",
@@ -840,7 +840,7 @@ class TestThermal:
         # Check PATCH with the wrong `cluster_id`
         bad_cluster_id = "bad_cluster"
         res = client.patch(
-            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{bad_cluster_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{bad_cluster_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "group": "Oil",
@@ -882,7 +882,7 @@ class TestThermal:
         # Cannot duplicate a fake cluster
         unknown_id = "unknown"
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/thermals/{unknown_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/thermals/{unknown_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": "duplicate"},
         )
@@ -893,7 +893,7 @@ class TestThermal:
 
         # Cannot duplicate with an existing id
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/{area_id}/thermals/{duplicated_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/thermals/{duplicated_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": new_name.upper()},  # different case but same ID
         )
@@ -1048,7 +1048,7 @@ class TestThermal:
             "remove_cluster",
         ]
 
-    def test_thermal_cluster_deletion(self, client: TestClient, user_access_token: str, internal_study: str) -> None:
+    def test_thermal_cluster_deletion(self, client: TestClient, user_access_token: str, internal_study_id: str) -> None:
         """
         Test that creating a thermal cluster with invalid properties raises a validation error.
         """
@@ -1057,7 +1057,7 @@ class TestThermal:
 
         # Create an area "area_1" in the study
         res = client.post(
-            f"/v1/studies/{internal_study}/areas",
+            f"/v1/studies/{internal_study_id}/areas",
             json={
                 "name": "area_1",
                 "type": "AREA",
@@ -1068,7 +1068,7 @@ class TestThermal:
 
         # Create an area "area_2" in the study
         res = client.post(
-            f"/v1/studies/{internal_study}/areas",
+            f"/v1/studies/{internal_study_id}/areas",
             json={
                 "name": "area_2",
                 "type": "AREA",
@@ -1079,7 +1079,7 @@ class TestThermal:
 
         # Create an area "area_3" in the study
         res = client.post(
-            f"/v1/studies/{internal_study}/areas",
+            f"/v1/studies/{internal_study_id}/areas",
             json={
                 "name": "area_3",
                 "type": "AREA",
@@ -1090,7 +1090,7 @@ class TestThermal:
 
         # Create a thermal cluster in the study for area_1
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/area_1/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/area_1/clusters/thermal",
             json={
                 "name": "cluster_1",
                 "group": "Nuclear",
@@ -1103,7 +1103,7 @@ class TestThermal:
 
         # Create a thermal cluster in the study for area_2
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/area_2/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/area_2/clusters/thermal",
             json={
                 "name": "cluster_2",
                 "group": "Nuclear",
@@ -1116,7 +1116,7 @@ class TestThermal:
 
         # Create a thermal cluster in the study for area_3
         res = client.post(
-            f"/v1/studies/{internal_study}/areas/area_3/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/area_3/clusters/thermal",
             json={
                 "name": "cluster_3",
                 "group": "Nuclear",
@@ -1143,7 +1143,7 @@ class TestThermal:
             ],
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/bindingconstraints",
+            f"/v1/studies/{internal_study_id}/bindingconstraints",
             json=bc_obj,
         )
         assert res.status_code == 200, res.json()
@@ -1164,54 +1164,54 @@ class TestThermal:
             ],
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/bindingconstraints",
+            f"/v1/studies/{internal_study_id}/bindingconstraints",
             json=bc_obj,
         )
         assert res.status_code == 200, res.json()
 
         # check that deleting the thermal cluster in area_1 fails
         res = client.delete(
-            f"/v1/studies/{internal_study}/areas/area_1/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/area_1/clusters/thermal",
             json=["cluster_1"],
         )
         assert res.status_code == 403, res.json()
 
         # now delete the binding constraint that references the thermal cluster in area_1
         res = client.delete(
-            f"/v1/studies/{internal_study}/bindingconstraints/bc_1",
+            f"/v1/studies/{internal_study_id}/bindingconstraints/bc_1",
         )
         assert res.status_code == 200, res.json()
 
         # check that deleting the thermal cluster in area_1 succeeds
         res = client.delete(
-            f"/v1/studies/{internal_study}/areas/area_1/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/area_1/clusters/thermal",
             json=["cluster_1"],
         )
         assert res.status_code == 204, res.json()
 
         # check that deleting the thermal cluster in area_2 fails
         res = client.delete(
-            f"/v1/studies/{internal_study}/areas/area_2/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/area_2/clusters/thermal",
             json=["cluster_2"],
         )
         assert res.status_code == 403, res.json()
 
         # now delete the binding constraint that references the thermal cluster in area_2
         res = client.delete(
-            f"/v1/studies/{internal_study}/bindingconstraints/bc_2",
+            f"/v1/studies/{internal_study_id}/bindingconstraints/bc_2",
         )
         assert res.status_code == 200, res.json()
 
         # check that deleting the thermal cluster in area_2 succeeds
         res = client.delete(
-            f"/v1/studies/{internal_study}/areas/area_2/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/area_2/clusters/thermal",
             json=["cluster_2"],
         )
         assert res.status_code == 204, res.json()
 
         # check that deleting the thermal cluster in area_3 succeeds
         res = client.delete(
-            f"/v1/studies/{internal_study}/areas/area_3/clusters/thermal",
+            f"/v1/studies/{internal_study_id}/areas/area_3/clusters/thermal",
             json=["cluster_3"],
         )
         assert res.status_code == 204, res.json()

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -287,7 +287,7 @@ class TestThermal:
         "version", [pytest.param(0, id="No Upgrade"), pytest.param(860, id="v8.6"), pytest.param(870, id="v8.7")]
     )
     def test_lifecycle(
-        self, client: TestClient, user_access_token: str, study_id: str, admin_access_token: str, version: int
+        self, client: TestClient, user_access_token: str, internal_study: str, admin_access_token: str, version: int
     ) -> None:
         # =============================
         #  STUDY UPGRADE
@@ -295,7 +295,7 @@ class TestThermal:
 
         if version != 0:
             res = client.put(
-                f"/v1/studies/{study_id}/upgrade",
+                f"/v1/studies/{internal_study}/upgrade",
                 headers={"Authorization": f"Bearer {admin_access_token}"},
                 params={"target_version": version},
             )
@@ -337,7 +337,7 @@ class TestThermal:
         attempts = [{}, {"name": ""}, {"name": "!??"}]
         for attempt in attempts:
             res = client.post(
-                f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal",
+                f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
                 headers={"Authorization": f"Bearer {user_access_token}"},
                 json=attempt,
             )
@@ -360,7 +360,7 @@ class TestThermal:
             "marketBidCost": 181.267,
         }
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=fr_gas_conventional_props,
         )
@@ -385,7 +385,7 @@ class TestThermal:
 
         # reading the properties of a thermal cluster
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -399,14 +399,14 @@ class TestThermal:
         matrix_path = f"input/thermal/prepro/{area_id}/{fr_gas_conventional_id.lower()}/data"
         args = {"target": matrix_path, "matrix": matrix}
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             json=[{"action": "replace_matrix", "args": args}],
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code in {200, 201}, res.json()
 
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": matrix_path},
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -419,7 +419,7 @@ class TestThermal:
 
         # Reading the list of thermal clusters
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -427,7 +427,7 @@ class TestThermal:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "name": "FR_Gas conventional old 1",
@@ -443,7 +443,7 @@ class TestThermal:
         assert res.json() == fr_gas_conventional_cfg
 
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -455,7 +455,7 @@ class TestThermal:
 
         # updating properties
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "marginalCost": 182.456,
@@ -477,7 +477,7 @@ class TestThermal:
         # The `unitCount` property must be an integer greater than 0.
         bad_properties = {"unitCount": 0}
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=bad_properties,
         )
@@ -486,7 +486,7 @@ class TestThermal:
 
         # The thermal cluster properties should not have been updated.
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -494,7 +494,7 @@ class TestThermal:
 
         # Update with a pollutant. Should succeed even with versions prior to v8.6
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"nox": 10.0},
         )
@@ -503,7 +503,7 @@ class TestThermal:
 
         # Update with the field `efficiency`. Should succeed even with versions prior to v8.7
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"efficiency": 97.0},
         )
@@ -516,7 +516,7 @@ class TestThermal:
 
         new_name = "Duplicate of Fr_Gas_Conventional"
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/thermals/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/thermals/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": new_name},
         )
@@ -536,7 +536,7 @@ class TestThermal:
         # asserts the matrix has also been duplicated
         new_cluster_matrix_path = f"input/thermal/prepro/{area_id}/{duplicated_id.lower()}/data"
         res = client.get(
-            f"/v1/studies/{study_id}/raw",
+            f"/v1/studies/{internal_study}/raw",
             params={"path": new_cluster_matrix_path},
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -549,7 +549,7 @@ class TestThermal:
 
         # Everything is fine at the beginning
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200
@@ -559,14 +559,14 @@ class TestThermal:
         _upload_matrix(
             client,
             user_access_token,
-            study_id,
+            internal_study,
             f"input/thermal/series/{area_id}/{fr_gas_conventional_id.lower()}/series",
             pd.DataFrame(np.random.randint(0, 10, size=(4, 1))),
         )
 
         # Validation should fail
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 422
@@ -578,14 +578,14 @@ class TestThermal:
         _upload_matrix(
             client,
             user_access_token,
-            study_id,
+            internal_study,
             f"input/thermal/series/{area_id}/{fr_gas_conventional_id.lower()}/series",
             pd.DataFrame(np.random.randint(0, 10, size=(8760, 4))),
         )
 
         # Validation should succeed again
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200
@@ -596,14 +596,14 @@ class TestThermal:
             _upload_matrix(
                 client,
                 user_access_token,
-                study_id,
+                internal_study,
                 f"input/thermal/series/{area_id}/{fr_gas_conventional_id.lower()}/CO2Cost",
                 pd.DataFrame(np.random.randint(0, 10, size=(8760, 3))),
             )
 
             # Validation should fail
             res = client.get(
-                f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
+                f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate",
                 headers={"Authorization": f"Bearer {user_access_token}"},
             )
             assert res.status_code == 422
@@ -640,7 +640,7 @@ class TestThermal:
 
         # noinspection SpellCheckingInspection
         res = client.post(
-            f"/v1/studies/{study_id}/bindingconstraints",
+            f"/v1/studies/{internal_study}/bindingconstraints",
             json=bc_obj,
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
@@ -649,7 +649,7 @@ class TestThermal:
         # verify that we can't delete the thermal cluster because it is referenced in a binding constraint
         res = client.request(
             "DELETE",
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_gas_conventional_id],
         )
@@ -660,7 +660,7 @@ class TestThermal:
 
         # delete the binding constraint
         res = client.delete(
-            f"/v1/studies/{study_id}/bindingconstraints/{bc_obj['name']}",
+            f"/v1/studies/{internal_study}/bindingconstraints/{bc_obj['name']}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -668,7 +668,7 @@ class TestThermal:
         # Now we can delete the thermal cluster
         res = client.request(
             "DELETE",
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_gas_conventional_id],
         )
@@ -677,7 +677,7 @@ class TestThermal:
         # check that the binding constraint has been deleted
         # noinspection SpellCheckingInspection
         res = client.get(
-            f"/v1/studies/{study_id}/bindingconstraints",
+            f"/v1/studies/{internal_study}/bindingconstraints",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -686,7 +686,7 @@ class TestThermal:
         # If the thermal cluster list is empty, the deletion should be a no-op.
         res = client.request(
             "DELETE",
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[],
         )
@@ -699,7 +699,7 @@ class TestThermal:
         other_cluster_id2 = "02_wind_on"
         res = client.request(
             "DELETE",
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[other_cluster_id1, other_cluster_id2],
         )
@@ -708,7 +708,7 @@ class TestThermal:
 
         # The list of thermal clusters should not contain the deleted ones.
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200, res.json()
@@ -724,7 +724,7 @@ class TestThermal:
         bad_area_id = "bad_area"
         res = client.request(
             "DELETE",
-            f"/v1/studies/{study_id}/areas/{bad_area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[fr_gas_conventional_id],
         )
@@ -753,7 +753,7 @@ class TestThermal:
 
         # Check GET with wrong `area_id`
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{bad_area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         obj = res.json()
@@ -784,7 +784,7 @@ class TestThermal:
 
         # Check POST with wrong `area_id`
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{bad_area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "name": fr_gas_conventional,
@@ -807,7 +807,7 @@ class TestThermal:
 
         # Check POST with wrong `group`
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={"name": fr_gas_conventional, "group": "GroupFoo"},
         )
@@ -818,7 +818,7 @@ class TestThermal:
 
         # Check PATCH with the wrong `area_id`
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{bad_area_id}/clusters/thermal/{fr_gas_conventional_id}",
+            f"/v1/studies/{internal_study}/areas/{bad_area_id}/clusters/thermal/{fr_gas_conventional_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "group": "Oil",
@@ -840,7 +840,7 @@ class TestThermal:
         # Check PATCH with the wrong `cluster_id`
         bad_cluster_id = "bad_cluster"
         res = client.patch(
-            f"/v1/studies/{study_id}/areas/{area_id}/clusters/thermal/{bad_cluster_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/clusters/thermal/{bad_cluster_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json={
                 "group": "Oil",
@@ -882,7 +882,7 @@ class TestThermal:
         # Cannot duplicate a fake cluster
         unknown_id = "unknown"
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/thermals/{unknown_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/thermals/{unknown_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": "duplicate"},
         )
@@ -893,7 +893,7 @@ class TestThermal:
 
         # Cannot duplicate with an existing id
         res = client.post(
-            f"/v1/studies/{study_id}/areas/{area_id}/thermals/{duplicated_id}",
+            f"/v1/studies/{internal_study}/areas/{area_id}/thermals/{duplicated_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"newName": new_name.upper()},  # different case but same ID
         )
@@ -1048,7 +1048,7 @@ class TestThermal:
             "remove_cluster",
         ]
 
-    def test_thermal_cluster_deletion(self, client: TestClient, user_access_token: str, study_id: str) -> None:
+    def test_thermal_cluster_deletion(self, client: TestClient, user_access_token: str, internal_study: str) -> None:
         """
         Test that creating a thermal cluster with invalid properties raises a validation error.
         """
@@ -1057,7 +1057,7 @@ class TestThermal:
 
         # Create an area "area_1" in the study
         res = client.post(
-            f"/v1/studies/{study_id}/areas",
+            f"/v1/studies/{internal_study}/areas",
             json={
                 "name": "area_1",
                 "type": "AREA",
@@ -1068,7 +1068,7 @@ class TestThermal:
 
         # Create an area "area_2" in the study
         res = client.post(
-            f"/v1/studies/{study_id}/areas",
+            f"/v1/studies/{internal_study}/areas",
             json={
                 "name": "area_2",
                 "type": "AREA",
@@ -1079,7 +1079,7 @@ class TestThermal:
 
         # Create an area "area_3" in the study
         res = client.post(
-            f"/v1/studies/{study_id}/areas",
+            f"/v1/studies/{internal_study}/areas",
             json={
                 "name": "area_3",
                 "type": "AREA",
@@ -1090,7 +1090,7 @@ class TestThermal:
 
         # Create a thermal cluster in the study for area_1
         res = client.post(
-            f"/v1/studies/{study_id}/areas/area_1/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/area_1/clusters/thermal",
             json={
                 "name": "cluster_1",
                 "group": "Nuclear",
@@ -1103,7 +1103,7 @@ class TestThermal:
 
         # Create a thermal cluster in the study for area_2
         res = client.post(
-            f"/v1/studies/{study_id}/areas/area_2/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/area_2/clusters/thermal",
             json={
                 "name": "cluster_2",
                 "group": "Nuclear",
@@ -1116,7 +1116,7 @@ class TestThermal:
 
         # Create a thermal cluster in the study for area_3
         res = client.post(
-            f"/v1/studies/{study_id}/areas/area_3/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/area_3/clusters/thermal",
             json={
                 "name": "cluster_3",
                 "group": "Nuclear",
@@ -1143,7 +1143,7 @@ class TestThermal:
             ],
         }
         res = client.post(
-            f"/v1/studies/{study_id}/bindingconstraints",
+            f"/v1/studies/{internal_study}/bindingconstraints",
             json=bc_obj,
         )
         assert res.status_code == 200, res.json()
@@ -1164,54 +1164,54 @@ class TestThermal:
             ],
         }
         res = client.post(
-            f"/v1/studies/{study_id}/bindingconstraints",
+            f"/v1/studies/{internal_study}/bindingconstraints",
             json=bc_obj,
         )
         assert res.status_code == 200, res.json()
 
         # check that deleting the thermal cluster in area_1 fails
         res = client.delete(
-            f"/v1/studies/{study_id}/areas/area_1/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/area_1/clusters/thermal",
             json=["cluster_1"],
         )
         assert res.status_code == 403, res.json()
 
         # now delete the binding constraint that references the thermal cluster in area_1
         res = client.delete(
-            f"/v1/studies/{study_id}/bindingconstraints/bc_1",
+            f"/v1/studies/{internal_study}/bindingconstraints/bc_1",
         )
         assert res.status_code == 200, res.json()
 
         # check that deleting the thermal cluster in area_1 succeeds
         res = client.delete(
-            f"/v1/studies/{study_id}/areas/area_1/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/area_1/clusters/thermal",
             json=["cluster_1"],
         )
         assert res.status_code == 204, res.json()
 
         # check that deleting the thermal cluster in area_2 fails
         res = client.delete(
-            f"/v1/studies/{study_id}/areas/area_2/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/area_2/clusters/thermal",
             json=["cluster_2"],
         )
         assert res.status_code == 403, res.json()
 
         # now delete the binding constraint that references the thermal cluster in area_2
         res = client.delete(
-            f"/v1/studies/{study_id}/bindingconstraints/bc_2",
+            f"/v1/studies/{internal_study}/bindingconstraints/bc_2",
         )
         assert res.status_code == 200, res.json()
 
         # check that deleting the thermal cluster in area_2 succeeds
         res = client.delete(
-            f"/v1/studies/{study_id}/areas/area_2/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/area_2/clusters/thermal",
             json=["cluster_2"],
         )
         assert res.status_code == 204, res.json()
 
         # check that deleting the thermal cluster in area_3 succeeds
         res = client.delete(
-            f"/v1/studies/{study_id}/areas/area_3/clusters/thermal",
+            f"/v1/studies/{internal_study}/areas/area_3/clusters/thermal",
             json=["cluster_3"],
         )
         assert res.status_code == 204, res.json()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1566,7 +1566,7 @@ def test_maintenance(client: TestClient, admin_access_token: str) -> None:
     assert res.json() == message
 
 
-def test_import(client: TestClient, admin_access_token: str, study_id: str) -> None:
+def test_import(client: TestClient, admin_access_token: str, internal_study: str) -> None:
     client.headers = {"Authorization": f"Bearer {admin_access_token}"}
 
     zip_path = ASSETS_DIR / "STA-mini.zip"
@@ -1642,12 +1642,12 @@ def test_import(client: TestClient, admin_access_token: str, study_id: str) -> N
     # tests outputs import for .zip
     output_path_zip = ASSETS_DIR / "output_adq.zip"
     client.post(
-        f"/v1/studies/{study_id}/output",
+        f"/v1/studies/{internal_study}/output",
         headers={"Authorization": f'Bearer {george_credentials["access_token"]}'},
         files={"output": io.BytesIO(output_path_zip.read_bytes())},
     )
     res = client.get(
-        f"/v1/studies/{study_id}/outputs",
+        f"/v1/studies/{internal_study}/outputs",
         headers={"Authorization": f'Bearer {george_credentials["access_token"]}'},
     )
     assert len(res.json()) == 6
@@ -1655,12 +1655,12 @@ def test_import(client: TestClient, admin_access_token: str, study_id: str) -> N
     # tests outputs import for .7z
     output_path_seven_zip = ASSETS_DIR / "output_adq.7z"
     client.post(
-        f"/v1/studies/{study_id}/output",
+        f"/v1/studies/{internal_study}/output",
         headers={"Authorization": f'Bearer {george_credentials["access_token"]}'},
         files={"output": io.BytesIO(output_path_seven_zip.read_bytes())},
     )
     res = client.get(
-        f"/v1/studies/{study_id}/outputs",
+        f"/v1/studies/{internal_study}/outputs",
         headers={"Authorization": f'Bearer {george_credentials["access_token"]}'},
     )
     assert len(res.json()) == 7
@@ -1688,11 +1688,11 @@ def test_import(client: TestClient, admin_access_token: str, study_id: str) -> N
         assert result[1]["name"] == "it.txt"
 
 
-def test_copy(client: TestClient, admin_access_token: str, study_id: str) -> None:
+def test_copy(client: TestClient, admin_access_token: str, internal_study: str) -> None:
     client.headers = {"Authorization": f"Bearer {admin_access_token}"}
 
     # Copy a study with admin user who belongs to a group
-    copied = client.post(f"/v1/studies/{study_id}/copy?dest=copied&use_task=false")
+    copied = client.post(f"/v1/studies/{internal_study}/copy?dest=copied&use_task=false")
     assert copied.status_code == 201
     # asserts that it has admin groups and PublicMode to NONE
     res = client.get(f"/v1/studies/{copied.json()}").json()
@@ -1705,7 +1705,7 @@ def test_copy(client: TestClient, admin_access_token: str, study_id: str) -> Non
 
     # George copies a study
     copied = client.post(
-        f"/v1/studies/{study_id}/copy?dest=copied&use_task=false",
+        f"/v1/studies/{internal_study}/copy?dest=copied&use_task=false",
         headers={"Authorization": f'Bearer {george_credentials["access_token"]}'},
     )
     assert copied.status_code == 201
@@ -1715,7 +1715,9 @@ def test_copy(client: TestClient, admin_access_token: str, study_id: str) -> Non
     assert res["public_mode"] == "READ"
 
 
-def test_areas_deletion_with_binding_constraints(client: TestClient, user_access_token: str, study_id: str) -> None:
+def test_areas_deletion_with_binding_constraints(
+    client: TestClient, user_access_token: str, internal_study: str
+) -> None:
     """
     Test the deletion of areas that are referenced in binding constraints.
     """
@@ -1747,7 +1749,7 @@ def test_areas_deletion_with_binding_constraints(client: TestClient, user_access
     for constraint_term in constraint_terms:
         # Create an area "area_1" in the study
         res = client.post(
-            f"/v1/studies/{study_id}/areas",
+            f"/v1/studies/{internal_study}/areas",
             json={"name": area1_id.title(), "type": "AREA", "metadata": {"country": "FR"}},
         )
         res.raise_for_status()
@@ -1755,12 +1757,12 @@ def test_areas_deletion_with_binding_constraints(client: TestClient, user_access
         if set(constraint_term["data"]) == {"area1", "area2"}:
             # Create a second area and a link between the two areas
             res = client.post(
-                f"/v1/studies/{study_id}/areas",
+                f"/v1/studies/{internal_study}/areas",
                 json={"name": area2_id.title(), "type": "AREA", "metadata": {"country": "DE"}},
             )
             res.raise_for_status()
             res = client.post(
-                f"/v1/studies/{study_id}/links",
+                f"/v1/studies/{internal_study}/links",
                 json={"area1": area1_id, "area2": area2_id},
             )
             res.raise_for_status()
@@ -1768,7 +1770,7 @@ def test_areas_deletion_with_binding_constraints(client: TestClient, user_access
         elif set(constraint_term["data"]) == {"area", "cluster"}:
             # Create a cluster in the first area
             res = client.post(
-                f"/v1/studies/{study_id}/areas/{area1_id}/clusters/thermal",
+                f"/v1/studies/{internal_study}/areas/{area1_id}/clusters/thermal",
                 json={"name": cluster_id.title(), "group": "Nuclear"},
             )
             res.raise_for_status()
@@ -1785,7 +1787,7 @@ def test_areas_deletion_with_binding_constraints(client: TestClient, user_access
             "operator": "less",
             "terms": [constraint_term],
         }
-        res = client.post(f"/v1/studies/{study_id}/bindingconstraints", json=bc_obj)
+        res = client.post(f"/v1/studies/{internal_study}/bindingconstraints", json=bc_obj)
         res.raise_for_status()
 
         if set(constraint_term["data"]) == {"area1", "area2"}:
@@ -1797,23 +1799,25 @@ def test_areas_deletion_with_binding_constraints(client: TestClient, user_access
 
         for area_id in areas_to_delete:
             # try to delete the areas
-            res = client.delete(f"/v1/studies/{study_id}/areas/{area_id}")
+            res = client.delete(f"/v1/studies/{internal_study}/areas/{area_id}")
             assert res.status_code == 403, res.json()
             description = res.json()["description"]
             assert all([elm in description for elm in [area_id, bc_id]])
             assert res.json()["exception"] == "ReferencedObjectDeletionNotAllowed"
 
         # delete the binding constraint
-        res = client.delete(f"/v1/studies/{study_id}/bindingconstraints/{bc_id}")
+        res = client.delete(f"/v1/studies/{internal_study}/bindingconstraints/{bc_id}")
         assert res.status_code == 200, res.json()
 
         for area_id in areas_to_delete:
             # delete the area
-            res = client.delete(f"/v1/studies/{study_id}/areas/{area_id}")
+            res = client.delete(f"/v1/studies/{internal_study}/areas/{area_id}")
             assert res.status_code == 200, res.json()
 
 
-def test_links_deletion_with_binding_constraints(client: TestClient, user_access_token: str, study_id: str) -> None:
+def test_links_deletion_with_binding_constraints(
+    client: TestClient, user_access_token: str, internal_study: str
+) -> None:
     """
     Test the deletion of links that are referenced in binding constraints.
     """
@@ -1823,7 +1827,7 @@ def test_links_deletion_with_binding_constraints(client: TestClient, user_access
 
     # Create an area "area_1" in the study
     res = client.post(
-        f"/v1/studies/{study_id}/areas",
+        f"/v1/studies/{internal_study}/areas",
         json={
             "name": "area_1",
             "type": "AREA",
@@ -1834,7 +1838,7 @@ def test_links_deletion_with_binding_constraints(client: TestClient, user_access
 
     # Create an area "area_2" in the study
     res = client.post(
-        f"/v1/studies/{study_id}/areas",
+        f"/v1/studies/{internal_study}/areas",
         json={
             "name": "area_2",
             "type": "AREA",
@@ -1845,7 +1849,7 @@ def test_links_deletion_with_binding_constraints(client: TestClient, user_access
 
     # create a link between the two areas
     res = client.post(
-        f"/v1/studies/{study_id}/links",
+        f"/v1/studies/{internal_study}/links",
         json={"area1": "area_1", "area2": "area_2"},
     )
     assert res.status_code == 200, res.json()
@@ -1864,20 +1868,20 @@ def test_links_deletion_with_binding_constraints(client: TestClient, user_access
             }
         ],
     }
-    res = client.post(f"/v1/studies/{study_id}/bindingconstraints", json=bc_obj)
+    res = client.post(f"/v1/studies/{internal_study}/bindingconstraints", json=bc_obj)
     assert res.status_code == 200, res.json()
 
     # try to delete the link before deleting the binding constraint
-    res = client.delete(f"/v1/studies/{study_id}/links/area_1/area_2")
+    res = client.delete(f"/v1/studies/{internal_study}/links/area_1/area_2")
     assert res.status_code == 403, res.json()
     description = res.json()["description"]
     assert all([elm in description for elm in ["area_1%area_2", "bc_1"]])
     assert res.json()["exception"] == "ReferencedObjectDeletionNotAllowed"
 
     # delete the binding constraint
-    res = client.delete(f"/v1/studies/{study_id}/bindingconstraints/bc_1")
+    res = client.delete(f"/v1/studies/{internal_study}/bindingconstraints/bc_1")
     assert res.status_code == 200, res.json()
 
     # delete the link
-    res = client.delete(f"/v1/studies/{study_id}/links/area_1/area_2")
+    res = client.delete(f"/v1/studies/{internal_study}/links/area_1/area_2")
     assert res.status_code == 200, res.json()

--- a/tests/integration/test_studies_upgrade.py
+++ b/tests/integration/test_studies_upgrade.py
@@ -11,9 +11,9 @@ RUN_ON_WINDOWS = os.name == "nt"
 
 class TestStudyUpgrade:
     @pytest.mark.skipif(RUN_ON_WINDOWS, reason="This test runs randomly on Windows")
-    def test_upgrade_study__next_version(self, client: TestClient, user_access_token: str, study_id: str):
+    def test_upgrade_study__next_version(self, client: TestClient, user_access_token: str, internal_study: str):
         res = client.put(
-            f"/v1/studies/{study_id}/upgrade",
+            f"/v1/studies/{internal_study}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200
@@ -24,10 +24,10 @@ class TestStudyUpgrade:
         assert "710" in task.result.message, f"Version not in {task.result.message=}"
 
     @pytest.mark.skipif(RUN_ON_WINDOWS, reason="This test runs randomly on Windows")
-    def test_upgrade_study__target_version(self, client: TestClient, user_access_token: str, study_id: str):
+    def test_upgrade_study__target_version(self, client: TestClient, user_access_token: str, internal_study: str):
         target_version = "720"
         res = client.put(
-            f"/v1/studies/{study_id}/upgrade",
+            f"/v1/studies/{internal_study}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": target_version},
         )
@@ -39,10 +39,10 @@ class TestStudyUpgrade:
         assert target_version in task.result.message, f"Version not in {task.result.message=}"
 
     @pytest.mark.skipif(RUN_ON_WINDOWS, reason="This test runs randomly on Windows")
-    def test_upgrade_study__bad_target_version(self, client: TestClient, user_access_token: str, study_id: str):
+    def test_upgrade_study__bad_target_version(self, client: TestClient, user_access_token: str, internal_study: str):
         target_version = "999"
         res = client.put(
-            f"/v1/studies/{study_id}/upgrade",
+            f"/v1/studies/{internal_study}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": target_version},
         )

--- a/tests/integration/test_studies_upgrade.py
+++ b/tests/integration/test_studies_upgrade.py
@@ -11,9 +11,9 @@ RUN_ON_WINDOWS = os.name == "nt"
 
 class TestStudyUpgrade:
     @pytest.mark.skipif(RUN_ON_WINDOWS, reason="This test runs randomly on Windows")
-    def test_upgrade_study__next_version(self, client: TestClient, user_access_token: str, internal_study: str):
+    def test_upgrade_study__next_version(self, client: TestClient, user_access_token: str, internal_study_id: str):
         res = client.put(
-            f"/v1/studies/{internal_study}/upgrade",
+            f"/v1/studies/{internal_study_id}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         assert res.status_code == 200
@@ -24,10 +24,10 @@ class TestStudyUpgrade:
         assert "710" in task.result.message, f"Version not in {task.result.message=}"
 
     @pytest.mark.skipif(RUN_ON_WINDOWS, reason="This test runs randomly on Windows")
-    def test_upgrade_study__target_version(self, client: TestClient, user_access_token: str, internal_study: str):
+    def test_upgrade_study__target_version(self, client: TestClient, user_access_token: str, internal_study_id: str):
         target_version = "720"
         res = client.put(
-            f"/v1/studies/{internal_study}/upgrade",
+            f"/v1/studies/{internal_study_id}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": target_version},
         )
@@ -39,10 +39,12 @@ class TestStudyUpgrade:
         assert target_version in task.result.message, f"Version not in {task.result.message=}"
 
     @pytest.mark.skipif(RUN_ON_WINDOWS, reason="This test runs randomly on Windows")
-    def test_upgrade_study__bad_target_version(self, client: TestClient, user_access_token: str, internal_study: str):
+    def test_upgrade_study__bad_target_version(
+        self, client: TestClient, user_access_token: str, internal_study_id: str
+    ):
         target_version = "999"
         res = client.put(
-            f"/v1/studies/{internal_study}/upgrade",
+            f"/v1/studies/{internal_study_id}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": target_version},
         )

--- a/tests/integration/variant_blueprint/test_renewable_cluster.py
+++ b/tests/integration/variant_blueprint/test_renewable_cluster.py
@@ -21,7 +21,7 @@ class TestRenewableCluster:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         # sourcery skip: extract-duplicate-method
 
@@ -32,7 +32,7 @@ class TestRenewableCluster:
         # We have an "old" study that we need to upgrade to version 810
         min_study_version = 810
         res = client.put(
-            f"/v1/studies/{internal_study}/upgrade",
+            f"/v1/studies/{internal_study_id}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": min_study_version},
         )
@@ -51,7 +51,7 @@ class TestRenewableCluster:
             "data": {"renewable-generation-modelling": "clusters"},
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "update_config", "args": args}],
         )
@@ -76,7 +76,7 @@ class TestRenewableCluster:
             },
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_renewables_cluster", "args": args}],
         )
@@ -97,7 +97,7 @@ class TestRenewableCluster:
             },
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_renewables_cluster", "args": args}],
         )
@@ -105,7 +105,7 @@ class TestRenewableCluster:
 
         # Check the properties of the renewable clusters in the "FR" area
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_fr_id}/clusters/renewable/{cluster_fr1_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_fr_id}/clusters/renewable/{cluster_fr1_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -122,7 +122,7 @@ class TestRenewableCluster:
         assert properties == expected
 
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_fr_id}/clusters/renewable/{cluster_fr2_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_fr_id}/clusters/renewable/{cluster_fr2_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -156,7 +156,7 @@ class TestRenewableCluster:
             "matrix": values_fr2.tolist(),
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[
                 {"action": "replace_matrix", "args": args_fr1},
@@ -167,7 +167,7 @@ class TestRenewableCluster:
 
         # Check the matrices of the renewable clusters in the "FR" area
         res = client.get(
-            f"/v1/studies/{internal_study}/raw?path=input/renewables/series/{area_fr_id}/{series_fr1_id}/series",
+            f"/v1/studies/{internal_study_id}/raw?path=input/renewables/series/{area_fr_id}/{series_fr1_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -175,7 +175,7 @@ class TestRenewableCluster:
         assert np.array(matrix_fr1["data"], dtype=np.float64).all() == values_fr1.all()
 
         res = client.get(
-            f"/v1/studies/{internal_study}/raw?path=input/renewables/series/{area_fr_id}/{series_fr2_id}/series",
+            f"/v1/studies/{internal_study_id}/raw?path=input/renewables/series/{area_fr_id}/{series_fr2_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -202,14 +202,14 @@ class TestRenewableCluster:
             },
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_renewables_cluster", "args": args}],
         )
         res.raise_for_status()
 
         res = client.get(
-            f"/v1/studies/{internal_study}/areas/{area_it_id}/clusters/renewable/{cluster_it1_id}",
+            f"/v1/studies/{internal_study_id}/areas/{area_it_id}/clusters/renewable/{cluster_it1_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -228,7 +228,7 @@ class TestRenewableCluster:
         # Check the matrices of the renewable clusters in the "IT" area
         series_it1_id = cluster_it1_id.lower()  # Series IDs are in lower case
         res = client.get(
-            f"/v1/studies/{internal_study}/raw?path=input/renewables/series/{area_it_id}/{series_it1_id}/series",
+            f"/v1/studies/{internal_study_id}/raw?path=input/renewables/series/{area_it_id}/{series_it1_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -242,7 +242,7 @@ class TestRenewableCluster:
         # The `remove_renewables_cluster` command allows you to delete a Renewable Cluster.
         args = {"area_id": area_fr_id, "cluster_id": cluster_fr2_id}
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "remove_renewables_cluster", "args": args}],
         )
@@ -250,7 +250,7 @@ class TestRenewableCluster:
 
         # Check the properties of all renewable clusters
         res = client.get(
-            f"/v1/studies/{internal_study}/raw?path=input/renewables/clusters&depth=4",
+            f"/v1/studies/{internal_study_id}/raw?path=input/renewables/clusters&depth=4",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -284,7 +284,7 @@ class TestRenewableCluster:
         # The `remove_renewables_cluster` command allows you to delete a Renewable Cluster.
         args = {"area_id": area_fr_id, "cluster_id": cluster_fr1_id}
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "remove_renewables_cluster", "args": args}],
         )
@@ -292,7 +292,7 @@ class TestRenewableCluster:
 
         # Check the properties of all renewable clusters
         res = client.get(
-            f"/v1/studies/{internal_study}/raw?path=input/renewables/clusters&depth=4",
+            f"/v1/studies/{internal_study_id}/raw?path=input/renewables/clusters&depth=4",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -319,7 +319,7 @@ class TestRenewableCluster:
         # this behavior is not yet implemented, so you will encounter a 500 error.
         args = {"area_id": area_fr_id, "cluster_id": cluster_fr2_id}
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "remove_renewables_cluster", "args": args}],
         )

--- a/tests/integration/variant_blueprint/test_renewable_cluster.py
+++ b/tests/integration/variant_blueprint/test_renewable_cluster.py
@@ -21,7 +21,7 @@ class TestRenewableCluster:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         # sourcery skip: extract-duplicate-method
 
@@ -32,7 +32,7 @@ class TestRenewableCluster:
         # We have an "old" study that we need to upgrade to version 810
         min_study_version = 810
         res = client.put(
-            f"/v1/studies/{study_id}/upgrade",
+            f"/v1/studies/{internal_study}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": min_study_version},
         )
@@ -51,7 +51,7 @@ class TestRenewableCluster:
             "data": {"renewable-generation-modelling": "clusters"},
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "update_config", "args": args}],
         )
@@ -76,7 +76,7 @@ class TestRenewableCluster:
             },
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_renewables_cluster", "args": args}],
         )
@@ -97,7 +97,7 @@ class TestRenewableCluster:
             },
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_renewables_cluster", "args": args}],
         )
@@ -105,7 +105,7 @@ class TestRenewableCluster:
 
         # Check the properties of the renewable clusters in the "FR" area
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_fr_id}/clusters/renewable/{cluster_fr1_id}",
+            f"/v1/studies/{internal_study}/areas/{area_fr_id}/clusters/renewable/{cluster_fr1_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -122,7 +122,7 @@ class TestRenewableCluster:
         assert properties == expected
 
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_fr_id}/clusters/renewable/{cluster_fr2_id}",
+            f"/v1/studies/{internal_study}/areas/{area_fr_id}/clusters/renewable/{cluster_fr2_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -156,7 +156,7 @@ class TestRenewableCluster:
             "matrix": values_fr2.tolist(),
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[
                 {"action": "replace_matrix", "args": args_fr1},
@@ -167,7 +167,7 @@ class TestRenewableCluster:
 
         # Check the matrices of the renewable clusters in the "FR" area
         res = client.get(
-            f"/v1/studies/{study_id}/raw?path=input/renewables/series/{area_fr_id}/{series_fr1_id}/series",
+            f"/v1/studies/{internal_study}/raw?path=input/renewables/series/{area_fr_id}/{series_fr1_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -175,7 +175,7 @@ class TestRenewableCluster:
         assert np.array(matrix_fr1["data"], dtype=np.float64).all() == values_fr1.all()
 
         res = client.get(
-            f"/v1/studies/{study_id}/raw?path=input/renewables/series/{area_fr_id}/{series_fr2_id}/series",
+            f"/v1/studies/{internal_study}/raw?path=input/renewables/series/{area_fr_id}/{series_fr2_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -202,14 +202,14 @@ class TestRenewableCluster:
             },
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_renewables_cluster", "args": args}],
         )
         res.raise_for_status()
 
         res = client.get(
-            f"/v1/studies/{study_id}/areas/{area_it_id}/clusters/renewable/{cluster_it1_id}",
+            f"/v1/studies/{internal_study}/areas/{area_it_id}/clusters/renewable/{cluster_it1_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -228,7 +228,7 @@ class TestRenewableCluster:
         # Check the matrices of the renewable clusters in the "IT" area
         series_it1_id = cluster_it1_id.lower()  # Series IDs are in lower case
         res = client.get(
-            f"/v1/studies/{study_id}/raw?path=input/renewables/series/{area_it_id}/{series_it1_id}/series",
+            f"/v1/studies/{internal_study}/raw?path=input/renewables/series/{area_it_id}/{series_it1_id}/series",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -242,7 +242,7 @@ class TestRenewableCluster:
         # The `remove_renewables_cluster` command allows you to delete a Renewable Cluster.
         args = {"area_id": area_fr_id, "cluster_id": cluster_fr2_id}
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "remove_renewables_cluster", "args": args}],
         )
@@ -250,7 +250,7 @@ class TestRenewableCluster:
 
         # Check the properties of all renewable clusters
         res = client.get(
-            f"/v1/studies/{study_id}/raw?path=input/renewables/clusters&depth=4",
+            f"/v1/studies/{internal_study}/raw?path=input/renewables/clusters&depth=4",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -284,7 +284,7 @@ class TestRenewableCluster:
         # The `remove_renewables_cluster` command allows you to delete a Renewable Cluster.
         args = {"area_id": area_fr_id, "cluster_id": cluster_fr1_id}
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "remove_renewables_cluster", "args": args}],
         )
@@ -292,7 +292,7 @@ class TestRenewableCluster:
 
         # Check the properties of all renewable clusters
         res = client.get(
-            f"/v1/studies/{study_id}/raw?path=input/renewables/clusters&depth=4",
+            f"/v1/studies/{internal_study}/raw?path=input/renewables/clusters&depth=4",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -319,7 +319,7 @@ class TestRenewableCluster:
         # this behavior is not yet implemented, so you will encounter a 500 error.
         args = {"area_id": area_fr_id, "cluster_id": cluster_fr2_id}
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "remove_renewables_cluster", "args": args}],
         )

--- a/tests/integration/variant_blueprint/test_st_storage.py
+++ b/tests/integration/variant_blueprint/test_st_storage.py
@@ -22,7 +22,7 @@ class TestSTStorage:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ):
         # =======================
         #  Study version upgrade
@@ -31,7 +31,7 @@ class TestSTStorage:
         # We have an "old" study that we need to upgrade to version 860
         min_study_version = 860
         res = client.put(
-            f"/v1/studies/{internal_study}/upgrade",
+            f"/v1/studies/{internal_study_id}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": min_study_version},
         )
@@ -42,12 +42,12 @@ class TestSTStorage:
 
         # We can check that the study is upgraded to the required version
         res = client.get(
-            f"/v1/studies/{internal_study}",
+            f"/v1/studies/{internal_study_id}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
         assert res.json() == {
-            "id": internal_study,
+            "id": internal_study_id,
             "name": "STA-mini",
             "version": min_study_version,
             "created": ANY,  # ISO8601 Date/time
@@ -69,7 +69,7 @@ class TestSTStorage:
 
         # Here is the list of available areas
         res = client.get(
-            f"/v1/studies/{internal_study}/areas",
+            f"/v1/studies/{internal_study_id}/areas",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -104,7 +104,7 @@ class TestSTStorage:
             },
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_st_storage", "args": args}],
         )
@@ -130,7 +130,7 @@ class TestSTStorage:
             "matrix": pmax_injection.tolist(),
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[
                 {"action": "replace_matrix", "args": args1},
@@ -166,7 +166,7 @@ class TestSTStorage:
             "inflows": inflows.tolist(),
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_st_storage", "args": args}],
         )
@@ -179,7 +179,7 @@ class TestSTStorage:
         # The `remove_st_storage` command allows you to delete a Short-Term Storage.
         args = {"area_id": area_id, "storage_id": siemens_battery_id}
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "remove_st_storage", "args": args}],
         )
@@ -215,7 +215,7 @@ class TestSTStorage:
             "inflows": inflows.tolist(),
         }
         res = client.post(
-            f"/v1/studies/{internal_study}/commands",
+            f"/v1/studies/{internal_study_id}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_st_storage", "args": args}],
         )

--- a/tests/integration/variant_blueprint/test_st_storage.py
+++ b/tests/integration/variant_blueprint/test_st_storage.py
@@ -22,7 +22,7 @@ class TestSTStorage:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ):
         # =======================
         #  Study version upgrade
@@ -31,7 +31,7 @@ class TestSTStorage:
         # We have an "old" study that we need to upgrade to version 860
         min_study_version = 860
         res = client.put(
-            f"/v1/studies/{study_id}/upgrade",
+            f"/v1/studies/{internal_study}/upgrade",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"target_version": min_study_version},
         )
@@ -42,12 +42,12 @@ class TestSTStorage:
 
         # We can check that the study is upgraded to the required version
         res = client.get(
-            f"/v1/studies/{study_id}",
+            f"/v1/studies/{internal_study}",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
         assert res.json() == {
-            "id": study_id,
+            "id": internal_study,
             "name": "STA-mini",
             "version": min_study_version,
             "created": ANY,  # ISO8601 Date/time
@@ -69,7 +69,7 @@ class TestSTStorage:
 
         # Here is the list of available areas
         res = client.get(
-            f"/v1/studies/{study_id}/areas",
+            f"/v1/studies/{internal_study}/areas",
             headers={"Authorization": f"Bearer {user_access_token}"},
         )
         res.raise_for_status()
@@ -104,7 +104,7 @@ class TestSTStorage:
             },
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_st_storage", "args": args}],
         )
@@ -130,7 +130,7 @@ class TestSTStorage:
             "matrix": pmax_injection.tolist(),
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[
                 {"action": "replace_matrix", "args": args1},
@@ -166,7 +166,7 @@ class TestSTStorage:
             "inflows": inflows.tolist(),
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_st_storage", "args": args}],
         )
@@ -179,7 +179,7 @@ class TestSTStorage:
         # The `remove_st_storage` command allows you to delete a Short-Term Storage.
         args = {"area_id": area_id, "storage_id": siemens_battery_id}
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "remove_st_storage", "args": args}],
         )
@@ -215,7 +215,7 @@ class TestSTStorage:
             "inflows": inflows.tolist(),
         }
         res = client.post(
-            f"/v1/studies/{study_id}/commands",
+            f"/v1/studies/{internal_study}/commands",
             headers={"Authorization": f"Bearer {user_access_token}"},
             json=[{"action": "create_st_storage", "args": args}],
         )

--- a/tests/integration/variant_blueprint/test_thermal_cluster.py
+++ b/tests/integration/variant_blueprint/test_thermal_cluster.py
@@ -43,7 +43,7 @@ class TestThermalCluster:
         self,
         client: TestClient,
         user_access_token: str,
-        study_id: str,
+        internal_study: str,
     ) -> None:
         """
         This test is based on the study "STA-mini.zip", which is a RAW study.
@@ -54,7 +54,7 @@ class TestThermalCluster:
         """
         # First, we create a copy of the study, and we convert it to a managed study.
         res = client.post(
-            f"/v1/studies/{study_id}/copy",
+            f"/v1/studies/{internal_study}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "default", "with_outputs": False, "use_task": False},
         )

--- a/tests/integration/variant_blueprint/test_thermal_cluster.py
+++ b/tests/integration/variant_blueprint/test_thermal_cluster.py
@@ -43,7 +43,7 @@ class TestThermalCluster:
         self,
         client: TestClient,
         user_access_token: str,
-        internal_study: str,
+        internal_study_id: str,
     ) -> None:
         """
         This test is based on the study "STA-mini.zip", which is a RAW study.
@@ -54,7 +54,7 @@ class TestThermalCluster:
         """
         # First, we create a copy of the study, and we convert it to a managed study.
         res = client.post(
-            f"/v1/studies/{internal_study}/copy",
+            f"/v1/studies/{internal_study_id}/copy",
             headers={"Authorization": f"Bearer {user_access_token}"},
             params={"dest": "default", "with_outputs": False, "use_task": False},
         )


### PR DESCRIPTION
## Description

In the context of API endpoint integration tests, we have a pytest fixture that allows us to locate the "STA-mini" study among the internalized studies (currently, there is only one). As a reminder, this study is automatically detected by the watcher when launching the FastAPI test application. Therefore, it is always available. The fixture searches for the internalized study in the database and returns its ID.

The aim of this PR is to rename the "study_id" fixture to "internal_study_id" in order to avoid any confusion between an arbitrary study identifier and the "STA-mini" test study. This confusion occurs in tests that do not use the internalized study, as it is common to name a study identifier `study_id`. There is also confusion caused by a PyCharm plugin when detecting fixtures not present in the parameters of test functions. Currently, this plugin generates false positives because it considers the `study_id` variable as a fixture, whereas in these tests that do not use the internalized study, it is a regular variable (for example, the ID of a newly created study for the test).

## How to check this PR?

To verify the validity of this PR, the reviewer should:

1. **Review the Code**: Ensure that the code has been correctly modified to reflect the fixture name change from 'study_id' to 'internal_study_id'. This includes all places where the fixture is used in the tests.

2. **Run the Tests**: Execute all unit and integration tests to ensure they still pass with the new fixture name. This includes tests that use the internalized study and those that do not.

3. **Check for Consistency**: Ensure that the new fixture name 'internal_study_id' is consistent with its usage and function in the code.

4. **Review False Positives**: Check if the PyCharm plugin no longer generates false positives by considering `study_id` as a fixture in tests that do not use the internalized study.

5. **Read the Documentation**: Ensure that any documentation or comments related to this fixture have been updated to reflect the name change.
