### PR TITLE
fix: enable foreign keys for sqlite

### DIFF
--- a/antarest/core/utils/fastapi_sqlalchemy/middleware.py
+++ b/antarest/core/utils/fastapi_sqlalchemy/middleware.py
@@ -19,7 +19,7 @@ _session: ContextVar[Optional[Session]] = ContextVar("_session", default=None)
 def _is_sqlite_connection(dbapi_connection: Any) -> bool:
     cls = dbapi_connection.__class__
     full_classe_name = f"{cls.__module__}{cls.__name__}"
-    return "sqlite" in full_classe_name
+    return "sqlite" in full_classe_name.lower()
 
 
 @event.listens_for(Engine, "connect")  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,9 @@ import pytest
 from tests.conftest_db import *
 
 # noinspection PyUnresolvedReferences
+from tests.conftest_instances import *
+
+# noinspection PyUnresolvedReferences
 from tests.conftest_services import *
 
 HERE = Path(__file__).parent.resolve()

--- a/tests/conftest_instances.py
+++ b/tests/conftest_instances.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+"""
+The aim of this module is to contain fixtures for
+instantiating objects such as users, studies, ...
+"""
+import pytest
+
+from antarest.core.jwt import DEFAULT_ADMIN_USER
+from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware, db
+from antarest.login.model import User
+
+
+@pytest.fixture
+def admin_user(db_middleware: DBSessionMiddleware) -> User:
+    with db(commit_on_exit=True):
+        user = User(id=DEFAULT_ADMIN_USER.id)
+        db.session.add(user)
+    return DEFAULT_ADMIN_USER

--- a/tests/core/test_tasks.py
+++ b/tests/core/test_tasks.py
@@ -42,6 +42,7 @@ from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.eventbus.business.local_eventbus import LocalEventBus
 from antarest.eventbus.service import EventBusService
 from antarest.login.model import User
+from antarest.login.repository import UserRepository
 from antarest.service_creator import SESSION_ARGS
 from antarest.study.model import RawStudy
 from antarest.worker.worker import AbstractWorker, WorkerTaskCommand
@@ -74,6 +75,10 @@ def db_engine_fixture(tmp_path: Path) -> t.Generator[Engine, None, None]:
 @with_db_context
 def test_service(core_config: Config, event_bus: IEventBus) -> None:
     engine = db.session.bind
+
+    user_repo = UserRepository(session=db.session)
+    user_repo.save(User(id=DEFAULT_ADMIN_USER.id))
+
     task_job_repo = TaskJobRepository()
 
     # Prepare a TaskJob in the database
@@ -200,7 +205,7 @@ def test_repository(db_session: Session) -> None:
 
     # Create a RawStudy in the database
     study_id = "e34fe4d5-5964-4ef2-9baf-fad66dadc512"
-    db_session.add(RawStudy(id="study_id", name="foo", version="860"))
+    db_session.add(RawStudy(id=study_id, name="foo", version="860"))
     db_session.commit()
 
     # Create a TaskJobService


### PR DESCRIPTION
By default, sqlite does not enforce foreign key constraints, this needs to be enabled explicitly.

This is in particular important to catch those errors in our unit tests, but also for 
desktop mode.

**Note**
I have checked that indeed, tests before [this fix](https://github.com/AntaresSimulatorTeam/AntaREST/pull/2169) did not pass.