### PR TITLE
feat(xpansion)!: introduce `create_xpansion_configuration` command

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -734,3 +734,8 @@ class FolderNotFoundInWorkspace(HTTPException):
 
     def __init__(self, message: str) -> None:
         super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, message)
+
+
+class XpansionConfigurationAlreadyExists(Exception):
+    def __init__(self, study_id: str) -> None:
+        super().__init__(HTTPStatus.CONFLICT, f"Xpansion configuration already exists for study {study_id}")

--- a/antarest/study/business/model/xpansion_model.py
+++ b/antarest/study/business/model/xpansion_model.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+from typing import Any, MutableMapping, Optional, Sequence
+
+from pydantic import Field, ValidationError, field_validator, model_validator
+
+from antarest.core.serde import AntaresBaseModel
+from antarest.study.business.all_optional_meta import all_optional_model
+from antarest.study.business.enum_ignore_case import EnumIgnoreCase
+
+
+class XpansionResourceFileType(EnumIgnoreCase):
+    CAPACITIES = "capacities"
+    WEIGHTS = "weights"
+    CONSTRAINTS = "constraints"
+
+
+class UcType(EnumIgnoreCase):
+    EXPANSION_FAST = "expansion_fast"
+    EXPANSION_ACCURATE = "expansion_accurate"
+
+
+class Master(EnumIgnoreCase):
+    INTEGER = "integer"
+    RELAXED = "relaxed"
+
+
+class Solver(EnumIgnoreCase):
+    CBC = "Cbc"
+    COIN = "Coin"
+    XPRESS = "Xpress"
+
+
+class XpansionSensitivitySettings(AntaresBaseModel):
+    """
+    A DTO representing the sensitivity analysis settings used for Xpansion.
+
+    The sensitivity analysis is optional.
+
+    Attributes:
+        epsilon: Max deviation from optimum (€).
+        projection: List of candidate names to project (the candidate names should be in "candidates.ini" file).
+        capex: Whether to include CAPEX in the sensitivity analysis.
+    """
+
+    epsilon: float = Field(default=0, ge=0, description="Max deviation from optimum (€)")
+    projection: list[str] = Field(default_factory=list, description="List of candidate names to project")
+    capex: bool = Field(default=False, description="Whether to include capex in the sensitivity analysis")
+
+    @field_validator("projection", mode="before")
+    def projection_validation(cls, v: Optional[Sequence[str]]) -> Sequence[str]:
+        return [] if v is None else v
+
+
+class XpansionSettings(AntaresBaseModel, extra="ignore", validate_assignment=True, populate_by_name=True):
+    """
+    A data transfer object representing the general settings used for Xpansion.
+
+    Attributes:
+        optimality_gap: Tolerance on absolute gap for the solution.
+        max_iteration: Maximum number of Benders iterations for the solver.
+        uc_type: Unit-commitment type used by Antares for the solver.
+        master: Resolution mode of the master problem for the solver.
+        yearly_weights: Path of the Monte-Carlo weights file for the solution.
+        additional_constraints: Path of the additional constraints file for the solution.
+        relaxed_optimality_gap: Threshold to switch from relaxed to integer master.
+        relative_gap: Tolerance on relative gap for the solution.
+        batch_size: Amount of batches in the Benders decomposition.
+        separation_parameter: The separation parameter used in the Benders decomposition.
+        solver: The solver used to solve the master and the sub-problems in the Benders decomposition.
+        timelimit: The timelimit (in seconds) of the Benders step.
+        log_level: The severity of the solver's logs in range [0, 3].
+        sensitivity_config: The sensitivity analysis configuration for Xpansion, if any.
+
+    Raises:
+        ValueError: If the `relaxed_optimality_gap` attribute is not a float
+        or a string ending with "%" and a valid float.
+        ValueError: If the `max_iteration` attribute is not a valid integer.
+    """
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#master
+    master: Master = Field(default=Master.INTEGER, description="Master problem resolution mode")
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#uc_type
+    uc_type: UcType = Field(default=UcType.EXPANSION_FAST, description="Unit commitment type")
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#optimality_gap
+    optimality_gap: float = Field(default=1, ge=0, description="Absolute optimality gap (€)")
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#relative_gap
+    relative_gap: float = Field(default=1e-6, ge=0, description="Relative optimality gap")
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#relaxed_optimality_gap
+    relaxed_optimality_gap: float = Field(default=1e-5, ge=0, description="Relative optimality gap for relaxation")
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#max_iteration
+    max_iteration: int = Field(default=1000, gt=0, description="Maximum number of iterations")
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#solver
+    solver: Solver = Field(default=Solver.XPRESS, description="Solver")
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#log_level
+    log_level: int = Field(default=0, ge=0, le=3, description="Log level in range [0, 3]")
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#separation_parameter
+    separation_parameter: float = Field(default=0.5, gt=0, le=1, description="Separation parameter in range ]0, 1]")
+
+    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#batch_size
+    batch_size: int = Field(default=96, ge=0, description="Number of batches")
+
+    yearly_weights: str = Field(
+        "",
+        alias="yearly-weights",
+        description="Yearly weights file",
+    )
+    additional_constraints: str = Field(
+        "",
+        alias="additional-constraints",
+        description="Additional constraints file",
+    )
+
+    # (deprecated field)
+    timelimit: int = int(1e12)
+
+    # The sensitivity analysis is optional
+    sensitivity_config: Optional[XpansionSensitivitySettings] = None
+
+    @model_validator(mode="before")
+    def validate_float_values(cls, values: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        if "relaxed-optimality-gap" in values:
+            values["relaxed_optimality_gap"] = values.pop("relaxed-optimality-gap")
+
+        relaxed_optimality_gap = values.get("relaxed_optimality_gap")
+        if relaxed_optimality_gap and isinstance(relaxed_optimality_gap, str):
+            relaxed_optimality_gap = relaxed_optimality_gap.strip()
+            if relaxed_optimality_gap.endswith("%"):
+                # Don't divide by 100, because the value is already a percentage.
+                values["relaxed_optimality_gap"] = float(relaxed_optimality_gap[:-1])
+            else:
+                values["relaxed_optimality_gap"] = float(relaxed_optimality_gap)
+
+        separation_parameter = values.get("separation_parameter")
+        if separation_parameter and isinstance(separation_parameter, str):
+            separation_parameter = separation_parameter.strip()
+            if separation_parameter.endswith("%"):
+                values["separation_parameter"] = float(separation_parameter[:-1]) / 100
+            else:
+                values["separation_parameter"] = float(separation_parameter)
+
+        if "max_iteration" in values:
+            max_iteration = float(values["max_iteration"])
+            if max_iteration == float("inf"):
+                values["max_iteration"] = 1000
+
+        return values
+
+
+class GetXpansionSettings(XpansionSettings):
+    """
+    DTO object used to get the Xpansion settings.
+    """
+
+    @classmethod
+    def from_config(cls, config_obj: dict[str, Any]) -> "GetXpansionSettings":
+        """
+        Create a GetXpansionSettings object from a JSON object.
+
+        First, make an attempt to validate the JSON object.
+        If it fails, try to read the settings without validation,
+        so that the user can fix the issue in the form.
+
+        Args:
+            config_obj: The JSON object to read.
+
+        Returns:
+            The object which may contains extra attributes or invalid values.
+        """
+        try:
+            return cls(**config_obj)
+        except ValidationError:
+            return cls.model_construct(**config_obj)
+
+
+@all_optional_model
+class UpdateXpansionSettings(XpansionSettings):
+    """
+    DTO object used to update the Xpansion settings.
+
+    Fields with a value of `None` are ignored, this allows a partial update of the settings.
+    For that reason the fields "yearly-weights" and "additional-constraints" must
+    be set to "" instead of `None` if you want to remove the file.
+    """
+
+    # note: for some reason, the alias is not taken into account when using the metaclass,
+    # so we have to redefine the fields with the alias.
+    yearly_weights: str = Field(
+        "",
+        alias="yearly-weights",
+        description="Yearly weights file",
+    )
+
+    additional_constraints: str = Field(
+        "",
+        alias="additional-constraints",
+        description="Additional constraints file",
+    )

--- a/antarest/study/business/model/xpansion_model.py
+++ b/antarest/study/business/model/xpansion_model.py
@@ -191,7 +191,7 @@ class GetXpansionSettings(XpansionSettings):
 
 
 @all_optional_model
-class UpdateXpansionSettings(XpansionSettings):
+class XpansionSettingsUpdate(XpansionSettings):
     """
     DTO object used to update the Xpansion settings.
 

--- a/antarest/study/business/xpansion_management.py
+++ b/antarest/study/business/xpansion_management.py
@@ -12,23 +12,20 @@
 
 import contextlib
 import http
-import io
 import logging
-import shutil
-import zipfile
-from typing import Any, List, MutableMapping, Optional, Sequence
+from typing import List, Optional
 
 from fastapi import HTTPException, UploadFile
-from pydantic import Field, ValidationError, field_validator, model_validator
+from pydantic import Field
 
-from antarest.core.exceptions import BadZipBinary, ChildNotFoundError, LinkNotFound
+from antarest.core.exceptions import ChildNotFoundError, LinkNotFound
 from antarest.core.model import JSON
 from antarest.core.serde import AntaresBaseModel
-from antarest.study.business.all_optional_meta import all_optional_model
 from antarest.study.business.enum_ignore_case import EnumIgnoreCase
+from antarest.study.business.model.xpansion_model import GetXpansionSettings, UpdateXpansionSettings
 from antarest.study.business.study_interface import StudyInterface
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-from antarest.study.storage.utils import fix_study_root
+from antarest.study.storage.variantstudy.model.command.create_xpansion_configuration import CreateXpansionConfiguration
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 
 logger = logging.getLogger(__name__)
@@ -38,197 +35,6 @@ class XpansionResourceFileType(EnumIgnoreCase):
     CAPACITIES = "capacities"
     WEIGHTS = "weights"
     CONSTRAINTS = "constraints"
-
-
-class UcType(EnumIgnoreCase):
-    EXPANSION_FAST = "expansion_fast"
-    EXPANSION_ACCURATE = "expansion_accurate"
-
-
-class Master(EnumIgnoreCase):
-    INTEGER = "integer"
-    RELAXED = "relaxed"
-
-
-class Solver(EnumIgnoreCase):
-    CBC = "Cbc"
-    COIN = "Coin"
-    XPRESS = "Xpress"
-
-
-class XpansionSensitivitySettings(AntaresBaseModel):
-    """
-    A DTO representing the sensitivity analysis settings used for Xpansion.
-
-    The sensitivity analysis is optional.
-
-    Attributes:
-        epsilon: Max deviation from optimum (€).
-        projection: List of candidate names to project (the candidate names should be in "candidates.ini" file).
-        capex: Whether to include CAPEX in the sensitivity analysis.
-    """
-
-    epsilon: float = Field(default=0, ge=0, description="Max deviation from optimum (€)")
-    projection: List[str] = Field(default_factory=list, description="List of candidate names to project")
-    capex: bool = Field(default=False, description="Whether to include capex in the sensitivity analysis")
-
-    @field_validator("projection", mode="before")
-    def projection_validation(cls, v: Optional[Sequence[str]]) -> Sequence[str]:
-        return [] if v is None else v
-
-
-class XpansionSettings(AntaresBaseModel, extra="ignore", validate_assignment=True, populate_by_name=True):
-    """
-    A data transfer object representing the general settings used for Xpansion.
-
-    Attributes:
-        optimality_gap: Tolerance on absolute gap for the solution.
-        max_iteration: Maximum number of Benders iterations for the solver.
-        uc_type: Unit-commitment type used by Antares for the solver.
-        master: Resolution mode of the master problem for the solver.
-        yearly_weights: Path of the Monte-Carlo weights file for the solution.
-        additional_constraints: Path of the additional constraints file for the solution.
-        relaxed_optimality_gap: Threshold to switch from relaxed to integer master.
-        relative_gap: Tolerance on relative gap for the solution.
-        batch_size: Amount of batches in the Benders decomposition.
-        separation_parameter: The separation parameter used in the Benders decomposition.
-        solver: The solver used to solve the master and the sub-problems in the Benders decomposition.
-        timelimit: The timelimit (in seconds) of the Benders step.
-        log_level: The severity of the solver's logs in range [0, 3].
-        sensitivity_config: The sensitivity analysis configuration for Xpansion, if any.
-
-    Raises:
-        ValueError: If the `relaxed_optimality_gap` attribute is not a float
-        or a string ending with "%" and a valid float.
-        ValueError: If the `max_iteration` attribute is not a valid integer.
-    """
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#master
-    master: Master = Field(default=Master.INTEGER, description="Master problem resolution mode")
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#uc_type
-    uc_type: UcType = Field(default=UcType.EXPANSION_FAST, description="Unit commitment type")
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#optimality_gap
-    optimality_gap: float = Field(default=1, ge=0, description="Absolute optimality gap (€)")
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#relative_gap
-    relative_gap: float = Field(default=1e-6, ge=0, description="Relative optimality gap")
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#relaxed_optimality_gap
-    relaxed_optimality_gap: float = Field(default=1e-5, ge=0, description="Relative optimality gap for relaxation")
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#max_iteration
-    max_iteration: int = Field(default=1000, gt=0, description="Maximum number of iterations")
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#solver
-    solver: Solver = Field(default=Solver.XPRESS, description="Solver")
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#log_level
-    log_level: int = Field(default=0, ge=0, le=3, description="Log level in range [0, 3]")
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#separation_parameter
-    separation_parameter: float = Field(default=0.5, gt=0, le=1, description="Separation parameter in range ]0, 1]")
-
-    # https://antares-xpansion.readthedocs.io/en/stable/user-guide/get-started/settings-definition/#batch_size
-    batch_size: int = Field(default=96, ge=0, description="Number of batches")
-
-    yearly_weights: str = Field(
-        "",
-        alias="yearly-weights",
-        description="Yearly weights file",
-    )
-    additional_constraints: str = Field(
-        "",
-        alias="additional-constraints",
-        description="Additional constraints file",
-    )
-
-    # (deprecated field)
-    timelimit: int = int(1e12)
-
-    # The sensitivity analysis is optional
-    sensitivity_config: Optional[XpansionSensitivitySettings] = None
-
-    @model_validator(mode="before")
-    def validate_float_values(cls, values: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
-        if "relaxed-optimality-gap" in values:
-            values["relaxed_optimality_gap"] = values.pop("relaxed-optimality-gap")
-
-        relaxed_optimality_gap = values.get("relaxed_optimality_gap")
-        if relaxed_optimality_gap and isinstance(relaxed_optimality_gap, str):
-            relaxed_optimality_gap = relaxed_optimality_gap.strip()
-            if relaxed_optimality_gap.endswith("%"):
-                # Don't divide by 100, because the value is already a percentage.
-                values["relaxed_optimality_gap"] = float(relaxed_optimality_gap[:-1])
-            else:
-                values["relaxed_optimality_gap"] = float(relaxed_optimality_gap)
-
-        separation_parameter = values.get("separation_parameter")
-        if separation_parameter and isinstance(separation_parameter, str):
-            separation_parameter = separation_parameter.strip()
-            if separation_parameter.endswith("%"):
-                values["separation_parameter"] = float(separation_parameter[:-1]) / 100
-            else:
-                values["separation_parameter"] = float(separation_parameter)
-
-        if "max_iteration" in values:
-            max_iteration = float(values["max_iteration"])
-            if max_iteration == float("inf"):
-                values["max_iteration"] = 1000
-
-        return values
-
-
-class GetXpansionSettings(XpansionSettings):
-    """
-    DTO object used to get the Xpansion settings.
-    """
-
-    @classmethod
-    def from_config(cls, config_obj: JSON) -> "GetXpansionSettings":
-        """
-        Create a GetXpansionSettings object from a JSON object.
-
-        First, make an attempt to validate the JSON object.
-        If it fails, try to read the settings without validation,
-        so that the user can fix the issue in the form.
-
-        Args:
-            config_obj: The JSON object to read.
-
-        Returns:
-            The object which may contains extra attributes or invalid values.
-        """
-        try:
-            return cls(**config_obj)
-        except ValidationError:
-            return cls.model_construct(**config_obj)
-
-
-@all_optional_model
-class UpdateXpansionSettings(XpansionSettings):
-    """
-    DTO object used to update the Xpansion settings.
-
-    Fields with a value of `None` are ignored, this allows a partial update of the settings.
-    For that reason the fields "yearly-weights" and "additional-constraints" must
-    be set to "" instead of `None` if you want to remove the file.
-    """
-
-    # note: for some reason, the alias is not taken into account when using the metaclass,
-    # so we have to redefine the fields with the alias.
-    yearly_weights: str = Field(
-        "",
-        alias="yearly-weights",
-        description="Yearly weights file",
-    )
-
-    additional_constraints: str = Field(
-        "",
-        alias="additional-constraints",
-        description="Additional constraints file",
-    )
 
 
 class XpansionCandidateDTO(AntaresBaseModel):
@@ -304,55 +110,11 @@ class XpansionManager:
     def __init__(self, command_context: CommandContext):
         self._command_context = command_context
 
-    def create_xpansion_configuration(self, study: StudyInterface, zipped_config: Optional[UploadFile] = None) -> None:
+    def create_xpansion_configuration(self, study: StudyInterface) -> None:
         logger.info(f"Initiating xpansion configuration for study '{study.id}'")
-        file_study = study.get_files()
-        try:
-            file_study.tree.get(["user", "expansion"])
-            logger.info(f"Using existing configuration for study '{study.id}'")
-        except ChildNotFoundError:
-            if zipped_config:
-                try:
-                    with zipfile.ZipFile(io.BytesIO(zipped_config.file.read())) as zip_output:
-                        logger.info(f"Importing zipped xpansion configuration for study '{study.id}'")
-                        zip_output.extractall(path=file_study.config.path / "user" / "expansion")
-                        fix_study_root(file_study.config.path / "user" / "expansion")
-                    return
-                except zipfile.BadZipFile:
-                    shutil.rmtree(
-                        file_study.config.path / "user" / "expansion",
-                        ignore_errors=True,
-                    )
-                    raise BadZipBinary("Only zip file are allowed.")
 
-            xpansion_settings = XpansionSettings()
-            settings_obj = xpansion_settings.model_dump(
-                mode="json",
-                by_alias=True,
-                exclude_none=True,
-                exclude={"sensitivity_config", "yearly_weights", "additional_constraints"},
-            )
-            if xpansion_settings.sensitivity_config:
-                sensitivity_obj = xpansion_settings.sensitivity_config.model_dump(
-                    mode="json", by_alias=True, exclude_none=True
-                )
-            else:
-                sensitivity_obj = {}
-
-            xpansion_configuration_data = {
-                "user": {
-                    "expansion": {
-                        "settings": settings_obj,
-                        "sensitivity": {"sensitivity_in": sensitivity_obj},
-                        "candidates": {},
-                        "capa": {},
-                        "weights": {},
-                        "constraints": {},
-                    }
-                }
-            }
-
-            file_study.tree.save(xpansion_configuration_data)
+        command = CreateXpansionConfiguration(command_context=self._command_context, study_version=study.version)
+        study.add_commands([command])
 
     def delete_xpansion_configuration(self, study: StudyInterface) -> None:
         logger.info(f"Deleting xpansion configuration for study '{study.id}'")

--- a/antarest/study/business/xpansion_management.py
+++ b/antarest/study/business/xpansion_management.py
@@ -22,7 +22,7 @@ from antarest.core.exceptions import ChildNotFoundError, LinkNotFound
 from antarest.core.model import JSON
 from antarest.core.serde import AntaresBaseModel
 from antarest.study.business.enum_ignore_case import EnumIgnoreCase
-from antarest.study.business.model.xpansion_model import GetXpansionSettings, UpdateXpansionSettings
+from antarest.study.business.model.xpansion_model import GetXpansionSettings, XpansionSettingsUpdate
 from antarest.study.business.study_interface import StudyInterface
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.create_xpansion_configuration import CreateXpansionConfiguration
@@ -133,7 +133,7 @@ class XpansionManager:
         return GetXpansionSettings.from_config(config_obj)
 
     def update_xpansion_settings(
-        self, study: StudyInterface, new_xpansion_settings: UpdateXpansionSettings
+        self, study: StudyInterface, new_xpansion_settings: XpansionSettingsUpdate
     ) -> GetXpansionSettings:
         logger.info(f"Updating xpansion settings for study '{study.id}'")
 
@@ -381,7 +381,7 @@ class XpansionManager:
         constraints_file_name = constraints_file_name or ""
         # noinspection PyArgumentList
         args = {"additional_constraints": constraints_file_name}
-        xpansion_settings = UpdateXpansionSettings.model_validate(args)
+        xpansion_settings = XpansionSettingsUpdate.model_validate(args)
         return self.update_xpansion_settings(study, xpansion_settings)
 
     def _raw_file_dir(self, raw_file_type: XpansionResourceFileType) -> List[str]:

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -95,7 +95,7 @@ from antarest.study.business.link_management import LinkManager
 from antarest.study.business.matrix_management import MatrixManager, MatrixManagerError
 from antarest.study.business.model.area_model import AreaCreationDTO, AreaInfoDTO, AreaType, UpdateAreaUi
 from antarest.study.business.model.link_model import LinkBaseDTO, LinkDTO
-from antarest.study.business.model.xpansion_model import GetXpansionSettings, UpdateXpansionSettings
+from antarest.study.business.model.xpansion_model import GetXpansionSettings, XpansionSettingsUpdate
 from antarest.study.business.optimization_management import OptimizationManager
 from antarest.study.business.playlist_management import PlaylistManager
 from antarest.study.business.scenario_builder_management import ScenarioBuilderManager
@@ -2373,7 +2373,7 @@ class StudyService:
     def update_xpansion_settings(
         self,
         uuid: str,
-        xpansion_settings_dto: UpdateXpansionSettings,
+        xpansion_settings_dto: XpansionSettingsUpdate,
         params: RequestParameters,
     ) -> GetXpansionSettings:
         study = self.get_study(uuid)

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -27,7 +27,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from antares.study.version import StudyVersion
-from fastapi import HTTPException, UploadFile
+from fastapi import HTTPException
 from markupsafe import escape
 from starlette.responses import FileResponse, Response
 from typing_extensions import override
@@ -95,6 +95,7 @@ from antarest.study.business.link_management import LinkManager
 from antarest.study.business.matrix_management import MatrixManager, MatrixManagerError
 from antarest.study.business.model.area_model import AreaCreationDTO, AreaInfoDTO, AreaType, UpdateAreaUi
 from antarest.study.business.model.link_model import LinkBaseDTO, LinkDTO
+from antarest.study.business.model.xpansion_model import GetXpansionSettings, UpdateXpansionSettings
 from antarest.study.business.optimization_management import OptimizationManager
 from antarest.study.business.playlist_management import PlaylistManager
 from antarest.study.business.scenario_builder_management import ScenarioBuilderManager
@@ -103,12 +104,7 @@ from antarest.study.business.table_mode_management import TableModeManager
 from antarest.study.business.thematic_trimming_management import ThematicTrimmingManager
 from antarest.study.business.timeseries_config_management import TimeSeriesConfigManager
 from antarest.study.business.utils import execute_or_add_commands
-from antarest.study.business.xpansion_management import (
-    GetXpansionSettings,
-    UpdateXpansionSettings,
-    XpansionCandidateDTO,
-    XpansionManager,
-)
+from antarest.study.business.xpansion_management import XpansionCandidateDTO, XpansionManager
 from antarest.study.model import (
     DEFAULT_WORKSPACE_NAME,
     NEW_DEFAULT_STUDY_VERSION,
@@ -2353,14 +2349,13 @@ class StudyService:
     def create_xpansion_configuration(
         self,
         uuid: str,
-        zipped_config: Optional[UploadFile],
         params: RequestParameters,
     ) -> None:
         study = self.get_study(uuid)
         assert_permission(params.user, study, StudyPermissionType.WRITE)
         self._assert_study_unarchived(study)
         study_interface = self.get_study_interface(study)
-        self.xpansion_manager.create_xpansion_configuration(study_interface, zipped_config)
+        self.xpansion_manager.create_xpansion_configuration(study_interface)
 
     def delete_xpansion_configuration(self, uuid: str, params: RequestParameters) -> None:
         study = self.get_study(uuid)

--- a/antarest/study/storage/variantstudy/command_factory.py
+++ b/antarest/study/storage/variantstudy/command_factory.py
@@ -28,6 +28,7 @@ from antarest.study.storage.variantstudy.model.command.create_link import Create
 from antarest.study.storage.variantstudy.model.command.create_renewables_cluster import CreateRenewablesCluster
 from antarest.study.storage.variantstudy.model.command.create_st_storage import CreateSTStorage
 from antarest.study.storage.variantstudy.model.command.create_user_resource import CreateUserResource
+from antarest.study.storage.variantstudy.model.command.create_xpansion_configuration import CreateXpansionConfiguration
 from antarest.study.storage.variantstudy.model.command.generate_thermal_cluster_timeseries import (
     GenerateThermalClusterTimeSeries,
 )
@@ -85,6 +86,7 @@ COMMAND_MAPPING: Dict[str, Type[ICommand]] = {
     CommandName.GENERATE_THERMAL_CLUSTER_TIMESERIES.value: GenerateThermalClusterTimeSeries,
     CommandName.CREATE_USER_RESOURCE.value: CreateUserResource,
     CommandName.REMOVE_USER_RESOURCE.value: RemoveUserResource,
+    CommandName.CREATE_XPANSION_CONFIGURATION.value: CreateXpansionConfiguration,
 }
 
 

--- a/antarest/study/storage/variantstudy/model/command/common.py
+++ b/antarest/study/storage/variantstudy/model/command/common.py
@@ -57,6 +57,7 @@ class CommandName(Enum):
     GENERATE_THERMAL_CLUSTER_TIMESERIES = "generate_thermal_cluster_timeseries"
     CREATE_USER_RESOURCE = "create_user_resource"
     REMOVE_USER_RESOURCE = "remove_user_resource"
+    CREATE_XPANSION_CONFIGURATION = "create_xpansion_configuration"
 
 
 def is_url_writeable(user_node: User, url: List[str]) -> bool:

--- a/antarest/study/storage/variantstudy/model/command/create_xpansion_configuration.py
+++ b/antarest/study/storage/variantstudy/model/command/create_xpansion_configuration.py
@@ -35,7 +35,7 @@ class CreateXpansionConfiguration(ICommand):
 
     @override
     def _apply_config(self, study_data: FileStudyTreeConfig) -> Tuple[CommandOutput, Dict[str, Any]]:
-        return CommandOutput(status=True, message="ok"), {}
+        return CommandOutput(status=True, message="Xpansion configuration created successfully"), {}
 
     @override
     def _apply(self, study_data: FileStudy, listener: Optional[ICommandListener] = None) -> CommandOutput:

--- a/antarest/study/storage/variantstudy/model/command/create_xpansion_configuration.py
+++ b/antarest/study/storage/variantstudy/model/command/create_xpansion_configuration.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+from typing import Any, Dict, List, Optional, Tuple
+
+from typing_extensions import override
+
+from antarest.core.exceptions import ChildNotFoundError, XpansionConfigurationAlreadyExists
+from antarest.study.business.model.xpansion_model import XpansionSettings
+from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
+from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
+from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput
+from antarest.study.storage.variantstudy.model.command.icommand import ICommand
+from antarest.study.storage.variantstudy.model.command_listener.command_listener import ICommandListener
+from antarest.study.storage.variantstudy.model.model import CommandDTO
+
+
+class CreateXpansionConfiguration(ICommand):
+    """
+    Command used to create the xpansion configuration of a study
+    """
+
+    # Overloaded metadata
+    # ===================
+
+    command_name: CommandName = CommandName.CREATE_XPANSION_CONFIGURATION
+
+    @override
+    def _apply_config(self, study_data: FileStudyTreeConfig) -> Tuple[CommandOutput, Dict[str, Any]]:
+        return CommandOutput(status=True, message="ok"), {}
+
+    @override
+    def _apply(self, study_data: FileStudy, listener: Optional[ICommandListener] = None) -> CommandOutput:
+        try:
+            study_data.tree.get(["user", "expansion"])
+        except ChildNotFoundError:
+            settings_obj = XpansionSettings().model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_none=True,
+                exclude={"sensitivity_config", "yearly_weights", "additional_constraints"},
+            )
+            xpansion_configuration_data = {
+                "user": {
+                    "expansion": {
+                        "settings": settings_obj,
+                        "sensitivity": {"sensitivity_in": {}},
+                        "candidates": {},
+                        "capa": {},
+                        "weights": {},
+                        "constraints": {},
+                    }
+                }
+            }
+
+            study_data.tree.save(xpansion_configuration_data)
+            return self._apply_config(study_data.config)[0]
+        else:
+            raise XpansionConfigurationAlreadyExists(study_data.config.study_id)
+
+    @override
+    def to_dto(self) -> CommandDTO:
+        return CommandDTO(action=self.command_name.value, args={}, study_version=self.study_version)
+
+    @override
+    def get_inner_matrices(self) -> List[str]:
+        return []

--- a/antarest/study/web/xpansion_studies_blueprint.py
+++ b/antarest/study/web/xpansion_studies_blueprint.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 import logging
-from typing import Any, Optional, Sequence
+from typing import Any, Sequence
 
 from fastapi import APIRouter, Depends, File, UploadFile
 from starlette.responses import Response
@@ -23,9 +23,8 @@ from antarest.core.requests import RequestParameters
 from antarest.core.serde.json import to_json
 from antarest.core.utils.web import APITag
 from antarest.login.auth import Auth
+from antarest.study.business.model.xpansion_model import GetXpansionSettings, UpdateXpansionSettings
 from antarest.study.business.xpansion_management import (
-    GetXpansionSettings,
-    UpdateXpansionSettings,
     XpansionCandidateDTO,
     XpansionResourceFileType,
 )
@@ -52,7 +51,6 @@ def create_xpansion_routes(study_service: StudyService, config: Config) -> APIRo
     )
     def create_xpansion_configuration(
         uuid: str,
-        file: Optional[UploadFile] = File(None),
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> Any:
         logger.info(
@@ -60,7 +58,7 @@ def create_xpansion_routes(study_service: StudyService, config: Config) -> APIRo
             extra={"user": current_user.id},
         )
         params = RequestParameters(user=current_user)
-        study_service.create_xpansion_configuration(uuid=uuid, zipped_config=file, params=params)
+        study_service.create_xpansion_configuration(uuid=uuid, params=params)
 
     @bp.delete(
         "/studies/{uuid}/extensions/xpansion",

--- a/antarest/study/web/xpansion_studies_blueprint.py
+++ b/antarest/study/web/xpansion_studies_blueprint.py
@@ -23,7 +23,7 @@ from antarest.core.requests import RequestParameters
 from antarest.core.serde.json import to_json
 from antarest.core.utils.web import APITag
 from antarest.login.auth import Auth
-from antarest.study.business.model.xpansion_model import GetXpansionSettings, UpdateXpansionSettings
+from antarest.study.business.model.xpansion_model import GetXpansionSettings, XpansionSettingsUpdate
 from antarest.study.business.xpansion_management import (
     XpansionCandidateDTO,
     XpansionResourceFileType,
@@ -99,7 +99,7 @@ def create_xpansion_routes(study_service: StudyService, config: Config) -> APIRo
     )
     def update_settings(
         uuid: str,
-        xpansion_settings: UpdateXpansionSettings,
+        xpansion_settings: XpansionSettingsUpdate,
         current_user: JWTUser = Depends(auth.get_current_user),
     ) -> GetXpansionSettings:
         logger.info(

--- a/tests/storage/business/test_xpansion_manager.py
+++ b/tests/storage/business/test_xpansion_manager.py
@@ -28,7 +28,7 @@ from antarest.study.business.area_management import AreaManager
 from antarest.study.business.link_management import LinkManager
 from antarest.study.business.model.area_model import AreaCreationDTO, AreaType
 from antarest.study.business.model.link_model import LinkDTO
-from antarest.study.business.model.xpansion_model import Master, Solver, UcType, UpdateXpansionSettings
+from antarest.study.business.model.xpansion_model import Master, Solver, UcType, XpansionSettingsUpdate
 from antarest.study.business.study_interface import FileStudyInterface, StudyInterface
 from antarest.study.business.xpansion_management import (
     FileCurrentlyUsedInSettings,
@@ -197,7 +197,7 @@ def test_update_xpansion_settings(xpansion_manager: XpansionManager, empty_study
         "sensitivity_config": {"epsilon": 10500.0, "projection": ["foo"], "capex": False},
     }
 
-    new_settings = UpdateXpansionSettings(**new_settings_obj)
+    new_settings = XpansionSettingsUpdate(**new_settings_obj)
 
     actual = xpansion_manager.update_xpansion_settings(study, new_settings)
 
@@ -465,7 +465,7 @@ def test_update_constraints_via_the_front(
     study.get_files().tree.save({"user": {"expansion": {"constraints": {"constraints.txt": b"0"}}}})
 
     # asserts we can update a field without writing the field additional constraint in the file
-    front_settings = UpdateXpansionSettings(master="relaxed")
+    front_settings = XpansionSettingsUpdate(master="relaxed")
     xpansion_manager.update_xpansion_settings(study, front_settings)
     json_content = study.get_files().tree.get(["user", "expansion", "settings"])
     assert "additional-constraints" not in json_content
@@ -473,14 +473,14 @@ def test_update_constraints_via_the_front(
 
     # asserts the front-end can fill additional constraints
     new_constraint = {"additional-constraints": "constraints.txt"}
-    front_settings = UpdateXpansionSettings.model_validate(new_constraint)
+    front_settings = XpansionSettingsUpdate.model_validate(new_constraint)
     actual_settings = xpansion_manager.update_xpansion_settings(study, front_settings)
     assert actual_settings.additional_constraints == "constraints.txt"
     json_content = study.get_files().tree.get(["user", "expansion", "settings"])
     assert json_content["additional-constraints"] == "constraints.txt"
 
     # asserts the front-end can unselect this constraint by not filling it
-    front_settings = UpdateXpansionSettings()
+    front_settings = XpansionSettingsUpdate()
     actual_settings = xpansion_manager.update_xpansion_settings(study, front_settings)
     assert actual_settings.additional_constraints == ""
     json_content = study.get_files().tree.get(["user", "expansion", "settings"])
@@ -498,7 +498,7 @@ def test_update_weights_via_the_front(
     study.get_files().tree.save({"user": {"expansion": {"weights": {"weights.txt": b"0"}}}})
 
     # asserts we can update a field without writing the field yearly-weights in the file
-    front_settings = UpdateXpansionSettings(master="relaxed")
+    front_settings = XpansionSettingsUpdate(master="relaxed")
     xpansion_manager.update_xpansion_settings(study, front_settings)
     json_content = study.get_files().tree.get(["user", "expansion", "settings"])
     assert "yearly-weights" not in json_content
@@ -506,14 +506,14 @@ def test_update_weights_via_the_front(
 
     # asserts the front-end can fill yearly weights
     new_constraint = {"yearly-weights": "weights.txt"}
-    front_settings = UpdateXpansionSettings.model_validate(new_constraint)
+    front_settings = XpansionSettingsUpdate.model_validate(new_constraint)
     actual_settings = xpansion_manager.update_xpansion_settings(study, front_settings)
     assert actual_settings.yearly_weights == "weights.txt"
     json_content = study.get_files().tree.get(["user", "expansion", "settings"])
     assert json_content["yearly-weights"] == "weights.txt"
 
     # asserts the front-end can unselect this weight by not filling it
-    front_settings = UpdateXpansionSettings()
+    front_settings = XpansionSettingsUpdate()
     actual_settings = xpansion_manager.update_xpansion_settings(study, front_settings)
     assert actual_settings.yearly_weights == ""
     json_content = study.get_files().tree.get(["user", "expansion", "settings"])
@@ -565,14 +565,14 @@ def test_add_resources(
 
     settings = xpansion_manager.get_xpansion_settings(study)
     settings.yearly_weights = filename3
-    update_settings = UpdateXpansionSettings(**settings.model_dump())
+    update_settings = XpansionSettingsUpdate(**settings.model_dump())
     xpansion_manager.update_xpansion_settings(study, update_settings)
 
     with pytest.raises(FileCurrentlyUsedInSettings):
         xpansion_manager.delete_resource(study, XpansionResourceFileType.WEIGHTS, filename3)
 
     settings.yearly_weights = ""
-    update_settings = UpdateXpansionSettings(**settings.model_dump())
+    update_settings = XpansionSettingsUpdate(**settings.model_dump())
     xpansion_manager.update_xpansion_settings(study, update_settings)
     xpansion_manager.delete_resource(study, XpansionResourceFileType.WEIGHTS, filename3)
 

--- a/tests/storage/business/test_xpansion_manager.py
+++ b/tests/storage/business/test_xpansion_manager.py
@@ -28,14 +28,11 @@ from antarest.study.business.area_management import AreaManager
 from antarest.study.business.link_management import LinkManager
 from antarest.study.business.model.area_model import AreaCreationDTO, AreaType
 from antarest.study.business.model.link_model import LinkDTO
+from antarest.study.business.model.xpansion_model import Master, Solver, UcType, UpdateXpansionSettings
 from antarest.study.business.study_interface import FileStudyInterface, StudyInterface
 from antarest.study.business.xpansion_management import (
     FileCurrentlyUsedInSettings,
     LinkNotFound,
-    Master,
-    Solver,
-    UcType,
-    UpdateXpansionSettings,
     XpansionCandidateDTO,
     XpansionFileNotFoundError,
     XpansionManager,


### PR DESCRIPTION
This PR introduces a breaking change that has been validated by the R scripts team:

Inside the endpoint POST `"/studies/{uuid}/extensions/xpansion"` used to create an xpansion configuration, the parameter `file` which was optional and not used by the front (nor the R scripts) no longer exists