### PR TITLE
build: Update tables and PyYaml versions for python > 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,8 @@ pydantic~=1.9.0
 PyQt5~=5.15.6
 python-json-logger~=2.0.7
 python-multipart~=0.0.5
-# See https://github.com/yaml/pyyaml/issues/724#issuecomment-1638801106
-PyYAML>=5.3.1; python_version <= '3.5'
-PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version >= '3.6' and python_version <= '3.11'
-PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
+PyYAML~=5.4.1; python_version <= '3.9'
+PyYAML~=6.0.1; python_version > '3.9'
 redis~=4.1.2
 requests~=2.27.1
 SQLAlchemy~=1.4.46

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ PyQt5~=5.15.6
 python-json-logger~=2.0.7
 python-multipart~=0.0.5
 PyYAML~=5.4.1; python_version <= '3.9'
-PyYAML~=6.0.1; python_version > '3.9'
+PyYAML~=5.3.1; python_version > '3.9'
 redis~=4.1.2
 requests~=2.27.1
 SQLAlchemy~=1.4.46

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,12 +22,16 @@ pydantic~=1.9.0
 PyQt5~=5.15.6
 python-json-logger~=2.0.7
 python-multipart~=0.0.5
-PyYAML~=5.4.1
+# See https://github.com/yaml/pyyaml/issues/724#issuecomment-1638801106
+PyYAML>=5.3.1; python_version <= '3.5'
+PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version >= '3.6' and python_version <= '3.11'
+PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
 redis~=4.1.2
 requests~=2.27.1
 SQLAlchemy~=1.4.46
 starlette~=0.17.1
-tables==3.6.1
+tables==3.6.1; python_version <= '3.8'
+tables==3.9.2; python_version > '3.8'
 typing_extensions~=4.7.1
 uvicorn[standard]~=0.15.0
 xlsxwriter~=3.2.0


### PR DESCRIPTION
**Description**
When working in python > 3.8 environment, a few dependencies are not available.

This PR allows to work with python >= 3.9 by having a conditional versioning for:
- tables
- pyyaml

For python 3.8, versions are unchanged.