### PR TITLE
fix(ci): multiply timeouts on windows platform

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Test with pytest
         run: |
-          pytest --cov antarest --cov-report xml -n auto
+          pytest --cov antarest --cov-report xml -n logical
       - name: Archive code coverage results
         if: matrix.os == 'ubuntu-20.04'
         uses: actions/upload-artifact@v4

--- a/tests/integration/prepare_proxy.py
+++ b/tests/integration/prepare_proxy.py
@@ -90,7 +90,7 @@ class PreparerProxy:
         task_id = res.json()
         assert task_id
 
-        task = wait_task_completion(self.client, self.user_access_token, task_id, timeout=20)
+        task = wait_task_completion(self.client, self.user_access_token, task_id, base_timeout=20)
         assert task.status == TaskStatus.COMPLETED
         return study_id
 
@@ -173,7 +173,7 @@ class PreparerProxy:
         task_id = res.json()
         assert task_id
 
-        task = wait_task_completion(self.client, self.user_access_token, task_id, timeout=20)
+        task = wait_task_completion(self.client, self.user_access_token, task_id, base_timeout=20)
         assert task.status == TaskStatus.COMPLETED
 
     def create_area(self, study_id: str, *, name: str, country: str = "FR") -> t.Dict[str, t.Any]:

--- a/tests/integration/raw_studies_blueprint/test_download_matrices.py
+++ b/tests/integration/raw_studies_blueprint/test_download_matrices.py
@@ -53,7 +53,7 @@ class PreparerProxy(Proxy):
         task_id = res.json()
         assert task_id
 
-        task = wait_task_completion(self.client, self.user_access_token, task_id, timeout=20)
+        task = wait_task_completion(self.client, self.user_access_token, task_id, base_timeout=20)
         assert task.status == TaskStatus.COMPLETED
         return study_820_id
 
@@ -91,7 +91,7 @@ class PreparerProxy(Proxy):
         task_id = res.json()
         assert task_id
 
-        task = wait_task_completion(self.client, self.user_access_token, task_id, timeout=20)
+        task = wait_task_completion(self.client, self.user_access_token, task_id, base_timeout=20)
         assert task.status == TaskStatus.COMPLETED
 
     def create_area(self, parent_id, *, name: str, country: str = "FR") -> str:


### PR DESCRIPTION
The aim is to solve irrelevant failures on windows CI.
It often fails when waiting for study upgrades, in particular.

The PR re-activates the use of more workers (logical cores
instead of CPUs).

ANT-2043