### PR TITLE
build(all): bump pydantic and linting packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         uses: psf/black@stable
         with:
           # Version of Black should match the versions set in `requirements-dev.txt`
-          version: "~=23.7.0"
+          version: "~=25.1.0"
           options: --check --diff
       - name: Check Typing (mypy)
         #continue-on-error: true

--- a/antarest/core/filetransfer/service.py
+++ b/antarest/core/filetransfer/service.py
@@ -79,9 +79,11 @@ class FileTransferManager:
                 Event(
                     type=EventType.DOWNLOAD_CREATED,
                     payload=download.to_dto(),
-                    permissions=PermissionInfo(owner=owner.impersonator)
-                    if owner
-                    else PermissionInfo(public_mode=PublicMode.READ),
+                    permissions=(
+                        PermissionInfo(owner=owner.impersonator)
+                        if owner
+                        else PermissionInfo(public_mode=PublicMode.READ)
+                    ),
                 )
             )
         return download
@@ -98,9 +100,11 @@ class FileTransferManager:
                 Event(
                     type=EventType.DOWNLOAD_READY,
                     payload=download.to_dto(),
-                    permissions=PermissionInfo(owner=download.owner)
-                    if download.owner
-                    else PermissionInfo(public_mode=PublicMode.READ),
+                    permissions=(
+                        PermissionInfo(owner=download.owner)
+                        if download.owner
+                        else PermissionInfo(public_mode=PublicMode.READ)
+                    ),
                 )
             )
 
@@ -116,9 +120,11 @@ class FileTransferManager:
             Event(
                 type=EventType.DOWNLOAD_FAILED,
                 payload=download.to_dto(),
-                permissions=PermissionInfo(owner=download.owner)
-                if download.owner
-                else PermissionInfo(public_mode=PublicMode.READ),
+                permissions=(
+                    PermissionInfo(owner=download.owner)
+                    if download.owner
+                    else PermissionInfo(public_mode=PublicMode.READ)
+                ),
             )
         )
 
@@ -185,9 +191,11 @@ class FileTransferManager:
                 Event(
                     type=EventType.DOWNLOAD_EXPIRED,
                     payload=download_id,
-                    permissions=PermissionInfo(owner=download_owner)
-                    if download_owner
-                    else PermissionInfo(public_mode=PublicMode.READ),
+                    permissions=(
+                        PermissionInfo(owner=download_owner)
+                        if download_owner
+                        else PermissionInfo(public_mode=PublicMode.READ)
+                    ),
                 )
             )
 

--- a/antarest/service_creator.py
+++ b/antarest/service_creator.py
@@ -127,9 +127,15 @@ def create_event_bus(app_ctxt: t.Optional[AppBuildContext], config: Config) -> t
     )
 
 
-def create_core_services(
-    app_ctxt: t.Optional[AppBuildContext], config: Config
-) -> t.Tuple[ICache, IEventBus, ITaskService, FileTransferManager, LoginService, MatrixService, StudyService,]:
+def create_core_services(app_ctxt: t.Optional[AppBuildContext], config: Config) -> t.Tuple[
+    ICache,
+    IEventBus,
+    ITaskService,
+    FileTransferManager,
+    LoginService,
+    MatrixService,
+    StudyService,
+]:
     event_bus, redis_client = create_event_bus(app_ctxt, config)
     cache = build_cache(config=config, redis_client=redis_client)
     filetransfer_service = build_filetransfer_service(app_ctxt, event_bus, config)

