### PR TITLE
feat(raw-api): add an endpoint to retrieve files in their original format

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -693,11 +693,6 @@ class PathIsAFolderError(HTTPException):
         super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, message)
 
 
-class InvalidContentError(HTTPException):
-    def __init__(self, message: str) -> None:
-        super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, message)
-
-
 class WorkspaceNotFound(HTTPException):
     """
     This will be raised when we try to load a workspace that does not exist

--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -711,15 +711,6 @@ class BadArchiveContent(Exception):
         super().__init__(message)
 
 
-class StudyNotArchived(HTTPException):
-    """
-    Exception raised when the study is supposed to be archived but is not.
-    """
-
-    def __init__(self, message: str = "") -> None:
-        super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, message)
-
-
 class FolderNotFoundInWorkspace(HTTPException):
     """
     This will be raised when we try to load a folder that does not exist

--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -688,6 +688,16 @@ class ChildNotFoundError(HTTPException):
         super().__init__(HTTPStatus.NOT_FOUND, message)
 
 
+class PathIsAFolderError(HTTPException):
+    def __init__(self, message: str) -> None:
+        super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, message)
+
+
+class InvalidContentError(HTTPException):
+    def __init__(self, message: str) -> None:
+        super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, message)
+
+
 class WorkspaceNotFound(HTTPException):
     """
     This will be raised when we try to load a workspace that does not exist
@@ -704,6 +714,15 @@ class BadArchiveContent(Exception):
 
     def __init__(self, message: str = "Unsupported archive format") -> None:
         super().__init__(message)
+
+
+class StudyNotArchived(HTTPException):
+    """
+    Exception raised when the study is supposed to be archived but is not.
+    """
+
+    def __init__(self, message: str = "") -> None:
+        super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, message)
 
 
 class FolderNotFoundInWorkspace(HTTPException):

--- a/antarest/core/swagger.py
+++ b/antarest/core/swagger.py
@@ -10,9 +10,10 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, List, Tuple
+import typing as t
 
 from fastapi import FastAPI
+from fastapi.openapi.models import Example
 from fastapi.routing import APIRoute
 
 sim = "{sim} = simulation index <br/>"
@@ -21,7 +22,7 @@ link = "{link} = link name to select <br/>"
 attachment = "User-defined file attachment <br/>"
 
 # noinspection SpellCheckingInspection
-urls: List[Tuple[str, str]] = [
+urls: t.List[t.Tuple[str, str]] = [
     ("layers/layers", ""),
     ("settings/generaldata", ""),
     ("output/{sim}/about-the-study/parameters", sim),
@@ -41,7 +42,7 @@ urls: List[Tuple[str, str]] = [
 ]
 
 
-def get_path_examples() -> Any:
+def get_path_examples() -> t.Dict[str, Example]:
     return {url: {"value": url, "description": des} for url, des in urls}
 
 

--- a/antarest/core/utils/archives.py
+++ b/antarest/core/utils/archives.py
@@ -145,6 +145,30 @@ def extract_file_to_tmp_dir(archive_path: Path, inside_archive_path: Path) -> t.
     return path, tmp_dir
 
 
+def read_original_file_in_archive(archive_path: Path, posix_path: str) -> bytes:
+    """
+    Read a file from an archive.
+
+    Args:
+        archive_path: the path to the archive file.
+        posix_path: path to the file inside the archive.
+
+    Returns:
+        The content of the file as `bytes`.
+    """
+
+    if archive_path.suffix == ArchiveFormat.ZIP:
+        with zipfile.ZipFile(archive_path) as zip_obj:
+            with zip_obj.open(posix_path) as f:
+                return f.read()
+    elif archive_path.suffix == ArchiveFormat.SEVEN_ZIP:
+        with py7zr.SevenZipFile(archive_path, mode="r") as szf:
+            output: bytes = szf.read([posix_path])[posix_path].read()
+            return output
+    else:
+        raise ValueError(f"Unsupported {archive_path.suffix} archive format for {archive_path}")
+
+
 def read_file_from_archive(archive_path: Path, posix_path: str) -> str:
     """
     Read a file from an archive.
