### PR TITLE
feat(aggregator_manager): enable aggregation size on endpoint

### DIFF
--- a/antarest/core/config.py
+++ b/antarest/core/config.py
@@ -190,6 +190,7 @@ class StorageConfig:
     auto_archive_dry_run: bool = False
     auto_archive_sleeping_time: int = 3600
     auto_archive_max_parallel: int = 5
+    aggregation_results_max_size: int = 200
     snapshot_retention_days: int = 7
     matrixstore_format: InternalMatrixFormat = InternalMatrixFormat.TSV
 
@@ -223,6 +224,9 @@ class StorageConfig:
             auto_archive_dry_run=data.get("auto_archive_dry_run", defaults.auto_archive_dry_run),
             auto_archive_sleeping_time=data.get("auto_archive_sleeping_time", defaults.auto_archive_sleeping_time),
             auto_archive_max_parallel=data.get("auto_archive_max_parallel", defaults.auto_archive_max_parallel),
+            aggregation_results_max_size=data.get(
+                "aggregation_results_max_size", defaults.aggregation_results_max_size
+            ),
             snapshot_retention_days=data.get("snapshot_retention_days", defaults.snapshot_retention_days),
             matrixstore_format=InternalMatrixFormat(data.get("matrixstore_format", defaults.matrixstore_format)),
         )

--- a/antarest/study/business/aggregator_management.py
+++ b/antarest/study/business/aggregator_management.py
@@ -379,12 +379,9 @@ class AggregatorManager:
             if not list_of_df_columns or set(list_of_df_columns) == {CLUSTER_ID_COL, TIME_ID_COL}:
                 return pd.DataFrame()
 
-            # checks if the estimated dataframe size does not exceed the limit
-            # This check is performed on 10 aggregated files to have a more accurate view of the final df.
-            if k == 10:
-                # The following formula is the more accurate one compared to the final csv file.
-                estimated_binary_size = final_df.memory_usage().sum()
-                _checks_estimated_size(nb_files, estimated_binary_size, k, self.aggregation_results_max_size)
+            # The following formula is the more accurate one compared to the final csv file.
+            estimated_binary_size = final_df.memory_usage().sum()
+            _checks_estimated_size(nb_files, estimated_binary_size, k, self.aggregation_results_max_size)
 
             column_name = AREA_COL if self.output_type == "areas" else LINK_COL
             new_column_order = _columns_ordering(list_of_df_columns, column_name, is_details, self.mc_root)

--- a/antarest/study/business/aggregator_management.py
+++ b/antarest/study/business/aggregator_management.py
@@ -25,7 +25,6 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.date_serializer imp
 )
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
 
-MC_TEMPLATE_PARTS = "economy/{mc_root}"
 # noinspection SpellCheckingInspection
 MCYEAR_COL = "mcYear"
 """Column name for the Monte Carlo year."""

--- a/antarest/study/business/aggregator_management.py
+++ b/antarest/study/business/aggregator_management.py
@@ -372,7 +372,7 @@ class AggregatorManager:
             # The following formula is the more accurate one compared to the final csv file.
             estimated_binary_size = final_df.memory_usage().sum()
             if estimated_binary_size > self.aggregation_results_max_size * 10**6:
-                raise FileTooLargeError(estimated_binary_size, estimated_binary_size)
+                raise FileTooLargeError(round(estimated_binary_size / 10**6, 2), self.aggregation_results_max_size)
 
             column_name = AREA_COL if self.output_type == "areas" else LINK_COL
             new_column_order = _columns_ordering(list_of_df_columns, column_name, is_details, self.mc_root)

--- a/antarest/study/business/aggregator_management.py
+++ b/antarest/study/business/aggregator_management.py
@@ -91,8 +91,10 @@ class MCAllLinksQueryFile(StrEnum):
     ID = "id"
 
 
-def _checks_estimated_size(nb_files: int, df_bytes_size: int, nb_files_checked: int) -> None:
-    maximum_size = 100  # size in Mo that corresponds to a 15 seconds task.
+def _checks_estimated_size(nb_files: int, df_bytes_size: int, nb_files_checked: int, maximum_size: int) -> None:
+    """
+    A `maximum_size` equivalent to 100 Mo corresponds to a 15 seconds task.
+    """
     estimated_df_size = nb_files * df_bytes_size // (nb_files_checked * 10**6)
     if estimated_df_size > maximum_size:
         raise FileTooLargeError(estimated_df_size, maximum_size)
