### PR TITLE
docs(user-guide): updating Binding Constraints Commands documentation and metadata for search

### DIFF
--- a/docs/user-guide/0-introduction.md
+++ b/docs/user-guide/0-introduction.md
@@ -1,3 +1,17 @@
+---
+title: Introduction to Antares Web
+author: Antares Web Team
+date: 2021-10-05
+category: User Guide
+tags:
+
+  - introduction
+  - variant
+  - solver
+  - manager
+
+---
+
 # Introduction
 
 ![](../assets/antares.png)

--- a/docs/user-guide/1-interface.md
+++ b/docs/user-guide/1-interface.md
@@ -1,3 +1,21 @@
+---
+title: User Interface
+author: Antares Web Team
+date: 2021-11-03
+category: User Guide
+tags:
+
+  - ui
+  - job
+  - api
+  - token
+  - variant
+  - matrix
+  - dataset
+  - batch
+  - launch
+---
+
 # User interface
 
 ## What's new (2.5.0)

--- a/docs/user-guide/2-study.md
+++ b/docs/user-guide/2-study.md
@@ -1,3 +1,20 @@
+---
+title: Study Configuration
+author: Antares Web Team
+date: 2023-12-21
+category: User Guide
+tags:
+
+  - configuration
+  - map
+  - network
+  - areas
+  - links
+  - binding-constraints
+  - debug
+  - table-mode
+---
+
 # Study Configuration
 
 This page is dedicated to configuring the study in the Antares Web application.

--- a/docs/user-guide/3-variant_manager.md
+++ b/docs/user-guide/3-variant_manager.md
@@ -1,3 +1,17 @@
+---
+title: Variant Manager
+author: Antares Web Team
+date: 2021-10-29
+category: User Guide
+tags:
+
+  - variant
+  - manager
+  - configuration
+  - command
+  - API
+---
+
 # Variant Manager
 
 ## Introduction

--- a/docs/user-guide/3-variant_manager.md
+++ b/docs/user-guide/3-variant_manager.md
@@ -236,9 +236,15 @@ Create a new binding constraint
   "enabled?": "<BOOLEAN> (default: True)",
   "time_step": "'hourly' | 'weekly' | 'daily'",
   "operator": "'equal' | 'both' | 'greater' | 'less'",
+  "comments?": "<STRING>",
+  "group?": "<STRING>",
+  "filter_year_by_year?": "<STRING>",
+  "filter_synthesis?": "<STRING>",
   "coeffs": "<LIST[CONSTRAINT_COEFF]>",
   "values?": "<MATRIX>",
-  "comments?": "<STRING>"
+  "less_term_matrix?": "<MATRIX>",
+  "greater_term_matrix?": "<MATRIX>",
+  "equal_term_matrix?": "<MATRIX>"
 }
 ```
 
@@ -264,6 +270,20 @@ Or link `CONSTRAINT_COEFF` is:
 }
 ```
 
+> **Available Since v8.3:**
+>
+> The `filter_year_by_year` and `filter_synthesis` fields are only available for studies since v8.3.
+> Those fields are used for the Geographic Trimming.
+> Possible values are on or several of the following: "hourly", "daily", "weekly", "monthly", "annual".
+
+> **Available Since v8.7:**
+>
+> The `group` fields and the `less_term_matrix`, `greater_term_matrix`, `equal_term_matrix` time series fields
+> are available since v8.7.
+> The `group` field is used to group constraints in the Monte Carlo Scenario Builder (default is `default`).
+> The time series matrices are used to define the Right-Hand Side (RHS) of the binding constraint.
+> Note that the `values` field must not be used when using the time series matrices.
+
 ### `update_binding_constraint`
 
 Update an existing binding constraint
@@ -274,11 +294,19 @@ Update an existing binding constraint
   "enabled?": "<BOOLEAN> (default: True)",
   "time_step": "'hourly' | 'weekly' | 'daily'",
   "operator": "'equal' | 'both' | 'greater' | 'less'",
+  "comments?": "<STRING>",
+  "group?": "<STRING>",
+  "filter_year_by_year?": "<STRING>",
+  "filter_synthesis?": "<STRING>",
   "coeffs": "<LIST[CONSTRAINT_COEFF]>",
   "values?": "<MATRIX>",
-  "comments?": "<STRING>"
+  "less_term_matrix?": "<MATRIX>",
+  "greater_term_matrix?": "<MATRIX>",
+  "equal_term_matrix?": "<MATRIX>"
 }
 ```
+
+See [create_binding_constraint](#create_binding_constraint) for the details of the fields.
 
 ### `remove_binding_constraint`
 
@@ -339,6 +367,8 @@ Replace arbitrary data file (must not be a matrix or ini target) with a base64 e
 
 ### `create_st_storage`
 
+> **Available Since v8.6**
+
 Create a new short-term storage
 
 ```json
@@ -354,6 +384,8 @@ Create a new short-term storage
 ```
 
 ### `remove_st_storage`
+
+> **Available Since v8.6**
 
 Remove an existing short-term storage
 


### PR DESCRIPTION
This PR makes changes to the doc of commands related to binding constraints, updating parameters and specifying the added fields or time series, as well as the versions in which they are available. Additionally, this PR introduces improvements in the metadata of User Guide articles to optimize results during full-text searches.  

The aim of these changes is twofold: on one hand, to provide users with up-to-date and accurate information on managing binding constraints, and on the other hand, to improve the user experience when searching for information in the User Guide.