### PR TITLE
fix(area): fix bug on allocation and correlation views

### DIFF
--- a/antarest/study/business/allocation_management.py
+++ b/antarest/study/business/allocation_management.py
@@ -139,7 +139,8 @@ class AllocationManager:
         if not allocation_data:
             raise AllocationDataNotFound(area_id)
 
-        return allocation_data.get("[allocation]", {})  # type: ignore
+        # allocation format can differ from the number of '[' (i.e. [[allocation]] or [allocation])
+        return allocation_data.get("[allocation]", allocation_data.get("allocation", {}))  # type: ignore
 
     def get_allocation_form_fields(
         self, all_areas: List[AreaInfoDTO], study: StudyInterface, area_id: str
@@ -243,7 +244,8 @@ class AllocationManager:
         array = np.zeros((len(rows), len(columns)), dtype=np.float64)
 
         for prod_area, allocation_dict in allocation_cfg.items():
-            allocations = allocation_dict["[allocation]"]
+            # allocation format can differ from the number of '[' (i.e. [[allocation]] or [allocation])
+            allocations = allocation_dict.get("[allocation]", allocation_dict.get("allocation", {}))
             for cons_area, coefficient in allocations.items():
                 row_idx = rows.index(cons_area)
                 col_idx = columns.index(prod_area)

--- a/antarest/study/business/correlation_management.py
+++ b/antarest/study/business/correlation_management.py
@@ -209,7 +209,13 @@ class CorrelationManager:
         file_study: FileStudy,
         area_ids: Sequence[str],
     ) -> npt.NDArray[np.float64]:
-        correlation_cfg = file_study.tree.get(self.url, depth=3)
+        try:
+            correlation_cfg = file_study.tree.get(self.url, depth=3)
+        except KeyError:
+            # some studies could not have an annual field
+            # make sure the other fields exist
+            assert file_study.tree.get(self.url[:-1])
+            correlation_cfg = {}
         return _config_to_array(area_ids, correlation_cfg)
 
     def _set_array(

--- a/antarest/study/storage/rawstudy/model/filesystem/config/thermal.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/thermal.py
@@ -13,7 +13,7 @@
 from typing import Annotated, Any, Dict, Optional, Type, TypeAlias, cast
 
 from antares.study.version import StudyVersion
-from pydantic import BeforeValidator, Field, TypeAdapter
+from pydantic import BeforeValidator, Field, TypeAdapter, field_validator
 from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import override
 
@@ -135,7 +135,7 @@ class ThermalProperties(ClusterProperties):
     )
     min_up_time: int = Field(
         default=1,
-        ge=0,
+        ge=1,
         le=168,
         description="Min. Up time (h)",
         alias="min-up-time",
@@ -143,7 +143,7 @@ class ThermalProperties(ClusterProperties):
     )
     min_down_time: int = Field(
         default=1,
-        ge=0,
+        ge=1,
         le=168,
         description="Min. Down time (h)",
         alias="min-down-time",
@@ -231,6 +231,10 @@ class ThermalProperties(ClusterProperties):
         description="Emission rate of CO2 (t/MWh)",
         title="Emission rate of CO2",
     )
+
+    @field_validator("min_down_time", "min_up_time", mode="before")
+    def _validate_min_up_and_down_time(cls, v: int) -> int:
+        return 1 if v < 1 else 168 if v > 168 else v
 
 
 class Thermal860Properties(ThermalProperties):

--- a/antarest/study/storage/rawstudy/model/filesystem/config/thermal.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/thermal.py
@@ -135,7 +135,7 @@ class ThermalProperties(ClusterProperties):
     )
     min_up_time: int = Field(
         default=1,
-        ge=1,
+        ge=0,
         le=168,
         description="Min. Up time (h)",
         alias="min-up-time",
@@ -143,7 +143,7 @@ class ThermalProperties(ClusterProperties):
     )
     min_down_time: int = Field(
         default=1,
-        ge=1,
+        ge=0,
         le=168,
         description="Min. Down time (h)",
         alias="min-down-time",

--- a/tests/integration/study_data_blueprint/test_hydro_correlation.py
+++ b/tests/integration/study_data_blueprint/test_hydro_correlation.py
@@ -11,6 +11,7 @@
 # This file is part of the Antares project.
 
 from http import HTTPStatus
+from pathlib import Path
 from typing import List
 
 import pytest
@@ -314,3 +315,23 @@ class TestHydroCorrelation:
             "index": ["de", "es", "it"],
         }
         assert actual == expected
+
+    def test_get_correlation_values__empty_annual(
+        self, client: TestClient, internal_study_id: str, user_access_token: str, tmp_path: Path
+    ):
+        area_id = "it"
+
+        correlation_file_path = tmp_path.joinpath("ext_workspace/STA-mini/input/hydro/prepro/correlation.ini")
+
+        # remove the annual field and its content
+        with open(correlation_file_path, "w") as f:
+            f.write("[general]\nmode = annual")
+
+        with open(correlation_file_path) as f:
+            assert f.read() == "[general]\nmode = annual"
+
+        res = client.get(
+            f"/v1/studies/{internal_study_id}/areas/{area_id}/hydro/correlation/form",
+            headers={"Authorization": f"Bearer {user_access_token}"},
+        )
+        assert res.status_code == HTTPStatus.OK, res.json()


### PR DESCRIPTION
Fix #[ANT-2960](https://gopro-tickets.rte-france.com/browse/ANT-2960)

This PR must fix bugs that happen when asking for the correlation view, the allocation view and their sub views (`view all correlations` and `view all allocations`). They exist only on a few studies (i.e. https://antares-web.rte-france.com/studies/5030aa35-3a3a-4153-843c-902189e9b6f7/explore/debug?path=input%2Fhydro%2Fprepro%2Fcorrelation on production).

I updated the checks in order to make them as permissive as the external tools which could modify studies too.

The bugs fixed are :
- accepting correlation.ini files that could have an empty "annual" property
- reading allocation.ini files that could have another format ("[" instead of "[[")
- respect rules of external tool that convert `min-up-time` and `min-down-time` values that exceed bounds to 1 if the value is lesser than 1 and 168 if the value is greater than 168