### PR TITLE
fix(pydantic): allow `str` fields to be populated by `int`

### DIFF
--- a/antarest/core/cache/business/local_chache.py
+++ b/antarest/core/cache/business/local_chache.py
@@ -18,12 +18,12 @@ from typing import Dict, List, Optional
 from antarest.core.config import CacheConfig
 from antarest.core.interfaces.cache import ICache
 from antarest.core.model import JSON
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 logger = logging.getLogger(__name__)
 
 
-class LocalCacheElement(BaseModelInHouse):
+class LocalCacheElement(AntaresBaseModel):
     timeout: int
     duration: int
     data: JSON

--- a/antarest/core/cache/business/local_chache.py
+++ b/antarest/core/cache/business/local_chache.py
@@ -15,16 +15,15 @@ import threading
 import time
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
-
 from antarest.core.config import CacheConfig
 from antarest.core.interfaces.cache import ICache
 from antarest.core.model import JSON
+from antarest.core.utils.utils import BaseModelInHouse
 
 logger = logging.getLogger(__name__)
 
 
-class LocalCacheElement(BaseModel):
+class LocalCacheElement(BaseModelInHouse):
     timeout: int
     duration: int
     data: JSON

--- a/antarest/core/cache/business/redis_cache.py
+++ b/antarest/core/cache/business/redis_cache.py
@@ -17,13 +17,12 @@ from redis.client import Redis
 
 from antarest.core.interfaces.cache import ICache
 from antarest.core.model import JSON
-from antarest.core.serialization import from_json
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel, from_json
 
 logger = logging.getLogger(__name__)
 
 
-class RedisCacheElement(BaseModelInHouse):
+class RedisCacheElement(AntaresBaseModel):
     duration: int
     data: JSON
 

--- a/antarest/core/cache/business/redis_cache.py
+++ b/antarest/core/cache/business/redis_cache.py
@@ -13,17 +13,17 @@
 import logging
 from typing import List, Optional
 
-from pydantic import BaseModel
 from redis.client import Redis
 
 from antarest.core.interfaces.cache import ICache
 from antarest.core.model import JSON
 from antarest.core.serialization import from_json
+from antarest.core.utils.utils import BaseModelInHouse
 
 logger = logging.getLogger(__name__)
 
 
-class RedisCacheElement(BaseModel):
+class RedisCacheElement(BaseModelInHouse):
     duration: int
     data: JSON
 

--- a/antarest/core/configdata/model.py
+++ b/antarest/core/configdata/model.py
@@ -16,10 +16,10 @@ from typing import Any, Optional
 from sqlalchemy import Column, Integer, String  # type: ignore
 
 from antarest.core.persistence import Base
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 
-class ConfigDataDTO(BaseModelInHouse):
+class ConfigDataDTO(AntaresBaseModel):
     key: str
     value: Optional[str]
 

--- a/antarest/core/configdata/model.py
+++ b/antarest/core/configdata/model.py
@@ -13,13 +13,13 @@
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel
 from sqlalchemy import Column, Integer, String  # type: ignore
 
 from antarest.core.persistence import Base
+from antarest.core.utils.utils import BaseModelInHouse
 
 
-class ConfigDataDTO(BaseModel):
+class ConfigDataDTO(BaseModelInHouse):
     key: str
     value: Optional[str]
 

--- a/antarest/core/core_blueprint.py
+++ b/antarest/core/core_blueprint.py
@@ -15,12 +15,12 @@ from typing import Any
 from fastapi import APIRouter
 
 from antarest.core.config import Config
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.core.utils.web import APITag
 from antarest.core.version_info import VersionInfoDTO, get_commit_id, get_dependencies
 
 
-class StatusDTO(BaseModelInHouse):
+class StatusDTO(AntaresBaseModel):
     status: str
 
 

--- a/antarest/core/core_blueprint.py
+++ b/antarest/core/core_blueprint.py
@@ -13,14 +13,14 @@
 from typing import Any
 
 from fastapi import APIRouter
-from pydantic import BaseModel
 
 from antarest.core.config import Config
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.core.utils.web import APITag
 from antarest.core.version_info import VersionInfoDTO, get_commit_id, get_dependencies
 
 
-class StatusDTO(BaseModel):
+class StatusDTO(BaseModelInHouse):
     status: str
 
 

--- a/antarest/core/filetransfer/model.py
+++ b/antarest/core/filetransfer/model.py
@@ -18,7 +18,7 @@ from typing import Optional
 from sqlalchemy import Boolean, Column, DateTime, Integer, String  # type: ignore
 
 from antarest.core.persistence import Base
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 
 class FileDownloadNotFound(HTTPException):
@@ -37,7 +37,7 @@ class FileDownloadNotReady(HTTPException):
         )
 
 
-class FileDownloadDTO(BaseModelInHouse):
+class FileDownloadDTO(AntaresBaseModel):
     id: str
     name: str
     filename: str
@@ -47,7 +47,7 @@ class FileDownloadDTO(BaseModelInHouse):
     error_message: str = ""
 
 
-class FileDownloadTaskDTO(BaseModelInHouse):
+class FileDownloadTaskDTO(AntaresBaseModel):
     file: FileDownloadDTO
     task: str
 

--- a/antarest/core/filetransfer/model.py
+++ b/antarest/core/filetransfer/model.py
@@ -15,10 +15,10 @@ from http import HTTPStatus
 from http.client import HTTPException
 from typing import Optional
 
-from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, DateTime, Integer, String  # type: ignore
 
 from antarest.core.persistence import Base
+from antarest.core.utils.utils import BaseModelInHouse
 
 
 class FileDownloadNotFound(HTTPException):
@@ -37,7 +37,7 @@ class FileDownloadNotReady(HTTPException):
         )
 
 
-class FileDownloadDTO(BaseModel):
+class FileDownloadDTO(BaseModelInHouse):
     id: str
     name: str
     filename: str
@@ -47,7 +47,7 @@ class FileDownloadDTO(BaseModel):
     error_message: str = ""
 
 
-class FileDownloadTaskDTO(BaseModel):
+class FileDownloadTaskDTO(BaseModelInHouse):
     file: FileDownloadDTO
     task: str
 

--- a/antarest/core/interfaces/eventbus.py
+++ b/antarest/core/interfaces/eventbus.py
@@ -14,9 +14,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Awaitable, Callable, List, Optional
 
-from pydantic import BaseModel
-
 from antarest.core.model import PermissionInfo
+from antarest.core.utils.utils import BaseModelInHouse
 
 
 class EventType(str, Enum):
@@ -56,7 +55,7 @@ class EventChannelDirectory:
     STUDY_GENERATION = "GENERATION_TASK/"
 
 
-class Event(BaseModel):
+class Event(BaseModelInHouse):
     type: EventType
     payload: Any
     permissions: PermissionInfo

--- a/antarest/core/interfaces/eventbus.py
+++ b/antarest/core/interfaces/eventbus.py
@@ -15,7 +15,7 @@ from enum import Enum
 from typing import Any, Awaitable, Callable, List, Optional
 
 from antarest.core.model import PermissionInfo
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 
 class EventType(str, Enum):
@@ -55,7 +55,7 @@ class EventChannelDirectory:
     STUDY_GENERATION = "GENERATION_TASK/"
 
 
-class Event(BaseModelInHouse):
+class Event(AntaresBaseModel):
     type: EventType
     payload: Any
     permissions: PermissionInfo

--- a/antarest/core/jwt.py
+++ b/antarest/core/jwt.py
@@ -13,11 +13,11 @@
 from typing import List, Union
 
 from antarest.core.roles import RoleType
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.login.model import ADMIN_ID, Group, Identity
 
 
-class JWTGroup(BaseModelInHouse):
+class JWTGroup(AntaresBaseModel):
     """
     Sub JWT domain with groups data belongs to user
     """
@@ -27,7 +27,7 @@ class JWTGroup(BaseModelInHouse):
     role: RoleType
 
 
-class JWTUser(BaseModelInHouse):
+class JWTUser(AntaresBaseModel):
     """
     JWT domain with user data.
     """

--- a/antarest/core/jwt.py
+++ b/antarest/core/jwt.py
@@ -12,13 +12,12 @@
 
 from typing import List, Union
 
-from pydantic import BaseModel
-
 from antarest.core.roles import RoleType
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.login.model import ADMIN_ID, Group, Identity
 
 
-class JWTGroup(BaseModel):
+class JWTGroup(BaseModelInHouse):
     """
     Sub JWT domain with groups data belongs to user
     """
@@ -28,7 +27,7 @@ class JWTGroup(BaseModel):
     role: RoleType
 
 
-class JWTUser(BaseModel):
+class JWTUser(BaseModelInHouse):
     """
     JWT domain with user data.
     """

--- a/antarest/core/model.py
+++ b/antarest/core/model.py
@@ -13,7 +13,7 @@
 import enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from antarest.core.utils.utils import BaseModelInHouse
 
 if TYPE_CHECKING:
     # These dependencies are only used for type checking with mypy.
@@ -43,7 +43,7 @@ class StudyPermissionType(str, enum.Enum):
     MANAGE_PERMISSIONS = "MANAGE_PERMISSIONS"
 
 
-class PermissionInfo(BaseModel):
+class PermissionInfo(BaseModelInHouse):
     owner: Optional[int] = None
     groups: List[str] = []
     public_mode: PublicMode = PublicMode.NONE

--- a/antarest/core/model.py
+++ b/antarest/core/model.py
@@ -13,7 +13,7 @@
 import enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 if TYPE_CHECKING:
     # These dependencies are only used for type checking with mypy.
@@ -43,7 +43,7 @@ class StudyPermissionType(str, enum.Enum):
     MANAGE_PERMISSIONS = "MANAGE_PERMISSIONS"
 
 
-class PermissionInfo(BaseModelInHouse):
+class PermissionInfo(AntaresBaseModel):
     owner: Optional[int] = None
     groups: List[str] = []
     public_mode: PublicMode = PublicMode.NONE

--- a/antarest/core/serialization/__init__.py
+++ b/antarest/core/serialization/__init__.py
@@ -32,3 +32,18 @@ def to_json(data: t.Any, indent: t.Optional[int] = None) -> bytes:
 
 def to_json_string(data: t.Any, indent: t.Optional[int] = None) -> str:
     return to_json(data, indent=indent).decode("utf-8")
+
+
+class AntaresBaseModel(pydantic.BaseModel):
+    """
+    Due to pydantic migration from v1 to v2, we can have this issue:
+
+    class A(BaseModel):
+        a: str
+
+    A(a=2) raises ValidationError as we give an int instead of a str
+
+    To avoid this issue we created our own BaseModel class that inherits from BaseModel and allows such object creation.
+    """
+
+    model_config = pydantic.config.ConfigDict(coerce_numbers_to_str=True)

--- a/antarest/core/tasks/model.py
+++ b/antarest/core/tasks/model.py
@@ -20,7 +20,7 @@ from sqlalchemy.engine.base import Engine  # type: ignore
 from sqlalchemy.orm import relationship, sessionmaker  # type: ignore
 
 from antarest.core.persistence import Base
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 if t.TYPE_CHECKING:
     # avoid circular import
@@ -57,30 +57,30 @@ class TaskStatus(Enum):
         ]
 
 
-class TaskResult(BaseModelInHouse, extra="forbid"):
+class TaskResult(AntaresBaseModel, extra="forbid"):
     success: bool
     message: str
     # Can be used to store json serialized result
     return_value: t.Optional[str] = None
 
 
-class TaskLogDTO(BaseModelInHouse, extra="forbid"):
+class TaskLogDTO(AntaresBaseModel, extra="forbid"):
     id: str
     message: str
 
 
