### PR TITLE
fix(docker): reduce docker image size

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "master"
       - "hotfix/**"
+      - "fix/reduce-docker-image-size"
 
 jobs:
   binary:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-          pip install -r requirements-desktop.txt
 
       - name: 🐍 Install Windows dependencies
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,8 +47,8 @@ jobs:
       - name: 🐍 Install development dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pydantic --no-binary pydantic
           pip install -r requirements-dev.txt
+          pip install -r requirements-desktop.txt
 
       - name: 🐍 Install Windows dependencies
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - "master"
       - "hotfix/**"
-      - "fix/reduce-docker-image-size"
 
 jobs:
   binary:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ COPY ./scripts /scripts
 COPY ./alembic /alembic
 COPY ./alembic.ini /alembic.ini
 
-RUN ./scripts/install-debug.sh
+#RUN ./scripts/install-debug.sh
 
-RUN pip3 install --upgrade pip \
-    && pip3 install -r /conf/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip \
+    && pip3 install --no-cache-dir -r /conf/requirements.txt
 
 
 ENTRYPOINT ["./scripts/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY ./scripts /scripts
 COPY ./alembic /alembic
 COPY ./alembic.ini /alembic.ini
 
-#RUN ./scripts/install-debug.sh
+RUN ./scripts/install-debug.sh
 
 RUN pip3 install --no-cache-dir --upgrade pip \
     && pip3 install --no-cache-dir -r /conf/requirements.txt

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Install back-end dependencies
 
 ```shell script
 python -m pip install --upgrade pip
-pip install pydantic --no-binary pydantic
 pip install -r requirements.txt  # use requirements-dev.txt if building a single binary with pyinstaller 
 ```
 

--- a/requirements-desktop.txt
+++ b/requirements-desktop.txt
@@ -1,2 +1,4 @@
 -r requirements-test.txt
+
+# PyQt is used for the systray app of desktop version
 PyQt5~=5.15.6

--- a/requirements-desktop.txt
+++ b/requirements-desktop.txt
@@ -1,0 +1,2 @@
+-r requirements-test.txt
+PyQt5~=5.15.6

--- a/requirements-desktop.txt
+++ b/requirements-desktop.txt
@@ -1,4 +1,4 @@
--r requirements-test.txt
+-r requirements.txt
 
 # PyQt is used for the systray app of desktop version
 PyQt5~=5.15.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements-test.txt
+-r requirements-desktop.txt
 # Version of Black should match the versions set in `.github/workflows/main.yml`
 black~=23.7.0
 isort~=5.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ paramiko~=3.4.1
 plyer~=2.0.0
 psycopg2-binary==2.9.4
 py7zr~=0.20.6
-PyQt5~=5.15.6
+#PyQt5~=5.15.6
 python-json-logger~=2.0.7
 PyYAML~=5.4.1; python_version <= '3.9'
 PyYAML~=5.3.1; python_version > '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ paramiko~=3.4.1
 plyer~=2.0.0
 psycopg2-binary==2.9.4
 py7zr~=0.20.6
-#PyQt5~=5.15.6
 python-json-logger~=2.0.7
 PyYAML~=5.4.1; python_version <= '3.9'
 PyYAML~=5.3.1; python_version > '3.9'


### PR DESCRIPTION

PyQT wheel is around 200Mo. Together with the cache which is enabled
in our docker build, it adds up around 400 Mo, whereas it's not used when
not running the desktop version.

