### PR TITLE
doc: fix broken links and disable default expansion

### DIFF
--- a/docs/developer-guide/architecture/0-introduction.md
+++ b/docs/developer-guide/architecture/0-introduction.md
@@ -2,7 +2,7 @@
 
 ## Full deployment
 
-![](../assets/media/img/deployment_architecture.png)
+![](../../assets/media/img/deployment_architecture.png)
 
 
 ## Entry points / applications
@@ -27,11 +27,11 @@ Each package/module is structured in the following way :
 - repository.py : define an utility class that will allow to query the database entities defined in the model
 - business / common / utils / ... : other directory to put business components, utility, interfaces, adapters, ...
 
-![](../assets/media/img/module_architecture.png)
+![](../../assets/media/img/module_architecture.png)
 
 ## Specific topics
 
 - [Database management](./1-database.md)
-- [Adding a new antares simulator version support](./1-add-new-antares-version.md)
+- [Adding a new antares simulator version support](../1-add-new-antares-version.md)
 
 

--- a/docs/user-guide/how-to/studies-import.md
+++ b/docs/user-guide/how-to/studies-import.md
@@ -53,18 +53,18 @@ To import a study into Antares Web, follow these steps from the "Studies" view:
 
 Click the "Import" button in the "Studies" view:
 
-![studies-import-main-view.png](../assets/media/how-to/studies-import-main-view.png)
+![studies-import-main-view.png](../../assets/media/how-to/studies-import-main-view.png)
 
 The import dialog box will appear. Click the "Browse" button to select the compressed file to import:
 
-![studies-import-drop-file-dialog.png](../assets/media/how-to/studies-import-drop-file-dialog.png)
+![studies-import-drop-file-dialog.png](../../assets/media/how-to/studies-import-drop-file-dialog.png)
 
 You can also drag and drop the compressed file into the dialog box.
 
 Once imported, you can see the study in the list of studies. Select the "default" workspace to view the imported study.
 You can also search for the study by name using the search input.
 
-![studies-import-studies-list.png](../assets/media/how-to/studies-import-studies-list.png)
+![studies-import-studies-list.png](../../assets/media/how-to/studies-import-studies-list.png)
 
 > **NOTE:** The properties of the imported study can be modified by clicking on the "More options" button and
 > selecting "Properties". You can change the study name, permission, and metadata.
@@ -135,7 +135,7 @@ Here is a breakdown of what each part of the code does:
 
 See also:
 
-- ["User account & api tokens"](../user-guide/1-interface.md#user-account-and-api-tokens) in the user guide.
+- ["User account & api tokens"](../../user-guide/1-interface.md#user-account-and-api-tokens) in the user guide.
 
 ## See also
 

--- a/docs/user-guide/how-to/studies-upgrade.md
+++ b/docs/user-guide/how-to/studies-upgrade.md
@@ -44,15 +44,15 @@ To upgrade your study to the latest version of Antares Web and Antares Simulator
 
 On the main page of the study, you can find the version number at the top of the menu bar:
 
-![studies-upgrade-menu_version.png](../assets/media/how-to/studies-upgrade-menu_version.png)
+![studies-upgrade-menu_version.png](../../assets/media/how-to/studies-upgrade-menu_version.png)
 
 To upgrade the study, click on the nemu and select "Upgrade Study".
 
-![studies-upgrade-menu_open.png](../assets/media/how-to/studies-upgrade-menu_open.png)
+![studies-upgrade-menu_open.png](../../assets/media/how-to/studies-upgrade-menu_open.png)
 
 The confirmation dialog box will appear, click "Yes" to start the upgrade:
 
-![studies-upgrade-menu_open.png](../assets/media/how-to/studies-upgrade-dialog_box.png)
+![studies-upgrade-menu_open.png](../../assets/media/how-to/studies-upgrade-dialog_box.png)
 
 The upgrade task is launched in the task manager.
 
@@ -61,7 +61,7 @@ The upgrade task is launched in the task manager.
 
 When the upgrade is done, you can see the version number updated:
 
-![](../assets/media/how-to/studies-upgrade-done.png)
+![](../../assets/media/how-to/studies-upgrade-done.png)
 
 Once the upgrade is complete, you can open your study and perform the manual upgrade in the configuration.
 

--- a/docs/user-guide/study/areas/08-st-storages.md
+++ b/docs/user-guide/study/areas/08-st-storages.md
@@ -28,10 +28,10 @@ To access the configuration of ST storages:
 
 ## ST Storage List
 
-![08-st-storages-list.png](../../../assets/media/user-guide/study/areas/08-st-storage-list.png)
+![08-st-storages-list.png](../../../assets/media/user-guide/study/areas/08-st-storages-list.png)
 _Screenshot for a study version under 8.8_
 
-![08-st-storages-list-enable.png](../../../assets/media/user-guide/study/areas/08-st-storage-list-enable.png)
+![08-st-storages-list-enable.png](../../../assets/media/user-guide/study/areas/08-st-storages-list-enable.png)
 _Screenshot for a study version in 8.8_
 
 On the ST storages page, you will find the following elements:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ theme:
   features:
     - navigation.instant
     - navigation.top
-    - navigation.expand
+  #  - navigation.expand
   #  - navigation.sections
   #   - header.autohide
   #   - toc.separate

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,16 +49,7 @@ nav:
               - 'Miscellaneous Generators': 'user-guide/study/areas/10-misc-gen.md'
           - 'Links': 'user-guide/study/03-links.md'
           - 'Binding Constraints': 'user-guide/study/04-binding-constraints.md'
-      - 'Simulation Configuration':
-          'General Configuration': 'user-guide/simulation-configuration/all-configurations.md#general-configuration'
-          'TS management': 'user-guide/simulation-configuration/all-configurations.md#time-series-management'
-          'Optimization preferences': 'user-guide/simulation-configuration/all-configurations.md#optimization-preferences'
-          'Adequacy Patch': 'user-guide/simulation-configuration/all-configurations.md#adequacy-patch'
-          'Advanced parameters': 'user-guide/simulation-configuration/all-configurations.md#advanced-parameters'
-          'Economic Opt.': 'user-guide/simulation-configuration/all-configurations.md#economic-opt'
-          'Geographic Trimming (Areas)': 'user-guide/simulation-configuration/all-configurations.md#geographic-trimming(areas)'
-          'Geographic Trimming (Links)': 'user-guide/simulation-configuration/all-configurations.md#geographic-trimming(links)'
-          'Geographic Trimming (Binding Constraints)': 'user-guide/simulation-configuration/all-configurations.md#geographic-trimming(binding-constrainte)'
+      - 'Simulation Configuration': 'user-guide/simulation-configuration/all-configurations.md'
       - 'Table Mode': 'user-guide/study/06-table-mode.md'
       - 'Xpansion' : user-guide/study/07-xpansion.md
       - 'Results' : user-guide/study/08-results.md


### PR DESCRIPTION

Many links were broken, and the expansion of all pages by default makes the structure
very difficult to get at first glance.