-class CustomTaskEventMessages(BaseModelInHouse, extra="forbid"):
+class CustomTaskEventMessages(AntaresBaseModel, extra="forbid"):
     start: str
     running: str
     end: str
 
 
-class TaskEventPayload(BaseModelInHouse, extra="forbid"):
+class TaskEventPayload(AntaresBaseModel, extra="forbid"):
     id: str
     message: str
 
 
-class TaskDTO(BaseModelInHouse, extra="forbid"):
+class TaskDTO(AntaresBaseModel, extra="forbid"):
     id: str
     name: str
     owner: t.Optional[int] = None
@@ -93,7 +93,7 @@ class TaskDTO(BaseModelInHouse, extra="forbid"):
     ref_id: t.Optional[str] = None
 
 
-class TaskListFilter(BaseModelInHouse, extra="forbid"):
+class TaskListFilter(AntaresBaseModel, extra="forbid"):
     status: t.List[TaskStatus] = []
     name: t.Optional[str] = None
     type: t.List[TaskType] = []

--- a/antarest/core/tasks/model.py
+++ b/antarest/core/tasks/model.py
@@ -15,12 +15,12 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, Sequence, String  # type: ignore
 from sqlalchemy.engine.base import Engine  # type: ignore
 from sqlalchemy.orm import relationship, sessionmaker  # type: ignore
 
 from antarest.core.persistence import Base
+from antarest.core.utils.utils import BaseModelInHouse
 
 if t.TYPE_CHECKING:
     # avoid circular import
@@ -57,30 +57,30 @@ class TaskStatus(Enum):
         ]
 
 
-class TaskResult(BaseModel, extra="forbid"):
+class TaskResult(BaseModelInHouse, extra="forbid"):
     success: bool
     message: str
     # Can be used to store json serialized result
     return_value: t.Optional[str] = None
 
 
-class TaskLogDTO(BaseModel, extra="forbid"):
+class TaskLogDTO(BaseModelInHouse, extra="forbid"):
     id: str
     message: str
 
 
-class CustomTaskEventMessages(BaseModel, extra="forbid"):
+class CustomTaskEventMessages(BaseModelInHouse, extra="forbid"):
     start: str
     running: str
     end: str
 
 
-class TaskEventPayload(BaseModel, extra="forbid"):
+class TaskEventPayload(BaseModelInHouse, extra="forbid"):
     id: str
     message: str
 
 
-class TaskDTO(BaseModel, extra="forbid"):
+class TaskDTO(BaseModelInHouse, extra="forbid"):
     id: str
     name: str
     owner: t.Optional[int] = None
@@ -93,7 +93,7 @@ class TaskDTO(BaseModel, extra="forbid"):
     ref_id: t.Optional[str] = None
 
 
-class TaskListFilter(BaseModel, extra="forbid"):
+class TaskListFilter(BaseModelInHouse, extra="forbid"):
     status: t.List[TaskStatus] = []
     name: t.Optional[str] = None
     type: t.List[TaskType] = []

--- a/antarest/core/utils/__init__.py
+++ b/antarest/core/utils/__init__.py
@@ -9,3 +9,5 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+
+__all__ = "BaseModelInHouse"

--- a/antarest/core/utils/__init__.py
+++ b/antarest/core/utils/__init__.py
@@ -10,4 +10,4 @@
 #
 # This file is part of the Antares project.
 
-__all__ = "BaseModelInHouse"
+__all__ = "AntaresBaseModel"

--- a/antarest/core/utils/utils.py
+++ b/antarest/core/utils/utils.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import py7zr
 import redis
 from fastapi import HTTPException
+from pydantic import BaseModel, ConfigDict
 
 from antarest.core.config import RedisConfig
 from antarest.core.exceptions import ShouldNotHappenException
@@ -33,6 +34,10 @@ from antarest.core.exceptions import ShouldNotHappenException
 logger = logging.getLogger(__name__)
 
 UUID_PATTERN = re.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+class BaseModelInHouse(BaseModel):
+    model_config = ConfigDict(coerce_numbers_to_str=True)
 
 
 class DTO:

--- a/antarest/core/utils/utils.py
+++ b/antarest/core/utils/utils.py
@@ -37,6 +37,17 @@ UUID_PATTERN = re.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9
 
 
 class BaseModelInHouse(BaseModel):
+    """
+    Due to pydantic migration from v1 to v2, we can have this issue:
+
+    class A(BaseModel):
+        a: str
+
+    A(a=2) raises ValidationError as we give an int instead of a str
+
+    To avoid this issue we created our own BaseModel class that inherits from BaseModel and allows such object creation.
+    """
+
     model_config = ConfigDict(coerce_numbers_to_str=True)
 
 

--- a/antarest/core/utils/utils.py
+++ b/antarest/core/utils/utils.py
@@ -25,28 +25,12 @@ from pathlib import Path
 
 import py7zr
 from fastapi import HTTPException
-from pydantic import BaseModel, ConfigDict
 
 from antarest.core.exceptions import ShouldNotHappenException
 
 logger = logging.getLogger(__name__)
 
 UUID_PATTERN = re.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
-
-
-class BaseModelInHouse(BaseModel):
-    """
-    Due to pydantic migration from v1 to v2, we can have this issue:
-
-    class A(BaseModel):
-        a: str
-
-    A(a=2) raises ValidationError as we give an int instead of a str
-
-    To avoid this issue we created our own BaseModel class that inherits from BaseModel and allows such object creation.
-    """
-
-    model_config = ConfigDict(coerce_numbers_to_str=True)
 
 
 class DTO:

--- a/antarest/core/utils/utils.py
+++ b/antarest/core/utils/utils.py
@@ -24,11 +24,9 @@ import zipfile
 from pathlib import Path
 
 import py7zr
-import redis
 from fastapi import HTTPException
 from pydantic import BaseModel, ConfigDict
 
-from antarest.core.config import RedisConfig
 from antarest.core.exceptions import ShouldNotHappenException
 
 logger = logging.getLogger(__name__)
@@ -145,17 +143,6 @@ def get_local_path() -> Path:
     # https: // pyinstaller.readthedocs.io / en / stable / runtime - information.html
     filepath = Path(__file__).parent.parent.parent.parent
     return filepath
-
-
-def new_redis_instance(config: RedisConfig) -> redis.Redis:  # type: ignore
-    redis_client = redis.Redis(
-        host=config.host,
-        port=config.port,
-        password=config.password,
-        db=0,
-        retry_on_error=[redis.ConnectionError, redis.TimeoutError],  # type: ignore
-    )
-    return redis_client  # type: ignore
 
 
 class StopWatch:

--- a/antarest/core/version_info.py
+++ b/antarest/core/version_info.py
@@ -18,10 +18,10 @@ import sys
 from pathlib import Path
 from typing import Dict
 
-from pydantic import BaseModel
+from antarest.core.utils.utils import BaseModelInHouse
 
 
-class VersionInfoDTO(BaseModel):
+class VersionInfoDTO(BaseModelInHouse):
     name: str = "AntaREST"
     version: str
     gitcommit: str

--- a/antarest/core/version_info.py
+++ b/antarest/core/version_info.py
@@ -18,10 +18,10 @@ import sys
 from pathlib import Path
 from typing import Dict
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 
-class VersionInfoDTO(BaseModelInHouse):
+class VersionInfoDTO(AntaresBaseModel):
     name: str = "AntaREST"
     version: str
     gitcommit: str

--- a/antarest/eventbus/web.py
+++ b/antarest/eventbus/web.py
@@ -17,7 +17,6 @@ from http import HTTPStatus
 from typing import List, Optional
 
 from fastapi import Depends, HTTPException, Query
-from pydantic import BaseModel
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from antarest.core.application import AppBuildContext
@@ -27,6 +26,7 @@ from antarest.core.jwt import DEFAULT_ADMIN_USER, JWTUser
 from antarest.core.model import PermissionInfo, StudyPermissionType
 from antarest.core.permissions import check_permission
 from antarest.core.serialization import to_json_string
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.fastapi_jwt_auth import AuthJWT
 from antarest.login.auth import Auth
 
@@ -38,7 +38,7 @@ class WebsocketMessageAction(str, Enum):
     UNSUBSCRIBE = "UNSUBSCRIBE"
 
 
-class WebsocketMessage(BaseModel):
+class WebsocketMessage(BaseModelInHouse):
     action: WebsocketMessageAction
     payload: str
 

--- a/antarest/eventbus/web.py
+++ b/antarest/eventbus/web.py
@@ -25,8 +25,7 @@ from antarest.core.interfaces.eventbus import Event, IEventBus
 from antarest.core.jwt import DEFAULT_ADMIN_USER, JWTUser
 from antarest.core.model import PermissionInfo, StudyPermissionType
 from antarest.core.permissions import check_permission
-from antarest.core.serialization import to_json_string
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel, to_json_string
 from antarest.fastapi_jwt_auth import AuthJWT
 from antarest.login.auth import Auth
 
@@ -38,7 +37,7 @@ class WebsocketMessageAction(str, Enum):
     UNSUBSCRIBE = "UNSUBSCRIBE"
 
 
-class WebsocketMessage(BaseModelInHouse):
+class WebsocketMessage(AntaresBaseModel):
     action: WebsocketMessageAction
     payload: str
 

--- a/antarest/front.py
+++ b/antarest/front.py
@@ -31,8 +31,8 @@ from starlette.responses import FileResponse
 from starlette.staticfiles import StaticFiles
 from starlette.types import ASGIApp
 
+from antarest.core.serialization import AntaresBaseModel
 from antarest.core.utils.string import to_camel_case
-from antarest.core.utils.utils import BaseModelInHouse
 
 
 class RedirectMiddleware(BaseHTTPMiddleware):
@@ -77,7 +77,7 @@ class RedirectMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-class BackEndConfig(BaseModelInHouse):
+class BackEndConfig(AntaresBaseModel):
     """
     Configuration about backend URLs served to the frontend.
     """

--- a/antarest/front.py
+++ b/antarest/front.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from typing import Any, Optional, Sequence
 
 from fastapi import FastAPI
-from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware, DispatchFunction, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import FileResponse
@@ -33,6 +32,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.types import ASGIApp
 
 from antarest.core.utils.string import to_camel_case
+from antarest.core.utils.utils import BaseModelInHouse
 
 
 class RedirectMiddleware(BaseHTTPMiddleware):
@@ -77,7 +77,7 @@ class RedirectMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-class BackEndConfig(BaseModel):
+class BackEndConfig(BaseModelInHouse):
     """
     Configuration about backend URLs served to the frontend.
     """

--- a/antarest/launcher/adapters/log_parser.py
+++ b/antarest/launcher/adapters/log_parser.py
@@ -14,7 +14,7 @@ import functools
 import re
 import typing as t
 
-from pydantic import BaseModel
+from antarest.core.utils.utils import BaseModelInHouse
 
 _SearchFunc = t.Callable[[str], t.Optional[t.Match[str]]]
 
@@ -63,7 +63,7 @@ _quitting = t.cast(
 )
 
 
-class LaunchProgressDTO(BaseModel):
+class LaunchProgressDTO(BaseModelInHouse):
     """
     Measure the progress of a study simulation.
 

--- a/antarest/launcher/adapters/log_parser.py
+++ b/antarest/launcher/adapters/log_parser.py
@@ -14,7 +14,7 @@ import functools
 import re
 import typing as t
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 _SearchFunc = t.Callable[[str], t.Optional[t.Match[str]]]
 
@@ -63,7 +63,7 @@ _quitting = t.cast(
 )
 
 
-class LaunchProgressDTO(BaseModelInHouse):
+class LaunchProgressDTO(AntaresBaseModel):
     """
     Measure the progress of a study simulation.
 