@@ -149,6 +151,7 @@ class AggregatorManager:
         frequency: MatrixFrequency,
         ids_to_consider: Sequence[str],
         columns_names: Sequence[str],
+        aggregation_results_max_size: int,
         mc_years: Optional[Sequence[int]] = None,
     ):
         self.output_path = output_path
@@ -158,6 +161,7 @@ class AggregatorManager:
         self.mc_years = mc_years
         self.columns_names = columns_names
         self.ids_to_consider = ids_to_consider
+        self.aggregation_results_max_size = aggregation_results_max_size
         self.output_type = (
             "areas"
             if (isinstance(query_file, MCIndAreasQueryFile) or isinstance(query_file, MCAllAreasQueryFile))
@@ -380,7 +384,7 @@ class AggregatorManager:
             if k == 10:
                 # The following formula is the more accurate one compared to the final csv file.
                 estimated_binary_size = final_df.memory_usage().sum()
-                _checks_estimated_size(nb_files, estimated_binary_size, k)
+                _checks_estimated_size(nb_files, estimated_binary_size, k, self.aggregation_results_max_size)
 
             column_name = AREA_COL if self.output_type == "areas" else LINK_COL
             new_column_order = _columns_ordering(list_of_df_columns, column_name, is_details, self.mc_root)

--- a/antarest/study/storage/output_service.py
+++ b/antarest/study/storage/output_service.py
@@ -510,6 +510,7 @@ class OutputService:
         columns_names: Sequence[str],
         ids_to_consider: Sequence[str],
         params: RequestParameters,
+        aggregation_results_max_size: int,
         mc_years: Optional[Sequence[int]] = None,
     ) -> pd.DataFrame:
         """
@@ -523,6 +524,7 @@ class OutputService:
             columns_names: regexes (if details) or columns to be selected, if empty, all columns are selected
             ids_to_consider: list of areas or links ids to consider, if empty, all areas are selected
             params: request parameters
+            aggregation_results_max_size: maximum size of results that can be aggregated
             mc_years: list of monte-carlo years, if empty, all years are selected (only for mc-ind)
 
         Returns: the aggregated data as a DataFrame
@@ -532,6 +534,6 @@ class OutputService:
         assert_permission(params.user, study, StudyPermissionType.READ)
         output_path = self._storage.get_output_path(study, output_id)
         aggregator_manager = AggregatorManager(
-            output_path, query_file, frequency, ids_to_consider, columns_names, mc_years
+            output_path, query_file, frequency, ids_to_consider, columns_names, aggregation_results_max_size, mc_years
         )
         return aggregator_manager.aggregate_output_data()

--- a/antarest/study/web/output_blueprint.py
+++ b/antarest/study/web/output_blueprint.py
@@ -258,7 +258,7 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
         return content
 
     @bp.get(
-        "/studies/{uuid}/outputs/{output_id}/mc-ind/areas",
+        "/studies/{uuid}/outputs/{output_id}/aggregate/mc-ind/areas",
         tags=[APITag.study_outputs],
         summary="Retrieve Aggregated Areas Raw Data from Study Economy MCs individual Outputs",
     )

--- a/antarest/study/web/output_blueprint.py
+++ b/antarest/study/web/output_blueprint.py
@@ -309,6 +309,7 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
             columns_names=_split_comma_separated_values(columns_names),
             ids_to_consider=_split_comma_separated_values(areas_ids),
             params=parameters,
+            aggregation_results_max_size=config.storage.aggregation_results_max_size,
             mc_years=[int(mc_year) for mc_year in _split_comma_separated_values(mc_years)],
         )
 
@@ -398,6 +399,7 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
             columns_names=_split_comma_separated_values(columns_names),
             ids_to_consider=_split_comma_separated_values(links_ids),
             params=parameters,
+            aggregation_results_max_size=config.storage.aggregation_results_max_size,
             mc_years=[int(mc_year) for mc_year in _split_comma_separated_values(mc_years)],
         )
 
@@ -486,6 +488,7 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
             columns_names=_split_comma_separated_values(columns_names),
             ids_to_consider=_split_comma_separated_values(areas_ids),
             params=parameters,
+            aggregation_results_max_size=config.storage.aggregation_results_max_size,
         )
 
         download_name = f"aggregated_output_{uuid}_{output_id}{export_format.suffix}"
@@ -571,6 +574,7 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
             columns_names=_split_comma_separated_values(columns_names),
             ids_to_consider=_split_comma_separated_values(links_ids),
             params=parameters,
+            aggregation_results_max_size=config.storage.aggregation_results_max_size,
         )
 
         download_name = f"aggregated_output_{uuid}_{output_id}{export_format.suffix}"

--- a/docs/developer-guide/install/1-CONFIG.md
+++ b/docs/developer-guide/install/1-CONFIG.md
@@ -304,6 +304,12 @@ default:
 - **Default value:** 5
 - **Description:** Max auto archival tasks in parallel.
 
+## **aggregation_results_max_size**
+
+- **Type**: Integer
+- **Default value:** 200
+- **Description:** Size in Mo of maximum size of results of aggregation.
+
 ## **snapshot_retention_days**
 
 - **Type:** Integer

--- a/tests/storage/test_config.py
+++ b/tests/storage/test_config.py
@@ -112,3 +112,12 @@ def test_storage_config_from_dict_validiation_errors(storage_config_default):
 
     with pytest.raises(ValueError):
         StorageConfig.from_dict(data)
+
+
+@pytest.mark.unit_test
+def test_storage_default_aggregation_results_max_size_value(storage_config_default):
+    data = {
+        **storage_config_default,
+    }
+    config = StorageConfig.from_dict(data)
+    assert config.aggregation_results_max_size == 200

--- a/tests/storage/test_config.py
+++ b/tests/storage/test_config.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 from pathlib import Path
+from typing import Dict, Union
 
 import pytest
 
@@ -17,7 +18,7 @@ from antarest.core.config import InternalMatrixFormat, StorageConfig
 
 
 @pytest.fixture
-def storage_config_default():
+def storage_config_default() -> Dict[str, Union[str, int]]:
     return {
         "matrixstore": "./custom_matrixstore",
         "archive_dir": "./custom_archives",
@@ -37,7 +38,7 @@ def storage_config_default():
     }
 
 
-def test_storage_config_from_dict(storage_config_default):
+def test_storage_config_from_dict(storage_config_default: Dict[str, Union[str, int]]):
     data = {
         **storage_config_default,
         "workspaces": {
@@ -71,7 +72,7 @@ def test_storage_config_from_dict(storage_config_default):
     assert config.matrixstore_format == InternalMatrixFormat.TSV
 
 
-def test_storage_config_from_dict_validiation_errors(storage_config_default):
+def test_storage_config_from_dict_validiation_errors(storage_config_default: Dict[str, Union[str, int]]):
     data = {
         **storage_config_default,
         "workspaces": {
@@ -115,7 +116,7 @@ def test_storage_config_from_dict_validiation_errors(storage_config_default):
 
 
 @pytest.mark.unit_test
-def test_storage_default_aggregation_results_max_size_value(storage_config_default):
+def test_storage_default_aggregation_results_max_size_value(storage_config_default: Dict[str, Union[str, int]]):
     data = {
         **storage_config_default,
     }

--- a/tests/storage/test_config.py
+++ b/tests/storage/test_config.py
@@ -117,8 +117,14 @@ def test_storage_config_from_dict_validiation_errors(storage_config_default: Dic
 
 @pytest.mark.unit_test
 def test_storage_default_aggregation_results_max_size_value(storage_config_default: Dict[str, Union[str, int]]):
+    # test aggregation_results_max_size default value
     data = {
         **storage_config_default,
     }
     config = StorageConfig.from_dict(data)
     assert config.aggregation_results_max_size == 200
+
+    # test a custom aggregation_results_max_size
+    data = {**storage_config_default, "aggregation_results_max_size": 100}
+    config = StorageConfig.from_dict(data)
+    assert config.aggregation_results_max_size == 100

--- a/tests/study/business/test_aggregator_manager.py
+++ b/tests/study/business/test_aggregator_manager.py
@@ -20,20 +20,8 @@ from antarest.study.business.aggregator_management import AggregatorManager, MCI
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
 
 
-@pytest.fixture(name="get_output_path")
-def get_output_path_fixture(tmp_path: Path, project_path: Path) -> Path:
-    # Prepare the directories used by the repos
-    zipped_study_path = project_path.joinpath("examples/studies/STA-mini.zip")
-
-    # Extract the sample study
-    with zipfile.ZipFile(zipped_study_path) as zip_output:
-        zip_output.extractall(path=tmp_path)
-
-    return tmp_path.joinpath("STA-mini/output")
-
-
 @pytest.mark.integration
-def test_storage_different_max_size_value(get_output_path: Path):
+def test_storage_different_max_size_value(tmp_path: Path, project_path: Path):
     """
     SetUp: This test unzip the STA-mini study that contains outputs.
     Initialize an aggregator manager first with a high value and next change it for a low value.
