### PR TITLE
feat(ui-bc): increases constraint terms field size

### DIFF
--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintTerm/OptionsList.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintTerm/OptionsList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { AllClustersAndLinks } from "../../../../../../../../common/types";
 import SelectSingle from "../../../../../../../common/SelectSingle";
 import { ConstraintTerm, generateTermId, isTermExist } from "../utils";
+import { Box } from "@mui/material";
 
 interface Option {
   id: string;
@@ -108,7 +109,7 @@ export default function OptionsList({
   ////////////////////////////////////////////////////////////////
 
   return (
-    <>
+    <Box sx={{ display: "flex", gap: 1 }}>
       <SelectSingle
         disabled
         size="small"
@@ -119,8 +120,7 @@ export default function OptionsList({
         list={areaOptions}
         handleChange={(key, value) => handleAreaChange(value as string)}
         sx={{
-          maxWidth: 200,
-          mr: 1,
+          minWidth: 300,
         }}
       />
       <SelectSingle
@@ -134,9 +134,9 @@ export default function OptionsList({
           handleClusterOrAreaChange(value as string)
         }
         sx={{
-          maxWidth: 200,
+          minWidth: 300,
         }}
       />
-    </>
+    </Box>
   );
 }

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/CreateAreaDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/CreateAreaDialog.tsx
@@ -6,6 +6,7 @@ import { SubmitHandlerPlus } from "../../../../../common/Form/types";
 import useAppSelector from "../../../../../../redux/hooks/useAppSelector";
 import { getAreas } from "../../../../../../redux/selectors";
 import { validateString } from "../../../../../../utils/validationUtils";
+import Fieldset from "../../../../../common/Fieldset";
 
 interface Props {
   studyId: string;
@@ -41,6 +42,7 @@ function CreateAreaDialog(props: Props) {
     <FormDialog
       title={t("study.modelization.map.newArea")}
       titleIcon={AddCircleIcon}
+      maxWidth="sm"
       open={open}
       onCancel={onClose}
       onSubmit={handleSubmit}
@@ -49,16 +51,18 @@ function CreateAreaDialog(props: Props) {
       }}
     >
       {({ control }) => (
-        <StringFE
-          label={t("global.name")}
-          name="name"
-          control={control}
-          fullWidth
-          rules={{
-            validate: (v) =>
-              validateString(v, { existingValues: existingAreas }),
-          }}
-        />
+        <Fieldset fullFieldWidth>
+          <StringFE
+            label={t("global.name")}
+            name="name"
+            control={control}
+            fullWidth
+            rules={{
+              validate: (v) =>
+                validateString(v, { existingValues: existingAreas }),
+            }}
+          />
+        </Fieldset>
       )}
     </FormDialog>
   );


### PR DESCRIPTION
User request to increase input size for constraint terms, due to difficulties to read long areas or clusters names, see:
![image](https://github.com/user-attachments/assets/79de205c-b470-4fe6-8017-ffe392ca23cd)

Added some additional width to fix the issue, **note that for very long name the text will be still truncated, that is acceptable.**
![Screenshot 2024-07-23 at 17-17-41 Antares Web BP23_A_saME_desinv_2025_0506_1000mc (Copie) (ed0e058a-58a9-498e-90af-b96cd10f4684)](https://github.com/user-attachments/assets/446d8364-ae71-4f91-bf6c-8a12973a2d5f)


Also fixed a minor issue on the `CreateAreaDialog`, the field was overflowing and the dialog was quite small:

![Screenshot 2024-07-23 at 17-46-32 Antares Web BP23_A_saME_desinv_2025_0506_1000mc (Copie) (ed0e058a-58a9-498e-90af-b96cd10f4684)](https://github.com/user-attachments/assets/c0f317bd-41b5-4931-bb2d-4fa8ba093dd5)
