### PR TITLE
docker-compose: change webapp folder from build to dist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,5 +61,5 @@ services:
       - 80:80
     volumes:
       - ./resources/deploy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./webapp/build:/www
+      - ./webapp/dist:/www
       - ./resources/deploy/web.config.json:/www/config.json:ro


### PR DESCRIPTION
After building the webapp according to the documentation, the files are in webapp/dist and not in webapp/build