### PR TITLE
ci(github): split npm jobs and add dependency caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,33 +65,90 @@ jobs:
           name: python-code-coverage-report
           path: coverage.xml
 
-  npm-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
+  npm-setup:
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout github repo
         uses: actions/checkout@v4
-      - name: Set up Node.js ${{ matrix.node-version }}
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 18.16.1
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: webapp/node_modules
+          key: ${{ runner.os }}-webapp-node-modules-${{ hashFiles('webapp/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-webapp-node-modules-
+            ${{ runner.os }}-
+          save-always: true
       - name: Install dependencies
         run: npm install
         working-directory: webapp
+
+  npm-lint:
+    needs: npm-setup
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout github repo
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.16.1
+      - name: Restore node modules
+        uses: actions/cache@v4
+        with:
+          path: webapp/node_modules
+          key: ${{ runner.os }}-webapp-node-modules-${{ hashFiles('webapp/package-lock.json') }}
+          save-always: true
+      - name: Lint
+        run: npm run lint
+        working-directory: webapp
+
+  npm-test:
+    needs: npm-setup
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout github repo
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.16.1
+      - name: Restore node modules
+        uses: actions/cache@v4
+        with:
+          path: webapp/node_modules
+          key: ${{ runner.os }}-webapp-node-modules-${{ hashFiles('webapp/package-lock.json') }}
+          save-always: true
+      - name: Test
+        run: npm run test
+        working-directory: webapp
+
+  npm-build:
+    needs: npm-setup
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout github repo
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.16.1
+      - name: Restore node modules
+        uses: actions/cache@v4
+        with:
+          path: webapp/node_modules
+          key: ${{ runner.os }}-webapp-node-modules-${{ hashFiles('webapp/package-lock.json') }}
+          save-always: true
       - name: Build
         run: npm run build
         working-directory: webapp
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           DISABLE_ESLINT_PLUGIN: true
-      - name: Lint
-        run: npm run lint
-        working-directory: webapp
-      - name: Test
-        run: npm run test
-        working-directory: webapp
 
   sonarcloud:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
- Refactor main.yml workflow to separate lint, test, and build jobs
- Implement caching for npm dependencies to speed up CI