### PR TITLE
build: use relative paths in coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,10 +54,6 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --cov antarest --cov-report xml
-      - name: Fix code coverage paths
-        if: matrix.os == 'ubuntu-20.04'
-        run: |
-          sed -i 's/\/home\/runner\/work\/AntaREST\/AntaREST/\/github\/workspace/g' coverage.xml
       - name: Archive code coverage results
         if: matrix.os == 'ubuntu-20.04'
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ platforms = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["antarest*"]  # alternatively: `exclude = ["additional*"]`
+include = ["antarest*"]
 
 [tool.mypy]
 strict = true
@@ -72,6 +72,7 @@ exclude = "(antares-?launcher/*|alembic/*)"
 
 [tool.coverage.run]
 omit = ["antarest/tools/cli.py", "antarest/tools/admin.py"]
+relative_files = true  # avoids absolute path issues in CI
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This allows to remove an unnecessary trick from CI, which could break if anything change on github side.