### PR TITLE
fix(ui-digest): make first column fixed

### DIFF
--- a/webapp/src/components/common/DataGridViewer.tsx
+++ b/webapp/src/components/common/DataGridViewer.tsx
@@ -21,25 +21,29 @@ import {
 } from "@glideapps/glide-data-grid";
 import { useMemo } from "react";
 import { formatGridNumber } from "./Matrix/shared/utils";
-import DataGrid from "@/components/common/DataGrid";
+import DataGrid, { type RowMarkers } from "@/components/common/DataGrid";
+import { isNumericValue } from "@/utils/numberUtils";
 
 type CellValue = number | string;
 
 interface DataGridViewerProps {
   data: CellValue[][];
   columns: GridColumn[];
+  freezeColumns?: number;
+  rowMarkers?: RowMarkers;
 }
 
-function DataGridViewer({ data, columns }: DataGridViewerProps) {
+function DataGridViewer({ data, columns, freezeColumns, rowMarkers }: DataGridViewerProps) {
   const getCellContent = useMemo(
     () => (cell: Item) => {
       const [col, row] = cell;
       const value = data[row]?.[col];
 
-      if (typeof value === "number") {
+      // Handle numeric values (both as numbers and as strings)
+      if (isNumericValue(value)) {
         return {
           kind: GridCellKind.Number,
-          data: value,
+          data: Number(value),
           displayData: formatGridNumber({ value, maxDecimals: 3 }),
           decimalSeparator: ".",
           thousandSeparator: " ",
@@ -55,6 +59,7 @@ function DataGridViewer({ data, columns }: DataGridViewerProps) {
         displayData: String(value ?? ""),
         readonly: true,
         allowOverlay: false,
+        contentAlign: "right",
       } satisfies TextCell;
     },
     [data],
@@ -72,8 +77,10 @@ function DataGridViewer({ data, columns }: DataGridViewerProps) {
       rows={data.length}
       columns={columns}
       getCellContent={getCellContent}
-      rowMarkers="none"
+      rowMarkers={rowMarkers}
       getCellsForSelection
+      freezeColumns={freezeColumns}
+      keybindings={{ copy: true, paste: false }}
     />
   );
 }

--- a/webapp/src/components/common/Matrix/shared/types.ts
+++ b/webapp/src/components/common/Matrix/shared/types.ts
@@ -60,7 +60,7 @@ export interface DataColumnsConfig {
 }
 
 export interface FormatGridNumberOptions {
-  value?: number;
+  value?: number | string;
   maxDecimals?: number;
 }
 

--- a/webapp/src/components/common/Matrix/shared/utils.ts
+++ b/webapp/src/components/common/Matrix/shared/utils.ts
@@ -47,9 +47,10 @@ import { groupHeaderTheme } from "../styles";
  * formatGridNumber({ value: 0, maxDecimals: 6 }) // "0"
  * formatGridNumber({ value: undefined }) // ""
  * formatGridNumber({ value: NaN }) // ""
+ * formatGridNumber({ value: "1234.56", maxDecimals: 1 }) // "1 234.5"
  * ```
  * @param options - The formatting options
- * @param options.value - The number to format.
+ * @param options.value - The number or numeric string to format.
  * @param options.maxDecimals - Maximum number of decimal places to show.
  * @returns A formatted string representation of the number with proper separators.
  */
@@ -355,7 +356,6 @@ export function groupResultColumns(
 /**
  * Generates an array of ResultColumn objects from a 2D array of column titles.
  * Each title array should follow the format [variable, unit, stat] as used in result matrices.
- 
  * This function is designed to work in conjunction with groupResultColumns()
  * to create properly formatted and grouped result matrix columns.
  *

--- a/webapp/src/components/common/dialogs/DigestDialog/DigestMatrix.tsx
+++ b/webapp/src/components/common/dialogs/DigestDialog/DigestMatrix.tsx
@@ -59,7 +59,12 @@ function DigestMatrix({ matrix }: DigestMatrixProps) {
       {!matrix.data[0]?.length ? (
         <EmptyView title={t("matrix.message.matrixEmpty")} icon={GridOff} />
       ) : (
-        <DataGridViewer data={matrix.data} columns={columns} />
+        <DataGridViewer
+          data={matrix.data}
+          columns={columns}
+          freezeColumns={1} // First column (areas) should be always visible
+          rowMarkers="checkbox"
+        />
       )}
     </>
   );

--- a/webapp/src/utils/numberUtils.ts
+++ b/webapp/src/utils/numberUtils.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2025, RTE (https://www.rte-france.com)
+ *
+ * See AUTHORS.txt
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This file is part of the Antares project.
+ */
+
+/**
+ * Checks if a string value is a valid numeric representation that can be parsed.
+ *
+ * @param value - The value to check
+ * @returns true if the value can be converted to a valid number, false otherwise
+ */
+export function isNumericValue(value: unknown) {
+  if (typeof value === "number") {
+    return !Number.isNaN(value);
+  }
+
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  if (value.trim() === "") {
+    return false;
+  }
+
+  const num = Number(value);
+  return !Number.isNaN(num);
+}

--- a/webapp/src/utils/validation/number.ts
+++ b/webapp/src/utils/validation/number.ts
@@ -55,7 +55,7 @@ export function validateNumber(
 
   const value = valueOrOpts;
 
-  if (!isFinite(value)) {
+  if (!Number.isFinite(value)) {
     return t("form.field.invalidNumber", { value });
   }
 


### PR DESCRIPTION
ANT-2996

Enhanced DataGridViewer component with several usability improvements:
- Fixed first column to ensure users can always see area names when scrolling horizontally
- Added row selection capability with checkbox markers and "select all" functionality in top-left corner
- Allow copy of the grid content
- Maintained existing column selection (click group header to select all sub-variables or Shift+click for multiple sub-headers)
- Implemented number formatting for string-type numeric values to ensure consistent display regardless of data format received from API

