### PR TITLE
feat(watcher): filter out upgrade and TS generation `.tmp` folders

### DIFF
--- a/antarest/study/storage/rawstudy/watcher.py
+++ b/antarest/study/storage/rawstudy/watcher.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from time import sleep, time
 from typing import List, Optional
 
+from antares.study.version.upgrade_app import is_temporary_upgrade_dir
 from filelock import FileLock
 
 from antarest.core.config import Config
@@ -130,6 +131,10 @@ class Watcher(IService):
         try:
             if (path / "AW_NO_SCAN").exists():
                 logger.info(f"No scan directive file found. Will skip further scan of folder {path}")
+                return []
+
+            if is_temporary_upgrade_dir(path):
+                logger.info(f"Upgrade temporary folder found. Will skip further scan of folder {path}")
                 return []
 
             if (path / "study.antares").exists():

--- a/antarest/study/storage/rawstudy/watcher.py
+++ b/antarest/study/storage/rawstudy/watcher.py
@@ -34,6 +34,7 @@ from antarest.core.utils.utils import StopWatch
 from antarest.login.model import Group
 from antarest.study.model import DEFAULT_WORKSPACE_NAME, StudyFolder
 from antarest.study.service import StudyService
+from antarest.study.storage.variantstudy.model.command.generate_thermal_cluster_timeseries import is_ts_gen_tmp_dir
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +136,10 @@ class Watcher(IService):
 
             if is_temporary_upgrade_dir(path):
                 logger.info(f"Upgrade temporary folder found. Will skip further scan of folder {path}")
+                return []
+
+            if is_ts_gen_tmp_dir(path):
+                logger.info(f"TS generation temporary folder found. Will skip further scan of folder {path}")
                 return []
 
             if (path / "study.antares").exists():

--- a/antarest/study/storage/variantstudy/model/command/generate_thermal_cluster_timeseries.py
+++ b/antarest/study/storage/variantstudy/model/command/generate_thermal_cluster_timeseries.py
@@ -36,6 +36,20 @@ logger = logging.getLogger(__name__)
 MODULATION_CAPACITY_COLUMN = 2
 FO_RATE_COLUMN = 2
 PO_RATE_COLUMN = 3
+TS_GEN_PREFIX = "~"
+TS_GEN_SUFFIX = ".thermal_timeseries_gen.tmp"
+
+
+def is_ts_gen_tmp_dir(path: Path) -> bool:
+    """
+    Check if a path is a temporary directory used for thermal timeseries generation
+    Args:
+        path: the path to check
+
+    Returns:
+        True if the path is a temporary directory used for thermal timeseries generation
+    """
+    return path.name.startswith(TS_GEN_PREFIX) and "".join(path.suffixes[-2:]) == TS_GEN_SUFFIX and path.is_dir()
 
 
 class GenerateThermalClusterTimeSeries(ICommand):
@@ -51,9 +65,7 @@ class GenerateThermalClusterTimeSeries(ICommand):
 
     def _apply(self, study_data: FileStudy) -> CommandOutput:
         study_path = study_data.config.study_path