@@ -44,7 +32,14 @@ def test_storage_different_max_size_value(get_output_path: Path):
     For this test we use the `20201014-1425eco-goodbye` outputs because it has enough data
     to check the estimated size of df.
     """
-    output_path = get_output_path.joinpath("20201014-1425eco-goodbye")
+    # Prepare the directories used by the repos
+    zipped_study_path = project_path.joinpath("examples/studies/STA-mini.zip")
+
+    # Extract the sample study
+    with zipfile.ZipFile(zipped_study_path) as zip_output:
+        zip_output.extractall(path=tmp_path)
+
+    output_path = tmp_path.joinpath("STA-mini/output/20201014-1425eco-goodbye")
 
     # aggregation_results_max_size equals to 200Mo
     aggregator_manager = AggregatorManager(
@@ -60,7 +55,7 @@ def test_storage_different_max_size_value(get_output_path: Path):
     res = aggregator_manager.aggregate_output_data()
     assert res.empty is False
 
-    aggregator_manager.aggregation_results_max_size = 0
+    aggregator_manager.aggregation_results_max_size = 1
 
     # must fail
     with pytest.raises(FileTooLargeError):

--- a/tests/study/business/test_aggregator_manager.py
+++ b/tests/study/business/test_aggregator_manager.py
@@ -8,8 +8,8 @@ from antarest.study.business.aggregator_management import AggregatorManager, MCA
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
 
 
-@pytest.fixture(name="set_up_studies")
-def studies_to_import_fixture(tmp_path: Path) -> Path:
+@pytest.fixture(name="get_output_path")
+def get_output_path_fixture(tmp_path: Path) -> Path:
     # Prepare the directories used by the repos
     assets_dir = Path(__file__).parent.joinpath("areas/assets/aggregator_manager")
 
@@ -18,11 +18,11 @@ def studies_to_import_fixture(tmp_path: Path) -> Path:
     with zipfile.ZipFile(study_path) as zip_output:
         zip_output.extractall(path=tmp_path)
 
-    return tmp_path.joinpath("viz_2")
+    return tmp_path.joinpath("viz_2/output")
 
 
 @pytest.mark.unit_test
-def test_storage_different_max_size_value(tmp_path: Path, set_up_studies: Path):
+def test_storage_different_max_size_value(tmp_path: Path, get_output_path: Path):
     """
     SetUp: This test unzip the viz_2 study that contains a great number of mc values located
     in the example directory.
