### PR TITLE
fix(st-storage): fix ST storage groups case for v8.6

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/st_storage/clusters/area/list.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/st_storage/clusters/area/list.py
@@ -21,13 +21,26 @@ from antarest.study.storage.rawstudy.model.filesystem.ini_file_node import IniFi
 
 _VALUE_PARSERS = {any_section_option_matcher("group"): LOWER_CASE_PARSER}
 
+_GROUPS_V8_6 = [
+    "PSP_open",
+    "PSP_closed",
+    "Pondage",
+    "Battery",
+    "Other1",
+    "Other2",
+    "Other3",
+    "Other4",
+    "Other5",
+]
+_GROUP_MAPPING_V8_6 = {v.lower(): v for v in _GROUPS_V8_6}
+
 
 def _write_group_8_6(input: str) -> str:
     """
     The solver was not case insensitive to group, before version 8.6.
-    We need to write it with a capital first letter.
+    We need to write it respecting the expected case.
     """
-    return input.title()
+    return _GROUP_MAPPING_V8_6.get(input.lower(), input.lower())
 
 
 def _get_group_serializer(study_version: StudyVersion) -> ValueSerializer:

--- a/tests/storage/repository/filesystem/special_node/test_lower_case_nodes.py
+++ b/tests/storage/repository/filesystem/special_node/test_lower_case_nodes.py
@@ -151,7 +151,7 @@ def test_st_storage_group_is_written_to_title_case_for_8_6(study_dir: Path, ini_
         textwrap.dedent(
             """
             [Cluster 1]
-            group = Gas
+            group = gas
             """
         )
     )
@@ -161,5 +161,5 @@ def test_st_storage_group_is_written_to_title_case_for_8_6(study_dir: Path, ini_
         area="area_test",
     )
 
-    node.save({"Cluster 1": {"group": "GAS"}})
-    assert IniReader().read(ini_file) == {"Cluster 1": {"group": "Gas"}}
+    node.save({"Cluster 1": {"group": "PsP_open"}, "Cluster 2": {"group": "UnknownGroup"}})
+    assert IniReader().read(ini_file) == {"Cluster 1": {"group": "PSP_open"}, "Cluster 2": {"group": "unknowngroup"}}


### PR DESCRIPTION

In v8.6, short term storage groups were not simply in title-case, 
this PR implements the exact correct case.