### PR TITLE
fix(ui): add missing `i18n` key and styles on `EmptyView`

### DIFF
--- a/webapp/src/components/common/MatrixInput/index.tsx
+++ b/webapp/src/components/common/MatrixInput/index.tsx
@@ -183,7 +183,7 @@ function MatrixInput({
             isPercentDisplayEnabled={enablePercentDisplay}
           />
         ) : (
-          !isLoading && <EmptyView title="matrix.message.matrixEmpty" />
+          !isLoading && <EmptyView title={t("matrix.message.matrixEmpty")} />
         )}
       </Content>
       {openImportDialog && (

--- a/webapp/src/components/common/page/SimpleContent.tsx
+++ b/webapp/src/components/common/page/SimpleContent.tsx
@@ -16,6 +16,7 @@ function EmptyView(props: EmptyViewProps) {
     <Box
       sx={{
         height: 1,
+        width: 1,
         display: "flex",
         flexDirection: "column",
         alignItems: "center",


### PR DESCRIPTION
- fix missing key for empty matrices and layout width distribution

![9c3fb0e3-1047-4ee6-9006-97432c2c9193](https://github.com/user-attachments/assets/3c253871-3839-4472-8048-c1a46d486371)