--- a/antarest/launcher/model.py
+++ b/antarest/launcher/model.py
@@ -14,23 +14,24 @@ import enum
 import typing as t
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, Sequence, String  # type: ignore
 from sqlalchemy.orm import relationship  # type: ignore
 
 from antarest.core.persistence import Base
 from antarest.core.serialization import from_json
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.login.model import Identity, UserInfo
 from antarest.study.business.all_optional_meta import camel_case_model
 
 
-class XpansionParametersDTO(BaseModel):
+class XpansionParametersDTO(BaseModelInHouse):
     output_id: t.Optional[str] = None
     sensitivity_mode: bool = False
     enabled: bool = True
 
 
-class LauncherParametersDTO(BaseModel):
+class LauncherParametersDTO(BaseModelInHouse):
     # Warning ! This class must be retro-compatible (that's the reason for the weird bool/XpansionParametersDTO union)
     # The reason is that it's stored in json format in database and deserialized using the latest class version
     # If compatibility is to be broken, an (alembic) data migration script should be added
@@ -91,7 +92,7 @@ class JobLogType(str, enum.Enum):
     AFTER = "AFTER"
 
 
-class JobResultDTO(BaseModel):
+class JobResultDTO(BaseModelInHouse):
     """
     A data transfer object (DTO) representing the job result.
 
@@ -232,16 +233,16 @@ class JobResult(Base):  # type: ignore
         )
 
 
-class JobCreationDTO(BaseModel):
+class JobCreationDTO(BaseModelInHouse):
     job_id: str
 
 
-class LauncherEnginesDTO(BaseModel):
+class LauncherEnginesDTO(BaseModelInHouse):
     engines: t.List[str]
 
 
 @camel_case_model
-class LauncherLoadDTO(BaseModel, extra="forbid", validate_assignment=True, populate_by_name=True):
+class LauncherLoadDTO(BaseModelInHouse, extra="forbid", validate_assignment=True, populate_by_name=True):
     """
     DTO representing the load of the SLURM cluster or local machine.
 

--- a/antarest/launcher/model.py
+++ b/antarest/launcher/model.py
@@ -19,19 +19,18 @@ from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, Sequence, St
 from sqlalchemy.orm import relationship  # type: ignore
 
 from antarest.core.persistence import Base
-from antarest.core.serialization import from_json
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel, from_json
 from antarest.login.model import Identity, UserInfo
 from antarest.study.business.all_optional_meta import camel_case_model
 
 
-class XpansionParametersDTO(BaseModelInHouse):
+class XpansionParametersDTO(AntaresBaseModel):
     output_id: t.Optional[str] = None
     sensitivity_mode: bool = False
     enabled: bool = True
 
 
-class LauncherParametersDTO(BaseModelInHouse):
+class LauncherParametersDTO(AntaresBaseModel):
     # Warning ! This class must be retro-compatible (that's the reason for the weird bool/XpansionParametersDTO union)
     # The reason is that it's stored in json format in database and deserialized using the latest class version
     # If compatibility is to be broken, an (alembic) data migration script should be added
@@ -92,7 +91,7 @@ class JobLogType(str, enum.Enum):
     AFTER = "AFTER"
 
 
-class JobResultDTO(BaseModelInHouse):
+class JobResultDTO(AntaresBaseModel):
     """
     A data transfer object (DTO) representing the job result.
 
@@ -233,16 +232,16 @@ class JobResult(Base):  # type: ignore
         )
 
 
-class JobCreationDTO(BaseModelInHouse):
+class JobCreationDTO(AntaresBaseModel):
     job_id: str
 
 
-class LauncherEnginesDTO(BaseModelInHouse):
+class LauncherEnginesDTO(AntaresBaseModel):
     engines: t.List[str]
 
 
 @camel_case_model
-class LauncherLoadDTO(BaseModelInHouse, extra="forbid", validate_assignment=True, populate_by_name=True):
+class LauncherLoadDTO(AntaresBaseModel, extra="forbid", validate_assignment=True, populate_by_name=True):
     """
     DTO representing the load of the SLURM cluster or local machine.
 

--- a/antarest/launcher/ssh_config.py
+++ b/antarest/launcher/ssh_config.py
@@ -16,10 +16,10 @@ from typing import Any, Dict, Optional
 import paramiko
 from pydantic import model_validator
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 
-class SSHConfigDTO(BaseModelInHouse):
+class SSHConfigDTO(AntaresBaseModel):
     config_path: pathlib.Path
     username: str
     hostname: str

--- a/antarest/launcher/ssh_config.py
+++ b/antarest/launcher/ssh_config.py
@@ -14,10 +14,12 @@ import pathlib
 from typing import Any, Dict, Optional
 
 import paramiko
-from pydantic import BaseModel, model_validator
+from pydantic import model_validator
+
+from antarest.core.utils.utils import BaseModelInHouse
 
 
-class SSHConfigDTO(BaseModel):
+class SSHConfigDTO(BaseModelInHouse):
     config_path: pathlib.Path
     username: str
     hostname: str

--- a/antarest/login/auth.py
+++ b/antarest/login/auth.py
@@ -15,13 +15,13 @@ from datetime import timedelta
 from typing import Any, Callable, Coroutine, Dict, Optional, Tuple, Union
 
 from fastapi import Depends
-from pydantic import BaseModel
 from ratelimit.types import Scope  # type: ignore
 from starlette.requests import Request
 
 from antarest.core.config import Config
 from antarest.core.jwt import DEFAULT_ADMIN_USER, JWTUser
 from antarest.core.serialization import from_json
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.fastapi_jwt_auth import AuthJWT
 
 logger = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ class Auth:
         return None
 
 
-class JwtSettings(BaseModel):
+class JwtSettings(BaseModelInHouse):
     authjwt_secret_key: str
     authjwt_token_location: Tuple[str, ...]
     authjwt_access_token_expires: Union[int, timedelta] = Auth.ACCESS_TOKEN_DURATION

--- a/antarest/login/auth.py
+++ b/antarest/login/auth.py
@@ -20,8 +20,7 @@ from starlette.requests import Request
 
 from antarest.core.config import Config
 from antarest.core.jwt import DEFAULT_ADMIN_USER, JWTUser
-from antarest.core.serialization import from_json
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel, from_json
 from antarest.fastapi_jwt_auth import AuthJWT
 
 logger = logging.getLogger(__name__)
@@ -79,7 +78,7 @@ class Auth:
         return None
 
 
-class JwtSettings(BaseModelInHouse):
+class JwtSettings(AntaresBaseModel):
     authjwt_secret_key: str
     authjwt_token_location: Tuple[str, ...]
     authjwt_access_token_expires: Union[int, timedelta] = Auth.ACCESS_TOKEN_DURATION

--- a/antarest/login/model.py
+++ b/antarest/login/model.py
@@ -15,7 +15,6 @@ import typing as t
 import uuid
 
 import bcrypt
-from pydantic.main import BaseModel
 from sqlalchemy import Boolean, Column, Enum, ForeignKey, Integer, Sequence, String  # type: ignore
 from sqlalchemy.engine.base import Engine  # type: ignore
 from sqlalchemy.exc import IntegrityError  # type: ignore
@@ -24,6 +23,7 @@ from sqlalchemy.orm import relationship, sessionmaker  # type: ignore
 
 from antarest.core.persistence import Base
 from antarest.core.roles import RoleType
+from antarest.core.utils.utils import BaseModelInHouse
 
 if t.TYPE_CHECKING:
     # avoid circular import
@@ -44,58 +44,58 @@ ADMIN_NAME = "admin"
 """Name of the site administrator."""
 
 
-class UserInfo(BaseModel):
+class UserInfo(BaseModelInHouse):
     id: int
     name: str
 
 
-class BotRoleCreateDTO(BaseModel):
+class BotRoleCreateDTO(BaseModelInHouse):
     group: str
     role: int
 
 
-class BotCreateDTO(BaseModel):
+class BotCreateDTO(BaseModelInHouse):
     name: str
     roles: t.List[BotRoleCreateDTO]
     is_author: bool = True
 
 
-class UserCreateDTO(BaseModel):
+class UserCreateDTO(BaseModelInHouse):
     name: str
     password: str
 
 
-class GroupDTO(BaseModel):
+class GroupDTO(BaseModelInHouse):
     id: t.Optional[str] = None
     name: str
 
 
-class RoleCreationDTO(BaseModel):
+class RoleCreationDTO(BaseModelInHouse):
     type: RoleType
     group_id: str
     identity_id: int
 
 
-class RoleDTO(BaseModel):
+class RoleDTO(BaseModelInHouse):
     group_id: t.Optional[str]
     group_name: str
     identity_id: int
     type: RoleType
 
 
-class IdentityDTO(BaseModel):
+class IdentityDTO(BaseModelInHouse):
     id: int
     name: str
     roles: t.List[RoleDTO]
 
 
-class RoleDetailDTO(BaseModel):
+class RoleDetailDTO(BaseModelInHouse):
     group: GroupDTO
     identity: UserInfo
     type: RoleType
 
 
-class BotIdentityDTO(BaseModel):
+class BotIdentityDTO(BaseModelInHouse):
     id: int
     name: str
     isAuthor: bool
@@ -107,7 +107,7 @@ class BotDTO(UserInfo):
     is_author: bool
 
 
-class UserRoleDTO(BaseModel):
+class UserRoleDTO(BaseModelInHouse):
     id: int
     name: str
     role: RoleType
@@ -311,7 +311,7 @@ class Role(Base):  # type: ignore
         )
 
 
-class CredentialsDTO(BaseModel):
+class CredentialsDTO(BaseModelInHouse):
     user: int
     access_token: str
     refresh_token: str

--- a/antarest/login/model.py
+++ b/antarest/login/model.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import relationship, sessionmaker  # type: ignore
 
 from antarest.core.persistence import Base
 from antarest.core.roles import RoleType
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 if t.TYPE_CHECKING:
     # avoid circular import
@@ -44,58 +44,58 @@ ADMIN_NAME = "admin"
 """Name of the site administrator."""
 
 
-class UserInfo(BaseModelInHouse):
+class UserInfo(AntaresBaseModel):
     id: int
     name: str
 
 
-class BotRoleCreateDTO(BaseModelInHouse):
+class BotRoleCreateDTO(AntaresBaseModel):
     group: str
     role: int
 
 
-class BotCreateDTO(BaseModelInHouse):
+class BotCreateDTO(AntaresBaseModel):
     name: str
     roles: t.List[BotRoleCreateDTO]
     is_author: bool = True
 
 
-class UserCreateDTO(BaseModelInHouse):
+class UserCreateDTO(AntaresBaseModel):
     name: str
     password: str
 
 
-class GroupDTO(BaseModelInHouse):
+class GroupDTO(AntaresBaseModel):
     id: t.Optional[str] = None
     name: str
 
 
-class RoleCreationDTO(BaseModelInHouse):
+class RoleCreationDTO(AntaresBaseModel):
     type: RoleType
     group_id: str
     identity_id: int
 
 
-class RoleDTO(BaseModelInHouse):
+class RoleDTO(AntaresBaseModel):
     group_id: t.Optional[str]
     group_name: str
     identity_id: int
     type: RoleType
 
 
-class IdentityDTO(BaseModelInHouse):
+class IdentityDTO(AntaresBaseModel):
     id: int
     name: str
     roles: t.List[RoleDTO]
 
 
-class RoleDetailDTO(BaseModelInHouse):
+class RoleDetailDTO(AntaresBaseModel):
     group: GroupDTO
     identity: UserInfo
     type: RoleType
 
 
