### PR TITLE
fix(commands): add missing index on commands table, for performances

### DIFF
--- a/alembic/versions/423fe2c8ee40_add_commandblock_index.py
+++ b/alembic/versions/423fe2c8ee40_add_commandblock_index.py
@@ -1,0 +1,25 @@
+"""add_commandblock_index
+
+Revision ID: 423fe2c8ee40
+Revises: bae9c99bc42d
+Create Date: 2025-02-27 14:08:50.413459
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "423fe2c8ee40"
+down_revision = "bae9c99bc42d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("commandblock", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_commandblock_study_id"), ["study_id"], unique=False)
+
+
+def downgrade():
+    with op.batch_alter_table("commandblock", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_commandblock_study_id"))


### PR DESCRIPTION
The commands tables is not indexed on study_id, in consequence, retrieving the commands
for one particular study requires the scan of the whole table.

Currently on prod env, we have 140 000 commands.
With that kind of size, the retrieval of study commands speeds up by **x100** with an index:

see analysis of a simple select **with an index**:
```
Bitmap Heap Scan on commandblock  (cost=5.24..391.09 rows=105 width=115) (actual time=0.069..0.123 rows=100 loops=1)
  Recheck Cond: ((study_id)::text = '0efa7fbb-81a6-4f09-81ac-3ed409fef63c'::text)
  Heap Blocks: exact=5
  ->  Bitmap Index Scan on ix_commandblock_study_id  (cost=0.00..5.21 rows=105 width=0) (actual time=0.051..0.051 rows=100 loops=1)
        Index Cond: ((study_id)::text = '0efa7fbb-81a6-4f09-81ac-3ed409fef63c'::text)
Planning Time: 0.162 ms
Execution Time: 0.175 ms
```

see analysis of a simple select **without an index**:
```
Gather  (cost=1000.00..11616.85 rows=105 width=115) (actual time=5.827..25.340 rows=100 loops=1)
  Workers Planned: 2
  Workers Launched: 2
  ->  Parallel Seq Scan on commandblock  (cost=0.00..10606.35 rows=44 width=115) (actual time=11.733..17.398 rows=33 loops=3)
        Filter: ((study_id)::text = '0efa7fbb-81a6-4f09-81ac-3ed409fef63c'::text)
        Rows Removed by Filter: 148341
Planning Time: 0.190 ms
Execution Time: 25.373 ms
```
(Note that it would be worse without the parallel workers, if the database is busy)