@@ -32,12 +32,11 @@ def test_storage_different_max_size_value(tmp_path: Path, set_up_studies: Path):
     Test: The call on aggregate_output_data of the first aggregator management should pass
     and the second should fail.
     """
-    output_id = set_up_studies.joinpath("20230912-1354eco").name
+    output_path = get_output_path.joinpath("20230912-1354eco")
 
     # aggregation_results_max_size equals to 400Mo
     aggregator_manager_high_bound = AggregatorManager(
-        study_path=set_up_studies,
-        output_id=output_id,
+        output_path=output_path,
         query_file=MCAllAreasQueryFile.VALUES,
         frequency=MatrixFrequency.HOURLY,
         ids_to_consider=[],
@@ -47,8 +46,7 @@ def test_storage_different_max_size_value(tmp_path: Path, set_up_studies: Path):
 
     # aggregation_results_max_size equals to 200Mo
     aggregator_manager_low_bound = AggregatorManager(
-        study_path=set_up_studies,
-        output_id=output_id,
+        output_path=output_path,
         query_file=MCAllAreasQueryFile.VALUES,
         frequency=MatrixFrequency.HOURLY,
         ids_to_consider=[],

--- a/tests/study/business/test_aggregator_manager.py
+++ b/tests/study/business/test_aggregator_manager.py
@@ -1,3 +1,15 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
 import zipfile
 from pathlib import Path
 

--- a/tests/study/business/test_aggregator_manager.py
+++ b/tests/study/business/test_aggregator_manager.py
@@ -21,9 +21,9 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import Matri
 
 
 @pytest.fixture(name="get_output_path")
-def get_output_path_fixture(tmp_path: Path) -> Path:
+def get_output_path_fixture(tmp_path: Path, project_path: Path) -> Path:
     # Prepare the directories used by the repos
-    zipped_study_path = tmp_path.parent.parent.joinpath("examples/studies/STA-mini.zip")
+    zipped_study_path = project_path.joinpath("examples/studies/STA-mini.zip")
 
     # Extract the sample study
     with zipfile.ZipFile(zipped_study_path) as zip_output:
@@ -32,7 +32,8 @@ def get_output_path_fixture(tmp_path: Path) -> Path:
     return tmp_path.joinpath("STA-mini/output")
 
 
-def test_storage_different_max_size_value(tmp_path: Path, get_output_path: Path):
+@pytest.mark.integration
+def test_storage_different_max_size_value(get_output_path: Path):
     """
     SetUp: This test unzip the STA-mini study that contains outputs.
     Initialize an aggregator manager first with a high value and next change it for a low value.

