### PR TITLE
fix(tasks): fix frozen task with load balanced pgpool

### DIFF
--- a/antarest/core/tasks/repository.py
+++ b/antarest/core/tasks/repository.py
@@ -27,15 +27,6 @@ class TaskJobRepository:
     Database connector to manage Tasks/Jobs entities.
     """
 
-    def __init__(self, session: t.Optional[Session] = None):
-        """
-        Initialize the repository.
-
-        Args:
-            session: Optional SQLAlchemy session to be used.
-        """
-        self._session = session
-
     @property
     def session(self) -> Session:
         """
@@ -44,11 +35,7 @@ class TaskJobRepository:
         Returns:
             SQLAlchemy session.
         """
-        if self._session is None:
-            # Get or create the session from a context variable (thread local variable)
-            return db.session
-        # Get the user-defined session
-        return self._session
+        return db.session
 
     def save(self, task: TaskJob) -> TaskJob:
         session = self.session

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -38,6 +38,7 @@ from antarest.core.tasks.model import (
 )
 from antarest.core.tasks.repository import TaskJobRepository
 from antarest.core.utils.fastapi_sqlalchemy import db
+from antarest.core.utils.utils import retry
 from antarest.worker.worker import WorkerTaskCommand, WorkerTaskResult
 
 logger = logging.getLogger(__name__)
@@ -395,8 +396,9 @@ class TaskJobService(ITaskService):
         try:
             # attention: this function is executed in a thread, not in the main process
             with db():
-                task = db.session.query(TaskJob).get(task_id)
-                assert task is not None
+                # Important to keep this retry for now,
+                # in case commit is not visible (read from replica ...)
+                task = retry(lambda: self.repo.get_or_raise(task_id))
                 task_type = task.type
                 study_id = task.ref_id
 

--- a/antarest/core/utils/utils.py
+++ b/antarest/core/utils/utils.py
@@ -105,7 +105,7 @@ def retry(func: t.Callable[[], T], attempts: int = 10, interval: float = 0.5) ->
             attempt += 1
             return func()
         except Exception as e:
-            logger.info(f"💤 Sleeping {interval} second(s)...")
+            logger.info(f"💤 Sleeping {interval} second(s) before retry...", exc_info=e)
             time.sleep(interval)
             caught_exception = e
     raise caught_exception or ShouldNotHappenException()


### PR DESCRIPTION
This work aims at fixing issues encountered with load balanced pgpool,
where a commit is not always instantly visible in another session (when
read from replica).

Fixes are:
- restore a workaround which consists in re-trying the read until success
- ensure exceptions occurring in the task execution thread are 
  ALL caught

Also removing a technical debt: 
- remove optional session from task job repo which was just used in tests.
  It did not work with code which uses both the repo and also the session
  from the singleton db.session.