-        with tempfile.TemporaryDirectory(
-            suffix=".thermal_timeseries_gen.tmp", prefix="~", dir=study_path.parent
-        ) as path:
+        with tempfile.TemporaryDirectory(suffix=TS_GEN_SUFFIX, prefix=TS_GEN_PREFIX, dir=study_path.parent) as path:
             tmp_dir = Path(path)
             try:
                 shutil.copytree(study_path / "input" / "thermal" / "series", tmp_dir, dirs_exist_ok=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Antares-Launcher==1.4.2
-antares-study-version==1.0.6
+antares-study-version==1.0.9
 antares-timeseries-generation~=0.1.5
 
 # When you install `fastapi[all]`, you get FastAPI along with additional dependencies:

--- a/tests/storage/business/test_watcher.py
+++ b/tests/storage/business/test_watcher.py
@@ -137,6 +137,11 @@ def test_partial_scan(tmp_path: Path, caplog: t.Any):
     upgrade_folder.mkdir(parents=True)
     (upgrade_folder / "study.antares").touch()
 
+    # create a temporary ts gen folder
+    ts_gen_folder = default / "folder/~ts_gen_folder.study.thermal_timeseries_gen.tmp"
+    ts_gen_folder.mkdir(parents=True)
+    (ts_gen_folder / "study.antares").touch()
+
     # study to be skipped because we check only the `default directory`
     diese = tmp_path / "diese"
     diese.mkdir()
@@ -172,8 +177,9 @@ def test_partial_scan(tmp_path: Path, caplog: t.Any):
         assert groups[0].name == "toto"
         assert call.args[1] == tmp_path / "test"
 
-    # verify that `upgrade_folder` has been skipped
+    # verify that `upgrade_folder` and `ts_gen_folder`  have been skipped
     assert f"Upgrade temporary folder found. Will skip further scan of folder {upgrade_folder}" in caplog.text
+    assert f"TS generation temporary folder found. Will skip further scan of folder {ts_gen_folder}" in caplog.text
 
 
 def process(x: int) -> bool:

--- a/tests/storage/business/test_watcher.py
+++ b/tests/storage/business/test_watcher.py
@@ -9,8 +9,9 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-
+import logging
 import os
+import typing as t
 from multiprocessing import Pool
 from pathlib import Path
 from unittest.mock import Mock
@@ -112,7 +113,7 @@ def test_scan(tmp_path: Path):
 
 
 @pytest.mark.unit_test
-def test_partial_scan(tmp_path: Path):
+def test_partial_scan(tmp_path: Path, caplog: t.Any):
     engine = create_engine("sqlite:///:memory:", echo=False)
     Base.metadata.create_all(engine)
     # noinspection SpellCheckingInspection
@@ -124,12 +125,19 @@ def test_partial_scan(tmp_path: Path):
 
     clean_files()
 
+    # study to be scanned
     default = tmp_path / "test"
     default.mkdir()
     a = default / "studyA"
     a.mkdir()
     (a / "study.antares").touch()
 
+    # create a temporary upgrade folder
+    upgrade_folder = default / "folder/~upgrade_folder.study.upgrade.tmp"
+    upgrade_folder.mkdir(parents=True)
+    (upgrade_folder / "study.antares").touch()
+
+    # study to be skipped because we check only the `default directory`
     diese = tmp_path / "diese"
     diese.mkdir()
     c = diese / "folder/studyC"
@@ -142,18 +150,30 @@ def test_partial_scan(tmp_path: Path):
     with pytest.raises(CannotScanInternalWorkspace):
         watcher.scan(workspace_name="default", workspace_directory_path=default)
 
-    watcher.scan(workspace_name="test", workspace_directory_path=default)
+    with caplog.at_level(level=logging.INFO, logger="antarest.study.storage.rawstudy.watcher"):
+        # scan the `default` directory
+        watcher.scan(workspace_name="test", workspace_directory_path=default)
 
-    assert service.sync_studies_on_disk.call_count == 1
-    call = service.sync_studies_on_disk.call_args_list[0]
-    assert len(call.args[0]) == 1
-    assert call.args[0][0].path == a
-    assert call.args[0][0].workspace == "test"
-    groups = call.args[0][0].groups
-    assert len(groups) == 1
-    assert groups[0].id == "toto"
-    assert groups[0].name == "toto"
-    assert call.args[1] == tmp_path / "test"
+        # verify that only one study has been scanned
+        assert service.sync_studies_on_disk.call_count == 1
+
+        # verify that the scan process has been called with the correct arguments
+        call = service.sync_studies_on_disk.call_args_list[0]
+
+        # verify that only one study has been scanned
+        assert len(call.args[0]) == 1
+
+        # verify that folder `a` has been processed correctly
+        assert call.args[0][0].path == a
+        assert call.args[0][0].workspace == "test"
+        groups = call.args[0][0].groups
+        assert len(groups) == 1
+        assert groups[0].id == "toto"
+        assert groups[0].name == "toto"
+        assert call.args[1] == tmp_path / "test"
+
+    # verify that `upgrade_folder` has been skipped
+    assert f"Upgrade temporary folder found. Will skip further scan of folder {upgrade_folder}" in caplog.text
 
 
 def process(x: int) -> bool:


### PR DESCRIPTION
Issue:
Temporary folders created during a study update are scanned by the watcher, which imports studies into the database that we do not want to import.

Solution:
To overcome this problem, we need to add a "hard coded" filter in the watcher in addition to the "filter_out" filters that come from the configuration, and other folders ignored by the watcher (AWS_NO_SCAN etc).  The convention of the upgrade is to create folders suffixed ".tmp": we can base ourselves on this convention. The best is probably to create a constant in the upgrade module, in order to understand where this filtering comes from.