--- a/tests/study/business/test_aggregator_manager.py
+++ b/tests/study/business/test_aggregator_manager.py
@@ -1,0 +1,65 @@
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from antarest.core.exceptions import FileTooLargeError
+from antarest.study.business.aggregator_management import AggregatorManager, MCAllAreasQueryFile
+from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
+
+
+@pytest.fixture(name="set_up_studies")
+def studies_to_import_fixture(tmp_path: Path) -> Path:
+    # Prepare the directories used by the repos
+    assets_dir = Path(__file__).parent.joinpath("areas/assets/aggregator_manager")
+
+    # Extract the sample study
+    study_path = assets_dir.joinpath("viz_2.zip")
+    with zipfile.ZipFile(study_path) as zip_output:
+        zip_output.extractall(path=tmp_path)
+
+    return tmp_path.joinpath("viz_2")
+
+
+@pytest.mark.unit_test
+def test_storage_different_max_size_value(tmp_path: Path, set_up_studies: Path):
+    """
+    SetUp: This test unzip the viz_2 study that contains a great number of mc values located
+    in the example directory.
+    Initialize one aggregator manager with a high number of output data tolerance
+    and one with a low number of output data tolerance.
+
+    Test: The call on aggregate_output_data of the first aggregator management should pass
+    and the second should fail.
+    """
+    output_id = set_up_studies.joinpath("20230912-1354eco").name
+
+    # aggregation_results_max_size equals to 400Mo
+    aggregator_manager_high_bound = AggregatorManager(
+        study_path=set_up_studies,
+        output_id=output_id,
+        query_file=MCAllAreasQueryFile.VALUES,
+        frequency=MatrixFrequency.HOURLY,
+        ids_to_consider=[],
+        columns_names=[],
+        aggregation_results_max_size=400,
+    )
+
+    # aggregation_results_max_size equals to 200Mo
+    aggregator_manager_low_bound = AggregatorManager(
+        study_path=set_up_studies,
+        output_id=output_id,
+        query_file=MCAllAreasQueryFile.VALUES,
+        frequency=MatrixFrequency.HOURLY,
+        ids_to_consider=[],
+        columns_names=[],
+        aggregation_results_max_size=200,
+    )
+
+    # must pass
+    res = aggregator_manager_high_bound.aggregate_output_data()
+    assert res.empty is False
+
+    # must fail
+    with pytest.raises(FileTooLargeError):
+        aggregator_manager_low_bound.aggregate_output_data()


### PR DESCRIPTION
Resolve [ANT-2718](https://gopro-tickets.rte-france.com/browse/ANT-2718)

The purpose of this PR is to use a variable to manage the maximum size of the results of aggregation operations instead of a static value. The default value of this variable should be equal to 200 and can be modified with the `application.yaml` file config.

The PR is also linked to [this MR](https://devin-source.rte-france.com/antares/antares-cd/-/merge_requests/80) in order to set the default values of each environment.