-class BotIdentityDTO(BaseModelInHouse):
+class BotIdentityDTO(AntaresBaseModel):
     id: int
     name: str
     isAuthor: bool
@@ -107,7 +107,7 @@ class BotDTO(UserInfo):
     is_author: bool
 
 
-class UserRoleDTO(BaseModelInHouse):
+class UserRoleDTO(AntaresBaseModel):
     id: int
     name: str
     role: RoleType
@@ -311,7 +311,7 @@ class Role(Base):  # type: ignore
         )
 
 
-class CredentialsDTO(BaseModelInHouse):
+class CredentialsDTO(AntaresBaseModel):
     user: int
     access_token: str
     refresh_token: str

--- a/antarest/login/web.py
+++ b/antarest/login/web.py
@@ -21,8 +21,7 @@ from antarest.core.config import Config
 from antarest.core.jwt import JWTGroup, JWTUser
 from antarest.core.requests import RequestParameters, UserHasNotPermissionError
 from antarest.core.roles import RoleType
-from antarest.core.serialization import from_json
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel, from_json
 from antarest.core.utils.web import APITag
 from antarest.fastapi_jwt_auth import AuthJWT
 from antarest.login.auth import Auth
@@ -46,7 +45,7 @@ from antarest.login.service import LoginService
 logger = logging.getLogger(__name__)
 
 
-class UserCredentials(BaseModelInHouse):
+class UserCredentials(AntaresBaseModel):
     username: str
     password: str
 

--- a/antarest/login/web.py
+++ b/antarest/login/web.py
@@ -16,13 +16,13 @@ from typing import Any, List, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException
 from markupsafe import escape
-from pydantic import BaseModel
 
 from antarest.core.config import Config
 from antarest.core.jwt import JWTGroup, JWTUser
 from antarest.core.requests import RequestParameters, UserHasNotPermissionError
 from antarest.core.roles import RoleType
 from antarest.core.serialization import from_json
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.core.utils.web import APITag
 from antarest.fastapi_jwt_auth import AuthJWT
 from antarest.login.auth import Auth
@@ -46,7 +46,7 @@ from antarest.login.service import LoginService
 logger = logging.getLogger(__name__)
 
 
-class UserCredentials(BaseModel):
+class UserCredentials(BaseModelInHouse):
     username: str
     password: str
 

--- a/antarest/matrixstore/matrix_editor.py
+++ b/antarest/matrixstore/matrix_editor.py
@@ -14,10 +14,12 @@ import functools
 import operator
 from typing import Any, Dict, List, Optional, Tuple
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
+
+from antarest.core.utils.utils import BaseModelInHouse
 
 
-class MatrixSlice(BaseModel):
+class MatrixSlice(BaseModelInHouse):
     # NOTE: This Markdown documentation is reflected in the Swagger API
     """
     Represents a group of cells in a matrix for updating.
@@ -97,7 +99,7 @@ OPERATIONS = {
 
 
 @functools.total_ordering
-class Operation(BaseModel):
+class Operation(BaseModelInHouse):
     # NOTE: This Markdown documentation is reflected in the Swagger API
     """
     Represents an update operation to be performed on matrix cells.
@@ -140,7 +142,7 @@ class Operation(BaseModel):
         return NotImplemented  # pragma: no cover
 
 
-class MatrixEditInstruction(BaseModel):
+class MatrixEditInstruction(BaseModelInHouse):
     # NOTE: This Markdown documentation is reflected in the Swagger API
     """
     Provides edit instructions to be applied to a matrix.

--- a/antarest/matrixstore/matrix_editor.py
+++ b/antarest/matrixstore/matrix_editor.py
@@ -16,10 +16,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import Field, field_validator, model_validator
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 
-class MatrixSlice(BaseModelInHouse):
+class MatrixSlice(AntaresBaseModel):
     # NOTE: This Markdown documentation is reflected in the Swagger API
     """
     Represents a group of cells in a matrix for updating.