@@ -157,16 +181,7 @@ def read_file_from_archive(archive_path: Path, posix_path: str) -> str:
         The content of the file as a string.
     """
 
-    if archive_path.suffix == ArchiveFormat.ZIP:
-        with zipfile.ZipFile(archive_path) as zip_obj:
-            with zip_obj.open(posix_path) as f:
-                return f.read().decode("utf-8")
-    elif archive_path.suffix == ArchiveFormat.SEVEN_ZIP:
-        with py7zr.SevenZipFile(archive_path, mode="r") as szf:
-            file_text: str = szf.read([posix_path])[posix_path].read().decode("utf-8")
-            return file_text
-    else:
-        raise ValueError(f"Unsupported {archive_path.suffix} archive format for {archive_path}")
+    return read_original_file_in_archive(archive_path, posix_path).decode("utf-8")
 
 
 def extract_lines_from_archive(root: Path, posix_path: str) -> t.List[str]:

--- a/antarest/study/business/matrix_management.py
+++ b/antarest/study/business/matrix_management.py
@@ -252,10 +252,7 @@ class MatrixManager:
 
         try:
             logger.info(f"Loading matrix data from node '{path}'...")
-            matrix_df = cast(
-                pd.DataFrame,
-                matrix_node.parse(return_dataframe=True),
-            )
+            matrix_df = matrix_node.parse_as_dataframe()
         except ValueError as exc:
             raise MatrixManagerError(f"Cannot parse matrix: {exc}") from exc
 

--- a/antarest/study/common/studystorage.py
+++ b/antarest/study/common/studystorage.py
@@ -17,18 +17,12 @@ from pathlib import Path
 from antarest.core.exceptions import StudyNotFoundError
 from antarest.core.model import JSON
 from antarest.core.requests import RequestParameters
-from antarest.core.serialization import AntaresBaseModel
 from antarest.study.model import Study, StudyMetadataDTO, StudyMetadataPatchDTO, StudySimResultDTO
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
+from antarest.study.storage.rawstudy.model.filesystem.inode import OriginalFile
 
 T = t.TypeVar("T", bound=Study)
-
-
-class OriginalFile(AntaresBaseModel):
-    suffix: str
-    content: bytes
-    filename: str
 
 
 class IStudyStorageService(ABC, t.Generic[T]):

--- a/antarest/study/common/studystorage.py
+++ b/antarest/study/common/studystorage.py
@@ -17,11 +17,18 @@ from pathlib import Path
 from antarest.core.exceptions import StudyNotFoundError
 from antarest.core.model import JSON
 from antarest.core.requests import RequestParameters
+from antarest.core.serialization import AntaresBaseModel
 from antarest.study.model import Study, StudyMetadataDTO, StudyMetadataPatchDTO, StudySimResultDTO
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
 T = t.TypeVar("T", bound=Study)
+
+
+class OriginalFile(AntaresBaseModel):
+    suffix: str
+    content: bytes
+    filename: str
 
 
 class IStudyStorageService(ABC, t.Generic[T]):
@@ -53,6 +60,23 @@ class IStudyStorageService(ABC, t.Generic[T]):
             formatted: indicate if raw files must be parsed and formatted
 
         Returns: study data formatted in json
+
+        """
+
+    @abstractmethod
+    def get_file(
+        self,
+        metadata: T,
+        url: str = "",
+    ) -> OriginalFile:
+        """
+        Entry point to fetch for a specific file inside a study folder
+
+        Args:
+            metadata: study
+            url: path data inside study to reach the file
+
+        Returns: study file content and extension
 
         """
 

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -104,6 +104,7 @@ from antarest.study.business.xpansion_management import (
     XpansionCandidateDTO,
     XpansionManager,
 )
