### PR TITLE
feat(ui-desktop): show recursive scan checkbox only on desktop

### DIFF
--- a/webapp/src/components/App/Studies/StudiesList/Header.tsx
+++ b/webapp/src/components/App/Studies/StudiesList/Header.tsx
@@ -98,7 +98,7 @@ function Header({ studyIds, selectedStudyIds, setSelectedStudyIds, setStudiesToL
   const isInDefaultWorkspace = folderList.length > 1 && folderList[1] === DEFAULT_WORKSPACE_NAME;
   const isRootFolder = folderList.length === 1;
   const canScan = !isRootFolder && !isInDefaultWorkspace;
-  const desktopMode = import.meta.env.MODE !== "desktop";
+  const desktopMode = import.meta.env.MODE === "desktop";
 
   ////////////////////////////////////////////////////////////////
   // Utils
@@ -246,7 +246,7 @@ function Header({ studyIds, selectedStudyIds, setSelectedStudyIds, setStudiesToL
           open
         >
           {`${t("studies.scanFolder")} ${folder}?`}
-          {desktopMode && (
+          {!desktopMode && (
             <CheckBoxFE
               label={t("studies.recursiveScan")}
               value={isRecursiveScan}

--- a/webapp/src/components/App/Studies/StudiesList/Header.tsx
+++ b/webapp/src/components/App/Studies/StudiesList/Header.tsx
@@ -98,6 +98,7 @@ function Header({ studyIds, selectedStudyIds, setSelectedStudyIds, setStudiesToL
   const isInDefaultWorkspace = folderList.length > 1 && folderList[1] === DEFAULT_WORKSPACE_NAME;
   const isRootFolder = folderList.length === 1;
   const canScan = !isRootFolder && !isInDefaultWorkspace;
+  const desktopMode = import.meta.env.MODE !== "desktop";
 
   ////////////////////////////////////////////////////////////////
   // Utils
@@ -216,25 +217,6 @@ function Header({ studyIds, selectedStudyIds, setSelectedStudyIds, setStudiesToL
               </IconButton>
             </Tooltip>
           )}
-          {confirmFolderScan && (
-            <ConfirmationDialog
-              titleIcon={RadarIcon}
-              onCancel={() => {
-                setConfirmFolderScan(false);
-                setIsRecursiveScan(false);
-              }}
-              onConfirm={handleFolderScan}
-              alert="warning"
-              open
-            >
-              {`${t("studies.scanFolder")} ${folder}?`}
-              <CheckBoxFE
-                label={t("studies.recursiveScan")}
-                value={isRecursiveScan}
-                onChange={handleRecursiveScan}
-              />
-            </ConfirmationDialog>
-          )}
           <RefreshButton mini />
           <SelectFE
             size="extra-small"
@@ -264,11 +246,13 @@ function Header({ studyIds, selectedStudyIds, setSelectedStudyIds, setStudiesToL
           open
         >
           {`${t("studies.scanFolder")} ${folder}?`}
-          <CheckBoxFE
-            label={t("studies.recursiveScan")}
-            value={isRecursiveScan}
-            onChange={handleRecursiveScan}
-          />
+          {desktopMode && (
+            <CheckBoxFE
+              label={t("studies.recursiveScan")}
+              value={isRecursiveScan}
+              onChange={handleRecursiveScan}
+            />
+          )}
         </ConfirmationDialog>
       )}
     </>

--- a/webapp/src/components/App/Studies/StudiesList/Header.tsx
+++ b/webapp/src/components/App/Studies/StudiesList/Header.tsx
@@ -98,7 +98,7 @@ function Header({ studyIds, selectedStudyIds, setSelectedStudyIds, setStudiesToL
   const isInDefaultWorkspace = folderList.length > 1 && folderList[1] === DEFAULT_WORKSPACE_NAME;
   const isRootFolder = folderList.length === 1;
   const canScan = !isRootFolder && !isInDefaultWorkspace;
-  const desktopMode = import.meta.env.MODE === "desktop";
+  const isDesktopMode = import.meta.env.MODE === "desktop";
 
   ////////////////////////////////////////////////////////////////
   // Utils
@@ -246,7 +246,7 @@ function Header({ studyIds, selectedStudyIds, setSelectedStudyIds, setStudiesToL
           open
         >
           {`${t("studies.scanFolder")} ${folder}?`}
-          {!desktopMode && (
+          {!isDesktopMode && (
             <CheckBoxFE
               label={t("studies.recursiveScan")}
               value={isRecursiveScan}


### PR DESCRIPTION
Use the flag set during build to check wether we're on desktop mode, disable the recursive scan checkbox when user is on desktop. 

Also, the code to open the scan dialog was duplicated. 