### PR TITLE
test(ui-utils): add tests for validation utils & refactor imports

### DIFF
--- a/webapp/src/common/types.ts
+++ b/webapp/src/common/types.ts
@@ -659,3 +659,5 @@ export interface TaskView {
   type: TaskType;
   status: string;
 }
+
+export type ValidationReturn = string | true;

--- a/webapp/src/components/App/Settings/Groups/dialog/GroupFormDialog/GroupForm.tsx
+++ b/webapp/src/components/App/Settings/Groups/dialog/GroupFormDialog/GroupForm.tsx
@@ -49,7 +49,7 @@ import { getGroups, getUsers } from "../../../../../../services/api/user";
 import { getAuthUser } from "../../../../../../redux/selectors";
 import useAppSelector from "../../../../../../redux/hooks/useAppSelector";
 import { UseFormReturnPlus } from "../../../../../common/Form/types";
-import { validateString } from "../../../../../../utils/validationUtils";
+import { validateString } from "@/utils/validation/string";
 
 function GroupForm(props: UseFormReturnPlus) {
   const {

--- a/webapp/src/components/App/Settings/Users/dialog/UserFormDialog/UserForm.tsx
+++ b/webapp/src/components/App/Settings/Users/dialog/UserFormDialog/UserForm.tsx
@@ -48,10 +48,7 @@ import usePromise from "../../../../../../hooks/usePromise";
 import { getGroups, getUsers } from "../../../../../../services/api/user";
 import { UserFormDialogProps } from ".";
 import { UseFormReturnPlus } from "../../../../../common/Form/types";
-import {
-  validatePassword,
-  validateString,
-} from "../../../../../../utils/validationUtils";
+import { validatePassword, validateString } from "@/utils/validation/string";
 
 interface Props extends UseFormReturnPlus {
   onlyPermissions?: UserFormDialogProps["onlyPermissions"];

--- a/webapp/src/components/App/Singlestudy/HomeView/InformationView/CreateVariantDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/HomeView/InformationView/CreateVariantDialog.tsx
@@ -24,7 +24,7 @@ import StringFE from "../../../../common/fieldEditors/StringFE";
 import Fieldset from "../../../../common/Fieldset";
 import SelectFE from "../../../../common/fieldEditors/SelectFE";
 import { SubmitHandlerPlus } from "../../../../common/Form/types";
-import { validateString } from "../../../../../utils/validationUtils";
+import { validateString } from "@/utils/validation/string";
 
 interface Props {
   parentId: string;

--- a/webapp/src/components/App/Singlestudy/PropertiesDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/PropertiesDialog.tsx
@@ -37,7 +37,7 @@ import Fieldset from "../../common/Fieldset";
 import { SubmitHandlerPlus } from "../../common/Form/types";
 import useAppDispatch from "../../../redux/hooks/useAppDispatch";
 import { updateStudy } from "../../../redux/ducks/studies";
-import { validateString } from "../../../utils/validationUtils";
+import { validateString } from "@/utils/validation/string";
 
 const logErr = debug("antares:createstudyform:error");
 

--- a/webapp/src/components/App/Singlestudy/explore/Configuration/AdequacyPatch/Fields.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Configuration/AdequacyPatch/Fields.tsx
@@ -22,7 +22,7 @@ import Fieldset from "../../../../../common/Fieldset";
 import { useFormContextPlus } from "../../../../../common/Form";
 import { AdequacyPatchFormFields, PRICE_TAKING_ORDER_OPTIONS } from "./utils";
 import { StudyMetadata } from "../../../../../../common/types";
-import { validateNumber } from "../../../../../../utils/validationUtils";
+import { validateNumber } from "@/utils/validation/number";
 
 function Fields() {
   const { t } = useTranslation();

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/Allocation/AllocationField.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/Allocation/AllocationField.tsx
@@ -17,7 +17,7 @@ import { FieldArrayWithId } from "react-hook-form";
 import NumberFE from "../../../../../../../common/fieldEditors/NumberFE";
 import { useFormContextPlus } from "../../../../../../../common/Form";
 import { AllocationFormFields } from "./utils";
-import { validateNumber } from "../../../../../../../../utils/validationUtils";
+import { validateNumber } from "@/utils/validation/number";
 
 interface Props {
   field: FieldArrayWithId<AllocationFormFields, "allocation">;

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/Correlation/CorrelationField.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/Correlation/CorrelationField.tsx
@@ -20,7 +20,7 @@ import { CorrelationFormFields } from "./utils";
 import { useFormContextPlus } from "../../../../../../../common/Form";
 import useAppSelector from "../../../../../../../../redux/hooks/useAppSelector";
 import { getCurrentArea } from "../../../../../../../../redux/selectors";
-import { validateNumber } from "../../../../../../../../utils/validationUtils";
+import { validateNumber } from "@/utils/validation/number";
 
 interface Props {
   field: FieldArrayWithId<CorrelationFormFields, "correlation">;

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/Fields.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/Fields.tsx
@@ -23,7 +23,7 @@ import { useFormContextPlus } from "../../../../../../common/Form";
 import { STORAGE_GROUPS, Storage } from "./utils";
 import { useOutletContext } from "react-router";
 import { StudyMetadata } from "../../../../../../../common/types";
-import { validateNumber } from "../../../../../../../utils/validationUtils";
+import { validateNumber } from "@/utils/validation/number";
 
 function Fields() {
   const [t] = useTranslation();

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Thermal/Fields.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Thermal/Fields.tsx
@@ -30,7 +30,7 @@ import {
   TS_GENERATION_OPTIONS,
   TS_LAW_OPTIONS,
 } from "./utils";
-import { validateNumber } from "../../../../../../../utils/validationUtils";
+import { validateNumber } from "@/utils/validation/number";
 
 function Fields() {
   const [t] = useTranslation();

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/AddDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/AddDialog.tsx
@@ -32,10 +32,10 @@ import SelectFE from "../../../../../common/fieldEditors/SelectFE";
 import StringFE from "../../../../../common/fieldEditors/StringFE";
 import SwitchFE from "../../../../../common/fieldEditors/SwitchFE";
 import { StudyMetadata } from "../../../../../../common/types";
-import { validateString } from "../../../../../../utils/validationUtils";
 import { setCurrentBindingConst } from "../../../../../../redux/ducks/studySyntheses";
 import useAppDispatch from "../../../../../../redux/hooks/useAppDispatch";
 import { useOutletContext } from "react-router";
+import { validateString } from "@/utils/validation/string";
 
 interface Props {
   open: boolean;

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintFields.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/ConstraintFields.tsx
@@ -27,10 +27,10 @@ import SwitchFE from "../../../../../../common/fieldEditors/SwitchFE";
 import { useFormContextPlus } from "../../../../../../common/Form";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { validateString } from "../../../../../../../utils/validationUtils";
 import Matrix from "./Matrix";
 import { Box, Button } from "@mui/material";
 import { Dataset } from "@mui/icons-material";
+import { validateString } from "@/utils/validation/string";
 
 interface Props {
   study: StudyMetadata;

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/CreateAreaDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/CreateAreaDialog.tsx
@@ -19,8 +19,8 @@ import StringFE from "../../../../../common/fieldEditors/StringFE";
 import { SubmitHandlerPlus } from "../../../../../common/Form/types";
 import useAppSelector from "../../../../../../redux/hooks/useAppSelector";
 import { getAreas } from "../../../../../../redux/selectors";
-import { validateString } from "../../../../../../utils/validationUtils";
 import Fieldset from "../../../../../common/Fieldset";
+import { validateString } from "@/utils/validation/string";
 
 interface Props {
   studyId: string;

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Districts/CreateDistrictDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Districts/CreateDistrictDialog.tsx
@@ -26,7 +26,7 @@ import useAppDispatch from "../../../../../../../../redux/hooks/useAppDispatch";
 import { createStudyMapDistrict } from "../../../../../../../../redux/ducks/studyMaps";
 import useAppSelector from "../../../../../../../../redux/hooks/useAppSelector";
 import { getStudyMapDistrictsById } from "../../../../../../../../redux/selectors";
-import { validateString } from "../../../../../../../../utils/validationUtils";
+import { validateString } from "@/utils/validation/string";
 
 interface Props {
   open: boolean;

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Layers/CreateLayerDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Layers/CreateLayerDialog.tsx
@@ -26,7 +26,7 @@ import useAppDispatch from "../../../../../../../../redux/hooks/useAppDispatch";
 import useEnqueueErrorSnackbar from "../../../../../../../../hooks/useEnqueueErrorSnackbar";
 import useAppSelector from "../../../../../../../../redux/hooks/useAppSelector";
 import { getStudyMapLayersById } from "../../../../../../../../redux/selectors";
-import { validateString } from "../../../../../../../../utils/validationUtils";
+import { validateString } from "@/utils/validation/string";
 
 interface Props {
   open: boolean;

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Layers/UpdateLayerDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Layers/UpdateLayerDialog.tsx
@@ -31,7 +31,7 @@ import {
   updateStudyMapLayer,
 } from "../../../../../../../../redux/ducks/studyMaps";
 import useAppDispatch from "../../../../../../../../redux/hooks/useAppDispatch";
-import { validateString } from "../../../../../../../../utils/validationUtils";
+import { validateString } from "@/utils/validation/string";
 
 interface Props {
   open: boolean;

--- a/webapp/src/components/App/Singlestudy/explore/TableModeList/dialogs/TableTemplateFormDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/TableModeList/dialogs/TableTemplateFormDialog.tsx
@@ -23,11 +23,9 @@ import SelectFE from "../../../../../common/fieldEditors/SelectFE";
 import StringFE from "../../../../../common/fieldEditors/StringFE";
 import { getTableColumnsForType, type TableTemplate } from "../utils";
 import { TABLE_MODE_TYPES } from "../../../../../../services/api/studies/tableMode/constants";
-import {
-  validateArray,
-  validateString,
-} from "../../../../../../utils/validationUtils";
 import { useMemo } from "react";
+import { validateArray } from "@/utils/validation/array";
+import { validateString } from "@/utils/validation/string";
 
 export interface TableTemplateFormDialogProps
   extends Pick<

--- a/webapp/src/components/App/Singlestudy/explore/Xpansion/Candidates/CreateCandidateDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Xpansion/Candidates/CreateCandidateDialog.tsx
@@ -25,7 +25,7 @@ import Fieldset from "../../../../../common/Fieldset";
 import SelectFE from "../../../../../common/fieldEditors/SelectFE";
 import NumberFE from "../../../../../common/fieldEditors/NumberFE";
 import { SubmitHandlerPlus } from "../../../../../common/Form/types";
-import { validateString } from "../../../../../../utils/validationUtils";
+import { validateString } from "@/utils/validation/string";
 
 interface PropType {
   open: boolean;

--- a/webapp/src/components/common/GroupedDataTable/CreateDialog.tsx
+++ b/webapp/src/components/common/GroupedDataTable/CreateDialog.tsx
@@ -18,9 +18,9 @@ import StringFE from "../fieldEditors/StringFE";
 import Fieldset from "../Fieldset";
 import { SubmitHandlerPlus } from "../Form/types";
 import SelectFE from "../fieldEditors/SelectFE";
-import { validateString } from "../../../utils/validationUtils";
 import type { TRow } from "./types";
 import { useTranslation } from "react-i18next";
+import { validateString } from "@/utils/validation/string";
 
 interface Props {
   open: boolean;

--- a/webapp/src/components/common/GroupedDataTable/DuplicateDialog.tsx
+++ b/webapp/src/components/common/GroupedDataTable/DuplicateDialog.tsx
@@ -18,7 +18,7 @@ import Fieldset from "../Fieldset";
 import FormDialog from "../dialogs/FormDialog";
 import { SubmitHandlerPlus } from "../Form/types";
 import StringFE from "../fieldEditors/StringFE";
-import { validateString } from "../../../utils/validationUtils";
+import { validateString } from "@/utils/validation/string";
 
 interface Props {
   open: boolean;

--- a/webapp/src/utils/validation/array.test.ts
+++ b/webapp/src/utils/validation/array.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2024, RTE (https://www.rte-france.com)
+ *
+ * See AUTHORS.txt
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This file is part of the Antares project.
+ */
+
+import { validateArray } from "./array";
+
+vi.mock("i18next", () => ({
+  t: vi.fn((key) => key),
+}));
+
+describe("validateArray", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("should return true for a non-empty array with no duplicates", () => {
+    expect(validateArray([1, 2, 3])).toBe(true);
+  });
+
+  test("should return an error message for an empty array when not allowed", () => {
+    expect(validateArray([])).toBe("form.field.required");
+  });
+
+  test("should return true for an empty array when allowed", () => {
+    expect(validateArray([], { allowEmpty: true })).toBe(true);
+  });
+
+  test("should return an error message for an array with duplicates when not allowed", () => {
+    expect(validateArray([1, 2, 2, 3])).toBe("form.field.duplicateNotAllowed");
+  });
+
+  test("should return true for an array with duplicates when allowed", () => {
+    expect(validateArray([1, 2, 2, 3], { allowDuplicate: true })).toBe(true);
+  });
+
+  test("should work with currying", () => {
+    const validator = validateArray({ allowDuplicate: false });
+    expect(validator([1, 2, 3])).toBe(true);
+    expect(validator([1, 1, 2, 3])).toBe("form.field.duplicateNotAllowed");
+  });
+
+  test("should work with different types of array elements", () => {
+    expect(validateArray(["a", "b", "c"])).toBe(true);
+    expect(validateArray([{ id: 1 }, { id: 2 }])).toBe(true);
+  });
+
+  test("should handle both options simultaneously", () => {
+    expect(validateArray([], { allowEmpty: true, allowDuplicate: false })).toBe(
+      true,
+    );
+    expect(
+      validateArray([1, 1], { allowEmpty: true, allowDuplicate: true }),
+    ).toBe(true);
+    expect(
+      validateArray([1, 1], { allowEmpty: true, allowDuplicate: false }),
+    ).toBe("form.field.duplicateNotAllowed");
+  });
+});

--- a/webapp/src/utils/validation/array.ts
+++ b/webapp/src/utils/validation/array.ts
@@ -12,10 +12,9 @@
  * This file is part of the Antares project.
  */
 
+import { ValidationReturn } from "@/common/types";
 import { t } from "i18next";
 import * as R from "ramda";
-
-type ValidationResponse = string | true;
 
 interface ArrayValidationOptions {
   allowEmpty?: boolean;
@@ -45,16 +44,16 @@ interface ArrayValidationOptions {
 export function validateArray<T>(
   value: T[],
   options?: ArrayValidationOptions,
-): ValidationResponse;
+): ValidationReturn;
 
 export function validateArray<T>(
   options?: ArrayValidationOptions,
-): (value: T[]) => ValidationResponse;
+): (value: T[]) => ValidationReturn;
 
 export function validateArray<T>(
   valueOrOpts?: T[] | ArrayValidationOptions,
   options: ArrayValidationOptions = {},
-): ValidationResponse | ((value: T[]) => ValidationResponse) {
+): ValidationReturn | ((value: T[]) => ValidationReturn) {
   if (!Array.isArray(valueOrOpts)) {
     return (v: T[]) => validateArray(v, valueOrOpts);
   }

--- a/webapp/src/utils/validation/array.ts
+++ b/webapp/src/utils/validation/array.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2024, RTE (https://www.rte-france.com)
+ *
+ * See AUTHORS.txt
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This file is part of the Antares project.
+ */
+
+import { t } from "i18next";
+import * as R from "ramda";
+
+type ValidationResponse = string | true;
+
+interface ArrayValidationOptions {
+  allowEmpty?: boolean;
+  allowDuplicate?: boolean;
+}
+
+/**
+ * Validates an array against specified criteria.
+ * This function checks for duplicate values in the array.
+ *
+ * @example
+ * validateArray([1, 2, 3], { allowDuplicate: false }); // true
+ * validateArray([1, 1, 2, 3], { allowDuplicate: false }); // Error message
+ *
+ *
+ * @example <caption>With currying.</caption>
+ * const fn = validateArray({ allowDuplicate: false });
+ * fn([1, 2, 3]); // true
+ * fn([1, 1, 2, 3]); // Error message
+ *
+ * @param value - The array to validate.
+ * @param [options] - Configuration options for validation.
+ * @param [options.allowEmpty=false] - Sets whether empty array is allowed or not.
+ * @param [options.allowDuplicate=false] - Sets whether duplicate values are allowed or not.
+ * @returns True if validation is successful, or a localized error message if it fails.
+ */
+export function validateArray<T>(
+  value: T[],
+  options?: ArrayValidationOptions,
+): ValidationResponse;
+
+export function validateArray<T>(
+  options?: ArrayValidationOptions,
+): (value: T[]) => ValidationResponse;
+
+export function validateArray<T>(
+  valueOrOpts?: T[] | ArrayValidationOptions,
+  options: ArrayValidationOptions = {},
+): ValidationResponse | ((value: T[]) => ValidationResponse) {
+  if (!Array.isArray(valueOrOpts)) {
+    return (v: T[]) => validateArray(v, valueOrOpts);
+  }
+
+  const value = valueOrOpts;
+  const { allowEmpty, allowDuplicate } = options;
+
+  if (!value.length && !allowEmpty) {
+    return t("form.field.required");
+  }
+
+  if (!allowDuplicate && R.uniq(value).length !== value.length) {
+    return t("form.field.duplicateNotAllowed");
+  }
+
+  return true;
+}

--- a/webapp/src/utils/validation/number.test.ts
+++ b/webapp/src/utils/validation/number.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2024, RTE (https://www.rte-france.com)
+ *
+ * See AUTHORS.txt
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This file is part of the Antares project.
+ */
+
+import { validateNumber } from "./number";
+
+// Mock i18next
+vi.mock("i18next", () => ({
+  t: vi.fn((key, options) => {
+    if (options) {
+      return `${key}: ${JSON.stringify(options)}`;
+    }
+    return key;
+  }),
+}));
+
+describe("validateNumber", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("should return true for a valid number", () => {
+    expect(validateNumber(5)).toBe(true);
+  });
+
+  test("should return an error for non-finite numbers", () => {
+    expect(validateNumber(NaN)).toBe(
+      'form.field.invalidNumber: {"value":null}',
+    );
+    expect(validateNumber(Infinity)).toBe(
+      'form.field.invalidNumber: {"value":null}',
+    );
+    expect(validateNumber(-Infinity)).toBe(
+      'form.field.invalidNumber: {"value":null}',
+    );
+  });
+
+  test("should handle minimum value validation", () => {
+    expect(validateNumber(5, { min: 0 })).toBe(true);
+    expect(validateNumber(-1, { min: 0 })).toBe('form.field.minValue: {"0":0}');
+  });
+
+  test("should handle maximum value validation", () => {
+    expect(validateNumber(5, { max: 10 })).toBe(true);
+    expect(validateNumber(11, { max: 10 })).toBe(
+      'form.field.maxValue: {"0":10}',
+    );
+  });
+
+  test("should handle both minimum and maximum value validation", () => {
+    expect(validateNumber(5, { min: 0, max: 10 })).toBe(true);
+    expect(validateNumber(-1, { min: 0, max: 10 })).toBe(
+      'form.field.minValue: {"0":0}',
+    );
+    expect(validateNumber(11, { min: 0, max: 10 })).toBe(
+      'form.field.maxValue: {"0":10}',
+    );
+  });
+
+  test("should handle integer validation", () => {
+    expect(validateNumber(5, { integer: true })).toBe(true);
+    expect(validateNumber(5.5, { integer: true })).toBe(
+      "form.field.mustBeInteger",
+    );
+  });
+
+  test("should work with currying", () => {
+    const validator = validateNumber({ min: 0, max: 10 });
+    expect(validator(5)).toBe(true);
+    expect(validator(-1)).toBe('form.field.minValue: {"0":0}');
+    expect(validator(11)).toBe('form.field.maxValue: {"0":10}');
+  });
+
+  test("should handle extreme values", () => {
+    expect(validateNumber(Number.MAX_SAFE_INTEGER)).toBe(true);
+    expect(validateNumber(Number.MIN_SAFE_INTEGER)).toBe(true);
+  });
+
+  test("should handle custom ranges", () => {
+    expect(validateNumber(50, { min: -100, max: 100 })).toBe(true);
+    expect(validateNumber(-150, { min: -100, max: 100 })).toBe(
+      'form.field.minValue: {"0":-100}',
+    );
+    expect(validateNumber(150, { min: -100, max: 100 })).toBe(
+      'form.field.maxValue: {"0":100}',
+    );
+  });
+
+  test("should handle decimal numbers", () => {
+    expect(validateNumber(3.14)).toBe(true);
+    expect(validateNumber(3.14, { min: 3, max: 4 })).toBe(true);
+    expect(validateNumber(2.99, { min: 3, max: 4 })).toBe(
+      'form.field.minValue: {"0":3}',
+    );
+  });
+});

--- a/webapp/src/utils/validation/number.ts
+++ b/webapp/src/utils/validation/number.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2024, RTE (https://www.rte-france.com)
+ *
+ * See AUTHORS.txt
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This file is part of the Antares project.
+ */
+
+import { t } from "i18next";
+
+type ValidationResponse = string | true;
+
+interface NumberValidationOptions {
+  min?: number;
+  max?: number;
+  integer?: boolean;
+}
+
+/**
+ * Validates a number against specified numerical limits.
+ *
+ * @example
+ * validateNumber(5, { min: 0, max: 10 }); // true
+ * validateNumber(9, { min: 10, max: 20 }); // Error message
+ *
+ *
+ * @example <caption>With currying.</caption>
+ * const fn = validateNumber({ min: 0, max: 10 });
+ * fn(5); // true
+ * fn(11); // Error message
+ *
+ * @param value - The number to validate.
+ * @param [options] - Configuration options for validation.
+ * @param [options.min=Number.MIN_SAFE_INTEGER] - Minimum allowed value.
+ * @param [options.max=Number.MAX_SAFE_INTEGER] - Maximum allowed value.
+ * @returns True if validation is successful, or a localized error message if it fails.
+ */
+export function validateNumber(
+  value: number,
+  options?: NumberValidationOptions,
+): ValidationResponse;
+
+export function validateNumber(
+  options?: NumberValidationOptions,
+): (value: number) => ValidationResponse;
+
+export function validateNumber(
+  valueOrOpts?: number | NumberValidationOptions,
+  options: NumberValidationOptions = {},
+): ValidationResponse | ((value: number) => ValidationResponse) {
+  if (typeof valueOrOpts !== "number") {
+    return (v: number) => validateNumber(v, valueOrOpts);
+  }
+
+  const value = valueOrOpts;
+
+  if (!isFinite(value)) {
+    return t("form.field.invalidNumber", { value });
+  }
+
+  const {
+    min = Number.MIN_SAFE_INTEGER,
+    max = Number.MAX_SAFE_INTEGER,
+    integer = false,
+  } = options;
+
+  if (integer && !Number.isInteger(valueOrOpts)) {
+    return t("form.field.mustBeInteger");
+  }
+
+  if (value < min) {
+    return t("form.field.minValue", { 0: min });
+  }
+
+  if (value > max) {
+    return t("form.field.maxValue", { 0: max });
+  }
+
+  return true;
+}

--- a/webapp/src/utils/validation/number.ts
+++ b/webapp/src/utils/validation/number.ts
@@ -12,9 +12,8 @@
  * This file is part of the Antares project.
  */
 
+import { ValidationReturn } from "@/common/types";
 import { t } from "i18next";
-
-type ValidationResponse = string | true;
 
 interface NumberValidationOptions {
   min?: number;
@@ -44,16 +43,16 @@ interface NumberValidationOptions {
 export function validateNumber(
   value: number,
   options?: NumberValidationOptions,
-): ValidationResponse;
+): ValidationReturn;
 
 export function validateNumber(
   options?: NumberValidationOptions,
-): (value: number) => ValidationResponse;
+): (value: number) => ValidationReturn;
 
 export function validateNumber(
   valueOrOpts?: number | NumberValidationOptions,
   options: NumberValidationOptions = {},
-): ValidationResponse | ((value: number) => ValidationResponse) {
+): ValidationReturn | ((value: number) => ValidationReturn) {
   if (typeof valueOrOpts !== "number") {
     return (v: number) => validateNumber(v, valueOrOpts);
   }

--- a/webapp/src/utils/validation/string.test.ts
+++ b/webapp/src/utils/validation/string.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2024, RTE (https://www.rte-france.com)
+ *
+ * See AUTHORS.txt
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This file is part of the Antares project.
+ */
+
+import { validatePassword, validateString } from "./string";
+
+vi.mock("i18next", () => ({
+  t: vi.fn((key, options) => {
+    if (options) {
+      return `${key}: ${JSON.stringify(options)}`;
+    }
+    return key;
+  }),
+}));
+
+describe("validateString", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("should return true for a valid string", () => {
+    expect(validateString("Valid String")).toBe(true);
+  });
+
+  test("should return an error for an empty string", () => {
+    expect(validateString("")).toBe("form.field.required");
+    expect(validateString("   ")).toBe("form.field.required");
+  });
+
+  test("should handle length restrictions", () => {
+    expect(validateString("abc", { minLength: 5 })).toBe(
+      'form.field.minLength: {"length":5}',
+    );
+    expect(validateString("abcdefghijk", { maxLength: 10 })).toBe(
+      'form.field.maxLength: {"length":10}',
+    );
+  });
+
+  test("should handle space restrictions", () => {
+    expect(validateString("no spaces", { allowSpaces: false })).toBe(
+      "form.field.spacesNotAllowed",
+    );
+  });
+
+  test("should handle special character restrictions", () => {
+    expect(validateString("abc123!@#", { allowSpecialChars: false })).toBe(
+      "form.field.specialCharsNotAllowed",
+    );
+    expect(
+      validateString("abc123!@#", {
+        allowSpecialChars: true,
+        specialChars: "!@#",
+      }),
+    ).toBe(true);
+    expect(
+      validateString("abc123$%^", {
+        allowSpecialChars: true,
+        specialChars: "!@#",
+      }),
+    ).toBe('form.field.specialChars: {"0":"!@#"}');
+  });
+
+  test("should handle duplicate checks", () => {
+    expect(
+      validateString("existing", { existingValues: ["EXISTING", "other"] }),
+    ).toBe("form.field.duplicate");
+    expect(
+      validateString("existing", {
+        existingValues: ["EXISTING", "other"],
+        isCaseSensitive: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("should handle excluded values", () => {
+    expect(
+      validateString("excluded", { excludedValues: ["EXCLUDED", "other"] }),
+    ).toBe('form.field.notAllowedValue: {"0":"excluded"}');
+    expect(
+      validateString("excluded", {
+        excludedValues: ["EXCLUDED", "other"],
+        isCaseSensitive: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("should ignore the edited value in duplicate checks", () => {
+    expect(
+      validateString("existing", {
+        existingValues: ["existing", "other"],
+        editedValue: "existing",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("validatePassword", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("should return true for a valid password", () => {
+    expect(validatePassword("ValidP@ssw0rd")).toBe(true);
+  });
+
+  test("should return an error for an empty password", () => {
+    expect(validatePassword("")).toBe("form.field.required");
+    expect(validatePassword("   ")).toBe("form.field.required");
+  });
+
+  test("should check minimum length", () => {
+    expect(validatePassword("Short1!")).toBe(
+      'form.field.minLength: {"length":8}',
+    );
+  });
+
+  test("should check maximum length", () => {
+    expect(validatePassword("A".repeat(51) + "a1!")).toBe(
+      'form.field.maxLength: {"length":50}',
+    );
+  });
+
+  test("should require lowercase letters", () => {
+    expect(validatePassword("UPPERCASE123!")).toBe(
+      "form.field.requireLowercase",
+    );
+  });
+
+  test("should require uppercase letters", () => {
+    expect(validatePassword("lowercase123!")).toBe(
+      "form.field.requireUppercase",
+    );
+  });
+
+  test("should require digits", () => {
+    expect(validatePassword("UpperAndLowercase!")).toBe(
+      "form.field.requireDigit",
+    );
+  });
+
+  test("should require special characters", () => {
+    expect(validatePassword("UpperAndLowercase123")).toBe(
+      "form.field.requireSpecialChars",
+    );
+  });
+});

--- a/webapp/src/utils/validation/string.ts
+++ b/webapp/src/utils/validation/string.ts
@@ -12,6 +12,7 @@
  * This file is part of the Antares project.
  */
 
+import { ValidationReturn } from "@/common/types";
 import { t } from "i18next";
 
 interface StringValidationOptions {
@@ -48,7 +49,7 @@ interface StringValidationOptions {
 export function validateString(
   value: string,
   options?: StringValidationOptions,
-): string | true {
+): ValidationReturn {
   const {
     existingValues = [],
     excludedValues = [],
@@ -122,7 +123,7 @@ export function validateString(
  * @param password - The password to validate.
  * @returns True if validation is successful, or a localized error message if it fails.
  */
-export function validatePassword(password: string): string | true {
+export function validatePassword(password: string): ValidationReturn {
   const trimmedPassword = password.trim();
 
   if (!trimmedPassword) {

--- a/webapp/src/utils/validation/string.ts
+++ b/webapp/src/utils/validation/string.ts
@@ -13,13 +13,6 @@
  */
 
 import { t } from "i18next";
-import * as R from "ramda";
-
-type ValidationResult = string | true;
-
-////////////////////////////////////////////////////////////////
-// String
-////////////////////////////////////////////////////////////////
 
 interface StringValidationOptions {
   existingValues?: string[];
@@ -55,7 +48,7 @@ interface StringValidationOptions {
 export function validateString(
   value: string,
   options?: StringValidationOptions,
-): ValidationResult {
+): string | true {
   const {
     existingValues = [],
     excludedValues = [],
@@ -129,7 +122,7 @@ export function validateString(
  * @param password - The password to validate.
  * @returns True if validation is successful, or a localized error message if it fails.
  */
-export function validatePassword(password: string): ValidationResult {
+export function validatePassword(password: string): string | true {
   const trimmedPassword = password.trim();
 
   if (!trimmedPassword) {
@@ -162,143 +155,6 @@ export function validatePassword(password: string): ValidationResult {
 
   return true;
 }
-
-////////////////////////////////////////////////////////////////
-// Number
-////////////////////////////////////////////////////////////////
-
-interface NumberValidationOptions {
-  min?: number;
-  max?: number;
-  integer?: boolean;
-}
-
-/**
- * Validates a number against specified numerical limits.
- *
- * @example
- * validateNumber(5, { min: 0, max: 10 }); // true
- * validateNumber(9, { min: 10, max: 20 }); // Error message
- *
- *
- * @example <caption>With currying.</caption>
- * const fn = validateNumber({ min: 0, max: 10 });
- * fn(5); // true
- * fn(11); // Error message
- *
- * @param value - The number to validate.
- * @param [options] - Configuration options for validation.
- * @param [options.min=Number.MIN_SAFE_INTEGER] - Minimum allowed value.
- * @param [options.max=Number.MAX_SAFE_INTEGER] - Maximum allowed value.
- * @returns True if validation is successful, or a localized error message if it fails.
- */
-export function validateNumber(
-  value: number,
-  options?: NumberValidationOptions,
-): ValidationResult;
-
-export function validateNumber(
-  options?: NumberValidationOptions,
-): (value: number) => ValidationResult;
-
-export function validateNumber(
-  valueOrOpts?: number | NumberValidationOptions,
-  options: NumberValidationOptions = {},
-): ValidationResult | ((value: number) => ValidationResult) {
-  if (typeof valueOrOpts !== "number") {
-    return (v: number) => validateNumber(v, valueOrOpts);
-  }
-
-  const value = valueOrOpts;
-
-  if (!isFinite(value)) {
-    return t("form.field.invalidNumber", { value });
-  }
-
-  const {
-    min = Number.MIN_SAFE_INTEGER,
-    max = Number.MAX_SAFE_INTEGER,
-    integer = false,
-  } = options;
-
-  if (integer && !Number.isInteger(valueOrOpts)) {
-    return t("form.field.mustBeInteger");
-  }
-
-  if (value < min) {
-    return t("form.field.minValue", { 0: min });
-  }
-
-  if (value > max) {
-    return t("form.field.maxValue", { 0: max });
-  }
-
-  return true;
-}
-
-////////////////////////////////////////////////////////////////
-// Array
-////////////////////////////////////////////////////////////////
-
-interface ArrayValidationOptions {
-  allowEmpty?: boolean;
-  allowDuplicate?: boolean;
-}
-
-/**
- * Validates an array against specified criteria.
- * This function checks for duplicate values in the array.
- *
- * @example
- * validateArray([1, 2, 3], { allowDuplicate: false }); // true
- * validateArray([1, 1, 2, 3], { allowDuplicate: false }); // Error message
- *
- *
- * @example <caption>With currying.</caption>
- * const fn = validateArray({ allowDuplicate: false });
- * fn([1, 2, 3]); // true
- * fn([1, 1, 2, 3]); // Error message
- *
- * @param value - The array to validate.
- * @param [options] - Configuration options for validation.
- * @param [options.allowEmpty=false] - Sets whether empty array is allowed or not.
- * @param [options.allowDuplicate=false] - Sets whether duplicate values are allowed or not.
- * @returns True if validation is successful, or a localized error message if it fails.
- */
-export function validateArray<T>(
-  value: T[],
-  options?: ArrayValidationOptions,
-): ValidationResult;
-
-export function validateArray<T>(
-  options?: ArrayValidationOptions,
-): (value: T[]) => ValidationResult;
-
-export function validateArray<T>(
-  valueOrOpts?: T[] | ArrayValidationOptions,
-  options: ArrayValidationOptions = {},
-): ValidationResult | ((value: T[]) => ValidationResult) {
-  if (!Array.isArray(valueOrOpts)) {
-    return (v: T[]) => validateArray(v, valueOrOpts);
-  }
-
-  const value = valueOrOpts;
-  const { allowEmpty, allowDuplicate } = options;
-
-  if (!value.length && !allowEmpty) {
-    return t("form.field.required");
-  }
-
-  if (!allowDuplicate && R.uniq(value).length !== value.length) {
-    return t("form.field.duplicateNotAllowed");
-  }
-
-  return true;
-}
-
-////////////////////////////////////////////////////////////////
-// Utils
-////////////////////////////////////////////////////////////////
 
 // Escape special characters in specialChars
 function escapeSpecialChars(chars: string) {

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -9,6 +9,10 @@
     ],
     "module": "ESNext",
     "skipLibCheck": true,
+     "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -14,6 +14,7 @@
 
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import path from "path";
 
 const SERVER_URL = "http://localhost:8080";
 
@@ -28,6 +29,11 @@ export default defineConfig(({ mode }) => {
     define: {
       // Not working in dev without `JSON.stringify`
       __BUILD_TIMESTAMP__: JSON.stringify(Date.now()),
+    },
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"), // Relative imports from the src directory
+      },
     },
     esbuild: {
       // Remove logs safely when building production bundle


### PR DESCRIPTION
Added tests for validation utility functions

- String validation tests
- Number validation tests
- Array validation tests

- Split validation utils into separate files for better organization
- Updated Vite config to support relative imports
- Added '@' alias for the src directory

- Updated `tsconfig.json` to support the new import alias
- Refactored import statements across the project to use the new '@' alias
- Updated dependencies if necessary