+from antarest.study.common.studystorage import OriginalFile
 from antarest.study.model import (
     DEFAULT_WORKSPACE_NAME,
     NEW_DEFAULT_STUDY_VERSION,
@@ -450,6 +451,30 @@ class StudyService:
         assert_permission(params.user, study, StudyPermissionType.READ)
 
         return self.storage_service.get_storage(study).get(study, url, depth, formatted)
+
+    def get_file(
+        self,
+        uuid: str,
+        url: str,
+        params: RequestParameters,
+    ) -> OriginalFile:
+        """
+        retrieve a file from a study folder
+
+        Args:
+            uuid: study uuid
+            url: route to follow inside study structure
+            params: request parameters
+
+        Returns: data study formatted in json
+
+        """
+        study = self.get_study(uuid)
+        assert_permission(params.user, study, StudyPermissionType.READ)
+
+        output = self.storage_service.get_storage(study).get_file(study, url)
+
+        return output
 
     def aggregate_output_data(
         self,

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -104,7 +104,6 @@ from antarest.study.business.xpansion_management import (
     XpansionCandidateDTO,
     XpansionManager,
 )
-from antarest.study.common.studystorage import OriginalFile
 from antarest.study.model import (
     DEFAULT_WORKSPACE_NAME,
     NEW_DEFAULT_STUDY_VERSION,
@@ -135,7 +134,7 @@ from antarest.study.repository import (
 from antarest.study.storage.matrix_profile import adjust_matrix_columns_index
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.ini_file_node import IniFileNode
-from antarest.study.storage.rawstudy.model.filesystem.inode import INode
+from antarest.study.storage.rawstudy.model.filesystem.inode import INode, OriginalFile
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
 from antarest.study.storage.rawstudy.model.filesystem.matrix.output_series_matrix import OutputSeriesMatrix

--- a/antarest/study/storage/abstract_storage_service.py
+++ b/antarest/study/storage/abstract_storage_service.py
@@ -18,17 +18,26 @@ from abc import ABC
 from pathlib import Path
 from uuid import uuid4
 
-import py7zr
-
 from antarest.core.config import Config
-from antarest.core.exceptions import BadOutputError, StudyOutputNotFoundError
+from antarest.core.exceptions import (
+    BadOutputError,
+    PathIsAFolderError,
+    ShouldNotHappenException,
+    StudyOutputNotFoundError,
+)
 from antarest.core.interfaces.cache import CacheConstants, ICache
 from antarest.core.model import JSON, PublicMode
 from antarest.core.serialization import from_json
-from antarest.core.utils.archives import ArchiveFormat, archive_dir, extract_archive, unzip
+from antarest.core.utils.archives import (
+    ArchiveFormat,
+    archive_dir,
+    extract_archive,
+    read_original_file_in_archive,
+    unzip,
+)
 from antarest.core.utils.utils import StopWatch
 from antarest.login.model import GroupDTO
-from antarest.study.common.studystorage import IStudyStorageService, T
+from antarest.study.common.studystorage import IStudyStorageService, OriginalFile, T
 from antarest.study.model import (
     DEFAULT_WORKSPACE_NAME,
     OwnerInfo,
@@ -45,10 +54,69 @@ from antarest.study.storage.patch_service import PatchService
 from antarest.study.storage.rawstudy.model.filesystem.config.files import get_playlist
 from antarest.study.storage.rawstudy.model.filesystem.config.model import Simulation
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy, StudyFactory
+from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
+from antarest.study.storage.rawstudy.model.filesystem.inode import INode
+from antarest.study.storage.rawstudy.model.filesystem.lazy_node import LazyNode
+from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
 from antarest.study.storage.rawstudy.model.helpers import FileStudyHelpers
 from antarest.study.storage.utils import extract_output_name, fix_study_root, remove_from_cache
 
 logger = logging.getLogger(__name__)
+
+
+def _assert_not_folder_node(file_node: INode[t.Any, t.Any, t.Any]) -> None:
+    if isinstance(file_node, FolderNode):
+        raise PathIsAFolderError("Node is a folder node.")
+
+
+def _parse_file_from_link(file_node: INode[t.Any, t.Any, t.Any], link: str) -> bytes:
+    if not isinstance(file_node, InputSeriesMatrix):
+        raise ShouldNotHappenException(f"Node {file_node.config.path} has a link but is not an InputSeriesMatrix.")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # target path to save the file
+        target_path = Path(tmp_dir) / file_node.config.path.name
+        # use `.tsv` as suffix for the file
+        target_path = target_path.with_suffix(".tsv")
+        # retrieve the file content
+        file_node.parse(return_dataframe=True).to_csv(  # type: ignore
+            target_path,
+            sep="\t",
+            index=False,
+            header=True,
+            float_format="%.6f",
+        )
+        output = target_path.read_bytes()
+    return output
+
+
+def _extract_original_file_from_unarchived_study(
+    file_node: INode[t.Any, t.Any, t.Any],
+) -> OriginalFile:
+    _assert_not_folder_node(file_node)
+    if isinstance(file_node, LazyNode) and file_node.get_link_path().is_file():
+        return OriginalFile(
+            suffix=".tsv",
+            content=_parse_file_from_link(file_node, file_node.get_link_path().read_text()),
+            filename=file_node.config.path.with_suffix(".tsv").name,
+        )
+    else:
+        return OriginalFile(
+            suffix=f"{file_node.config.path.suffix}",
+            content=file_node.config.path.read_bytes(),
+            filename=file_node.config.path.name,
+        )
+
+
+def _extract_original_file_from_archived_study(
+    file_node: INode[t.Any, t.Any, t.Any], archive_path: Path
+) -> OriginalFile:
+    _assert_not_folder_node(file_node)
+    relative_path_inside_archive = str(file_node.get_relative_path_inside_archive())
+    return OriginalFile(
+        suffix=f"{file_node.config.path.suffix}",
+        content=read_original_file_in_archive(archive_path, relative_path_inside_archive),
+        filename=file_node.config.path.name,
+    )
 
 
 class AbstractStorageService(IStudyStorageService[T], ABC):
@@ -170,6 +238,33 @@ class AbstractStorageService(IStudyStorageService[T], ABC):
             data = study.tree.get(parts, depth=depth, formatted=formatted)
         del study
         return data
+
+    def get_file(
+        self,
+        metadata: T,
+        url: str = "",
+        use_cache: bool = True,
+    ) -> OriginalFile:
+        """
+        Entry point to fetch data inside study.
+        Args:
+            metadata: study
+            url: path data inside study to reach
+            use_cache: indicate if the cache must be used
+
+        Returns: a file content with its extension and name
+
+        """
+        self._check_study_exists(metadata)
+        study = self.get_raw(metadata, use_cache)
+        parts = [item for item in url.split("/") if item]
+
+        file_node = study.tree.get_node(parts)
+
+        if file_node.config.archive_path:
+            return _extract_original_file_from_archived_study(file_node, file_node.config.archive_path)
+        else:
+            return _extract_original_file_from_unarchived_study(file_node)
 
     def get_study_sim_result(
         self,

--- a/antarest/study/storage/abstract_storage_service.py
+++ b/antarest/study/storage/abstract_storage_service.py
@@ -26,7 +26,7 @@ from antarest.core.serialization import from_json
 from antarest.core.utils.archives import ArchiveFormat, archive_dir, extract_archive, unzip
 from antarest.core.utils.utils import StopWatch
 from antarest.login.model import GroupDTO
-from antarest.study.common.studystorage import IStudyStorageService, OriginalFile, T
+from antarest.study.common.studystorage import IStudyStorageService, T
 from antarest.study.model import (
     DEFAULT_WORKSPACE_NAME,
     OwnerInfo,
@@ -43,6 +43,7 @@ from antarest.study.storage.patch_service import PatchService
 from antarest.study.storage.rawstudy.model.filesystem.config.files import get_playlist
 from antarest.study.storage.rawstudy.model.filesystem.config.model import Simulation
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy, StudyFactory
+from antarest.study.storage.rawstudy.model.filesystem.inode import OriginalFile
 from antarest.study.storage.rawstudy.model.helpers import FileStudyHelpers
 from antarest.study.storage.utils import extract_output_name, fix_study_root, remove_from_cache
 
@@ -191,8 +192,7 @@ class AbstractStorageService(IStudyStorageService[T], ABC):
 
         file_node = study.tree.get_node(parts)
 
-        content, suffix, filename = file_node.get_file_content()
-        return OriginalFile(content=content, suffix=suffix, filename=filename)
+        return file_node.get_file_content()
 
     def get_study_sim_result(
         self,

--- a/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
@@ -218,4 +218,4 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
         return names, sub_url
 
     def get_file_content(self) -> t.Tuple[bytes, str, str]:
-        raise PathIsAFolderError("Node is a folder node.")
+        raise PathIsAFolderError(f"Node at {self.config.path} is a folder node.")

--- a/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
@@ -14,7 +14,7 @@ import shutil
 import typing as t
 from abc import ABC, abstractmethod
 
-from antarest.core.exceptions import ChildNotFoundError
+from antarest.core.exceptions import ChildNotFoundError, PathIsAFolderError
 from antarest.core.model import JSON, SUB_JSON
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.context import ContextServer
@@ -216,3 +216,6 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
             if not isinstance(children[name], child_class):
                 raise FilterError("Filter selection has different classes")
         return names, sub_url
+
+    def get_file_content(self) -> t.Tuple[bytes, str, str]:
+        raise PathIsAFolderError("Node is a folder node.")

--- a/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
@@ -218,4 +218,5 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
         return names, sub_url
 
     def get_file_content(self) -> t.Tuple[bytes, str, str]:
-        raise PathIsAFolderError(f"Node at {self.config.path} is a folder node.")
+        relative_path = self.config.path.relative_to(self.config.study_path).as_posix()
+        raise PathIsAFolderError(f"Node at {relative_path} is a folder node.")

--- a/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/folder_node.py
@@ -18,7 +18,7 @@ from antarest.core.exceptions import ChildNotFoundError, PathIsAFolderError
 from antarest.core.model import JSON, SUB_JSON
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.context import ContextServer
-from antarest.study.storage.rawstudy.model.filesystem.inode import TREE, INode
+from antarest.study.storage.rawstudy.model.filesystem.inode import TREE, INode, OriginalFile
 
 
 class FilterError(Exception):
@@ -217,6 +217,6 @@ class FolderNode(INode[JSON, SUB_JSON, JSON], ABC):
                 raise FilterError("Filter selection has different classes")
         return names, sub_url
 
-    def get_file_content(self) -> t.Tuple[bytes, str, str]:
+    def get_file_content(self) -> OriginalFile:
         relative_path = self.config.path.relative_to(self.config.study_path).as_posix()
         raise PathIsAFolderError(f"Node at {relative_path} is a folder node.")

--- a/antarest/study/storage/rawstudy/model/filesystem/inode.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/inode.py
@@ -14,8 +14,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
 
-from antarest.core.exceptions import ShouldNotHappenException, StudyNotArchived, WritingInsideZippedFileException
-from antarest.core.utils.archives import extract_file_to_tmp_dir
+from antarest.core.exceptions import StudyNotArchived, WritingInsideZippedFileException
+from antarest.core.utils.archives import extract_file_to_tmp_dir, read_original_file_in_archive
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 
 G = TypeVar("G")
@@ -123,6 +123,26 @@ class INode(ABC, Generic[G, S, V]):
 
         """
         raise NotImplementedError()
+
+    def get_file_content(self) -> Tuple[bytes, str, str]:
+        """
+        Get file content
+
+        Returns:
+            file content, as bytes
+            file suffix
+            file name
+        """
+        suffix = self.config.path.suffix
+        filename = self.config.path.name
+        if self.config.archive_path:
+            return (
+                read_original_file_in_archive(self.config.archive_path, str(self.get_relative_path_inside_archive())),
+                suffix,
+                filename,
+            )
+        else:
+            return self.config.path.read_bytes(), suffix, filename
 
     def get_relative_path_inside_archive(self) -> Path:
         archive_path = self.config.archive_path

--- a/antarest/study/storage/rawstudy/model/filesystem/inode.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/inode.py
@@ -14,7 +14,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
 
-from antarest.core.exceptions import WritingInsideZippedFileException
+from antarest.core.exceptions import ShouldNotHappenException, StudyNotArchived, WritingInsideZippedFileException
 from antarest.core.utils.archives import extract_file_to_tmp_dir
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 
@@ -123,6 +123,15 @@ class INode(ABC, Generic[G, S, V]):
 
         """
         raise NotImplementedError()
+
+    def get_relative_path_inside_archive(self) -> Path:
+        archive_path = self.config.archive_path
+        if archive_path:
+            return self.config.path.relative_to(archive_path.parent / self.config.study_id)
+        else:
+            raise StudyNotArchived(
+                f"Study with uuid={self.config.study_id} supposed to be archived but archive_path is None."
+            )
 
     def _assert_url_end(self, url: Optional[List[str]] = None) -> None:
         """

--- a/antarest/study/storage/rawstudy/model/filesystem/inode.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/inode.py
@@ -137,21 +137,18 @@ class INode(ABC, Generic[G, S, V]):
         filename = self.config.path.name
         if self.config.archive_path:
             return (
-                read_original_file_in_archive(self.config.archive_path, str(self.get_relative_path_inside_archive())),
+                read_original_file_in_archive(
+                    self.config.archive_path,
+                    str(self.get_relative_path_inside_archive(self.config.archive_path)),
+                ),
                 suffix,
                 filename,
             )
         else:
             return self.config.path.read_bytes(), suffix, filename
 
-    def get_relative_path_inside_archive(self) -> Path:
-        archive_path = self.config.archive_path
-        if archive_path:
-            return self.config.path.relative_to(archive_path.parent / self.config.study_id)
-        else:
-            raise StudyNotArchived(
-                f"Study with uuid={self.config.study_id} supposed to be archived but archive_path is None."
-            )
+    def get_relative_path_inside_archive(self, archive_path: Path) -> Path:
+        return self.config.path.relative_to(archive_path.parent / self.config.study_id)
 
     def _assert_url_end(self, url: Optional[List[str]] = None) -> None:
         """

--- a/antarest/study/storage/rawstudy/model/filesystem/inode.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/inode.py
@@ -14,7 +14,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
 
-from antarest.core.exceptions import StudyNotArchived, WritingInsideZippedFileException
+from antarest.core.exceptions import WritingInsideZippedFileException
 from antarest.core.utils.archives import extract_file_to_tmp_dir, read_original_file_in_archive
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 

--- a/antarest/study/storage/rawstudy/model/filesystem/inode.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/inode.py
@@ -139,7 +139,7 @@ class INode(ABC, Generic[G, S, V]):
             return (
                 read_original_file_in_archive(
                     self.config.archive_path,
-                    str(self.get_relative_path_inside_archive(self.config.archive_path)),
+                    self.get_relative_path_inside_archive(self.config.archive_path),
                 ),
                 suffix,
                 filename,
@@ -147,8 +147,8 @@ class INode(ABC, Generic[G, S, V]):
         else:
             return self.config.path.read_bytes(), suffix, filename
 
-    def get_relative_path_inside_archive(self, archive_path: Path) -> Path:
-        return self.config.path.relative_to(archive_path.parent / self.config.study_id)
+    def get_relative_path_inside_archive(self, archive_path: Path) -> str:
+        return self.config.path.relative_to(archive_path.parent / self.config.study_id).as_posix()
 
     def _assert_url_end(self, url: Optional[List[str]] = None) -> None:
         """

--- a/antarest/study/storage/rawstudy/model/filesystem/lazy_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/lazy_node.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-
+import tempfile
 import typing as t
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from zipfile import ZipFile
 
+from antarest.core.utils.archives import read_original_file_in_archive
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.context import ContextServer
 from antarest.study.storage.rawstudy.model.filesystem.inode import G, INode, S, V
@@ -145,6 +146,42 @@ class LazyNode(INode, ABC, t.Generic[G, S, V]):  # type: ignore
         expanded: bool = False,
     ) -> str:
         return f"file://{self.config.path.name}"
+
+    def get_file_content(self) -> t.Tuple[bytes, str, str]:
+        """
+        Get file content
+
+        Returns:
+            file content, as bytes
+            file suffix
+            file name
+        """
+        suffix = self.config.path.suffix
+        filename = self.config.path.name
+        if self.config.archive_path:
+            return (
+                read_original_file_in_archive(self.config.archive_path, str(self.get_relative_path_inside_archive())),
+                suffix,
+                filename,
+            )
+        elif self.get_link_path().is_file():
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                # target path to save the file
+                target_path = Path(tmp_dir) / self.config.path.name
+                # use `.tsv` as suffix for the file
+                target_path = target_path.with_suffix(".tsv")
+                # retrieve the file content
+                self.parse(return_dataframe=True).to_csv(  # type: ignore
+                    target_path,
+                    sep="\t",
+                    index=False,
+                    header=True,
+                    float_format="%.6f",
+                )
+                output = target_path.read_bytes()
+            return output, target_path.suffix, target_path.name
+        else:
+            return self.config.path.read_bytes(), suffix, filename
 
     @abstractmethod
     def load(

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -53,12 +53,6 @@ class InputSeriesMatrix(MatrixNode):
             self.default_empty = np.copy(default_empty)
             self.default_empty.flags.writeable = True
 
-    def parse_from_link(self, link: str) -> pd.DataFrame:
-        matrix_json = self.context.resolver.resolve(link)
-        matrix_json = t.cast(JSON, matrix_json)
-        matrix: pd.DataFrame = pd.DataFrame(**matrix_json)
-        return matrix
-
     def parse(
         self,
         file_path: t.Optional[Path] = None,
@@ -72,7 +66,9 @@ class InputSeriesMatrix(MatrixNode):
             link_path = self.get_link_path()
             if link_path.exists():
                 link = link_path.read_text()
-                matrix: pd.DataFrame = self.parse_from_link(link)
+                matrix_json = self.context.resolver.resolve(link)
+                matrix_json = t.cast(JSON, matrix_json)
+                matrix: pd.DataFrame = pd.DataFrame(**matrix_json)
             else:
                 try:
                     matrix = pd.read_csv(
@@ -157,7 +153,7 @@ class InputSeriesMatrix(MatrixNode):
                 filename,
             )
         elif self.get_link_path().is_file():
-            target_path = self.config.path.with_suffix(".tsv")
+            target_path = self.config.path.with_suffix(".txt")
             buffer = io.StringIO()
             self.parse(return_dataframe=True).to_csv(  # type: ignore
                 buffer,

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -147,7 +147,7 @@ class InputSeriesMatrix(MatrixNode):
         if self.config.archive_path:
             return (
                 read_original_file_in_archive(
-                    self.config.archive_path, str(self.get_relative_path_inside_archive(self.config.archive_path))
+                    self.config.archive_path, self.get_relative_path_inside_archive(self.config.archive_path)
                 ),
                 suffix,
                 filename,

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -52,6 +52,12 @@ class InputSeriesMatrix(MatrixNode):
             self.default_empty = np.copy(default_empty)
             self.default_empty.flags.writeable = True
 
+    def parse_from_link(self, link: str) -> pd.DataFrame:
+        matrix_json = self.context.resolver.resolve(link)
+        matrix_json = cast(JSON, matrix_json)
+        matrix: pd.DataFrame = pd.DataFrame(**matrix_json)
+        return matrix
+
     def parse(
         self,
         file_path: Optional[Path] = None,
@@ -65,9 +71,7 @@ class InputSeriesMatrix(MatrixNode):
             link_path = self.get_link_path()
             if link_path.exists():
                 link = link_path.read_text()
-                matrix_json = self.context.resolver.resolve(link)
-                matrix_json = cast(JSON, matrix_json)
-                matrix: pd.DataFrame = pd.DataFrame(**matrix_json)
+                matrix: pd.DataFrame = self.parse_from_link(link)
             else:
                 try:
                     matrix = pd.read_csv(

--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -51,13 +51,13 @@ from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import assert_this, suppress_exception
 from antarest.login.model import Identity
 from antarest.matrixstore.service import MatrixService
-from antarest.study.common.studystorage import OriginalFile
 from antarest.study.model import RawStudy, Study, StudyAdditionalData, StudyMetadataDTO, StudySimResultDTO
 from antarest.study.repository import AccessPermissions, StudyFilter
 from antarest.study.storage.abstract_storage_service import AbstractStorageService
 from antarest.study.storage.patch_service import PatchService
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig, FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy, StudyFactory
+from antarest.study.storage.rawstudy.model.filesystem.inode import OriginalFile
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
 from antarest.study.storage.utils import assert_permission, export_study_flat, is_managed, remove_from_cache
 from antarest.study.storage.variantstudy.business.utils import transform_command_to_dto

--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -51,6 +51,7 @@ from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import assert_this, suppress_exception
 from antarest.login.model import Identity
 from antarest.matrixstore.service import MatrixService
+from antarest.study.common.studystorage import OriginalFile
 from antarest.study.model import RawStudy, Study, StudyAdditionalData, StudyMetadataDTO, StudySimResultDTO
 from antarest.study.repository import AccessPermissions, StudyFilter
 from antarest.study.storage.abstract_storage_service import AbstractStorageService
@@ -557,6 +558,29 @@ class VariantStudyService(AbstractStorageService[VariantStudy]):
             url=url,
             depth=depth,
             formatted=formatted,
+            use_cache=use_cache,
+        )
+
+    def get_file(
+        self,
+        metadata: VariantStudy,
+        url: str = "",
+        use_cache: bool = True,
+    ) -> OriginalFile:
+        """
+        Entry point to fetch for a file inside a study folder.
+        Args:
+            metadata: study
+            url: path data inside study to reach
+            use_cache: indicate if cache should be used to fetch study tree
+
+        Returns: the file content and extension
+        """
+        self._safe_generation(metadata, timeout=600)
+        self.repository.refresh(metadata)
+        return super().get_file(
+            metadata=metadata,
+            url=url,
             use_cache=use_cache,
         )
 

--- a/tests/storage/repository/filesystem/matrix/test_matrix_node.py
+++ b/tests/storage/repository/filesystem/matrix/test_matrix_node.py
@@ -11,7 +11,6 @@
 # This file is part of the Antares project.
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import List, Optional
 from unittest.mock import Mock
 
@@ -39,22 +38,8 @@ class MockMatrixNode(MatrixNode):
             freq=MatrixFrequency.ANNUAL,
         )
 
-    def parse(
-        self,
-        file_path: Optional[Path] = None,
-        tmp_dir: Optional[TemporaryDirectory] = None,
-        return_dataframe: bool = False,
-    ) -> JSON:
+    def parse_as_json(self, file_path: Optional[Path] = None) -> JSON:
         return MOCK_MATRIX_JSON
-
-    # def dump(
-    #     self, data: Union[bytes, JSON], url: Optional[List[str]] = None
-    # ) -> None:
-    #     """Dump the matrix data in JSON format to simplify the tests"""
-    #     self.config.path.parent.mkdir(exist_ok=True, parents=True)
-    #     self.config.path.write_text(
-    #         json.dumps(data, indent=2), encoding="utf-8"
-    #     )
 
     def check_errors(self, data: str, url: Optional[List[str]] = None, raising: bool = False) -> List[str]:
         pass  # not used


### PR DESCRIPTION
Context:
Users found it a little inconvenient to work with some files (retrieved using the `raw` API) e.g. dealing with a `.json` file while it should be a `.ini` file as it is in its original format

Solution:
Create an new endpoint to retrieve files in their original format