### PR TITLE
fix(sts): fix create_st_storage v1 parsing

### DIFF
--- a/antarest/study/storage/variantstudy/model/command/create_st_storage.py
+++ b/antarest/study/storage/variantstudy/model/command/create_st_storage.py
@@ -62,7 +62,8 @@ class CreateSTStorage(ICommand):
 
     command_name: CommandName = CommandName.CREATE_ST_STORAGE
 
-    # version 2: remove cluster_name and type parameters as STStoragePropertiesType
+    # version 2: parameters changed from STStorageConfigType to STStoragePropertiesType
+    #            This actually did not require a version increment, but was done by mistake.
     _SERIALIZATION_VERSION: Final[int] = 2
 
     # Command parameters
@@ -105,10 +106,7 @@ class CreateSTStorage(ICommand):
     @classmethod
     def validate_model(cls, values: Dict[str, Any], info: ValidationInfo) -> Dict[str, Any]:
         if isinstance(values["parameters"], dict):
-            parameters = values["parameters"]
-            if info.context and info.context.version == 1:
-                parameters["name"] = values.pop("cluster_name")
-            values["parameters"] = create_st_storage_properties(values["study_version"], parameters)
+            values["parameters"] = create_st_storage_properties(values["study_version"], data=values["parameters"])
         return values
 
     @staticmethod

--- a/tests/variantstudy/test_command_factory.py
+++ b/tests/variantstudy/test_command_factory.py
@@ -820,12 +820,13 @@ def test_parse_create_cluster_dto_v1(command_factory: CommandFactory):
 
 def test_parse_create_st_storage_dto_v1(command_factory: CommandFactory):
     dto = CommandDTO(
+        id="9f01931b-0f18-4477-9ef4-ac682c970d75",
         action=CommandName.CREATE_ST_STORAGE.value,
         version=1,
         args={
             "area_id": "area_name",
-            "cluster_name": "cluster_name",
             "parameters": {
+                "name": "battery storage_2 candidate",
                 "group": "Battery",
                 "injectionnominalcapacity": 0,
                 "withdrawalnominalcapacity": 0,
@@ -833,6 +834,7 @@ def test_parse_create_st_storage_dto_v1(command_factory: CommandFactory):
                 "efficiency": 1,
                 "initiallevel": 0,
                 "initialleveloptim": False,
+                "enabled": True,
             },
             "pmax_injection": "matrix://59ea6c83-6348-466d-9530-c35c51ca4c37",
             "pmax_withdrawal": "matrix://5f988548-dadc-4bbb-8ce8-87a544dbf756",
@@ -847,8 +849,7 @@ def test_parse_create_st_storage_dto_v1(command_factory: CommandFactory):
     command = commands[0]
     dto = command.to_dto()
     assert dto.version == 2
-    assert dto.args["parameters"]["name"] == "cluster_name"
-    assert "cluster_name" not in dto.args
+    assert dto.args["parameters"]["name"] == "battery storage_2 candidate"
 
 
 def test_parse_create_renewable_cluster_dto_v1(command_factory: CommandFactory):


### PR DESCRIPTION
The parsing of existing commands of type `create_st_storage` raises an error, because the presence of a `cluster_name` property is assumed.

This was a mistake, the command never had such a field (unlike command `create_cluster` which inspired it).

We need to keep the v2 version anyway, because some commands may have been created with this new version number.
