### PR TITLE
fix(snapshot_cleaning): set `ref_id` to `None` to prevent postgresql crash

### DIFF
--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -1082,7 +1082,7 @@ class VariantStudyService(AbstractStorageService[VariantStudy]):
             snapshot_clearing_task_instance,
             task_name,
             task_type=TaskType.SNAPSHOT_CLEARING,
-            ref_id="SNAPSHOT_CLEANING",
+            ref_id=None,
             custom_event_messages=None,
             request_params=params,
         )


### PR DESCRIPTION
Fix bug on the clear-snapshot endpoint