### PR TITLE
ci(test): parallel pytest execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Test with pytest
         run: |
-          pytest --cov antarest --cov-report xml
+          pytest --cov antarest --cov-report xml -n 4
       - name: Archive code coverage results
         if: matrix.os == 'ubuntu-20.04'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Test with pytest
         run: |
-          pytest --cov antarest --cov-report xml -n 4
+          pytest --cov antarest --cov-report xml -n auto
       - name: Archive code coverage results
         if: matrix.os == 'ubuntu-20.04'
         uses: actions/upload-artifact@v4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,9 @@
 -r requirements.txt
 checksumdir~=1.2.0
-pytest~=6.2.5
+pytest~=8.3.0
+pytest-xdist~=3.6.0
 pytest-cov~=4.0.0
+pytest-mock~=3.14.0
 
 # In this version DataFrame conversion to Excel is done using 'xlsxwriter' library.
 # But Excel files reading is done using 'openpyxl' library, during testing only.

--- a/tests/integration/filesystem_blueprint/test_model.py
+++ b/tests/integration/filesystem_blueprint/test_model.py
@@ -16,6 +16,8 @@ import re
 import shutil
 from pathlib import Path
 
+from pytest_mock import MockerFixture
+
 from antarest.core.filesystem_blueprint import FileInfoDTO, FilesystemDTO, MountPointDTO
 
 
@@ -63,15 +65,16 @@ class TestMountPointDTO:
         assert dto.free_bytes == 0
         assert dto.message.startswith("N/A:"), dto.message
 
