### PR TITLE
fix(hydro_management): fix read and write in hydro.ini

### DIFF
--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -117,25 +117,25 @@ class HydroManager:
 
     # @staticmethod
     # def get_id(area_id: str, field_dict: Dict[str, FieldInfo]) -> str:
-        """
-        Try to match the current area_id with the one from the original file.
-        These two ids could mismatch based on their character cases since the id from
-        the filesystem could have been modified with capital letters.
-        We first convert it into lower case in order to compare both ids.
+    """
+    Try to match the current area_id with the one from the original file.
+    These two ids could mismatch based on their character cases since the id from
+    the filesystem could have been modified with capital letters.
+    We first convert it into lower case in order to compare both ids.
 
-        Returns the area id from the file if both values matched, the initial area id otherwise.
-        """
-     #   for file_area_id in field_dict:
-     #        if LowerCaseIdentifier.generate_id(file_area_id) == area_id:
-     #            return file_area_id
-     #    return area_id
+    Returns the area id from the file if both values matched, the initial area id otherwise.
+    """
+    #   for file_area_id in field_dict:
+    #        if LowerCaseIdentifier.generate_id(file_area_id) == area_id:
+    #            return file_area_id
+    #    return area_id
 
     # def get_hydro_config(self, study) -> Dict[str, Dict[str, FieldInfo]]:
-        """
-            Returns a dictionary of hydro configurations
-        """
-        # file_study = self.storage_service.get_storage(study).get_raw(study)
-        # return file_study.tree.get(HYDRO_PATH.split("/"))
+    #     """
+    #         Returns a dictionary of hydro configurations
+    #     """
+    #   file_study = self.storage_service.get_storage(study).get_raw(study)
+    #   return file_study.tree.get(HYDRO_PATH.split("/"))
 
     def __init__(self, command_context: CommandContext) -> None:
         self._command_context = command_context

--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -17,8 +17,11 @@ from pydantic import Field
 from antarest.study.business.all_optional_meta import all_optional_model
 from antarest.study.business.study_interface import StudyInterface
 from antarest.study.business.utils import FieldInfo, FormFieldsBaseModel
+#from antarest.study.model import Study
+# from antarest.study.storage.storage_service import StudyStorageService
 from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
+# from antarest.study.storage.rawstudy.model.filesystem.config.identifier import LowerCaseIdentifier
 
 INFLOW_PATH = "input/hydro/prepro/{area_id}/prepro/prepro"
 
