### PR TITLE
fix(ui-digest): conditionally render digest button based on synthesis availability

### DIFF
--- a/webapp/src/components/App/Singlestudy/HomeView/InformationView/LauncherHistory/index.tsx
+++ b/webapp/src/components/App/Singlestudy/HomeView/InformationView/LauncherHistory/index.tsx
@@ -146,7 +146,7 @@ function LauncherHistory(props: Props) {
       <Typography color="text.secondary" sx={{ display: "flex", alignItems: "center", gap: 1 }}>
         <HistoryIcon /> {t("global.jobs")}
       </Typography>
-      <JobStepper jobs={studyJobs} jobsProgress={studyJobsProgress} />
+      {study && <JobStepper studyId={study.id} jobs={studyJobs} jobsProgress={studyJobsProgress} />}
     </Paper>
   );
 }

--- a/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/ResultFilters.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/ResultFilters.tsx
@@ -187,9 +187,12 @@ function ResultFilters({
       id: "search",
       label: "",
       field: (
-        <Box sx={{ width: 200 }}>
-          <SearchFE value={filters.search} onChange={(e) => handleSearchChange(e.target.value)} />
-        </Box>
+        <SearchFE
+          value={filters.search}
+          size="extra-small"
+          onChange={(e) => handleSearchChange(e.target.value)}
+          sx={{ width: 150, mr: 1 }}
+        />
       ),
     },
     {
@@ -241,11 +244,13 @@ function ResultFilters({
             trueText="Synthesis"
             falseText="Year by year"
             variant="outlined"
+            size="extra-small"
             onChange={(event) => setYear(event?.target.value ? -1 : 1)}
           />
           {localYear > 0 && (
             <NumberFE
               variant="outlined"
+              size="extra-small"
               value={localYear}
               sx={{ m: 0, ml: 1, width: 80 }}
               inputProps={{
@@ -271,6 +276,7 @@ function ResultFilters({
             { value: DataType.STStorage, label: "ST Storages" },
           ]}
           variant="outlined"
+          size="extra-small"
           onChange={(event) => setDataType(event?.target.value as DataType)}
         />
       ),
@@ -288,6 +294,7 @@ function ResultFilters({
             { value: Timestep.Annual, label: "Annual" },
           ]}
           variant="outlined"
+          size="extra-small"
           onChange={(event) => setTimestep(event?.target.value as Timestep)}
         />
       ),

--- a/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
@@ -97,18 +97,11 @@ function ResultDetails() {
 
   const maxYear = output?.nbyears ?? MAX_YEAR;
 
-  useEffect(
-    () => {
-      const isValidSelectedItem =
-        !!selectedItemId && filteredItems.find((item) => item.id === selectedItemId);
-
-      if (!isValidSelectedItem) {
-        setSelectedItemId(filteredItems.length > 0 ? filteredItems[0].id : "");
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filteredItems],
-  );
+  useEffect(() => {
+    if (!selectedItem) {
+      setSelectedItemId(filteredItems.length > 0 ? filteredItems[0].id : "");
+    }
+  }, [filteredItems, selectedItem]);
 
   const path = useMemo(() => {
     if (output && selectedItem && !isSynthesis) {
@@ -250,7 +243,11 @@ function ResultDetails() {
               >
                 <ToggleButton value={OutputItemType.Areas}>{t("study.areas")}</ToggleButton>
                 <ToggleButton value={OutputItemType.Links}>{t("study.links")}</ToggleButton>
-                <ToggleButton value={OutputItemType.Synthesis}>{t("study.synthesis")}</ToggleButton>
+                {output?.synthesis && (
+                  <ToggleButton value={OutputItemType.Synthesis}>
+                    {t("study.synthesis")}
+                  </ToggleButton>
+                )}
               </ToggleButtonGroup>
               <ListElement
                 list={filteredItems}

--- a/webapp/src/components/App/Singlestudy/explore/Results/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Results/index.tsx
@@ -374,19 +374,20 @@ function Results() {
                             )}
 
                             {row.job && <LaunchJobLogView job={row.job} logButton logErrorButton />}
-                            {row.job?.status === "success" && (
-                              <Tooltip title="Digest">
-                                <EqualizerIcon
-                                  onClick={() => {
-                                    setDialogState({
-                                      type: "digest",
-                                      data: row.job as LaunchJob,
-                                    });
-                                  }}
-                                  sx={iconStyle}
-                                />
-                              </Tooltip>
-                            )}
+                            {row.job?.status === "success" &&
+                              row.output?.settings?.output?.synthesis && (
+                                <Tooltip title="Digest">
+                                  <EqualizerIcon
+                                    onClick={() => {
+                                      setDialogState({
+                                        type: "digest",
+                                        data: row.job as LaunchJob,
+                                      });
+                                    }}
+                                    sx={iconStyle}
+                                  />
+                                </Tooltip>
+                              )}
                             <Box sx={{ height: "24px", margin: 0.5 }}>
                               <Tooltip title={t("global.delete") as string}>
                                 <DeleteForeverIcon

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -86,11 +86,34 @@ export interface StudyMetadataPatchDTO {
 export interface StudyOutput {
   name: string;
   type: string;
+  settings: {
+    general: {
+      mode: string;
+      horizon: number;
+      nbyears: number;
+      simulation: {
+        start: number;
+        end: number;
+      };
+    };
+    input: {
+      import: string;
+    };
+    output: {
+      synthesis: boolean;
+      storenewset: boolean;
+      archives: string;
+    };
+    optimization: object;
+    otherPreferences: object;
+    advancedParameters: object;
+    seedsMersenneTwister: object;
+    playlist: unknown[];
+  };
   completionDate: string;
   status: string;
   archived: boolean;
 }
-
 export interface StudyLayer {
   areas: string[];
   id: string;


### PR DESCRIPTION
## Description

Prevent 404 errors by only showing the digest button when outputs contain synthesis data. Previously, the button appeared for all successful jobs, causing errors when accessing digest for outputs generated without synthesis.
Issue Jira ANT-2837

## Changes
- Added conditional rendering for the digest button based on the presence of synthesis data in outputs
- Implemented proper loading state handling for outputs data

## Testing
Verified that the digest button only appears for outputs containing synthesis data, preventing invalid digest access attempts.