### PR TITLE
feat(debug): allow files and folder deletion inside debug view

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -343,6 +343,16 @@ class StudyVariantUpgradeError(HTTPException):
             super().__init__(HTTPStatus.EXPECTATION_FAILED, "Upgrade not supported for parent of variants")
 
 
+class FileDeletionNotAllowed(HTTPException):
+    """
+    Exception raised when deleting a file or a folder which isn't inside the 'User' folder.
+    """
+
+    def __init__(self, message: str) -> None:
+        msg = f"Raw deletion failed because {message}"
+        super().__init__(HTTPStatus.FORBIDDEN, msg)
+
+
 class ReferencedObjectDeletionNotAllowed(HTTPException):
     """
     Exception raised when a binding constraint is not allowed to be deleted because it references

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -2665,8 +2665,7 @@ class StudyService:
             raise FileDeletionNotAllowed(f"the targeted data isn't inside the 'User' folder: {path}")
 
         study_tree = self.storage_service.raw_study_service.get_raw(study, True).tree
-        user_node = study_tree.build()["user"]
-        assert isinstance(user_node, User)
+        user_node = t.cast(User,study_tree.get_node(["user"]))
         if url[1] in [file.filename for file in user_node.registered_files]:
             raise FileDeletionNotAllowed(f"you are not allowed to delete this resource : {path}")
 

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -2665,13 +2665,14 @@ class StudyService:
         if url[1] == "expansion":
             raise FileDeletionNotAllowed(f"you cannot delete a file/folder inside 'expansion' folder : {path}")
 
-        study_tree = self.storage_service.raw_study_service.get_raw(study, True).tree.build()
+        study_tree = self.storage_service.raw_study_service.get_raw(study, True).tree
+        builded_tree = study_tree.build()
         try:
-            study_tree["user"].delete(url[1:])
+            builded_tree["user"].delete(url[1:])
         except ChildNotFoundError as e:
-            raise FileDeletionNotAllowed(f"the given path doesn't exist: {e.detail}")
+            raise FileDeletionNotAllowed("the given path doesn't exist") from e
 
         # update cache
         cache_id = f"{CacheConstants.RAW_STUDY}/{study.id}"
-        updated_tree = self.storage_service.raw_study_service.get_raw(study, False).tree.get()
+        updated_tree = study_tree.get()
         self.storage_service.get_storage(study).cache.put(cache_id, updated_tree)  # type: ignore

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -48,7 +48,7 @@ from antarest.core.exceptions import (
 )
 from antarest.core.filetransfer.model import FileDownloadTaskDTO
 from antarest.core.filetransfer.service import FileTransferManager
-from antarest.core.interfaces.cache import ICache
+from antarest.core.interfaces.cache import CacheConstants, ICache
 from antarest.core.interfaces.eventbus import Event, EventType, IEventBus
 from antarest.core.jwt import DEFAULT_ADMIN_USER, JWTGroup, JWTUser
 from antarest.core.model import JSON, SUB_JSON, PermissionInfo, PublicMode, StudyPermissionType
@@ -2670,3 +2670,8 @@ class StudyService:
             study_tree["user"].delete(url[1:])
         except ChildNotFoundError as e:
             raise FileDeletionNotAllowed(f"the given path doesn't exist: {e.detail}")
+
+        # update cache
+        cache_id = f"{CacheConstants.RAW_STUDY}/{study.id}"
+        updated_tree = self.storage_service.raw_study_service.get_raw(study, False).tree.get()
+        self.storage_service.get_storage(study).cache.put(cache_id, updated_tree)  # type: ignore

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -2665,7 +2665,7 @@ class StudyService:
             raise FileDeletionNotAllowed(f"the targeted data isn't inside the 'User' folder: {path}")
 
         study_tree = self.storage_service.raw_study_service.get_raw(study, True).tree
-        user_node = t.cast(User,study_tree.get_node(["user"]))
+        user_node = t.cast(User, study_tree.get_node(["user"]))
         if url[1] in [file.filename for file in user_node.registered_files]:
             raise FileDeletionNotAllowed(f"you are not allowed to delete this resource : {path}")
 

--- a/antarest/study/web/raw_studies_blueprint.py
+++ b/antarest/study/web/raw_studies_blueprint.py
@@ -191,6 +191,21 @@ def create_raw_study_routes(
         ).encode("utf-8")
         return Response(content=json_response, media_type="application/json")
 
+    @bp.delete(
+        "/studies/{uuid}/raw",
+        tags=[APITag.study_raw_data],
+        summary="Delete files or folders located inside the 'User' folder",
+        response_model=None,
+    )
+    def delete_file(
+        uuid: str,
+        path: str = Param("/", examples=["user/wind_solar/synthesis_windSolar.xlsx"]),  # type: ignore
+        current_user: JWTUser = Depends(auth.get_current_user),
+    ) -> t.Any:
+        uuid = sanitize_uuid(uuid)
+        logger.info(f"Deleting some data for study {uuid}", extra={"user": current_user.id})
+        study_service.delete_file_or_folder(uuid, path, current_user)
+
     @bp.get(
         "/studies/{uuid}/areas/aggregate/mc-ind/{output_id}",
         tags=[APITag.study_raw_data],

--- a/antarest/study/web/raw_studies_blueprint.py
+++ b/antarest/study/web/raw_studies_blueprint.py
@@ -203,7 +203,7 @@ def create_raw_study_routes(
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> t.Any:
         uuid = sanitize_uuid(uuid)
-        logger.info(f"Deleting some data for study {uuid}", extra={"user": current_user.id})
+        logger.info(f"Deleting path {path} inside study {uuid}", extra={"user": current_user.id})
         study_service.delete_file_or_folder(uuid, path, current_user)
 
     @bp.get(

--- a/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
@@ -314,7 +314,7 @@ def test_delete_raw(client: TestClient, user_access_token: str, internal_study_i
     res = client.delete(f"/v1/studies/{internal_study_id}/raw?path=/user/expansion")
     assert res.status_code == 403
     assert res.json()["exception"] == "FileDeletionNotAllowed"
-    assert "you cannot delete a file/folder inside 'expansion' folder" in res.json()["description"]
+    assert "you are not allowed to delete this resource" in res.json()["description"]
 
     # try to delete a file which isn't inside the 'User' folder
     res = client.delete(f"/v1/studies/{internal_study_id}/raw?path=/input/thermal")

--- a/webapp/src/services/api/studies/raw/index.ts
+++ b/webapp/src/services/api/studies/raw/index.ts
@@ -1,9 +1,14 @@
 import client from "../../client";
-import type { DownloadMatrixParams, ImportFileParams } from "./types";
+import type {
+  DeleteFileParams,
+  DownloadMatrixParams,
+  ImportFileParams,
+} from "./types";
 
 export async function downloadMatrix(params: DownloadMatrixParams) {
   const { studyId, ...queryParams } = params;
   const url = `v1/studies/${studyId}/raw/download`;
+
   const res = await client.get<Blob>(url, {
     params: queryParams,
     responseType: "blob",
@@ -16,6 +21,7 @@ export async function importFile(params: ImportFileParams) {
   const { studyId, file, onUploadProgress, ...queryParams } = params;
   const url = `v1/studies/${studyId}/raw`;
   const body = { file };
+
   await client.putForm<void>(url, body, {
     params: {
       ...queryParams,
@@ -23,4 +29,11 @@ export async function importFile(params: ImportFileParams) {
     },
     onUploadProgress,
   });
+}
+
+export async function deleteFile(params: DeleteFileParams) {
+  const { studyId, path } = params;
+  const url = `v1/studies/${studyId}/raw`;
+
+  await client.delete<void>(url, { params: { path } });
 }

--- a/webapp/src/services/api/studies/raw/types.ts
+++ b/webapp/src/services/api/studies/raw/types.ts
@@ -16,3 +16,8 @@ export interface ImportFileParams {
   createMissing?: boolean;
   onUploadProgress?: AxiosRequestConfig["onUploadProgress"];
 }
+
+export interface DeleteFileParams {
+  studyId: StudyMetadata["id"];
+  path: string;
+}


### PR DESCRIPTION
Introduces a new endpoint inside the back-end to fix [ANT-2083]
Samir will also add the front-end part

*NB*: I didn't specify inside the endpoint signature that it was for the User folder because I think we might use it for other folders such as the one for .yaml models that comes with Andromede modeling