@@ -108,6 +111,32 @@ FIELDS_INFO: Dict[str, FieldInfo] = {
 
 
 class HydroManager:
+    # def __init__(self, storage_service: StudyStorageService) -> None:
+    #    self.storage_service = storage_service
+    #    self.area_id = ""
+
+    # @staticmethod
+    # def get_id(area_id: str, field_dict: Dict[str, FieldInfo]) -> str:
+        """
+            Try to match the current area_id with the one from the original file.
+            These two ids could mismatch based on their character cases since the id from
+            the filesystem could have been modified with capital letters.
+            We first convert it into lower case in order to compare both ids.
+
+            Returns the area id from the file if both values matched, the initial area id otherwise.
+        """
+     #   for file_area_id in field_dict:
+     #        if LowerCaseIdentifier.generate_id(file_area_id) == area_id:
+     #            return file_area_id
+     #    return area_id
+
+    # def get_hydro_config(self, study) -> Dict[str, Dict]:
+        """
+            Returns a dictionary of hydro configurations
+        """
+        # file_study = self.storage_service.get_storage(study).get_raw(study)
+        # return file_study.tree.get(HYDRO_PATH.split("/"))
+
     def __init__(self, command_context: CommandContext) -> None:
         self._command_context = command_context
 
@@ -117,11 +146,17 @@ class HydroManager:
         """
         file_study = study.get_files()
         hydro_config = file_study.tree.get(HYDRO_PATH.split("/"))
-
+        #   hydro_config = self.get_hydro_config(study)
         def get_value(field_info: FieldInfo) -> Any:
             path = field_info["path"]
             target_name = path.split("/")[-1]
+            # field_dict = hydro_config.get(target_name, {})
+            # return field_dict.get(self.get_id(area_id, field_dict), field_info["default_value"])
+
             return hydro_config.get(target_name, {}).get(area_id, field_info["default_value"])
+
+        # management_options_data = {name: get_value(info) for name, info in FIELDS_INFO.items()}
+        # return ManagementOptionsFormFields.model_construct(**management_options_data)
 
         return ManagementOptionsFormFields.model_construct(
             **{name: get_value(info) for name, info in FIELDS_INFO.items()}
@@ -134,19 +169,30 @@ class HydroManager:
         area_id: str,
     ) -> None:
         """
-        Set management options for a given area
+            Set management options for a given area
         """
         commands: List[UpdateConfig] = []
 
+        hydro_config = self.get_hydro_config(study)
+
+        # create a reformatted hydro config dictionary so the fields name can match `FIELDS_INFO` fields name
+        reformat_hydro_config = {}
+        for key, value in hydro_config.items():
+            reformat_hydro_config[key.replace("-", "_").replace(" ", "_")] = value
+
         for field_name, value in field_values.__iter__():
             if value is not None:
+                # retrieve the area id from the original file, including its capital letters
+                file_area_id = self.get_id(area_id, reformat_hydro_config.get(field_name, {}))
                 info = FIELDS_INFO[field_name]
 
                 commands.append(
                     UpdateConfig(
+                        # target="/".join([info["path"], file_area_id]), # update the right fields
                         target="/".join([info["path"], area_id]),
                         data=value,
                         command_context=self._command_context,
+                        # command_context=self.storage_service.variant_study_service.command_factory.command_context,
                         study_version=study.version,
                     )
                 )

--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -198,7 +198,6 @@ class HydroManager:
         """
         # NOTE: Focusing on the single field "intermonthly-correlation" due to current model scope.
         path = INFLOW_PATH.format(area_id=area_id)
-        # file_study = self.storage_service.get_storage(study).get_raw(study)
         file_study = study.get_files()
         inter_monthly_correlation = file_study.tree.get(path.split("/")).get("intermonthly-correlation", 0.5)
         return InflowStructure(inter_monthly_correlation=inter_monthly_correlation)

--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -136,9 +136,7 @@ class HydroManager:
         file_study = study.get_files()
         return file_study.tree.get(HYDRO_PATH.split("/"))
 
-    def get_field_values(
-        self, study: StudyInterface, area_id: str
-    ) -> ManagementOptionsFormFields:
+    def get_field_values(self, study: StudyInterface, area_id: str) -> ManagementOptionsFormFields:
         """
         Get management options for a given area
         """
@@ -148,9 +146,7 @@ class HydroManager:
             path = field_info["path"]
             target_name = path.split("/")[-1]
             field_dict = hydro_config.get(target_name, {})
-            return field_dict.get(
-                self.get_id(area_id, field_dict), field_info["default_value"]
-            )
+            return field_dict.get(self.get_id(area_id, field_dict), field_info["default_value"])
 
         return ManagementOptionsFormFields.model_construct(
             **{name: get_value(info) for name, info in FIELDS_INFO.items()}
@@ -177,16 +173,12 @@ class HydroManager:
         for field_name, value in field_values.__iter__():
             if value is not None:
                 # retrieve the area id from the original file, including its capital letters
-                file_area_id = self.get_id(
-                    area_id, reformat_hydro_config.get(field_name, {})
-                )
+                file_area_id = self.get_id(area_id, reformat_hydro_config.get(field_name, {}))
                 info = FIELDS_INFO[field_name]
 
                 commands.append(
                     UpdateConfig(
-                        target="/".join(
-                            [info["path"], file_area_id]
-                        ),  # update the right fields
+                        target="/".join([info["path"], file_area_id]),  # update the right fields
                         data=value,
                         command_context=self._command_context,
                         study_version=study.version,
@@ -197,9 +189,7 @@ class HydroManager:
             study.add_commands(commands)
 
     # noinspection SpellCheckingInspection
-    def get_inflow_structure(
-        self, study: StudyInterface, area_id: str
-    ) -> InflowStructure:
+    def get_inflow_structure(self, study: StudyInterface, area_id: str) -> InflowStructure:
         """
         Retrieves inflow structure values for a specific area within a study.
 
@@ -210,15 +200,11 @@ class HydroManager:
         path = INFLOW_PATH.format(area_id=area_id)
         # file_study = self.storage_service.get_storage(study).get_raw(study)
         file_study = study.get_files()
-        inter_monthly_correlation = file_study.tree.get(path.split("/")).get(
-            "intermonthly-correlation", 0.5
-        )
+        inter_monthly_correlation = file_study.tree.get(path.split("/")).get("intermonthly-correlation", 0.5)
         return InflowStructure(inter_monthly_correlation=inter_monthly_correlation)
 
     # noinspection SpellCheckingInspection
-    def update_inflow_structure(
-        self, study: StudyInterface, area_id: str, values: InflowStructure
-    ) -> None:
+    def update_inflow_structure(self, study: StudyInterface, area_id: str, values: InflowStructure) -> None:
         """
         Updates inflow structure values for a specific area within a study.
 

--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -118,19 +118,19 @@ class HydroManager:
     # @staticmethod
     # def get_id(area_id: str, field_dict: Dict[str, FieldInfo]) -> str:
         """
-            Try to match the current area_id with the one from the original file.
-            These two ids could mismatch based on their character cases since the id from
-            the filesystem could have been modified with capital letters.
-            We first convert it into lower case in order to compare both ids.
+        Try to match the current area_id with the one from the original file.
+        These two ids could mismatch based on their character cases since the id from
+        the filesystem could have been modified with capital letters.
+        We first convert it into lower case in order to compare both ids.
 
-            Returns the area id from the file if both values matched, the initial area id otherwise.
+        Returns the area id from the file if both values matched, the initial area id otherwise.
         """
      #   for file_area_id in field_dict:
      #        if LowerCaseIdentifier.generate_id(file_area_id) == area_id:
      #            return file_area_id
      #    return area_id
 
-    # def get_hydro_config(self, study) -> Dict[str, Dict]:
+    # def get_hydro_config(self, study) -> Dict[str, Dict[str, FieldInfo]]:
         """
             Returns a dictionary of hydro configurations
         """
@@ -188,7 +188,7 @@ class HydroManager:
 
                 commands.append(
                     UpdateConfig(
-                        # target="/".join([info["path"], file_area_id]), # update the right fields
+                        # target="/".join([info["path"], file_area_id]),  # update the right fields
                         target="/".join([info["path"], area_id]),
                         data=value,
                         command_context=self._command_context,
@@ -210,6 +210,7 @@ class HydroManager:
         """
         # NOTE: Focusing on the single field "intermonthly-correlation" due to current model scope.
         path = INFLOW_PATH.format(area_id=area_id)
+        # file_study = self.storage_service.get_storage(study).get_raw(study)
         file_study = study.get_files()
         inter_monthly_correlation = file_study.tree.get(path.split("/")).get("intermonthly-correlation", 0.5)
         return InflowStructure(inter_monthly_correlation=inter_monthly_correlation)

--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -17,11 +17,9 @@ from pydantic import Field
 from antarest.study.business.all_optional_meta import all_optional_model
 from antarest.study.business.study_interface import StudyInterface
 from antarest.study.business.utils import FieldInfo, FormFieldsBaseModel
-#from antarest.study.model import Study
-# from antarest.study.storage.storage_service import StudyStorageService
+from antarest.study.storage.rawstudy.model.filesystem.config.identifier import LowerCaseIdentifier
 from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-# from antarest.study.storage.rawstudy.model.filesystem.config.identifier import LowerCaseIdentifier
 
 INFLOW_PATH = "input/hydro/prepro/{area_id}/prepro/prepro"
 
@@ -111,52 +109,48 @@ FIELDS_INFO: Dict[str, FieldInfo] = {
 
 
 class HydroManager:
-    # def __init__(self, storage_service: StudyStorageService) -> None:
-    #    self.storage_service = storage_service
-    #    self.area_id = ""
-
-    # @staticmethod
-    # def get_id(area_id: str, field_dict: Dict[str, FieldInfo]) -> str:
-    """
-    Try to match the current area_id with the one from the original file.
-    These two ids could mismatch based on their character cases since the id from
-    the filesystem could have been modified with capital letters.
-    We first convert it into lower case in order to compare both ids.
-
-    Returns the area id from the file if both values matched, the initial area id otherwise.
-    """
-    #   for file_area_id in field_dict:
-    #        if LowerCaseIdentifier.generate_id(file_area_id) == area_id:
-    #            return file_area_id
-    #    return area_id
-
-    # def get_hydro_config(self, study) -> Dict[str, Dict[str, FieldInfo]]:
-    #     """
-    #         Returns a dictionary of hydro configurations
-    #     """
-    #   file_study = self.storage_service.get_storage(study).get_raw(study)
-    #   return file_study.tree.get(HYDRO_PATH.split("/"))
-
     def __init__(self, command_context: CommandContext) -> None:
         self._command_context = command_context
+        self.area_id = ""
 
-    def get_field_values(self, study: StudyInterface, area_id: str) -> ManagementOptionsFormFields:
+    @staticmethod
+    def get_id(area_id: str, field_dict: Dict[str, FieldInfo]) -> str:
+        """
+        Try to match the current area_id with the one from the original file.
+        These two ids could mismatch based on their character cases since the id from
+        the filesystem could have been modified with capital letters.
+        We first convert it into lower case in order to compare both ids.
+
+        Returns the area id from the file if both values matched, the initial area id otherwise.
+        """
+        for file_area_id in field_dict:
+            if LowerCaseIdentifier.generate_id(file_area_id) == area_id:
+                return file_area_id
+        return area_id
+
+    @staticmethod
+    def get_hydro_config(study: StudyInterface) -> Dict[str, Dict[str, FieldInfo]]:
+        """
+        Returns a dictionary of hydro configurations
+        """
+        file_study = study.get_files()
+        return file_study.tree.get(HYDRO_PATH.split("/"))
+
+    def get_field_values(
+        self, study: StudyInterface, area_id: str
+    ) -> ManagementOptionsFormFields:
         """
         Get management options for a given area
         """
-        file_study = study.get_files()
-        hydro_config = file_study.tree.get(HYDRO_PATH.split("/"))
-        #   hydro_config = self.get_hydro_config(study)
+        hydro_config = self.get_hydro_config(study)
+
         def get_value(field_info: FieldInfo) -> Any:
             path = field_info["path"]
             target_name = path.split("/")[-1]
-            # field_dict = hydro_config.get(target_name, {})
-            # return field_dict.get(self.get_id(area_id, field_dict), field_info["default_value"])
-
-            return hydro_config.get(target_name, {}).get(area_id, field_info["default_value"])
-
-        # management_options_data = {name: get_value(info) for name, info in FIELDS_INFO.items()}
-        # return ManagementOptionsFormFields.model_construct(**management_options_data)
+            field_dict = hydro_config.get(target_name, {})
+            return field_dict.get(
+                self.get_id(area_id, field_dict), field_info["default_value"]
+            )
 
         return ManagementOptionsFormFields.model_construct(
             **{name: get_value(info) for name, info in FIELDS_INFO.items()}
@@ -169,7 +163,7 @@ class HydroManager:
         area_id: str,
     ) -> None:
         """
-            Set management options for a given area
+        Set management options for a given area
         """
         commands: List[UpdateConfig] = []
 
@@ -183,16 +177,18 @@ class HydroManager:
         for field_name, value in field_values.__iter__():
             if value is not None:
                 # retrieve the area id from the original file, including its capital letters
-                file_area_id = self.get_id(area_id, reformat_hydro_config.get(field_name, {}))
+                file_area_id = self.get_id(
+                    area_id, reformat_hydro_config.get(field_name, {})
+                )
                 info = FIELDS_INFO[field_name]
 
                 commands.append(
                     UpdateConfig(
-                        # target="/".join([info["path"], file_area_id]),  # update the right fields
-                        target="/".join([info["path"], area_id]),
+                        target="/".join(
+                            [info["path"], file_area_id]
+                        ),  # update the right fields
                         data=value,
                         command_context=self._command_context,
-                        # command_context=self.storage_service.variant_study_service.command_factory.command_context,
                         study_version=study.version,
                     )
                 )
@@ -201,7 +197,9 @@ class HydroManager:
             study.add_commands(commands)
 
     # noinspection SpellCheckingInspection
-    def get_inflow_structure(self, study: StudyInterface, area_id: str) -> InflowStructure:
+    def get_inflow_structure(
+        self, study: StudyInterface, area_id: str
+    ) -> InflowStructure:
         """
         Retrieves inflow structure values for a specific area within a study.
 
@@ -212,11 +210,15 @@ class HydroManager:
         path = INFLOW_PATH.format(area_id=area_id)
         # file_study = self.storage_service.get_storage(study).get_raw(study)
         file_study = study.get_files()
-        inter_monthly_correlation = file_study.tree.get(path.split("/")).get("intermonthly-correlation", 0.5)
+        inter_monthly_correlation = file_study.tree.get(path.split("/")).get(
+            "intermonthly-correlation", 0.5
+        )
         return InflowStructure(inter_monthly_correlation=inter_monthly_correlation)
 
     # noinspection SpellCheckingInspection
-    def update_inflow_structure(self, study: StudyInterface, area_id: str, values: InflowStructure) -> None:
+    def update_inflow_structure(
+        self, study: StudyInterface, area_id: str, values: InflowStructure
+    ) -> None:
         """
         Updates inflow structure values for a specific area within a study.
 

--- a/antarest/study/business/areas/hydro_management.py
+++ b/antarest/study/business/areas/hydro_management.py
@@ -121,8 +121,7 @@ class HydroManager:
 
         Returns the area id from the file if both values matched, the initial area id otherwise.
         """
-        next((file_area_id for file_area_id in field_dict if file_area_id.lower() == area_id), area_id)
-        return area_id
+        return next((file_area_id for file_area_id in field_dict if file_area_id.lower() == area_id.lower()), area_id)
 
     @staticmethod
     def _get_hydro_config(study: StudyInterface) -> Dict[str, Dict[str, FieldInfo]]:

--- a/tests/study/business/areas/test_hydro_management.py
+++ b/tests/study/business/areas/test_hydro_management.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
 import datetime
 from pathlib import Path
 from typing import Tuple

--- a/tests/study/business/areas/test_hydro_management.py
+++ b/tests/study/business/areas/test_hydro_management.py
@@ -1,0 +1,184 @@
+import datetime
+from pathlib import Path
+from typing import Tuple
+from unittest.mock import Mock
+
+from antarest.core.config import Config
+from antarest.core.filetransfer.service import FileTransferManager
+from antarest.core.interfaces.cache import ICache
+from antarest.core.interfaces.eventbus import IEventBus
+from antarest.core.model import PublicMode
+from antarest.core.tasks.service import TaskJobService
+from antarest.core.utils.fastapi_sqlalchemy import db
+from antarest.login.model import User
+from antarest.login.service import LoginService
+from antarest.study.business.areas.hydro_management import ManagementOptionsFormFields
+from antarest.study.business.model.area_model import AreaCreationDTO, AreaType
+from antarest.study.model import RawStudy
+from antarest.study.repository import StudyMetadataRepository
+from antarest.study.service import StudyService
+from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
+from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
+from tests.helpers import with_db_context
+
+
+class TestHydroManagement:
+    """ """
+    @staticmethod
+    def setup(
+        raw_study_service: RawStudyService,
+        variant_study_service: VariantStudyService,
+        tmp_path: Path,
+        task_service: TaskJobService,
+        core_cache: ICache,
+        event_bus: IEventBus
+    ) -> Tuple[RawStudy, StudyService]:
+        """
+        Set up data for the next tests
+        - Create a raw study
+        - Initialize a study service
+        - Create an area in this study
+        """
+        # create a raw study
+        user = User(id=30, name="regular")
+        db.session.add(user)
+
+        path = tmp_path / "area_test_study"
+        raw_study = RawStudy(
+            id="my_raw_study",
+            name=path.name,
+            version="860",
+            author="John Smith",
+            public_mode=PublicMode.FULL,
+            owner=user,
+            path=str(path),
+            created_at=datetime.datetime.utcnow(),
+            updated_at=datetime.datetime.utcnow(),
+        )
+        db.session.add(raw_study)
+
+        db.session.commit()
+
+        raw_study = raw_study_service.create(raw_study)
+
+        # Initialize a study service
+        repository = StudyMetadataRepository(core_cache)
+        study_service = StudyService(
+            raw_study_service=raw_study_service,
+            variant_study_service=variant_study_service,
+            user_service=Mock(spec=LoginService),
+            repository=repository,
+            event_bus=event_bus,
+            task_service=task_service,
+            file_transfer_manager=Mock(spec=FileTransferManager),
+            cache_service=core_cache,
+            config=Mock(spec=Config),
+        )
+
+        return raw_study, study_service
+
+    @with_db_context
+    def test_get_field_values(
+        self,
+        raw_study_service: RawStudyService,
+        variant_study_service: VariantStudyService,
+        tmp_path: Path,
+        task_service: TaskJobService,
+        core_cache: ICache,
+        event_bus: IEventBus
+    ):
+        """
+        Create an area, edit manually some fields with capital letters
+        Check if data retrieved match the original files
+        """
+        # retrieve setup data
+        raw_study, study_service = self.setup(
+            raw_study_service,
+            variant_study_service,
+            tmp_path,
+            task_service,
+            core_cache,
+            event_bus
+        )
+        # create an area
+        area_creation_dto = AreaCreationDTO(name="AreaTestGet", type=AreaType.AREA)
+        area = study_service.area_manager.create_area(raw_study, area_creation_dto)
+        path = Path(raw_study.path)
+
+        # gather initial data of the area
+        initial_data = study_service.hydro_manager.get_field_values(raw_study, area.id)
+
+        # change `area_id` case and edit one field (inter-daily-breakdown)
+        hydro_ini_path = path.joinpath("input/hydro/hydro.ini")
+        with open(hydro_ini_path) as f:
+            old_content = f.read()
+            new_content = old_content.replace("areatestget", "AreaTestGet").replace(
+                "[inter-daily-breakdown]\n" "AreaTestGet = 1",
+                "[inter-daily-breakdown]\n" "AreaTestGet = 2",
+            )
+
+        with open(hydro_ini_path, "w") as f:
+            f.write(new_content)
+
+        # retrieve new values
+        new_data = study_service.hydro_manager.get_field_values(raw_study, area.id)
+
+        # if `get_fields_values` returns correct values, it must differ from its previous version
+        assert new_data != initial_data
+
+    @with_db_context
+    def test_set_field_values(
+        self,
+        raw_study_service: RawStudyService,
+        variant_study_service: VariantStudyService,
+        tmp_path: Path,
+        task_service: TaskJobService,
+        core_cache: ICache,
+        event_bus: IEventBus
+    ):
+        """
+        Test if set_field_values works as expected
+        Modify some fields
+        """
+        # retrieve setup data
+        raw_study, study_service = self.setup(
+            raw_study_service,
+            variant_study_service,
+            tmp_path,
+            task_service,
+            core_cache,
+            event_bus
+        )
+        # create an area
+        area_creation_dto = AreaCreationDTO(name="AreaTestSet", type=AreaType.AREA)
+        area = study_service.area_manager.create_area(raw_study, area_creation_dto)
+        path = Path(raw_study.path)
+
+        # gather initial data
+        initial_data = study_service.hydro_manager.get_field_values(raw_study, area.id).dict()
+
+        # set area id with capital letters
+        hydro_ini_path = path.joinpath("input/hydro/hydro.ini")
+        with open(hydro_ini_path) as f:
+            old_content = f.read()
+            new_content = old_content.replace("areatestset", "AreaTestSet")
+
+        with open(hydro_ini_path, "w") as f:
+            f.write(new_content)
+
+        # set multiple values with set_field_values
+        new_field_values = ManagementOptionsFormFields(**{"inter_daily_breakdown": 5, "reservoir": True})
+        study_service.hydro_manager.set_field_values(raw_study, new_field_values, area.id)
+
+        # retrieve new values
+        new_data = study_service.hydro_manager.get_field_values(raw_study, area.id).dict()
+
+        assert new_data != initial_data
+
+        for field_name, value in new_data.items():
+            # fields that were modified must retrieve different values
+            if field_name in ["inter_daily_breakdown", "reservoir"]:
+                assert value != initial_data[field_name]
+            # fields that were not must be the same
+            else:
+                assert value == initial_data[field_name]

--- a/tests/study/business/areas/test_hydro_management.py
+++ b/tests/study/business/areas/test_hydro_management.py
@@ -55,72 +55,63 @@ hydro_ini_content = {
 }
 
 
+@pytest.fixture(name="study_service")
+def study_service_fixture(
+    raw_study_service: RawStudyService,
+    generator_matrix_constants: GeneratorMatrixConstants,
+    simple_matrix_service: SimpleMatrixService,
+) -> StudyService:
+    study_service = StudyService(
+        raw_study_service=raw_study_service,
+        variant_study_service=Mock(spec=VariantStudyService),
+        command_context=CommandContext(
+            generator_matrix_constants=generator_matrix_constants,
+            matrix_service=simple_matrix_service,
+        ),
+        user_service=Mock(spec=LoginService),
+        repository=Mock(StudyMetadataRepository),
+        event_bus=Mock(spec=IEventBus),
+        task_service=Mock(spec=TaskJobService),
+        file_transfer_manager=Mock(spec=FileTransferManager),
+        cache_service=Mock(spec=ICache),
+        config=Mock(spec=Config),
+    )
+
+    return study_service
+
+
+@pytest.fixture(name="study")
+def study_interface_fixture(tmp_path: Path) -> StudyInterface:
+    study_id = "study_test"
+    study_path = tmp_path.joinpath(f"tmp/{study_id}")
+    config = build(study_path, study_id)
+    tree = FileStudyTree(Mock(spec=ContextServer), config)
+    tree.save(hydro_ini_content)
+
+    file_study = Mock(spec=FileStudy, config=config, tree=FileStudyTree(Mock(spec=ContextServer), config))
+
+    study = Mock(spec=StudyInterface, version=860)
+    study.get_files.return_value = file_study
+    return study
+
+
 class TestHydroManagement:
-    @staticmethod
-    def create_study_service(
-        raw_study_service: RawStudyService,
-        generator_matrix_constants: GeneratorMatrixConstants,
-        simple_matrix_service: SimpleMatrixService,
-    ) -> StudyService:
-        # Initialize a study service
-        study_service = StudyService(
-            raw_study_service=raw_study_service,
-            variant_study_service=Mock(spec=VariantStudyService),
-            command_context=CommandContext(
-                generator_matrix_constants=generator_matrix_constants,
-                matrix_service=simple_matrix_service,
-            ),
-            user_service=Mock(spec=LoginService),
-            repository=Mock(StudyMetadataRepository),
-            event_bus=Mock(spec=IEventBus),
-            task_service=Mock(spec=TaskJobService),
-            file_transfer_manager=Mock(spec=FileTransferManager),
-            cache_service=Mock(spec=ICache),
-            config=Mock(spec=Config),
-        )
-
-        return study_service
-
-    @staticmethod
-    def create_study_interface(tmp_path: Path) -> StudyInterface:
-        study_id = "study_test"
-        study_path = tmp_path.joinpath(f"tmp/{study_id}")
-        config = build(study_path, study_id)
-        tree = FileStudyTree(Mock(spec=ContextServer), config)
-        tree.save(hydro_ini_content)
-
-        file_study = Mock(spec=FileStudy, config=config, tree=FileStudyTree(Mock(spec=ContextServer), config))
-
-        study = Mock(spec=StudyInterface, version=860)
-        study.get_files.return_value = file_study
-        return study
-
     @pytest.mark.unit_test
-    def test_get_field_values(
-        self,
-        raw_study_service: RawStudyService,
-        tmp_path: Path,
-        generator_matrix_constants: GeneratorMatrixConstants,
-        simple_matrix_service: SimpleMatrixService,
-    ) -> None:
+    def test_get_field_values(self, study_service: StudyService, study: StudyInterface) -> None:
         """
         Set up:
-            Create a study service, a study and some areas with different letter cases.
+            Retrieve a study service and a study interface
+            Create some areas with different letter cases
         Test:
             Check if `get_field_values` returns the right values
         """
-        # retrieve setup data
-        study_service = self.create_study_service(raw_study_service, generator_matrix_constants, simple_matrix_service)
-
-        study = self.create_study_interface(tmp_path)
-
         # add som areas
         areas = ["AreaTest1", "AREATEST2", "area_test_3"]
 
         # gather initial data of the area
         for area in areas:
             # get actual value
-            data = study_service.hydro_manager.get_field_values(study, area).dict()
+            data = study_service.hydro_manager.get_field_values(study, area).model_dump()
 
             # set expected value based on defined fields dict
             raw_data = hydro_ini_content["input"]["hydro"]["hydro"]
@@ -137,34 +128,23 @@ class TestHydroManagement:
             assert data == initial_data
 
     @pytest.mark.unit_test
-    def test_set_field_values(
-        self,
-        raw_study_service: RawStudyService,
-        tmp_path: Path,
-        generator_matrix_constants,
-        simple_matrix_service,
-    ) -> None:
+    def test_set_field_values(self, study_service: StudyService, study: StudyInterface) -> None:
         """
         Set up:
-            Create a study service, study and some areas with different letter cases
+            Retrieve a study service and a study interface
+            Create some areas with different letter cases
 
         Test:
             Get initial data
             Edit one field (intra_daily_modulation)
             Check if the field was successfully edited for each area
         """
-        # create a study service
-        study_service = self.create_study_service(raw_study_service, generator_matrix_constants, simple_matrix_service)
-
-        # create a study
-        study = self.create_study_interface(tmp_path)
-
         # store the area ids
         areas = ["AreaTest1", "AREATEST2", "area_test_3"]
 
         for area in areas:
             # get initial values with get_field_values
-            initial_data = study_service.hydro_manager.get_field_values(study, area).dict()
+            initial_data = study_service.hydro_manager.get_field_values(study, area).model_dump()
 
             # set multiple values with set_field_values
             initial_data["intra_daily_modulation"] = 5
@@ -172,7 +152,7 @@ class TestHydroManagement:
             study_service.hydro_manager.set_field_values(study, new_field_values, area)
 
             # retrieve edited
-            new_data = study_service.hydro_manager.get_field_values(study, area).dict()
+            new_data = study_service.hydro_manager.get_field_values(study, area).model_dump()
 
             # check if the intra daily modulation was modified
             for field, value in new_data.items():

--- a/tests/study/business/areas/test_hydro_management.py
+++ b/tests/study/business/areas/test_hydro_management.py
@@ -42,7 +42,7 @@ class TestHydroManagement:
         tmp_path: Path,
         task_service: TaskJobService,
         core_cache: ICache,
-        event_bus: IEventBus
+        event_bus: IEventBus,
     ) -> Tuple[RawStudy, StudyService]:
         """
         Set up data for the next tests
@@ -89,7 +89,6 @@ class TestHydroManagement:
 
         return raw_study, study_service
 
-
     @with_db_context
     def test_get_field_values(
         self,
@@ -98,7 +97,7 @@ class TestHydroManagement:
         tmp_path: Path,
         task_service: TaskJobService,
         core_cache: ICache,
-        event_bus: IEventBus
+        event_bus: IEventBus,
     ):
         """
         Create an area, edit manually some fields with capital letters
@@ -109,12 +108,7 @@ class TestHydroManagement:
 
         # retrieve setup data
         raw_study, study_service = self.setup(
-            raw_study_service,
-            variant_study_service,
-            tmp_path,
-            task_service,
-            core_cache,
-            event_bus
+            raw_study_service, variant_study_service, tmp_path, task_service, core_cache, event_bus
         )
         # create an area
         area_creation_dto = AreaCreationDTO(name="AreaTestGet", type=AreaType.AREA)
@@ -129,8 +123,8 @@ class TestHydroManagement:
         with open(hydro_ini_path) as f:
             old_content = f.read()
             new_content = old_content.replace("areatestget", "AreaTestGet").replace(
-                "[inter-daily-breakdown]\n" "AreaTestGet = 1",
-                "[inter-daily-breakdown]\n" "AreaTestGet = 2",
+                "[inter-daily-breakdown]\nAreaTestGet = 1",
+                "[inter-daily-breakdown]\nAreaTestGet = 2",
             )
 
         with open(hydro_ini_path, "w") as f:
@@ -150,7 +144,7 @@ class TestHydroManagement:
         tmp_path: Path,
         task_service: TaskJobService,
         core_cache: ICache,
-        event_bus: IEventBus
+        event_bus: IEventBus,
     ):
         """
         Test if set_field_values works as expected
@@ -158,12 +152,7 @@ class TestHydroManagement:
         """
         # retrieve setup data
         raw_study, study_service = self.setup(
-            raw_study_service,
-            variant_study_service,
-            tmp_path,
-            task_service,
-            core_cache,
-            event_bus
+            raw_study_service, variant_study_service, tmp_path, task_service, core_cache, event_bus
         )
         # create an area
         area_creation_dto = AreaCreationDTO(name="AreaTestSet", type=AreaType.AREA)

--- a/tests/study/business/areas/test_hydro_management.py
+++ b/tests/study/business/areas/test_hydro_management.py
@@ -23,7 +23,6 @@ from tests.helpers import with_db_context
 
 
 class TestHydroManagement:
-    """ """
     @staticmethod
     def setup(
         raw_study_service: RawStudyService,
@@ -66,6 +65,7 @@ class TestHydroManagement:
         study_service = StudyService(
             raw_study_service=raw_study_service,
             variant_study_service=variant_study_service,
+            command_context=Mock(),
             user_service=Mock(spec=LoginService),
             repository=repository,
             event_bus=event_bus,
@@ -76,6 +76,7 @@ class TestHydroManagement:
         )
 
         return raw_study, study_service
+
 
     @with_db_context
     def test_get_field_values(
@@ -91,6 +92,9 @@ class TestHydroManagement:
         Create an area, edit manually some fields with capital letters
         Check if data retrieved match the original files
         """
+        user = db.session.add(User(id=30, name="regular"))
+        print(f"hello, {user.name}")
+
         # retrieve setup data
         raw_study, study_service = self.setup(
             raw_study_service,


### PR DESCRIPTION
Fix [ANT-2734](https://gopro-tickets.rte-france.com/browse/ANT-2734)

Antares Web use area_id to retrieve and save data about areas. However, as described in the ticket, in the case of an area creating using another tool, if this area has capital characters in its name, AW won't be able to recognize it.

In this PR, we allow the program to read and save the area_id regardless its case.

Two tests for read and save operations has been added too.