@@ -99,7 +99,7 @@ OPERATIONS = {
 
 
 @functools.total_ordering
-class Operation(BaseModelInHouse):
+class Operation(AntaresBaseModel):
     # NOTE: This Markdown documentation is reflected in the Swagger API
     """
     Represents an update operation to be performed on matrix cells.
@@ -142,7 +142,7 @@ class Operation(BaseModelInHouse):
         return NotImplemented  # pragma: no cover
 
 
-class MatrixEditInstruction(BaseModelInHouse):
+class MatrixEditInstruction(AntaresBaseModel):
     # NOTE: This Markdown documentation is reflected in the Swagger API
     """
     Provides edit instructions to be applied to a matrix.

--- a/antarest/matrixstore/model.py
+++ b/antarest/matrixstore/model.py
@@ -14,11 +14,11 @@ import datetime
 import typing as t
 import uuid
 
-from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Table  # type: ignore
 from sqlalchemy.orm import relationship  # type: ignore
 
 from antarest.core.persistence import Base
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.login.model import GroupDTO, Identity, UserInfo
 
 
@@ -58,12 +58,12 @@ class Matrix(Base):  # type: ignore
         return res
 
 
-class MatrixInfoDTO(BaseModel):
+class MatrixInfoDTO(BaseModelInHouse):
     id: str
     name: str
 
 
-class MatrixDataSetDTO(BaseModel):
+class MatrixDataSetDTO(BaseModelInHouse):
     id: str
     name: str
     matrices: t.List[MatrixInfoDTO]
@@ -209,7 +209,7 @@ class MatrixDataSet(Base):  # type: ignore
 MatrixData = float
 
 
-class MatrixDTO(BaseModel):
+class MatrixDTO(BaseModelInHouse):
     width: int
     height: int
     index: t.List[str]
@@ -219,7 +219,7 @@ class MatrixDTO(BaseModel):
     id: str = ""
 
 
-class MatrixContent(BaseModel):
+class MatrixContent(BaseModelInHouse):
     """
     Matrix content (Data Frame array)
 
@@ -234,7 +234,7 @@ class MatrixContent(BaseModel):
     columns: t.List[t.Union[int, str]]
 
 
-class MatrixDataSetUpdateDTO(BaseModel):
+class MatrixDataSetUpdateDTO(BaseModelInHouse):
     name: str
     groups: t.List[str]
     public: bool

--- a/antarest/matrixstore/model.py
+++ b/antarest/matrixstore/model.py
@@ -18,7 +18,7 @@ from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, T
 from sqlalchemy.orm import relationship  # type: ignore
 
 from antarest.core.persistence import Base
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.login.model import GroupDTO, Identity, UserInfo
 
 
@@ -58,12 +58,12 @@ class Matrix(Base):  # type: ignore
         return res
 
 
-class MatrixInfoDTO(BaseModelInHouse):
+class MatrixInfoDTO(AntaresBaseModel):
     id: str
     name: str
 
 
-class MatrixDataSetDTO(BaseModelInHouse):
+class MatrixDataSetDTO(AntaresBaseModel):
     id: str
     name: str
     matrices: t.List[MatrixInfoDTO]
@@ -209,7 +209,7 @@ class MatrixDataSet(Base):  # type: ignore
 MatrixData = float
 
 
-class MatrixDTO(BaseModelInHouse):
+class MatrixDTO(AntaresBaseModel):
     width: int
     height: int
     index: t.List[str]
@@ -219,7 +219,7 @@ class MatrixDTO(BaseModelInHouse):
     id: str = ""
 
 
-class MatrixContent(BaseModelInHouse):
+class MatrixContent(AntaresBaseModel):
     """
     Matrix content (Data Frame array)
 
@@ -234,7 +234,7 @@ class MatrixContent(BaseModelInHouse):
     columns: t.List[t.Union[int, str]]
 
 
-class MatrixDataSetUpdateDTO(BaseModelInHouse):
+class MatrixDataSetUpdateDTO(AntaresBaseModel):
     name: str
     groups: t.List[str]
     public: bool

--- a/antarest/service_creator.py
+++ b/antarest/service_creator.py
@@ -25,7 +25,7 @@ from sqlalchemy.pool import NullPool  # type: ignore
 
 from antarest.core.application import AppBuildContext
 from antarest.core.cache.main import build_cache
-from antarest.core.config import Config
+from antarest.core.config import Config, RedisConfig
 from antarest.core.filetransfer.main import build_filetransfer_service
 from antarest.core.filetransfer.service import FileTransferManager
 from antarest.core.interfaces.cache import ICache
@@ -34,7 +34,6 @@ from antarest.core.maintenance.main import build_maintenance_manager
 from antarest.core.persistence import upgrade_db
 from antarest.core.tasks.main import build_taskjob_manager
 from antarest.core.tasks.service import ITaskService
-from antarest.core.utils.utils import new_redis_instance
 from antarest.eventbus.main import build_eventbus
 from antarest.launcher.main import build_launcher
 from antarest.login.main import build_login
@@ -107,6 +106,17 @@ def init_db_engine(
     engine = create_engine(config.db.db_url, echo=config.debug, connect_args=connect_args, **extra)
 
     return engine
+
+
+def new_redis_instance(config: RedisConfig) -> redis.Redis:  # type: ignore
+    redis_client = redis.Redis(
+        host=config.host,
+        port=config.port,
+        password=config.password,
+        db=0,
+        retry_on_error=[redis.ConnectionError, redis.TimeoutError],  # type: ignore
+    )
+    return redis_client  # type: ignore
 
 
 def create_event_bus(app_ctxt: t.Optional[AppBuildContext], config: Config) -> t.Tuple[IEventBus, t.Optional[redis.Redis]]:  # type: ignore

--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -15,10 +15,11 @@ import logging
 import re
 import typing as t
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from antarest.core.exceptions import ConfigFileNotFound, DuplicateAreaName, LayerNotAllowedToBeDeleted, LayerNotFound
 from antarest.core.model import JSON
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import Patch, PatchArea, PatchCluster, RawStudy, Study
@@ -47,7 +48,7 @@ class AreaType(enum.Enum):
     DISTRICT = "DISTRICT"
 
 
-class AreaCreationDTO(BaseModel):
+class AreaCreationDTO(BaseModelInHouse):
     name: str
     type: AreaType
     metadata: t.Optional[PatchArea] = None
@@ -76,13 +77,13 @@ class AreaInfoDTO(AreaCreationDTO):
     thermals: t.Optional[t.List[ClusterInfoDTO]] = None
 
 
-class LayerInfoDTO(BaseModel):
+class LayerInfoDTO(BaseModelInHouse):
     id: str
     name: str
     areas: t.List[str]
 
 
-class UpdateAreaUi(BaseModel, extra="forbid", populate_by_name=True):
+class UpdateAreaUi(BaseModelInHouse, extra="forbid", populate_by_name=True):
     """
     DTO for updating area UI
 

--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -19,7 +19,7 @@ from pydantic import Field
 
 from antarest.core.exceptions import ConfigFileNotFound, DuplicateAreaName, LayerNotAllowedToBeDeleted, LayerNotFound
 from antarest.core.model import JSON
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import Patch, PatchArea, PatchCluster, RawStudy, Study
@@ -48,7 +48,7 @@ class AreaType(enum.Enum):
     DISTRICT = "DISTRICT"
 
 
-class AreaCreationDTO(BaseModelInHouse):
+class AreaCreationDTO(AntaresBaseModel):
     name: str
     type: AreaType
     metadata: t.Optional[PatchArea] = None
@@ -77,13 +77,13 @@ class AreaInfoDTO(AreaCreationDTO):
     thermals: t.Optional[t.List[ClusterInfoDTO]] = None
 
 
-class LayerInfoDTO(BaseModelInHouse):
+class LayerInfoDTO(AntaresBaseModel):
     id: str
     name: str
     areas: t.List[str]
 
 
-class UpdateAreaUi(BaseModelInHouse, extra="forbid", populate_by_name=True):
+class UpdateAreaUi(AntaresBaseModel, extra="forbid", populate_by_name=True):
     """
     DTO for updating area UI
 

--- a/antarest/study/business/areas/st_storage_management.py
+++ b/antarest/study/business/areas/st_storage_management.py
@@ -28,7 +28,7 @@ from antarest.core.exceptions import (
 )
 from antarest.core.model import JSON
 from antarest.core.requests import CaseInsensitiveDict
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import Study
@@ -118,7 +118,7 @@ class STStorageOutput(STStorage880Config):
 # =============
 
 
-class STStorageMatrix(BaseModelInHouse):
+class STStorageMatrix(AntaresBaseModel):
     """
     Short-Term Storage Matrix  Model.
 
@@ -158,7 +158,7 @@ class STStorageMatrix(BaseModelInHouse):
 
 
 # noinspection SpellCheckingInspection
-class STStorageMatrices(BaseModelInHouse):
+class STStorageMatrices(AntaresBaseModel):
     """
     Short-Term Storage Matrices Validation Model.
 

--- a/antarest/study/business/areas/st_storage_management.py
+++ b/antarest/study/business/areas/st_storage_management.py
@@ -15,7 +15,7 @@ import operator
 import typing as t
 
 import numpy as np
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import field_validator, model_validator
 from typing_extensions import Literal
 
 from antarest.core.exceptions import (
@@ -28,6 +28,7 @@ from antarest.core.exceptions import (
 )
 from antarest.core.model import JSON
 from antarest.core.requests import CaseInsensitiveDict
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import Study
@@ -117,7 +118,7 @@ class STStorageOutput(STStorage880Config):
 # =============
 
 
-class STStorageMatrix(BaseModel):
+class STStorageMatrix(BaseModelInHouse):
     """
     Short-Term Storage Matrix  Model.
 
@@ -157,7 +158,7 @@ class STStorageMatrix(BaseModel):
 
 
 # noinspection SpellCheckingInspection
-class STStorageMatrices(BaseModel):
+class STStorageMatrices(BaseModelInHouse):
     """
     Short-Term Storage Matrices Validation Model.
 

--- a/antarest/study/business/binding_constraint_management.py
+++ b/antarest/study/business/binding_constraint_management.py
@@ -15,7 +15,7 @@ import logging
 import typing as t
 
 import numpy as np
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from antarest.core.exceptions import (
     BindingConstraintNotFound,
@@ -31,6 +31,7 @@ from antarest.core.exceptions import (
 from antarest.core.model import JSON
 from antarest.core.requests import CaseInsensitiveDict
 from antarest.core.utils.string import to_camel_case
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.study.business.all_optional_meta import camel_case_model
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import Study
@@ -79,7 +80,7 @@ OPERATOR_CONFLICT_MAP = {
 }
 
 
-class LinkTerm(BaseModel):
+class LinkTerm(BaseModelInHouse):
     """
     DTO for a constraint term on a link between two areas.
 
@@ -98,7 +99,7 @@ class LinkTerm(BaseModel):
         return "%".join(ids)
 
 
-class ClusterTerm(BaseModel):
+class ClusterTerm(BaseModelInHouse):
     """
     DTO for a constraint term on a cluster in an area.
 
@@ -117,7 +118,7 @@ class ClusterTerm(BaseModel):
         return ".".join(ids)
 
 
-class ConstraintTerm(BaseModel):
+class ConstraintTerm(BaseModelInHouse):
     """
     DTO for a constraint term.
 
@@ -147,7 +148,7 @@ class ConstraintTerm(BaseModel):
         return self.data.generate_id()
 
 
-class ConstraintFilters(BaseModel, frozen=True, extra="forbid"):
+class ConstraintFilters(BaseModelInHouse, frozen=True, extra="forbid"):
     """
     Binding Constraint Filters gathering the main filtering parameters.
 

--- a/antarest/study/business/binding_constraint_management.py
+++ b/antarest/study/business/binding_constraint_management.py
@@ -30,8 +30,8 @@ from antarest.core.exceptions import (
 )
 from antarest.core.model import JSON
 from antarest.core.requests import CaseInsensitiveDict
+from antarest.core.serialization import AntaresBaseModel
 from antarest.core.utils.string import to_camel_case
-from antarest.core.utils.utils import BaseModelInHouse
 from antarest.study.business.all_optional_meta import camel_case_model
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import Study
@@ -80,7 +80,7 @@ OPERATOR_CONFLICT_MAP = {
 }
 
 
-class LinkTerm(BaseModelInHouse):
+class LinkTerm(AntaresBaseModel):
     """
     DTO for a constraint term on a link between two areas.
 
@@ -99,7 +99,7 @@ class LinkTerm(BaseModelInHouse):
         return "%".join(ids)
 
 
-class ClusterTerm(BaseModelInHouse):
+class ClusterTerm(AntaresBaseModel):
     """
     DTO for a constraint term on a cluster in an area.
 
@@ -118,7 +118,7 @@ class ClusterTerm(BaseModelInHouse):
         return ".".join(ids)
 
 
-class ConstraintTerm(BaseModelInHouse):
+class ConstraintTerm(AntaresBaseModel):
     """
     DTO for a constraint term.
 
@@ -148,7 +148,7 @@ class ConstraintTerm(BaseModelInHouse):
         return self.data.generate_id()
 
 
-class ConstraintFilters(BaseModelInHouse, frozen=True, extra="forbid"):
+class ConstraintFilters(AntaresBaseModel, frozen=True, extra="forbid"):
     """
     Binding Constraint Filters gathering the main filtering parameters.
 

--- a/antarest/study/business/district_manager.py
+++ b/antarest/study/business/district_manager.py
@@ -13,7 +13,7 @@
 from typing import List
 
 from antarest.core.exceptions import AreaNotFound, DistrictAlreadyExist, DistrictNotFound
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import Study
 from antarest.study.storage.rawstudy.model.filesystem.config.model import transform_name_to_id
@@ -23,7 +23,7 @@ from antarest.study.storage.variantstudy.model.command.remove_district import Re
 from antarest.study.storage.variantstudy.model.command.update_district import UpdateDistrict
 
 
-class DistrictUpdateDTO(BaseModelInHouse):
+class DistrictUpdateDTO(AntaresBaseModel):
     #: Indicates whether this district is used in the output (usually all
     #: districts are visible, but the user can decide to hide some of them).
     output: bool

--- a/antarest/study/business/district_manager.py
+++ b/antarest/study/business/district_manager.py
@@ -12,9 +12,8 @@
 
 from typing import List
 
-from pydantic import BaseModel
-
 from antarest.core.exceptions import AreaNotFound, DistrictAlreadyExist, DistrictNotFound
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import Study
 from antarest.study.storage.rawstudy.model.filesystem.config.model import transform_name_to_id
@@ -24,7 +23,7 @@ from antarest.study.storage.variantstudy.model.command.remove_district import Re
 from antarest.study.storage.variantstudy.model.command.update_district import UpdateDistrict
 
 
-class DistrictUpdateDTO(BaseModel):
+class DistrictUpdateDTO(BaseModelInHouse):
     #: Indicates whether this district is used in the output (usually all
     #: districts are visible, but the user can decide to hide some of them).
     output: bool

--- a/antarest/study/business/link_management.py
+++ b/antarest/study/business/link_management.py
@@ -12,10 +12,9 @@
 
 import typing as t
 
-from pydantic import BaseModel
-
 from antarest.core.exceptions import ConfigFileNotFound
 from antarest.core.model import JSON
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import RawStudy
@@ -28,13 +27,13 @@ from antarest.study.storage.variantstudy.model.command.update_config import Upda
 _ALL_LINKS_PATH = "input/links"
 
 
-class LinkUIDTO(BaseModel):
+class LinkUIDTO(BaseModelInHouse):
     color: str
     width: float
     style: str
 
 
-class LinkInfoDTO(BaseModel):
+class LinkInfoDTO(BaseModelInHouse):
     area1: str
     area2: str
     ui: t.Optional[LinkUIDTO] = None

--- a/antarest/study/business/link_management.py
+++ b/antarest/study/business/link_management.py
@@ -14,7 +14,7 @@ import typing as t
 
 from antarest.core.exceptions import ConfigFileNotFound
 from antarest.core.model import JSON
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 from antarest.study.business.utils import execute_or_add_commands
 from antarest.study.model import RawStudy
@@ -27,13 +27,13 @@ from antarest.study.storage.variantstudy.model.command.update_config import Upda
 _ALL_LINKS_PATH = "input/links"
 
 
-class LinkUIDTO(BaseModelInHouse):
+class LinkUIDTO(AntaresBaseModel):
     color: str
     width: float
     style: str
 
 
-class LinkInfoDTO(BaseModelInHouse):
+class LinkInfoDTO(AntaresBaseModel):
     area1: str
     area2: str
     ui: t.Optional[LinkUIDTO] = None

--- a/antarest/study/business/xpansion_management.py
+++ b/antarest/study/business/xpansion_management.py
@@ -23,7 +23,7 @@ from pydantic import Field, ValidationError, field_validator, model_validator
 
 from antarest.core.exceptions import BadZipBinary, ChildNotFoundError
 from antarest.core.model import JSON
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.study.business.all_optional_meta import all_optional_model
 from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.model import Study
@@ -56,7 +56,7 @@ class Solver(EnumIgnoreCase):
     XPRESS = "Xpress"
 
 
-class XpansionSensitivitySettings(BaseModelInHouse):
+class XpansionSensitivitySettings(AntaresBaseModel):
     """
     A DTO representing the sensitivity analysis settings used for Xpansion.
 
@@ -77,7 +77,7 @@ class XpansionSensitivitySettings(BaseModelInHouse):
         return [] if v is None else v
 
 
-class XpansionSettings(BaseModelInHouse, extra="ignore", validate_assignment=True, populate_by_name=True):
+class XpansionSettings(AntaresBaseModel, extra="ignore", validate_assignment=True, populate_by_name=True):
     """
     A data transfer object representing the general settings used for Xpansion.
 
@@ -231,7 +231,7 @@ class UpdateXpansionSettings(XpansionSettings):
     )
 
 
-class XpansionCandidateDTO(BaseModelInHouse):
+class XpansionCandidateDTO(AntaresBaseModel):
     # The id of the candidate is irrelevant, so it should stay hidden for the user
     # The names should be the section titles of the file, and the id should be removed
     name: str

--- a/antarest/study/business/xpansion_management.py
+++ b/antarest/study/business/xpansion_management.py
@@ -19,10 +19,11 @@ import typing as t
 import zipfile
 
 from fastapi import HTTPException, UploadFile
-from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 
 from antarest.core.exceptions import BadZipBinary, ChildNotFoundError
 from antarest.core.model import JSON
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.study.business.all_optional_meta import all_optional_model
 from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 from antarest.study.model import Study
@@ -55,7 +56,7 @@ class Solver(EnumIgnoreCase):
     XPRESS = "Xpress"
 
 
-class XpansionSensitivitySettings(BaseModel):
+class XpansionSensitivitySettings(BaseModelInHouse):
     """
     A DTO representing the sensitivity analysis settings used for Xpansion.
 
@@ -76,7 +77,7 @@ class XpansionSensitivitySettings(BaseModel):
         return [] if v is None else v
 
 
-class XpansionSettings(BaseModel, extra="ignore", validate_assignment=True, populate_by_name=True):
+class XpansionSettings(BaseModelInHouse, extra="ignore", validate_assignment=True, populate_by_name=True):
     """
     A data transfer object representing the general settings used for Xpansion.
 
@@ -230,7 +231,7 @@ class UpdateXpansionSettings(XpansionSettings):
     )
 
 
-class XpansionCandidateDTO(BaseModel):
+class XpansionCandidateDTO(BaseModelInHouse):
     # The id of the candidate is irrelevant, so it should stay hidden for the user
     # The names should be the section titles of the file, and the id should be removed
     name: str

--- a/antarest/study/model.py
+++ b/antarest/study/model.py
@@ -34,7 +34,7 @@ from sqlalchemy.orm import relationship  # type: ignore
 from antarest.core.exceptions import ShouldNotHappenException
 from antarest.core.model import PublicMode
 from antarest.core.persistence import Base
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.login.model import Group, GroupDTO, Identity
 from antarest.study.css4_colors import COLOR_NAMES
 
@@ -151,7 +151,7 @@ class StudyContentStatus(enum.Enum):
     ERROR = "ERROR"
 
 
-class CommentsDto(BaseModelInHouse):
+class CommentsDto(AntaresBaseModel):
     comments: str
 
 
@@ -300,7 +300,7 @@ class StudyFolder:
     groups: t.List[Group]
 
 
-class PatchStudy(BaseModelInHouse):
+class PatchStudy(AntaresBaseModel):
     scenario: t.Optional[str] = None
     doc: t.Optional[str] = None
     status: t.Optional[str] = None
@@ -308,12 +308,12 @@ class PatchStudy(BaseModelInHouse):
     tags: t.List[str] = []
 
 
-class PatchArea(BaseModelInHouse):
+class PatchArea(AntaresBaseModel):
     country: t.Optional[str] = None
     tags: t.List[str] = []
 
 
-class PatchCluster(BaseModelInHouse):
+class PatchCluster(AntaresBaseModel):
     type: t.Optional[str] = None
     code_oi: t.Optional[str] = None
 
@@ -323,23 +323,23 @@ class PatchCluster(BaseModelInHouse):
             return "-".join(string.split("_"))
 
 
-class PatchOutputs(BaseModelInHouse):
+class PatchOutputs(AntaresBaseModel):
     reference: t.Optional[str] = None
 
 
-class Patch(BaseModelInHouse):
+class Patch(AntaresBaseModel):
     study: t.Optional[PatchStudy] = None
     areas: t.Optional[t.Dict[str, PatchArea]] = None
     thermal_clusters: t.Optional[t.Dict[str, PatchCluster]] = None
     outputs: t.Optional[PatchOutputs] = None
 
 
-class OwnerInfo(BaseModelInHouse):
+class OwnerInfo(AntaresBaseModel):
     id: t.Optional[int] = None
     name: str
 
 
-class StudyMetadataDTO(BaseModelInHouse):
+class StudyMetadataDTO(AntaresBaseModel):
     id: str
     name: str
     version: int
@@ -365,7 +365,7 @@ class StudyMetadataDTO(BaseModelInHouse):
         return str(val) if val else val  # type: ignore
 
 
-class StudyMetadataPatchDTO(BaseModelInHouse):
+class StudyMetadataPatchDTO(AntaresBaseModel):
     name: t.Optional[str] = None
     author: t.Optional[str] = None
     horizon: t.Optional[str] = None
@@ -388,7 +388,7 @@ class StudyMetadataPatchDTO(BaseModelInHouse):
         return tags
 
 
-class StudySimSettingsDTO(BaseModelInHouse):
+class StudySimSettingsDTO(AntaresBaseModel):
     general: t.Dict[str, t.Any]
     input: t.Dict[str, t.Any]
     output: t.Dict[str, t.Any]
@@ -399,7 +399,7 @@ class StudySimSettingsDTO(BaseModelInHouse):
     playlist: t.Optional[t.List[int]] = None
 
 
-class StudySimResultDTO(BaseModelInHouse):
+class StudySimResultDTO(AntaresBaseModel):
     name: str
     type: str
     settings: StudySimSettingsDTO
@@ -479,7 +479,7 @@ class ExportFormat(str, enum.Enum):
         return mapping[self]
 
 
-class StudyDownloadDTO(BaseModelInHouse):
+class StudyDownloadDTO(AntaresBaseModel):
     """
     DTO used to download outputs
     """
@@ -495,32 +495,32 @@ class StudyDownloadDTO(BaseModelInHouse):
     includeClusters: bool = False
 
 
-class MatrixIndex(BaseModelInHouse):
+class MatrixIndex(AntaresBaseModel):
     start_date: str = ""
     steps: int = 8760
     first_week_size: int = 7
     level: StudyDownloadLevelDTO = StudyDownloadLevelDTO.HOURLY
 
 
-class TimeSerie(BaseModelInHouse):
+class TimeSerie(AntaresBaseModel):
     name: str
     unit: str
     data: t.List[t.Optional[float]] = []
 
 
-class TimeSeriesData(BaseModelInHouse):
+class TimeSeriesData(AntaresBaseModel):
     type: StudyDownloadType
     name: str
     data: t.Dict[str, t.List[TimeSerie]] = {}
 
 
-class MatrixAggregationResultDTO(BaseModelInHouse):
+class MatrixAggregationResultDTO(AntaresBaseModel):
     index: MatrixIndex
     data: t.List[TimeSeriesData]
     warnings: t.List[str]
 
 
-class MatrixAggregationResult(BaseModelInHouse):
+class MatrixAggregationResult(AntaresBaseModel):
     index: MatrixIndex
     data: t.Dict[t.Tuple[StudyDownloadType, str], t.Dict[str, t.List[TimeSerie]]]
     warnings: t.List[str]
@@ -540,6 +540,6 @@ class MatrixAggregationResult(BaseModelInHouse):
         )
 
 
-class ReferenceStudy(BaseModelInHouse):
+class ReferenceStudy(AntaresBaseModel):
     version: str
     template_name: str

--- a/antarest/study/model.py
+++ b/antarest/study/model.py
@@ -18,7 +18,7 @@ import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from pydantic import BaseModel, field_validator
+from pydantic import field_validator
 from sqlalchemy import (  # type: ignore
     Boolean,
     Column,
@@ -34,6 +34,7 @@ from sqlalchemy.orm import relationship  # type: ignore
 from antarest.core.exceptions import ShouldNotHappenException
 from antarest.core.model import PublicMode
 from antarest.core.persistence import Base
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.login.model import Group, GroupDTO, Identity
 from antarest.study.css4_colors import COLOR_NAMES
 
@@ -150,7 +151,7 @@ class StudyContentStatus(enum.Enum):
     ERROR = "ERROR"
 
 
-class CommentsDto(BaseModel):
+class CommentsDto(BaseModelInHouse):
     comments: str
 
 
@@ -299,7 +300,7 @@ class StudyFolder:
     groups: t.List[Group]
 
 
-class PatchStudy(BaseModel):
+class PatchStudy(BaseModelInHouse):
     scenario: t.Optional[str] = None
     doc: t.Optional[str] = None
     status: t.Optional[str] = None
@@ -307,12 +308,12 @@ class PatchStudy(BaseModel):
     tags: t.List[str] = []
 
 
-class PatchArea(BaseModel):
+class PatchArea(BaseModelInHouse):
     country: t.Optional[str] = None
     tags: t.List[str] = []
 
 
-class PatchCluster(BaseModel):
+class PatchCluster(BaseModelInHouse):
     type: t.Optional[str] = None
     code_oi: t.Optional[str] = None
 
@@ -322,23 +323,23 @@ class PatchCluster(BaseModel):
             return "-".join(string.split("_"))
 
 
-class PatchOutputs(BaseModel):
+class PatchOutputs(BaseModelInHouse):
     reference: t.Optional[str] = None
 
 
-class Patch(BaseModel):
+class Patch(BaseModelInHouse):
     study: t.Optional[PatchStudy] = None
     areas: t.Optional[t.Dict[str, PatchArea]] = None
     thermal_clusters: t.Optional[t.Dict[str, PatchCluster]] = None
     outputs: t.Optional[PatchOutputs] = None
 
 
-class OwnerInfo(BaseModel):
+class OwnerInfo(BaseModelInHouse):
     id: t.Optional[int] = None
     name: str
 
 
-class StudyMetadataDTO(BaseModel):
+class StudyMetadataDTO(BaseModelInHouse):
     id: str
     name: str
     version: int
@@ -364,7 +365,7 @@ class StudyMetadataDTO(BaseModel):
         return str(val) if val else val  # type: ignore
 
 
-class StudyMetadataPatchDTO(BaseModel):
+class StudyMetadataPatchDTO(BaseModelInHouse):
     name: t.Optional[str] = None
     author: t.Optional[str] = None
     horizon: t.Optional[str] = None
@@ -387,7 +388,7 @@ class StudyMetadataPatchDTO(BaseModel):
         return tags
 
 
-class StudySimSettingsDTO(BaseModel):
+class StudySimSettingsDTO(BaseModelInHouse):
     general: t.Dict[str, t.Any]
     input: t.Dict[str, t.Any]
     output: t.Dict[str, t.Any]
@@ -398,7 +399,7 @@ class StudySimSettingsDTO(BaseModel):
     playlist: t.Optional[t.List[int]] = None
 
 
-class StudySimResultDTO(BaseModel):
+class StudySimResultDTO(BaseModelInHouse):
     name: str
     type: str
     settings: StudySimSettingsDTO
@@ -478,7 +479,7 @@ class ExportFormat(str, enum.Enum):
         return mapping[self]
 
 
-class StudyDownloadDTO(BaseModel):
+class StudyDownloadDTO(BaseModelInHouse):
     """
     DTO used to download outputs
     """
@@ -494,32 +495,32 @@ class StudyDownloadDTO(BaseModel):
     includeClusters: bool = False
 
 
-class MatrixIndex(BaseModel):
+class MatrixIndex(BaseModelInHouse):
     start_date: str = ""
     steps: int = 8760
     first_week_size: int = 7
     level: StudyDownloadLevelDTO = StudyDownloadLevelDTO.HOURLY
 
 
-class TimeSerie(BaseModel):
+class TimeSerie(BaseModelInHouse):
     name: str
     unit: str
     data: t.List[t.Optional[float]] = []
 
 
-class TimeSeriesData(BaseModel):
+class TimeSeriesData(BaseModelInHouse):
     type: StudyDownloadType
     name: str
     data: t.Dict[str, t.List[TimeSerie]] = {}
 
 
-class MatrixAggregationResultDTO(BaseModel):
+class MatrixAggregationResultDTO(BaseModelInHouse):
     index: MatrixIndex
     data: t.List[TimeSeriesData]
     warnings: t.List[str]
 
 
-class MatrixAggregationResult(BaseModel):
+class MatrixAggregationResult(BaseModelInHouse):
     index: MatrixIndex
     data: t.Dict[t.Tuple[StudyDownloadType, str], t.Dict[str, t.List[TimeSerie]]]
     warnings: t.List[str]
@@ -539,6 +540,6 @@ class MatrixAggregationResult(BaseModel):
         )
 
 
-class ReferenceStudy(BaseModel):
+class ReferenceStudy(BaseModelInHouse):
     version: str
     template_name: str

--- a/antarest/study/repository.py
+++ b/antarest/study/repository.py
@@ -22,8 +22,8 @@ from antarest.core.interfaces.cache import ICache
 from antarest.core.jwt import JWTUser
 from antarest.core.model import PublicMode
 from antarest.core.requests import RequestParameters
+from antarest.core.serialization import AntaresBaseModel
 from antarest.core.utils.fastapi_sqlalchemy import db
-from antarest.core.utils.utils import BaseModelInHouse
 from antarest.login.model import Group
 from antarest.study.model import DEFAULT_WORKSPACE_NAME, RawStudy, Study, StudyAdditionalData, Tag
 
@@ -48,7 +48,7 @@ def escape_like(string: str, escape_char: str = "\\") -> str:
     return string.replace(escape_char, escape_char * 2).replace("%", escape_char + "%").replace("_", escape_char + "_")
 
 
-class AccessPermissions(BaseModelInHouse, frozen=True, extra="forbid"):
+class AccessPermissions(AntaresBaseModel, frozen=True, extra="forbid"):
     """
     This class object is build to pass on the user identity and its associated groups information
     into the listing function get_all below
@@ -85,7 +85,7 @@ class AccessPermissions(BaseModelInHouse, frozen=True, extra="forbid"):
             return cls()
 
 
-class StudyFilter(BaseModelInHouse, frozen=True, extra="forbid"):
+class StudyFilter(AntaresBaseModel, frozen=True, extra="forbid"):
     """Study filter class gathering the main filtering parameters
 
     Attributes:
@@ -128,7 +128,7 @@ class StudySortBy(str, enum.Enum):
     DATE_DESC = "-date"
 
 
-class StudyPagination(BaseModelInHouse, frozen=True, extra="forbid"):
+class StudyPagination(AntaresBaseModel, frozen=True, extra="forbid"):
     """
     Pagination of a studies query results
 

--- a/antarest/study/repository.py
+++ b/antarest/study/repository.py
@@ -14,7 +14,7 @@ import datetime
 import enum
 import typing as t
 
-from pydantic import BaseModel, NonNegativeInt
+from pydantic import NonNegativeInt
 from sqlalchemy import and_, func, not_, or_, sql  # type: ignore
 from sqlalchemy.orm import Query, Session, joinedload, with_polymorphic  # type: ignore
 
@@ -23,6 +23,7 @@ from antarest.core.jwt import JWTUser
 from antarest.core.model import PublicMode
 from antarest.core.requests import RequestParameters
 from antarest.core.utils.fastapi_sqlalchemy import db
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.login.model import Group
 from antarest.study.model import DEFAULT_WORKSPACE_NAME, RawStudy, Study, StudyAdditionalData, Tag
 
@@ -47,7 +48,7 @@ def escape_like(string: str, escape_char: str = "\\") -> str:
     return string.replace(escape_char, escape_char * 2).replace("%", escape_char + "%").replace("_", escape_char + "_")
 
 
-class AccessPermissions(BaseModel, frozen=True, extra="forbid"):
+class AccessPermissions(BaseModelInHouse, frozen=True, extra="forbid"):
     """
     This class object is build to pass on the user identity and its associated groups information
     into the listing function get_all below
@@ -84,7 +85,7 @@ class AccessPermissions(BaseModel, frozen=True, extra="forbid"):
             return cls()
 
 
-class StudyFilter(BaseModel, frozen=True, extra="forbid"):
+class StudyFilter(BaseModelInHouse, frozen=True, extra="forbid"):
     """Study filter class gathering the main filtering parameters
 
     Attributes:
@@ -127,7 +128,7 @@ class StudySortBy(str, enum.Enum):
     DATE_DESC = "-date"
 
 
-class StudyPagination(BaseModel, frozen=True, extra="forbid"):
+class StudyPagination(BaseModelInHouse, frozen=True, extra="forbid"):
     """
     Pagination of a studies query results
 

--- a/antarest/study/storage/rawstudy/model/filesystem/config/cluster.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/cluster.py
@@ -19,12 +19,14 @@ In the near future, this set of classes may be used for solar, wind and hydro cl
 import functools
 import typing as t
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from antarest.core.utils.utils import BaseModelInHouse
 
 
 @functools.total_ordering
 class ItemProperties(
-    BaseModel,
+    BaseModelInHouse,
     extra="forbid",
     validate_assignment=True,
     populate_by_name=True,

--- a/antarest/study/storage/rawstudy/model/filesystem/config/cluster.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/cluster.py
@@ -21,12 +21,12 @@ import typing as t
 
 from pydantic import Field
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 
 @functools.total_ordering
 class ItemProperties(
-    BaseModelInHouse,
+    AntaresBaseModel,
     extra="forbid",
     validate_assignment=True,
     populate_by_name=True,

--- a/antarest/study/storage/rawstudy/model/filesystem/config/identifier.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/identifier.py
@@ -16,11 +16,11 @@ from pydantic import Field, model_validator
 
 __all__ = ("IgnoreCaseIdentifier", "LowerCaseIdentifier")
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 
 
 class IgnoreCaseIdentifier(
-    BaseModelInHouse,
+    AntaresBaseModel,
     extra="forbid",
     validate_assignment=True,
     populate_by_name=True,

--- a/antarest/study/storage/rawstudy/model/filesystem/config/identifier.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/identifier.py
@@ -12,13 +12,15 @@
 
 import typing as t
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
 __all__ = ("IgnoreCaseIdentifier", "LowerCaseIdentifier")
 
+from antarest.core.utils.utils import BaseModelInHouse
+
 
 class IgnoreCaseIdentifier(
-    BaseModel,
+    BaseModelInHouse,
     extra="forbid",
     validate_assignment=True,
     populate_by_name=True,

--- a/antarest/study/storage/rawstudy/model/filesystem/config/model.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/model.py
@@ -16,7 +16,8 @@ from pathlib import Path
 
 from pydantic import Field, model_validator
 
-from antarest.core.utils.utils import DTO, BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
+from antarest.core.utils.utils import DTO
 from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 
 from .binding_constraint import (
@@ -49,7 +50,7 @@ class EnrModelling(EnumIgnoreCase):
         return self.value
 
 
-class Link(BaseModelInHouse, extra="ignore"):
+class Link(AntaresBaseModel, extra="ignore"):
     """
     Object linked to /input/links/<link>/properties.ini information
 
@@ -74,7 +75,7 @@ class Link(BaseModelInHouse, extra="ignore"):
         return values
 
 
-class Area(BaseModelInHouse, extra="forbid"):
+class Area(AntaresBaseModel, extra="forbid"):
     """
     Object linked to /input/<area>/optimization.ini information
     """
@@ -89,7 +90,7 @@ class Area(BaseModelInHouse, extra="forbid"):
     st_storages: t.List[STStorageConfigType] = []
 
 
-class DistrictSet(BaseModelInHouse):
+class DistrictSet(AntaresBaseModel):
     """
     Object linked to /inputs/sets.ini information
     """
@@ -108,7 +109,7 @@ class DistrictSet(BaseModelInHouse):
         return self.areas or []
 
 
-class Simulation(BaseModelInHouse):
+class Simulation(AntaresBaseModel):
     """
     Object linked to /output/<simulation_name>/about-the-study/** information
     """
@@ -130,7 +131,7 @@ class Simulation(BaseModelInHouse):
         return f"{self.date}{modes[self.mode]}{dash}{self.name}"
 
 
-class BindingConstraintDTO(BaseModelInHouse):
+class BindingConstraintDTO(AntaresBaseModel):
     """
     Object linked to `input/bindingconstraints/bindingconstraints.ini` information
 
@@ -302,7 +303,7 @@ def transform_name_to_id(name: str, lower: bool = True) -> str:
     return valid_id.lower() if lower else valid_id
 
 
-class FileStudyTreeConfigDTO(BaseModelInHouse):
+class FileStudyTreeConfigDTO(AntaresBaseModel):
     study_path: Path
     path: Path
     study_id: str

--- a/antarest/study/storage/rawstudy/model/filesystem/config/model.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/model.py
@@ -14,9 +14,9 @@ import re
 import typing as t
 from pathlib import Path
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
-from antarest.core.utils.utils import DTO
+from antarest.core.utils.utils import DTO, BaseModelInHouse
 from antarest.study.business.enum_ignore_case import EnumIgnoreCase
 
 from .binding_constraint import (
@@ -49,7 +49,7 @@ class EnrModelling(EnumIgnoreCase):
         return self.value
 
 
-class Link(BaseModel, extra="ignore"):
+class Link(BaseModelInHouse, extra="ignore"):
     """
     Object linked to /input/links/<link>/properties.ini information
 
@@ -74,7 +74,7 @@ class Link(BaseModel, extra="ignore"):
         return values
 
 
-class Area(BaseModel, extra="forbid"):
+class Area(BaseModelInHouse, extra="forbid"):
     """
     Object linked to /input/<area>/optimization.ini information
     """
@@ -89,7 +89,7 @@ class Area(BaseModel, extra="forbid"):
     st_storages: t.List[STStorageConfigType] = []
 
 
-class DistrictSet(BaseModel):
+class DistrictSet(BaseModelInHouse):
     """
     Object linked to /inputs/sets.ini information
     """
@@ -108,7 +108,7 @@ class DistrictSet(BaseModel):
         return self.areas or []
 
 
-class Simulation(BaseModel):
+class Simulation(BaseModelInHouse):
     """
     Object linked to /output/<simulation_name>/about-the-study/** information
     """
@@ -130,7 +130,7 @@ class Simulation(BaseModel):
         return f"{self.date}{modes[self.mode]}{dash}{self.name}"
 
 
-class BindingConstraintDTO(BaseModel):
+class BindingConstraintDTO(BaseModelInHouse):
     """
     Object linked to `input/bindingconstraints/bindingconstraints.ini` information
 
@@ -302,7 +302,7 @@ def transform_name_to_id(name: str, lower: bool = True) -> str:
     return valid_id.lower() if lower else valid_id
 
 
-class FileStudyTreeConfigDTO(BaseModel):
+class FileStudyTreeConfigDTO(BaseModelInHouse):
     study_path: Path
     path: Path
     study_id: str

--- a/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
@@ -15,8 +15,9 @@ from abc import ABCMeta
 from enum import Enum
 
 import numpy as np
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.matrixstore.model import MatrixData
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint import (
@@ -90,7 +91,7 @@ def check_matrix_values(time_step: BindingConstraintFrequency, values: MatrixTyp
 # =================================================================================
 
 
-class BindingConstraintPropertiesBase(BaseModel, extra="forbid", populate_by_name=True):
+class BindingConstraintPropertiesBase(BaseModelInHouse, extra="forbid", populate_by_name=True):
     enabled: bool = True
     time_step: BindingConstraintFrequency = Field(DEFAULT_TIMESTEP, alias="type")
     operator: BindingConstraintOperator = DEFAULT_OPERATOR
@@ -163,7 +164,7 @@ class OptionalProperties(BindingConstraintProperties870):
 
 
 @camel_case_model
-class BindingConstraintMatrices(BaseModel, extra="forbid", populate_by_name=True):
+class BindingConstraintMatrices(BaseModelInHouse, extra="forbid", populate_by_name=True):
     """
     Class used to store the matrices of a binding constraint.
     """

--- a/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
@@ -17,7 +17,7 @@ from enum import Enum
 import numpy as np
 from pydantic import Field, field_validator, model_validator
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.matrixstore.model import MatrixData
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint import (
@@ -91,7 +91,7 @@ def check_matrix_values(time_step: BindingConstraintFrequency, values: MatrixTyp
 # =================================================================================
 
 
-class BindingConstraintPropertiesBase(BaseModelInHouse, extra="forbid", populate_by_name=True):
+class BindingConstraintPropertiesBase(AntaresBaseModel, extra="forbid", populate_by_name=True):
     enabled: bool = True
     time_step: BindingConstraintFrequency = Field(DEFAULT_TIMESTEP, alias="type")
     operator: BindingConstraintOperator = DEFAULT_OPERATOR
@@ -164,7 +164,7 @@ class OptionalProperties(BindingConstraintProperties870):
 
 
 @camel_case_model
-class BindingConstraintMatrices(BaseModelInHouse, extra="forbid", populate_by_name=True):
+class BindingConstraintMatrices(AntaresBaseModel, extra="forbid", populate_by_name=True):
     """
     Class used to store the matrices of a binding constraint.
     """

--- a/antarest/study/storage/variantstudy/model/command_context.py
+++ b/antarest/study/storage/variantstudy/model/command_context.py
@@ -10,14 +10,13 @@
 #
 # This file is part of the Antares project.
 
-from pydantic import BaseModel
-
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.storage.patch_service import PatchService
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 
 
-class CommandContext(BaseModel):
+class CommandContext(BaseModelInHouse):
     generator_matrix_constants: GeneratorMatrixConstants
     matrix_service: ISimpleMatrixService
     patch_service: PatchService

--- a/antarest/study/storage/variantstudy/model/command_context.py
+++ b/antarest/study/storage/variantstudy/model/command_context.py
@@ -10,13 +10,13 @@
 #
 # This file is part of the Antares project.
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.storage.patch_service import PatchService
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 
 
-class CommandContext(BaseModelInHouse):
+class CommandContext(AntaresBaseModel):
     generator_matrix_constants: GeneratorMatrixConstants
     matrix_service: ISimpleMatrixService
     patch_service: PatchService

--- a/antarest/study/storage/variantstudy/model/model.py
+++ b/antarest/study/storage/variantstudy/model/model.py
@@ -14,9 +14,9 @@ import typing as t
 import uuid
 
 import typing_extensions as te
-from pydantic import BaseModel
 
 from antarest.core.model import JSON
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.study.model import StudyMetadataDTO
 
 LegacyDetailsDTO = t.Tuple[str, bool, str]
@@ -45,7 +45,7 @@ class NewDetailsDTO(te.TypedDict):
 DetailsDTO = t.Union[LegacyDetailsDTO, NewDetailsDTO]
 
 
-class GenerationResultInfoDTO(BaseModel):
+class GenerationResultInfoDTO(BaseModelInHouse):
     """
     Result information of a snapshot generation process.
 
@@ -58,7 +58,7 @@ class GenerationResultInfoDTO(BaseModel):
     details: t.MutableSequence[DetailsDTO]
 
 
-class CommandDTO(BaseModel):
+class CommandDTO(BaseModelInHouse):
     """
     This class represents a command.
 
@@ -75,7 +75,7 @@ class CommandDTO(BaseModel):
     version: int = 1
 
 
-class CommandResultDTO(BaseModel):
+class CommandResultDTO(BaseModelInHouse):
     """
     This class represents the result of a command.
 

--- a/antarest/study/storage/variantstudy/model/model.py
+++ b/antarest/study/storage/variantstudy/model/model.py
@@ -16,7 +16,7 @@ import uuid
 import typing_extensions as te
 
 from antarest.core.model import JSON
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.study.model import StudyMetadataDTO
 
 LegacyDetailsDTO = t.Tuple[str, bool, str]
@@ -45,7 +45,7 @@ class NewDetailsDTO(te.TypedDict):
 DetailsDTO = t.Union[LegacyDetailsDTO, NewDetailsDTO]
 
 
-class GenerationResultInfoDTO(BaseModelInHouse):
+class GenerationResultInfoDTO(AntaresBaseModel):
     """
     Result information of a snapshot generation process.
 
@@ -58,7 +58,7 @@ class GenerationResultInfoDTO(BaseModelInHouse):
     details: t.MutableSequence[DetailsDTO]
 
 
-class CommandDTO(BaseModelInHouse):
+class CommandDTO(AntaresBaseModel):
     """
     This class represents a command.
 
@@ -75,7 +75,7 @@ class CommandDTO(BaseModelInHouse):
     version: int = 1
 
 
-class CommandResultDTO(BaseModelInHouse):
+class CommandResultDTO(AntaresBaseModel):
     """
     This class represents the result of a command.
 

--- a/antarest/worker/archive_worker.py
+++ b/antarest/worker/archive_worker.py
@@ -13,18 +13,16 @@
 import logging
 from pathlib import Path
 
-from pydantic import BaseModel
-
 from antarest.core.config import Config
 from antarest.core.interfaces.eventbus import IEventBus
 from antarest.core.tasks.model import TaskResult
-from antarest.core.utils.utils import StopWatch, unzip
+from antarest.core.utils.utils import BaseModelInHouse, StopWatch, unzip
 from antarest.worker.worker import AbstractWorker, WorkerTaskCommand
 
 logger = logging.getLogger(__name__)
 
 
-class ArchiveTaskArgs(BaseModel):
+class ArchiveTaskArgs(BaseModelInHouse):
     src: str
     dest: str
     remove_src: bool = False

--- a/antarest/worker/archive_worker.py
+++ b/antarest/worker/archive_worker.py
@@ -15,14 +15,15 @@ from pathlib import Path
 
 from antarest.core.config import Config
 from antarest.core.interfaces.eventbus import IEventBus
+from antarest.core.serialization import AntaresBaseModel
 from antarest.core.tasks.model import TaskResult
-from antarest.core.utils.utils import BaseModelInHouse, StopWatch, unzip
+from antarest.core.utils.utils import StopWatch, unzip
 from antarest.worker.worker import AbstractWorker, WorkerTaskCommand
 
 logger = logging.getLogger(__name__)
 
 
-class ArchiveTaskArgs(BaseModelInHouse):
+class ArchiveTaskArgs(AntaresBaseModel):
     src: str
     dest: str
     remove_src: bool = False

--- a/antarest/worker/simulator_worker.py
+++ b/antarest/worker/simulator_worker.py
@@ -18,13 +18,12 @@ import time
 from pathlib import Path
 from typing import cast
 
-from pydantic import BaseModel
-
 from antarest.core.cache.business.local_chache import LocalCache
 from antarest.core.config import Config, LocalConfig
 from antarest.core.interfaces.eventbus import IEventBus
 from antarest.core.tasks.model import TaskResult
 from antarest.core.utils.fastapi_sqlalchemy import db
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.launcher.adapters.log_manager import follow
 from antarest.matrixstore.service import MatrixService
 from antarest.matrixstore.uri_resolver_service import UriResolverService
@@ -38,7 +37,7 @@ GENERATE_TIMESERIES_TASK_NAME = "generate-timeseries"
 GENERATE_KIRSHOFF_CONSTRAINTS_TASK_NAME = "generate-kirshoff-constraints"
 
 
-class GenerateTimeseriesTaskArgs(BaseModel):
+class GenerateTimeseriesTaskArgs(BaseModelInHouse):
     study_id: str
     study_path: str
     managed: bool

--- a/antarest/worker/simulator_worker.py
+++ b/antarest/worker/simulator_worker.py
@@ -21,9 +21,9 @@ from typing import cast
 from antarest.core.cache.business.local_chache import LocalCache
 from antarest.core.config import Config, LocalConfig
 from antarest.core.interfaces.eventbus import IEventBus
+from antarest.core.serialization import AntaresBaseModel
 from antarest.core.tasks.model import TaskResult
 from antarest.core.utils.fastapi_sqlalchemy import db
-from antarest.core.utils.utils import BaseModelInHouse
 from antarest.launcher.adapters.log_manager import follow
 from antarest.matrixstore.service import MatrixService
 from antarest.matrixstore.uri_resolver_service import UriResolverService
@@ -37,7 +37,7 @@ GENERATE_TIMESERIES_TASK_NAME = "generate-timeseries"
 GENERATE_KIRSHOFF_CONSTRAINTS_TASK_NAME = "generate-kirshoff-constraints"
 
 
-class GenerateTimeseriesTaskArgs(BaseModelInHouse):
+class GenerateTimeseriesTaskArgs(AntaresBaseModel):
     study_id: str
     study_path: str
     managed: bool

--- a/antarest/worker/worker.py
+++ b/antarest/worker/worker.py
@@ -19,20 +19,20 @@ from typing import Any, Dict, List, Union
 from antarest.core.interfaces.eventbus import Event, EventType, IEventBus
 from antarest.core.interfaces.service import IService
 from antarest.core.model import PermissionInfo, PublicMode
+from antarest.core.serialization import AntaresBaseModel
 from antarest.core.tasks.model import TaskResult
-from antarest.core.utils.utils import BaseModelInHouse
 
 logger = logging.getLogger(__name__)
 
 MAX_WORKERS = 10
 
 
-class WorkerTaskResult(BaseModelInHouse):
+class WorkerTaskResult(AntaresBaseModel):
     task_id: str
     task_result: TaskResult
 
 
-class WorkerTaskCommand(BaseModelInHouse):
+class WorkerTaskCommand(AntaresBaseModel):
     task_id: str
     task_type: str
     task_args: Dict[str, Union[int, float, bool, str]]

--- a/antarest/worker/worker.py
+++ b/antarest/worker/worker.py
@@ -16,24 +16,23 @@ from abc import abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Dict, List, Union
 
-from pydantic import BaseModel
-
 from antarest.core.interfaces.eventbus import Event, EventType, IEventBus
 from antarest.core.interfaces.service import IService
 from antarest.core.model import PermissionInfo, PublicMode
 from antarest.core.tasks.model import TaskResult
+from antarest.core.utils.utils import BaseModelInHouse
 
 logger = logging.getLogger(__name__)
 
 MAX_WORKERS = 10
 
 
-class WorkerTaskResult(BaseModel):
+class WorkerTaskResult(BaseModelInHouse):
     task_id: str
     task_result: TaskResult
 
 
-class WorkerTaskCommand(BaseModel):
+class WorkerTaskCommand(BaseModelInHouse):
     task_id: str
     task_type: str
     task_args: Dict[str, Union[int, float, bool, str]]

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -349,8 +349,10 @@ class TestThermal:
         # creating a thermal cluster with a name as a string should not raise an Exception
         res = client.post(f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal", json={"name": 111})
         assert res.status_code == 200, res.json()
-        res = client.request("DELETE", f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal", json=[111])
-        assert res.status_code == 200, res.json()
+        res = client.request(
+            "DELETE", f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal", json=["111"]
+        )
+        assert res.status_code == 204, res.json()
 
         # We can create a thermal cluster with the following properties:
         fr_gas_conventional_props = {

--- a/tests/study/business/test_all_optional_metaclass.py
+++ b/tests/study/business/test_all_optional_metaclass.py
@@ -10,12 +10,13 @@
 #
 # This file is part of the Antares project.
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from antarest.core.utils.utils import BaseModelInHouse
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 
 
-class Model(BaseModel):
+class Model(BaseModelInHouse):
     float_with_default: float = 1
     float_without_default: float
     boolean_with_default: bool = True

--- a/tests/study/business/test_all_optional_metaclass.py
+++ b/tests/study/business/test_all_optional_metaclass.py
@@ -12,11 +12,11 @@
 
 from pydantic import Field
 
-from antarest.core.utils.utils import BaseModelInHouse
+from antarest.core.serialization import AntaresBaseModel
 from antarest.study.business.all_optional_meta import all_optional_model, camel_case_model
 
 
-class Model(BaseModelInHouse):
+class Model(AntaresBaseModel):
     float_with_default: float = 1
     float_without_default: float
     boolean_with_default: bool = True


### PR DESCRIPTION
Fix [ANT-2255]

1- Introduces a class `BaseModelInHouse` to allow coercing and use it everywhere in the code
2- Little refactor to avoid circular import
3- Add test case that used to fail: Creation of a thermal cluster with the name 1111