### PR TITLE
fix(ui-adq-patch): fix display of `includeHurdleCostCsr` switch

### DIFF
--- a/webapp/src/components/App/Singlestudy/explore/Configuration/AdequacyPatch/Fields.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Configuration/AdequacyPatch/Fields.tsx
@@ -86,6 +86,7 @@ function Fields() {
               <span>
                 <SwitchFE
                   label={t("study.configuration.adequacyPatch.includeHurdleCostCsr")}
+                  sx={{ textWrap: "nowrap" }}
                   name="includeHurdleCostCsr"
                   control={control}
                 />


### PR DESCRIPTION
The purpose of this PR is to fix the unwanted display of the `includeHurdleCostCsr` switch that seemed to take 2 or 3 lines depending on the choosen language.