### PR TITLE
chore(typing): add TypeAlias where missing

### DIFF
--- a/antarest/core/filesystem_blueprint.py
+++ b/antarest/core/filesystem_blueprint.py
@@ -20,7 +20,7 @@ import os
 import shutil
 import stat
 from pathlib import Path
-from typing import Iterator, Mapping, Sequence, Tuple
+from typing import Iterator, Mapping, Sequence, Tuple, TypeAlias
 
 import typing_extensions as te
 from fastapi import APIRouter, Depends, HTTPException
@@ -32,8 +32,8 @@ from antarest.core.serde import AntaresBaseModel
 from antarest.core.utils.web import APITag
 from antarest.login.auth import Auth
 
-FilesystemName = te.Annotated[str, Field(pattern=r"^\w+$", description="Filesystem name")]
-MountPointName = te.Annotated[str, Field(pattern=r"^\w+$", description="Mount point name")]
+FilesystemName: TypeAlias = te.Annotated[str, Field(pattern=r"^\w+$", description="Filesystem name")]
+MountPointName: TypeAlias = te.Annotated[str, Field(pattern=r"^\w+$", description="Mount point name")]
 
 
 class FilesystemDTO(

--- a/antarest/core/interfaces/eventbus.py
+++ b/antarest/core/interfaces/eventbus.py
@@ -12,7 +12,7 @@
 
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import Any, Awaitable, Callable, List, Optional
+from typing import Any, Awaitable, Callable, List, Optional, TypeAlias
 
 from typing_extensions import override
 
@@ -65,7 +65,7 @@ class Event(AntaresBaseModel):
     channel: str = ""
 
 
-EventListener = Callable[[Event], Awaitable[None]]
+EventListener: TypeAlias = Callable[[Event], Awaitable[None]]
 
 
 class IEventBus(ABC):

--- a/antarest/core/model.py
+++ b/antarest/core/model.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 import enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeAlias, Union
 
 import typing_extensions as te
 from pydantic import StringConstraints
@@ -22,10 +22,10 @@ if TYPE_CHECKING:
     # These dependencies are only used for type checking with mypy.
     from antarest.study.model import Study, StudyMetadataDTO
 
-JSON = Dict[str, Any]
-ELEMENT = Union[str, int, float, bool, bytes]
-SUB_JSON = Union[ELEMENT, JSON, List[Any], None]
-LowerCaseStr = te.Annotated[str, StringConstraints(to_lower=True)]
+JSON: TypeAlias = Dict[str, Any]
+ELEMENT: TypeAlias = Union[str, int, float, bool, bytes]
+SUB_JSON: TypeAlias = Union[ELEMENT, JSON, List[Any], None]
+LowerCaseStr: TypeAlias = te.Annotated[str, StringConstraints(to_lower=True)]
 
 
 class PublicMode(enum.StrEnum):

--- a/antarest/core/serde/ini_common.py
+++ b/antarest/core/serde/ini_common.py
@@ -11,9 +11,9 @@
 # This file is part of the Antares project.
 
 import dataclasses
-from typing import Optional
+from typing import Optional, TypeAlias
 
-PrimitiveType = str | int | float | bool
+PrimitiveType: TypeAlias = str | int | float | bool
 
 
 @dataclasses.dataclass(frozen=True)

--- a/antarest/core/serde/ini_reader.py
+++ b/antarest/core/serde/ini_reader.py
@@ -13,14 +13,14 @@ import dataclasses
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Optional, Pattern, Sequence, TextIO, cast
+from typing import Any, Callable, Dict, Mapping, Optional, Pattern, Sequence, TextIO, TypeAlias, cast
 
 from typing_extensions import override
 
 from antarest.core.model import JSON
 from antarest.core.serde.ini_common import OptionMatcher, PrimitiveType, any_section_option_matcher
 
-ValueParser = Callable[[str], PrimitiveType]
+ValueParser: TypeAlias = Callable[[str], PrimitiveType]
 
 
 def _lower_case(input: str) -> str:

--- a/antarest/core/serde/ini_writer.py
+++ b/antarest/core/serde/ini_writer.py
@@ -13,7 +13,7 @@
 import ast
 import configparser
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, TypeAlias
 
 from typing_extensions import override
 
@@ -21,7 +21,7 @@ from antarest.core.model import JSON
 from antarest.core.serde.ini_common import OptionMatcher, PrimitiveType, any_section_option_matcher
 
 # Value serializers may be used to customize the way INI options are serialized
-ValueSerializer = Callable[[str], PrimitiveType]
+ValueSerializer: TypeAlias = Callable[[str], PrimitiveType]
 
 
 def _lower_case(input: str) -> str:

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -16,7 +16,7 @@ import time
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
 from http import HTTPStatus
-from typing import Awaitable, Callable, Dict, List, Optional
+from typing import Awaitable, Callable, Dict, List, Optional, TypeAlias
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session  # type: ignore
@@ -60,7 +60,7 @@ class ITaskNotifier(ABC):
         raise NotImplementedError()
 
 
-Task = Callable[[ITaskNotifier], TaskResult]
+Task: TypeAlias = Callable[[ITaskNotifier], TaskResult]
 
 
 class ITaskService(ABC):

--- a/antarest/launcher/adapters/log_parser.py
+++ b/antarest/launcher/adapters/log_parser.py
@@ -12,11 +12,11 @@
 
 import functools
 import re
-from typing import Callable, Iterable, Match, Optional, cast
+from typing import Callable, Iterable, Match, Optional, TypeAlias, cast
 
 from antarest.core.serde import AntaresBaseModel
 
-_SearchFunc = Callable[[str], Optional[Match[str]]]
+_SearchFunc: TypeAlias = Callable[[str], Optional[Match[str]]]
 
 _compile = functools.partial(re.compile, flags=re.IGNORECASE | re.VERBOSE)
 

--- a/antarest/matrixstore/model.py
+++ b/antarest/matrixstore/model.py
@@ -12,7 +12,7 @@
 
 import datetime
 import uuid
-from typing import Any, List
+from typing import Any, List, TypeAlias
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Table  # type: ignore
 from sqlalchemy.orm import relationship  # type: ignore
@@ -213,7 +213,7 @@ class MatrixDataSet(Base):  # type: ignore
 # Reverting to only float because Any cause problem retrieving data from a node
 # will have pandas forcing all to float anyway...
 # this cause matrix dump on disk (and then hash id) to be different for basically the same matrices
-MatrixData = float
+MatrixData: TypeAlias = float
 
 
 class MatrixDTO(AntaresBaseModel):

--- a/antarest/study/business/adequacy_patch_management.py
+++ b/antarest/study/business/adequacy_patch_management.py
@@ -10,9 +10,10 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, List
+from typing import Annotated, Any, Dict, List, TypeAlias
 
-from pydantic.types import StrictBool, confloat, conint
+from pydantic import Field
+from pydantic.types import StrictBool
 
 from antarest.study.business.all_optional_meta import all_optional_model
 from antarest.study.business.enum_ignore_case import EnumIgnoreCase
@@ -28,7 +29,7 @@ class PriceTakingOrder(EnumIgnoreCase):
     LOAD = "Load"
 
 
-ThresholdType = confloat(ge=0)
+ThresholdType: TypeAlias = Annotated[float, Field(ge=0)]
 
 
 @all_optional_model
@@ -41,9 +42,9 @@ class AdequacyPatchFormFields(FormFieldsBaseModel):
     price_taking_order: PriceTakingOrder
     include_hurdle_cost_csr: StrictBool
     check_csr_cost_function: StrictBool
-    threshold_initiate_curtailment_sharing_rule: ThresholdType  # type: ignore
-    threshold_display_local_matching_rule_violations: ThresholdType  # type: ignore
-    threshold_csr_variable_bounds_relaxation: conint(ge=0, strict=True)  # type: ignore
+    threshold_initiate_curtailment_sharing_rule: ThresholdType
+    threshold_display_local_matching_rule_violations: ThresholdType
+    threshold_csr_variable_bounds_relaxation: Annotated[int, Field(ge=0, strict=True)]
 
 
 ADEQUACY_PATCH_PATH = f"{GENERAL_DATA_PATH}/adequacy patch"

--- a/antarest/study/business/areas/st_storage_management.py
+++ b/antarest/study/business/areas/st_storage_management.py
@@ -12,7 +12,7 @@
 
 import collections
 import operator
-from typing import Any, List, Mapping, MutableMapping, Sequence
+from typing import Any, List, Mapping, MutableMapping, Sequence, TypeAlias
 
 import numpy as np
 from antares.study.version import StudyVersion
@@ -144,7 +144,7 @@ class STStorageMatrices(AntaresBaseModel):
 
 
 # noinspection SpellCheckingInspection
-STStorageTimeSeries = Literal[
+STStorageTimeSeries: TypeAlias = Literal[
     "pmax_injection",
     "pmax_withdrawal",
     "lower_rule_curve",

--- a/antarest/study/business/binding_constraint_management.py
+++ b/antarest/study/business/binding_constraint_management.py
@@ -12,7 +12,7 @@
 
 import collections
 import logging
-from typing import Any, Dict, List, Mapping, MutableSequence, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, MutableSequence, Optional, Sequence, Tuple, TypeAlias
 
 import numpy as np
 from antares.study.version import StudyVersion
@@ -341,7 +341,7 @@ class ConstraintOutput870(ConstraintOutput830):
 
 # WARNING: Do not change the order of the following line, it is used to determine
 # the type of the output constraint in the FastAPI endpoint.
-ConstraintOutput = ConstraintOutputBase | ConstraintOutput830 | ConstraintOutput870
+ConstraintOutput: TypeAlias = ConstraintOutputBase | ConstraintOutput830 | ConstraintOutput870
 
 
 def _get_references_by_widths(

--- a/antarest/study/business/general_management.py
+++ b/antarest/study/business/general_management.py
@@ -10,9 +10,9 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, List, Union, cast
+from typing import Annotated, Any, Dict, List, TypeAlias, Union, cast
 
-from pydantic import PositiveInt, StrictBool, ValidationInfo, conint, model_validator
+from pydantic import Field, PositiveInt, StrictBool, ValidationInfo, model_validator
 
 from antarest.study.business.all_optional_meta import all_optional_model
 from antarest.study.business.enum_ignore_case import EnumIgnoreCase
@@ -60,14 +60,14 @@ class BuildingMode(EnumIgnoreCase):
     DERATED = "Derated"
 
 
-DayNumberType = conint(ge=1, le=366)
+DayNumberType: TypeAlias = Annotated[int, Field(ge=1, le=366)]
 
 
 @all_optional_model
 class GeneralFormFields(FormFieldsBaseModel):
     mode: Mode
-    first_day: DayNumberType  # type: ignore
-    last_day: DayNumberType  # type: ignore
+    first_day: DayNumberType
+    last_day: DayNumberType
     horizon: Union[str, int]
     first_month: Month
     first_week_day: WeekDay

--- a/antarest/study/business/model/link_model.py
+++ b/antarest/study/business/model/link_model.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 from dataclasses import field
-from typing import Annotated, List, Optional, Self, Type
+from typing import Annotated, List, Optional, Self, Type, TypeAlias
 
 from antares.study.version import StudyVersion
 from pydantic import BeforeValidator, ConfigDict, Field, PlainSerializer, model_validator
@@ -123,7 +123,7 @@ def join_with_comma(values: List[FilterOption]) -> str:
     return ", ".join(value.name.lower() for value in values)
 
 
-comma_separated_enum_list = Annotated[
+CommaSeparatedFilterOptions: TypeAlias = Annotated[
     List[FilterOption],
     BeforeValidator(lambda x: validate_filters(x, FilterOption)),
     PlainSerializer(lambda x: join_with_comma(x)),
@@ -154,8 +154,8 @@ class LinkBaseDTO(AntaresBaseModel):
     colorg: int = Field(default=DEFAULT_COLOR, ge=0, le=255)
     link_width: float = 1
     link_style: LinkStyle = LinkStyle.PLAIN
-    filter_synthesis: Optional[comma_separated_enum_list] = field(default_factory=lambda: FILTER_VALUES)
-    filter_year_by_year: Optional[comma_separated_enum_list] = field(default_factory=lambda: FILTER_VALUES)
+    filter_synthesis: Optional[CommaSeparatedFilterOptions] = field(default_factory=lambda: FILTER_VALUES)
+    filter_year_by_year: Optional[CommaSeparatedFilterOptions] = field(default_factory=lambda: FILTER_VALUES)
 
 
 class Area(AntaresBaseModel):
@@ -203,8 +203,8 @@ class LinkInternal(AntaresBaseModel):
     colorg: int = Field(default=DEFAULT_COLOR, ge=0, le=255)
     link_width: float = 1
     link_style: LinkStyle = LinkStyle.PLAIN
-    filter_synthesis: Optional[comma_separated_enum_list] = field(default_factory=lambda: FILTER_VALUES)
-    filter_year_by_year: Optional[comma_separated_enum_list] = field(default_factory=lambda: FILTER_VALUES)
+    filter_synthesis: Optional[CommaSeparatedFilterOptions] = field(default_factory=lambda: FILTER_VALUES)
+    filter_year_by_year: Optional[CommaSeparatedFilterOptions] = field(default_factory=lambda: FILTER_VALUES)
 
     def to_dto(self) -> LinkDTO:
         data = self.model_dump()

--- a/antarest/study/business/model/xpansion_model.py
+++ b/antarest/study/business/model/xpansion_model.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import Annotated, Any, MutableMapping, Optional, Sequence
+from typing import Annotated, Any, MutableMapping, Optional, Sequence, TypeAlias
 
 from pydantic import BeforeValidator, Field, PlainSerializer, ValidationError, field_validator, model_validator
 
@@ -237,7 +237,8 @@ def split_areas(x: str) -> dict[str, str]:
     return {"area_from": area_list[0], "area_to": area_list[1]}
 
 
-xpansion_link = Annotated[
+# link parsed and serialized as "area1 - area2"
+XpansionLinkStr: TypeAlias = Annotated[
     XpansionLink,
     BeforeValidator(lambda x: split_areas(x)),
     PlainSerializer(lambda x: x.serialize()),
@@ -246,7 +247,7 @@ xpansion_link = Annotated[
 
 class XpansionCandidateBase(AntaresBaseModel, populate_by_name=True):
     name: str
-    link: xpansion_link
+    link: XpansionLinkStr
     annual_cost_per_mw: float = Field(gt=0)
     unit_size: Optional[float] = Field(default=None, ge=0)
     max_units: Optional[int] = Field(default=None, ge=0)

--- a/antarest/study/business/table_mode_management.py
+++ b/antarest/study/business/table_mode_management.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 import collections
-from typing import Any, Mapping, MutableMapping, Optional, Sequence, cast
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, TypeAlias, cast
 
 import numpy as np
 import pandas as pd
@@ -37,7 +37,7 @@ from antarest.study.model import STUDY_VERSION_8_2
 _TableIndex = str  # row name
 _TableColumn = str  # column name
 _CellValue = Any  # cell value (str, int, float, bool, enum, etc.)
-TableDataDTO = Mapping[_TableIndex, Mapping[_TableColumn, _CellValue]]
+TableDataDTO: TypeAlias = Mapping[_TableIndex, Mapping[_TableColumn, _CellValue]]
 
 
 class TableModeType(EnumIgnoreCase):

--- a/antarest/study/model.py
+++ b/antarest/study/model.py
@@ -16,7 +16,7 @@ import secrets
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path, PurePath, PurePosixPath
-from typing import TYPE_CHECKING, Annotated, Any, Dict, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Annotated, Any, Dict, List, Optional, Tuple, TypeAlias, cast
 
 from antares.study.version import StudyVersion
 from pydantic import BeforeValidator, ConfigDict, Field, PlainSerializer, computed_field, field_validator
@@ -63,8 +63,8 @@ STUDY_VERSION_8_8 = NEW_DEFAULT_STUDY_VERSION
 STUDY_VERSION_9_1 = StudyVersion.parse("9.1")
 STUDY_VERSION_9_2 = StudyVersion.parse("9.2")
 
-StudyVersionStr = Annotated[StudyVersion, BeforeValidator(StudyVersion.parse), PlainSerializer(str)]
-StudyVersionInt = Annotated[StudyVersion, BeforeValidator(StudyVersion.parse), PlainSerializer(int)]
+StudyVersionStr: TypeAlias = Annotated[StudyVersion, BeforeValidator(StudyVersion.parse), PlainSerializer(str)]
+StudyVersionInt: TypeAlias = Annotated[StudyVersion, BeforeValidator(StudyVersion.parse), PlainSerializer(int)]
 
 
 STUDY_REFERENCE_TEMPLATES: set[StudyVersion] = {

--- a/antarest/study/storage/rawstudy/model/filesystem/config/field_validators.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/field_validators.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import Annotated, Any, List, Mapping, MutableMapping
+from typing import Annotated, Any, List, Mapping, MutableMapping, TypeAlias
 
 from pydantic import BeforeValidator, Field
 
@@ -30,13 +30,13 @@ def _validate_item_name(name: Any) -> str:
 
 # Type to be used for item names, will raise an error if name
 # does not comply with antares-simulator limitations.
-ItemName = Annotated[str, BeforeValidator(_validate_item_name)]
+ItemName: TypeAlias = Annotated[str, BeforeValidator(_validate_item_name)]
 
 # Type to be used for area identifiers. An ID is valid if it contains
 # only lower case alphanumeric characters, parenthesis, comma,
 # ampersand, spaces, underscores, or dashes, as defined by
 # antares-simulator.
-AreaId = Annotated[str, Field(description="Area ID", pattern=r"^[a-z0-9_(),& -]+$")]
+AreaId: TypeAlias = Annotated[str, Field(description="Area ID", pattern=r"^[a-z0-9_(),& -]+$")]
 
 
 def extract_filtering(v: Any) -> List[str]:

--- a/antarest/study/storage/rawstudy/model/filesystem/config/renewable.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/renewable.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Optional, Type, cast
+from typing import Any, Optional, Type, TypeAlias, cast
 
 from antares.study.version import StudyVersion
 from pydantic import Field
@@ -120,8 +120,8 @@ class RenewableConfig(RenewableProperties, IgnoreCaseIdentifier):
     """
 
 
-RenewableConfigType = RenewableConfig
-RenewablePropertiesType = RenewableProperties
+RenewableConfigType: TypeAlias = RenewableConfig
+RenewablePropertiesType: TypeAlias = RenewableProperties
 
 
 def get_renewable_config_cls(study_version: StudyVersion) -> Type[RenewableConfig]:

--- a/antarest/study/storage/rawstudy/model/filesystem/config/st_storage.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/st_storage.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, Type
+from typing import Any, Dict, Type, TypeAlias
 
 from antares.study.version import StudyVersion
 from pydantic import Field
@@ -163,8 +163,8 @@ class STStorage880Config(STStorage880Properties, LowerCaseIdentifier):
 
 # NOTE: In the following Union, it is important to place the older version first,
 # because otherwise, creating a short term storage always creates a v8.8 one.
-STStorageConfigType = STStorageConfig | STStorage880Config
-STStoragePropertiesType = STStorageProperties | STStorage880Properties
+STStorageConfigType: TypeAlias = STStorageConfig | STStorage880Config
+STStoragePropertiesType: TypeAlias = STStorageProperties | STStorage880Properties
 
 
 def create_st_storage_properties(study_version: StudyVersion, data: Dict[str, Any]) -> STStoragePropertiesType:

--- a/antarest/study/storage/rawstudy/model/filesystem/config/thermal.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/thermal.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, Optional, Type, cast
+from typing import Any, Dict, Optional, Type, TypeAlias, cast
 
 from antares.study.version import StudyVersion
 from pydantic import Field
@@ -412,8 +412,8 @@ class Thermal870Config(Thermal870Properties, IgnoreCaseIdentifier):
 
 # NOTE: In the following Union, it is important to place the most specific type first,
 # because the type matching generally occurs sequentially from left to right within the union.
-ThermalConfigType = Thermal870Config | Thermal860Config | ThermalConfig
-ThermalPropertiesType = Thermal870Properties | Thermal860Properties | ThermalProperties
+ThermalConfigType: TypeAlias = Thermal870Config | Thermal860Config | ThermalConfig
+ThermalPropertiesType: TypeAlias = Thermal870Properties | Thermal860Properties | ThermalProperties
 
 
 def get_thermal_config_cls(study_version: StudyVersion) -> Type[ThermalConfigType]:

--- a/antarest/study/storage/rawstudy/model/filesystem/inode.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/inode.py
@@ -13,7 +13,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Tuple, TypeAlias, TypeVar
 
 from antarest.core.exceptions import WritingInsideZippedFileException
 from antarest.core.utils.archives import extract_file_to_tmp_dir, read_original_file_in_archive
@@ -178,4 +178,4 @@ class INode(ABC, Generic[G, S, V]):
             raise WritingInsideZippedFileException("Trying to save inside a zipped file")
 
 
-TREE = Dict[str, INode[Any, Any, Any]]
+TREE: TypeAlias = Dict[str, INode[Any, Any, Any]]

--- a/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
@@ -12,7 +12,7 @@
 
 from abc import ABCMeta
 from enum import Enum
-from typing import Any, Dict, Final, List, Optional, Set, Tuple, Type
+from typing import Any, Dict, Final, List, Optional, Set, Tuple, Type, TypeAlias
 
 import numpy as np
 from antares.study.version import StudyVersion
@@ -46,7 +46,7 @@ from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.command_listener.command_listener import ICommandListener
 from antarest.study.storage.variantstudy.model.model import CommandDTO
 
-MatrixType = List[List[MatrixData]]
+MatrixType: TypeAlias = List[List[MatrixData]]
 
 EXPECTED_MATRIX_SHAPES = {
     BindingConstraintFrequency.HOURLY: (8784, 3),
@@ -124,7 +124,7 @@ class BindingConstraintProperties870(BindingConstraintProperties830):
     group: LowerCaseStr = DEFAULT_GROUP
 
 
-BindingConstraintProperties = (
+BindingConstraintProperties: TypeAlias = (
     BindingConstraintPropertiesBase | BindingConstraintProperties830 | BindingConstraintProperties870
 )
 

--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -34,7 +34,7 @@ from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.command_listener.command_listener import ICommandListener
 from antarest.study.storage.variantstudy.model.model import CommandDTO
 
-OptionalMatrixData = List[List[MatrixData]] | str | None
+OptionalMatrixData: t.TypeAlias = List[List[MatrixData]] | str | None
 
 
 class CreateCluster(ICommand):

--- a/antarest/study/storage/variantstudy/model/command/create_st_storage.py
+++ b/antarest/study/storage/variantstudy/model/command/create_st_storage.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 
-from typing import Any, Dict, Final, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Final, List, Optional, Tuple, TypeAlias, Union, cast
 
 import numpy as np
 from pydantic import Field, ValidationInfo, model_validator
@@ -48,7 +48,7 @@ _MATRIX_NAMES = (
 # Minimum required version.
 REQUIRED_VERSION = STUDY_VERSION_8_6
 
-MatrixType = List[List[MatrixData]]
+MatrixType: TypeAlias = List[List[MatrixData]]
 
 
 # noinspection SpellCheckingInspection

--- a/antarest/study/storage/variantstudy/model/model.py
+++ b/antarest/study/storage/variantstudy/model/model.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 import datetime
 import uuid
-from typing import List, MutableSequence, Optional, Tuple
+from typing import List, MutableSequence, Optional, Tuple, TypeAlias
 
 import typing_extensions as te
 
@@ -19,7 +19,7 @@ from antarest.core.model import JSON
 from antarest.core.serde import AntaresBaseModel
 from antarest.study.model import StudyMetadataDTO, StudyVersionStr
 
-LegacyDetailsDTO = Tuple[str, bool, str]
+LegacyDetailsDTO: TypeAlias = Tuple[str, bool, str]
 """
 Legacy details DTO: triplet of name, output status and output message.
 """
@@ -42,7 +42,7 @@ class NewDetailsDTO(te.TypedDict):
     msg: str
 
 
-DetailsDTO = LegacyDetailsDTO | NewDetailsDTO
+DetailsDTO: TypeAlias = LegacyDetailsDTO | NewDetailsDTO
 
 
 class GenerationResultInfoDTO(AntaresBaseModel):

--- a/antarest/worker/archive_worker_service.py
+++ b/antarest/worker/archive_worker_service.py
@@ -13,7 +13,7 @@
 import argparse
 import logging
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional, Sequence, TypeAlias
 
 from antarest import __version__
 from antarest.core.config import Config
@@ -24,7 +24,7 @@ from antarest.service_creator import create_archive_worker
 # use the real module name instead of `__name__` (because `__name__ == "__main__"`)
 logger = logging.getLogger("antarest.worker.archive_worker_service")
 
-ArgsType = Optional[Sequence[str]]
+ArgsType: TypeAlias = Optional[Sequence[str]]
 
 
 def parse_arguments(args: ArgsType = None) -> argparse.Namespace:


### PR DESCRIPTION
Many types are defined as type aliases, but not annotated accordingly,
which is bothering in particular for tooling (pycharm for example).

This PR aims at adding most missing `TypeAlias` annotations

Also renames all type aliases in `CamelCase`.