--- a/antarest/study/business/general_management.py
+++ b/antarest/study/business/general_management.py
@@ -307,9 +307,11 @@ class GeneralManager:
 
         return [
             UpdateConfig(
-                target=f"{GENERAL_PATH}/custom-scenario"
-                if study_version >= STUDY_VERSION_8
-                else f"{GENERAL_PATH}/custom-ts-numbers",
+                target=(
+                    f"{GENERAL_PATH}/custom-scenario"
+                    if study_version >= STUDY_VERSION_8
+                    else f"{GENERAL_PATH}/custom-ts-numbers"
+                ),
                 data=new_value == BuildingMode.CUSTOM,
                 command_context=cmd_context,
                 study_version=study_version,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 -r requirements-test.txt
 -r requirements-desktop.txt
 # Version of Black should match the versions set in `.github/workflows/main.yml`
-black~=23.7.0
-isort~=5.12.0
-mypy~=1.11.1
+black~=25.1.0
+isort~=6.0.0
+mypy~=1.15.0
 pyinstaller==6.10.0
 pyinstaller-hooks-contrib==2024.8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,7 @@ click~=8.0.3
 contextvars~=2.4
 filelock~=3.4.2
 gunicorn~=20.1.0
-humanize~=4.10.0; python_version <= '3.8'
-humanize~=4.11.0; python_version > '3.8'
+humanize~=4.11.0
 jsonref~=0.2
 PyJWT~=2.9.0
 MarkupSafe~=2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ antares-timeseries-generation==0.1.7
 # and **manage their versions** for better control and to avoid unnecessary dependencies.
 fastapi~=0.110.3
 uvicorn[standard]~=0.30.6
-pydantic~=2.8.2
+pydantic~=2.10.0
 httpx~=0.27.0
 python-multipart~=0.0.9
 

--- a/tests/integration/studies_blueprint/test_get_studies.py
+++ b/tests/integration/studies_blueprint/test_get_studies.py
@@ -1404,9 +1404,11 @@ class TestStudiesListing:
             res = client.get(
                 STUDIES_URL,
                 headers={"Authorization": f"Bearer {users_tokens['user_1']}"},
-                params={"groups": ",".join(request_groups_ids), "pageNb": 1, "pageSize": 2}
-                if request_groups_ids
-                else {"pageNb": 1, "pageSize": 2},
+                params=(
+                    {"groups": ",".join(request_groups_ids), "pageNb": 1, "pageSize": 2}
+                    if request_groups_ids
+                    else {"pageNb": 1, "pageSize": 2}
+                ),
             )
             assert res.status_code == LIST_STATUS_CODE, res.json()
             assert len(res.json()) == max(0, min(2, len(expected_studies) - 2))

--- a/tests/variantstudy/model/command/test_remove_st_storage.py
+++ b/tests/variantstudy/model/command/test_remove_st_storage.py
@@ -81,16 +81,19 @@ class TestRemoveSTStorage:
                 storage_id="?%$$",  # bad name
                 study_version=STUDY_VERSION_8_8,
             )
-        assert ctx.value.errors() == [
+        expected_error = [
             {
                 "ctx": {"pattern": "[a-z0-9_(),& -]+"},
                 "input": "?%$$",
                 "loc": ("storage_id",),
                 "msg": "String should match pattern '[a-z0-9_(),& -]+'",
                 "type": "string_pattern_mismatch",
-                "url": "https://errors.pydantic.dev/2.8/v/string_pattern_mismatch",
             }
         ]
+        actual_errors = ctx.value.errors()
+        for error in actual_errors:
+            error.pop("url")
+        assert actual_errors == expected_error
 
     def test_apply_config__invalid_version(self, empty_study: FileStudy, command_context: CommandContext):
         # Given an old study in version 720

--- a/tests/variantstudy/model/command/test_remove_st_storage.py
+++ b/tests/variantstudy/model/command/test_remove_st_storage.py
@@ -81,19 +81,16 @@ class TestRemoveSTStorage:
                 storage_id="?%$$",  # bad name
                 study_version=STUDY_VERSION_8_8,
             )
-        expected_error = [
+        assert ctx.value.errors() == [
             {
                 "ctx": {"pattern": "[a-z0-9_(),& -]+"},
                 "input": "?%$$",
                 "loc": ("storage_id",),
                 "msg": "String should match pattern '[a-z0-9_(),& -]+'",
                 "type": "string_pattern_mismatch",
+                "url": "https://errors.pydantic.dev/2.10/v/string_pattern_mismatch",
             }
         ]
-        actual_errors = ctx.value.errors()
-        for error in actual_errors:
-            error.pop("url")
-        assert actual_errors == expected_error
 
     def test_apply_config__invalid_version(self, empty_study: FileStudy, command_context: CommandContext):
         # Given an old study in version 720


### PR DESCRIPTION
Upgrade pydantic to 2.9 because it introduces performances improvement. I pushed it to 2.10 because it does not contain breaking changes.
I also upgraded mypy, black and isort because why not