-    def test_from_path__file(self, tmp_path: Path) -> None:
+    def test_from_path__file(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        mocker.patch("shutil.disk_usage", return_value=(100, 200, 300))
+
         name = "foo"
         dto = asyncio.run(MountPointDTO.from_path(name, tmp_path))
-        total_bytes, used_bytes, free_bytes = shutil.disk_usage(tmp_path)
         assert dto.name == name
         assert dto.path == tmp_path
-        assert dto.total_bytes == total_bytes
-        assert dto.used_bytes == used_bytes
-        assert dto.free_bytes == free_bytes
+        assert dto.total_bytes == 100
+        assert dto.used_bytes == 200
+        assert dto.free_bytes == 300
         assert re.fullmatch(r"\d+(?:\.\d+)?% used", dto.message), dto.message
 
 

--- a/tests/storage/repository/filesystem/config/test_utils.py
+++ b/tests/storage/repository/filesystem/config/test_utils.py
@@ -33,12 +33,12 @@ def test_transform_name_to_id__valid_chars(name):
     assert transform_name_to_id(name, lower=False) == name
 
 
-@pytest.mark.parametrize("name", set(string.punctuation) - set(VALID_CHARS))
+@pytest.mark.parametrize("name", sorted(set(string.punctuation) - set(VALID_CHARS)))
 def test_transform_name_to_id__punctuation(name):
     assert not transform_name_to_id(name)
 
 
-@pytest.mark.parametrize("name", set(string.whitespace) - set(VALID_CHARS))
+@pytest.mark.parametrize("name", sorted(set(string.whitespace) - set(VALID_CHARS)))
 def test_transform_name_to_id__whitespace(name):
     assert not transform_name_to_id(name)
 

--- a/tests/variantstudy/test_command_factory.py
+++ b/tests/variantstudy/test_command_factory.py
@@ -13,6 +13,7 @@
 import importlib
 import itertools
 import pkgutil
+from typing import List, Set
 from unittest.mock import Mock
 
 import pytest
@@ -25,18 +26,385 @@ from antarest.study.storage.variantstudy.model.command.common import CommandName
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.model import CommandDTO
 
+COMMANDS: List[CommandDTO] = [
+    CommandDTO(
+        action=CommandName.CREATE_AREA.value,
+        args={"area_name": "area_name"},
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_AREA.value,
+        args=[
+            {"area_name": "area_name"},
+            {"area_name": "area2"},
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_AREA.value,
+        args={"id": "id"},
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_AREA.value,
+        args=[{"id": "id"}],
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_DISTRICT.value,
+        args={
+            "name": "id",
+            "filter_items": ["a"],
+            "output": True,
+            "comments": "",
+        },
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_DISTRICT.value,
+        args=[
+            {
+                "name": "id",
+                "base_filter": "add-all",
+                "output": True,
+                "comments": "",
+            }
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_DISTRICT.value,
+        args={"id": "id"},
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_DISTRICT.value,
+        args=[{"id": "id"}],
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_LINK.value,
+        args={
+            "area1": "area1",
+            "area2": "area2",
+            "parameters": {},
+            "series": "series",
+        },
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_LINK.value,
+        args=[
+            {
+                "area1": "area1",
+                "area2": "area2",
+                "parameters": {},
+                "series": "series",
+            }
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_LINK.value,
+        args={
+            "area1": "area1",
+            "area2": "area2",
+        },
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_LINK.value,
+        args=[
+            {
+                "area1": "area1",
+                "area2": "area2",
+            }
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_BINDING_CONSTRAINT.value,
+        args={"name": "name"},
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_BINDING_CONSTRAINT.value,
+        args=[
+            {
+                "name": "name",
+                "enabled": True,
+                "time_step": "hourly",
+                "operator": "equal",
+                "values": "values",
+                "group": "group_1",
+            },
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_BINDING_CONSTRAINT.value,
+        args={
+            "id": "id",
+            "enabled": True,
+            "time_step": "hourly",
+            "operator": "equal",
+            "values": "values",
+        },
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_BINDING_CONSTRAINT.value,
+        args=[
+            {
+                "id": "id",
+                "enabled": True,
+                "time_step": "hourly",
+                "operator": "equal",
+            }
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_BINDING_CONSTRAINT.value,
+        args={"id": "id"},
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_BINDING_CONSTRAINT.value,
+        args=[{"id": "id"}],
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_THERMAL_CLUSTER.value,
+        args={
+            "area_id": "area_name",
+            "cluster_name": "cluster_name",
+            "parameters": {
+                "group": "group",
+                "unitcount": "unitcount",
+                "nominalcapacity": "nominalcapacity",
+                "marginal-cost": "marginal-cost",
+                "market-bid-cost": "market-bid-cost",
+            },
+            "prepro": "prepro",
+            "modulation": "modulation",
+        },
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_THERMAL_CLUSTER.value,
+        args=[
+            {
+                "area_id": "area_name",
+                "cluster_name": "cluster_name",
+                "parameters": {
+                    "group": "group",
+                    "unitcount": "unitcount",
+                    "nominalcapacity": "nominalcapacity",
+                    "marginal-cost": "marginal-cost",
+                    "market-bid-cost": "market-bid-cost",
+                },
+                "prepro": "prepro",
+                "modulation": "modulation",
+            }
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_THERMAL_CLUSTER.value,
+        args={"area_id": "area_name", "cluster_id": "cluster_name"},
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_THERMAL_CLUSTER.value,
+        args=[{"area_id": "area_name", "cluster_id": "cluster_name"}],
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_RENEWABLES_CLUSTER.value,
+        args={
+            "area_id": "area_name",
+            "cluster_name": "cluster_name",
+            "parameters": {
+                "name": "name",
+                "ts-interpretation": "power-generation",
+            },
+        },
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_RENEWABLES_CLUSTER.value,
+        args=[
+            {
+                "area_id": "area_name",
+                "cluster_name": "cluster_name",
+                "parameters": {
+                    "name": "name",
+                    "ts-interpretation": "power-generation",
+                },
+            }
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_RENEWABLES_CLUSTER.value,
+        args={"area_id": "area_name", "cluster_id": "cluster_name"},
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_RENEWABLES_CLUSTER.value,
+        args=[{"area_id": "area_name", "cluster_id": "cluster_name"}],
+    ),
+    CommandDTO(
+        action=CommandName.REPLACE_MATRIX.value,
+        args={"target": "target_element", "matrix": "matrix"},
+    ),
+    CommandDTO(
+        action=CommandName.REPLACE_MATRIX.value,
+        args=[{"target": "target_element", "matrix": "matrix"}],
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_CONFIG.value,
+        args={"target": "target", "data": {}},
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_CONFIG.value,
+        args=[{"target": "target", "data": {}}],
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_COMMENTS.value,
+        args={"comments": "comments"},
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_COMMENTS.value,
+        args=[{"comments": "comments"}],
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_FILE.value,
+        args={
+            "target": "settings/resources/study",
+            "b64Data": "",
+        },
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_DISTRICT.value,
+        args={"id": "id", "filter_items": ["a"]},
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_DISTRICT.value,
+        args=[{"id": "id", "base_filter": "add-all"}],
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_PLAYLIST.value,
+        args=[{"active": True, "items": [1, 3], "reverse": False}],
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_PLAYLIST.value,
+        args={
+            "active": True,
+            "items": [1, 3],
+            "weights": {1: 5.0},
+            "reverse": False,
+        },
+    ),
+    CommandDTO(
+        action=CommandName.UPDATE_SCENARIO_BUILDER.value,
+        args={
+            "data": {
+                "ruleset test": {
+                    "l": {"area1": {"0": 1}},
+                    "ntc": {"area1 / area2": {"1": 23}},
+                    "t": {"area1": {"thermal": {"1": 2}}},
+                },
+            }
+        },
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_ST_STORAGE.value,
+        args={
+            "area_id": "area 1",
+            "parameters": {
+                "name": "Storage 1",
+                "group": "Battery",
+                "injectionnominalcapacity": 0,
+                "withdrawalnominalcapacity": 0,
+                "reservoircapacity": 0,
+                "efficiency": 1,
+                "initiallevel": 0,
+                "initialleveloptim": False,
+            },
+            "pmax_injection": "matrix://59ea6c83-6348-466d-9530-c35c51ca4c37",
+            "pmax_withdrawal": "matrix://5f988548-dadc-4bbb-8ce8-87a544dbf756",
+            "lower_rule_curve": "matrix://8ce4fcea-cc97-4d2c-b641-a27a53454612",
+            "upper_rule_curve": "matrix://8ce614c8-c687-41af-8b24-df8a49cc52af",
+            "inflows": "matrix://df9b25e1-e3f7-4a57-8182-0ff9791439e5",
+        },
+    ),
+    CommandDTO(
+        action=CommandName.CREATE_ST_STORAGE.value,
+        args=[
+            {
+                "area_id": "area 1",
+                "parameters": {
+                    "efficiency": 1,
+                    "group": "Battery",
+                    "initiallevel": 0,
+                    "initialleveloptim": False,
+                    "injectionnominalcapacity": 0,
+                    "name": "Storage 1",
+                    "reservoircapacity": 0,
+                    "withdrawalnominalcapacity": 0,
+                },
+                "pmax_injection": "matrix://59ea6c83-6348-466d-9530-c35c51ca4c37",
+                "pmax_withdrawal": "matrix://5f988548-dadc-4bbb-8ce8-87a544dbf756",
+                "lower_rule_curve": "matrix://8ce4fcea-cc97-4d2c-b641-a27a53454612",
+                "upper_rule_curve": "matrix://8ce614c8-c687-41af-8b24-df8a49cc52af",
+                "inflows": "matrix://df9b25e1-e3f7-4a57-8182-0ff9791439e5",
+            },
+            {
+                "area_id": "area 1",
+                "parameters": {
+                    "efficiency": 0.94,
+                    "group": "Battery",
+                    "initiallevel": 0,
+                    "initialleveloptim": False,
+                    "injectionnominalcapacity": 0,
+                    "name": "Storage 2",
+                    "reservoircapacity": 0,
+                    "withdrawalnominalcapacity": 0,
+                },
+                "pmax_injection": "matrix://3f5b3746-3995-49b7-a6da-622633472e05",
+                "pmax_withdrawal": "matrix://4b64a31f-927b-4887-b4cd-adcddd39bdcd",
+                "lower_rule_curve": "matrix://16c7c3ae-9824-4ef2-aa68-51145884b025",
+                "upper_rule_curve": "matrix://9a6104e9-990a-415f-a6e2-57507e13b58c",
+                "inflows": "matrix://e8923768-9bdd-40c2-a6ea-2da2523be727",
+            },
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_ST_STORAGE.value,
+        args={
+            "area_id": "area 1",
+            "storage_id": "storage 1",
+        },
+    ),
+    CommandDTO(
+        action=CommandName.REMOVE_ST_STORAGE.value,
+        args=[
+            {
+                "area_id": "area 1",
+                "storage_id": "storage 1",
+            },
+            {
+                "area_id": "area 1",
+                "storage_id": "storage 2",
+            },
+        ],
+    ),
+    CommandDTO(
+        action=CommandName.GENERATE_THERMAL_CLUSTER_TIMESERIES.value,
+        args=[{}],
+    ),
+]
+
+
+@pytest.fixture
+def command_factory() -> CommandFactory:
+    def get_matrix_id(matrix: str) -> str:
+        # str.removeprefix() is not available in Python 3.8
+        prefix = "matrix://"
+        if matrix.startswith(prefix):
+            return matrix[len(prefix) :]
+        return matrix
+
+    return CommandFactory(
+        generator_matrix_constants=Mock(spec=GeneratorMatrixConstants),
+        matrix_service=Mock(spec=MatrixService, get_matrix_id=get_matrix_id),
+        patch_service=Mock(spec=PatchService),
+    )
+
 
 class TestCommandFactory:
-    # noinspection SpellCheckingInspection
-    def setup_class(self):
+    def _get_command_classes(self) -> Set[str]:
         """
-        Set up the test class.
-
         Imports all modules from the `antarest.study.storage.variantstudy.model.command` package
         and creates a set of command class names derived from the `ICommand` abstract class.
         The objective is to ensure that the unit test covers all commands in this package.
-
-        This method is executed once before any tests in the test class are run.
         """
         for module_loader, name, ispkg in pkgutil.iter_modules(["antarest/study/storage/variantstudy/model/command"]):
             importlib.import_module(
@@ -44,383 +412,21 @@ class TestCommandFactory:
                 package="antarest.study.storage.variantstudy.model.command",
             )
         abstract_commands = {"AbstractBindingConstraintCommand"}
-        self.command_class_set = {
-            cmd.__name__ for cmd in ICommand.__subclasses__() if cmd.__name__ not in abstract_commands
-        }
+        return {cmd.__name__ for cmd in ICommand.__subclasses__() if cmd.__name__ not in abstract_commands}
+
+    def test_all_commands_are_tested(self, command_factory: CommandFactory):
+        commands = sum([command_factory.to_command(command_dto=cmd) for cmd in COMMANDS], [])
+        tested_classes = {c.__class__.__name__ for c in commands}
+
+        assert self._get_command_classes().issubset(tested_classes)
 
     # noinspection SpellCheckingInspection
     @pytest.mark.parametrize(
         "command_dto",
-        [
-            CommandDTO(
-                action=CommandName.CREATE_AREA.value,
-                args={"area_name": "area_name"},
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_AREA.value,
-                args=[
-                    {"area_name": "area_name"},
-                    {"area_name": "area2"},
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_AREA.value,
-                args={"id": "id"},
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_AREA.value,
-                args=[{"id": "id"}],
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_DISTRICT.value,
-                args={
-                    "name": "id",
-                    "filter_items": ["a"],
-                    "output": True,
-                    "comments": "",
-                },
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_DISTRICT.value,
-                args=[
-                    {
-                        "name": "id",
-                        "base_filter": "add-all",
-                        "output": True,
-                        "comments": "",
-                    }
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_DISTRICT.value,
-                args={"id": "id"},
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_DISTRICT.value,
-                args=[{"id": "id"}],
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_LINK.value,
-                args={
-                    "area1": "area1",
-                    "area2": "area2",
-                    "parameters": {},
-                    "series": "series",
-                },
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_LINK.value,
-                args=[
-                    {
-                        "area1": "area1",
-                        "area2": "area2",
-                        "parameters": {},
-                        "series": "series",
-                    }
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_LINK.value,
-                args={
-                    "area1": "area1",
-                    "area2": "area2",
-                },
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_LINK.value,
-                args=[
-                    {
-                        "area1": "area1",
-                        "area2": "area2",
-                    }
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_BINDING_CONSTRAINT.value,
-                args={"name": "name"},
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_BINDING_CONSTRAINT.value,
-                args=[
-                    {
-                        "name": "name",
-                        "enabled": True,
-                        "time_step": "hourly",
-                        "operator": "equal",
-                        "values": "values",
-                        "group": "group_1",
-                    },
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_BINDING_CONSTRAINT.value,
-                args={
-                    "id": "id",
-                    "enabled": True,
-                    "time_step": "hourly",
-                    "operator": "equal",
-                    "values": "values",
-                },
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_BINDING_CONSTRAINT.value,
-                args=[
-                    {
-                        "id": "id",
-                        "enabled": True,
-                        "time_step": "hourly",
-                        "operator": "equal",
-                    }
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_BINDING_CONSTRAINT.value,
-                args={"id": "id"},
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_BINDING_CONSTRAINT.value,
-                args=[{"id": "id"}],
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_THERMAL_CLUSTER.value,
-                args={
-                    "area_id": "area_name",
-                    "cluster_name": "cluster_name",
-                    "parameters": {
-                        "group": "group",
-                        "unitcount": "unitcount",
-                        "nominalcapacity": "nominalcapacity",
-                        "marginal-cost": "marginal-cost",
-                        "market-bid-cost": "market-bid-cost",
-                    },
-                    "prepro": "prepro",
-                    "modulation": "modulation",
-                },
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_THERMAL_CLUSTER.value,
-                args=[
-                    {
-                        "area_id": "area_name",
-                        "cluster_name": "cluster_name",
-                        "parameters": {
-                            "group": "group",
-                            "unitcount": "unitcount",
-                            "nominalcapacity": "nominalcapacity",
-                            "marginal-cost": "marginal-cost",
-                            "market-bid-cost": "market-bid-cost",
-                        },
-                        "prepro": "prepro",
-                        "modulation": "modulation",
-                    }
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_THERMAL_CLUSTER.value,
-                args={"area_id": "area_name", "cluster_id": "cluster_name"},
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_THERMAL_CLUSTER.value,
-                args=[{"area_id": "area_name", "cluster_id": "cluster_name"}],
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_RENEWABLES_CLUSTER.value,
-                args={
-                    "area_id": "area_name",
-                    "cluster_name": "cluster_name",
-                    "parameters": {
-                        "name": "name",
-                        "ts-interpretation": "power-generation",
-                    },
-                },
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_RENEWABLES_CLUSTER.value,
-                args=[
-                    {
-                        "area_id": "area_name",
-                        "cluster_name": "cluster_name",
-                        "parameters": {
-                            "name": "name",
-                            "ts-interpretation": "power-generation",
-                        },
-                    }
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_RENEWABLES_CLUSTER.value,
-                args={"area_id": "area_name", "cluster_id": "cluster_name"},
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_RENEWABLES_CLUSTER.value,
-                args=[{"area_id": "area_name", "cluster_id": "cluster_name"}],
-            ),
-            CommandDTO(
-                action=CommandName.REPLACE_MATRIX.value,
-                args={"target": "target_element", "matrix": "matrix"},
-            ),
-            CommandDTO(
-                action=CommandName.REPLACE_MATRIX.value,
-                args=[{"target": "target_element", "matrix": "matrix"}],
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_CONFIG.value,
-                args={"target": "target", "data": {}},
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_CONFIG.value,
-                args=[{"target": "target", "data": {}}],
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_COMMENTS.value,
-                args={"comments": "comments"},
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_COMMENTS.value,
-                args=[{"comments": "comments"}],
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_FILE.value,
-                args={
-                    "target": "settings/resources/study",
-                    "b64Data": "",
-                },
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_DISTRICT.value,
-                args={"id": "id", "filter_items": ["a"]},
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_DISTRICT.value,
-                args=[{"id": "id", "base_filter": "add-all"}],
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_PLAYLIST.value,
-                args=[{"active": True, "items": [1, 3], "reverse": False}],
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_PLAYLIST.value,
-                args={
-                    "active": True,
-                    "items": [1, 3],
-                    "weights": {1: 5.0},
-                    "reverse": False,
-                },
-            ),
-            CommandDTO(
-                action=CommandName.UPDATE_SCENARIO_BUILDER.value,
-                args={
-                    "data": {
-                        "ruleset test": {
-                            "l": {"area1": {"0": 1}},
-                            "ntc": {"area1 / area2": {"1": 23}},
-                            "t": {"area1": {"thermal": {"1": 2}}},
-                        },
-                    }
-                },
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_ST_STORAGE.value,
-                args={
-                    "area_id": "area 1",
-                    "parameters": {
-                        "name": "Storage 1",
-                        "group": "Battery",
-                        "injectionnominalcapacity": 0,
-                        "withdrawalnominalcapacity": 0,
-                        "reservoircapacity": 0,
-                        "efficiency": 1,
-                        "initiallevel": 0,
-                        "initialleveloptim": False,
-                    },
-                    "pmax_injection": "matrix://59ea6c83-6348-466d-9530-c35c51ca4c37",
-                    "pmax_withdrawal": "matrix://5f988548-dadc-4bbb-8ce8-87a544dbf756",
-                    "lower_rule_curve": "matrix://8ce4fcea-cc97-4d2c-b641-a27a53454612",
-                    "upper_rule_curve": "matrix://8ce614c8-c687-41af-8b24-df8a49cc52af",
-                    "inflows": "matrix://df9b25e1-e3f7-4a57-8182-0ff9791439e5",
-                },
-            ),
-            CommandDTO(
-                action=CommandName.CREATE_ST_STORAGE.value,
-                args=[
-                    {
-                        "area_id": "area 1",
-                        "parameters": {
-                            "efficiency": 1,
-                            "group": "Battery",
-                            "initiallevel": 0,
-                            "initialleveloptim": False,
-                            "injectionnominalcapacity": 0,
-                            "name": "Storage 1",
-                            "reservoircapacity": 0,
-                            "withdrawalnominalcapacity": 0,
-                        },
-                        "pmax_injection": "matrix://59ea6c83-6348-466d-9530-c35c51ca4c37",
-                        "pmax_withdrawal": "matrix://5f988548-dadc-4bbb-8ce8-87a544dbf756",
-                        "lower_rule_curve": "matrix://8ce4fcea-cc97-4d2c-b641-a27a53454612",
-                        "upper_rule_curve": "matrix://8ce614c8-c687-41af-8b24-df8a49cc52af",
-                        "inflows": "matrix://df9b25e1-e3f7-4a57-8182-0ff9791439e5",
-                    },
-                    {
-                        "area_id": "area 1",
-                        "parameters": {
-                            "efficiency": 0.94,
-                            "group": "Battery",
-                            "initiallevel": 0,
-                            "initialleveloptim": False,
-                            "injectionnominalcapacity": 0,
-                            "name": "Storage 2",
-                            "reservoircapacity": 0,
-                            "withdrawalnominalcapacity": 0,
-                        },
-                        "pmax_injection": "matrix://3f5b3746-3995-49b7-a6da-622633472e05",
-                        "pmax_withdrawal": "matrix://4b64a31f-927b-4887-b4cd-adcddd39bdcd",
-                        "lower_rule_curve": "matrix://16c7c3ae-9824-4ef2-aa68-51145884b025",
-                        "upper_rule_curve": "matrix://9a6104e9-990a-415f-a6e2-57507e13b58c",
-                        "inflows": "matrix://e8923768-9bdd-40c2-a6ea-2da2523be727",
-                    },
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_ST_STORAGE.value,
-                args={
-                    "area_id": "area 1",
-                    "storage_id": "storage 1",
-                },
-            ),
-            CommandDTO(
-                action=CommandName.REMOVE_ST_STORAGE.value,
-                args=[
-                    {
-                        "area_id": "area 1",
-                        "storage_id": "storage 1",
-                    },
-                    {
-                        "area_id": "area 1",
-                        "storage_id": "storage 2",
-                    },
-                ],
-            ),
-            CommandDTO(
-                action=CommandName.GENERATE_THERMAL_CLUSTER_TIMESERIES.value,
-                args=[{}],
-            ),
-        ],
+        COMMANDS,
     )
     @pytest.mark.unit_test
-    def test_command_factory(self, command_dto: CommandDTO):
-        def get_matrix_id(matrix: str) -> str:
-            # str.removeprefix() is not available in Python 3.8
-            prefix = "matrix://"
-            if matrix.startswith(prefix):
-                return matrix[len(prefix) :]
-            return matrix
-
-        command_factory = CommandFactory(
-            generator_matrix_constants=Mock(spec=GeneratorMatrixConstants),
-            matrix_service=Mock(spec=MatrixService, get_matrix_id=get_matrix_id),
-            patch_service=Mock(spec=PatchService),
-        )
+    def test_command_factory(self, command_dto: CommandDTO, command_factory: CommandFactory):
         commands = command_factory.to_command(command_dto=command_dto)
 
         if isinstance(command_dto.args, dict):
@@ -439,12 +445,6 @@ class TestCommandFactory:
             assert actual_dto.action == expected_action
             assert actual_args == expected_args
             assert actual_version == expected_version
-
-        self.command_class_set.discard(type(commands[0]).__name__)
-
-    def teardown_class(self):
-        # Check that all command classes have been tested
-        assert not self.command_class_set
 
 
 @pytest.mark.unit_test


### PR DESCRIPTION

Experiment the use of pytest-xdist to speed up test execution in CI and dev environment:
see for example [this job](https://github.com/AntaresSimulatorTeam/AntaREST/actions/runs/10668008235/job/29566771799) where tests are executed in under 10min on ubuntu.

Following issues with parallel execution of tests are solved :

- some checks depended on the consistency at 2 moments in time of the result of disk_usage, which was anyway not a good idea (dependent on what happens elsewhere on the machine). It's now replaced with mocking
- some parameterized tests had random sort order, which is not allowed by pytest-xdist (all workers must have exactly the same tests in the same order)
- the command_factory test checked something in its teardown, assuming all tests were executed in the same process, which is not the case anymore. The same check is done as a separate unit tests.