### PR TITLE
refactor(thermal)!: introduce the DAO layer for thermal clusters

### DIFF
--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -269,7 +269,7 @@ class ThermalManager:
         study_dao = study.get_study_dao()
 
         prepro_matrix = study_dao.get_thermal_prepro(area_id, lower_source_id).to_numpy().tolist()
-        matrices.append(("input/thermal/prepro/{area_id}/{lower_new_id}/data", prepro_matrix))
+        matrices.append((f"input/thermal/prepro/{area_id}/{lower_new_id}/data", prepro_matrix))
 
         modulation_matrix = study_dao.get_thermal_modulation(area_id, lower_source_id).to_numpy().tolist()
         matrices.append((f"input/thermal/prepro/{area_id}/{lower_new_id}/modulation", modulation_matrix))

--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -128,7 +128,7 @@ class ThermalManager:
             for thermal_id, update_cluster in update_thermals_by_ids.items():
                 # Update the thermal cluster properties.
                 old_cluster = old_thermals_by_ids[thermal_id]
-                new_cluster = old_cluster.model_copy(update=update_cluster.model_dump(mode="json", exclude_none=True))
+                new_cluster = update_thermal_cluster(old_cluster, update_cluster)
                 new_thermals_by_areas[area_id][thermal_id] = new_cluster
 
         study.add_commands([command])

--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -33,10 +33,6 @@ from antarest.study.storage.variantstudy.model.command.replace_matrix import Rep
 from antarest.study.storage.variantstudy.model.command.update_thermal_clusters import UpdateThermalClusters
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 
-_CLUSTER_PATH = "input/thermal/clusters/{area_id}/list/{cluster_id}"
-_CLUSTERS_PATH = "input/thermal/clusters/{area_id}/list"
-_ALL_CLUSTERS_PATH = "input/thermal/clusters"
-
 
 class ThermalManager:
     """

--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -10,18 +10,12 @@
 #
 # This file is part of the Antares project.
 
-import collections
 from pathlib import Path
 from typing import List, Mapping, MutableMapping, MutableSequence, Sequence
 
-from antares.study.version import StudyVersion
-
 from antarest.core.exceptions import (
-    AreaNotFound,
     DuplicateThermalCluster,
     MatrixWidthMismatchError,
-    ThermalClusterConfigNotFound,
-    ThermalClusterNotFound,
     WrongMatrixHeightError,
 )
 from antarest.core.model import JSON
@@ -36,7 +30,6 @@ from antarest.study.business.model.thermal_cluster_model import (
 from antarest.study.business.study_interface import StudyInterface
 from antarest.study.model import STUDY_VERSION_8_7
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
-from antarest.study.storage.rawstudy.model.filesystem.config.thermal import parse_thermal_cluster
 from antarest.study.storage.variantstudy.model.command.create_cluster import CreateCluster
 from antarest.study.storage.variantstudy.model.command.remove_cluster import RemoveCluster
 from antarest.study.storage.variantstudy.model.command.replace_matrix import ReplaceMatrix
@@ -115,23 +108,7 @@ class ThermalManager:
         Raises:
             ThermalClusterConfigNotFound: If no clusters are found in the specified area.
         """
-
-        file_study = study.get_files()
-        path = _ALL_CLUSTERS_PATH
-        try:
-            # may raise KeyError if the path is missing
-            clusters = file_study.tree.get(path.split("/"), depth=5)
-            # may raise KeyError if "list" is missing
-            clusters = {area_id: cluster_list["list"] for area_id, cluster_list in clusters.items()}
-        except KeyError:
-            raise ThermalClusterConfigNotFound(path) from None
-
-        thermals_by_areas: MutableMapping[str, MutableMapping[str, ThermalCluster]]
-        thermals_by_areas = collections.defaultdict(dict)
-        for area_id, cluster_obj in clusters.items():
-            for cluster_id, cluster in cluster_obj.items():
-                thermals_by_areas[area_id][cluster_id] = parse_thermal_cluster(study.version, cluster)
-        return thermals_by_areas
+        return study.get_study_dao().get_all_thermals()
 
     def update_thermals_props(
         self,
@@ -179,21 +156,16 @@ class ThermalManager:
             The created cluster.
         """
 
-        command = self._make_create_cluster_cmd(area_id, cluster_data, study.version)
-        study.add_commands([command])
-        return create_thermal_cluster(cluster_data, study.version)
-
-    def _make_create_cluster_cmd(
-        self, area_id: str, cluster: ThermalClusterCreation, study_version: StudyVersion
-    ) -> CreateCluster:
-        # NOTE: currently, in the `CreateCluster` class, there is a confusion
-        # between the cluster name and the cluster ID (which is a section name).
-        return CreateCluster(
+        command = CreateCluster(
             area_id=area_id,
-            parameters=cluster,
-            study_version=study_version,
+            parameters=cluster_data,
+            study_version=study.version,
             command_context=self._command_context,
         )
+        # NOTE: currently, in the `CreateCluster` class, there is a confusion
+        # between the cluster name and the cluster ID (which is a section name).
+        study.add_commands([command])
+        return create_thermal_cluster(cluster_data, study.version)
 
     def update_cluster(
         self,
@@ -219,18 +191,7 @@ class ThermalManager:
             ThermalClusterNotFound: If the provided `cluster_id` does not match the ID of the cluster
             in the provided cluster_data.
         """
-        file_study = study.get_files()
-        path = _CLUSTER_PATH.format(area_id=area_id, cluster_id=cluster_id)
-
-        try:
-            area = file_study.config.areas[area_id]
-        except KeyError:
-            raise AreaNotFound(area_id)
-
-        thermal_cluster = next((thermal for thermal in area.thermals if thermal.id == cluster_id), None)
-        if thermal_cluster is None:
-            raise ThermalClusterNotFound(path, cluster_id)
-
+        thermal_cluster = self.get_cluster(study, area_id, cluster_id)
         updated_thermal_cluster = update_thermal_cluster(thermal_cluster, cluster_data)
 
         command = UpdateThermalClusters(

--- a/antarest/study/business/areas/thermal_management.py
+++ b/antarest/study/business/areas/thermal_management.py
@@ -77,14 +77,7 @@ class ThermalManager:
         Raises:
             ThermalClusterNotFound: If the specified cluster does not exist.
         """
-
-        file_study = study.get_files()
-        path = _CLUSTER_PATH.format(area_id=area_id, cluster_id=cluster_id)
-        try:
-            cluster_data = file_study.tree.get(path.split("/"), depth=1)
-        except KeyError:
-            raise ThermalClusterNotFound(path, cluster_id) from None
-        return parse_thermal_cluster(study.version, cluster_data)
+        return study.get_study_dao().get_thermal(area_id, cluster_id)
 
     def get_clusters(
         self,
@@ -104,14 +97,7 @@ class ThermalManager:
         Raises:
             ThermalClusterConfigNotFound: If no clusters are found in the specified area.
         """
-
-        file_study = study.get_files()
-        path = _CLUSTERS_PATH.format(area_id=area_id)
-        try:
-            clusters_data = file_study.tree.get(path.split("/"), depth=3)
-        except KeyError:
-            raise ThermalClusterConfigNotFound(path, area_id) from None
-        return [parse_thermal_cluster(study.version, c) for c in clusters_data.values()]
+        return study.get_study_dao().get_all_thermals_for_area(area_id)
 
     def get_all_thermals_props(
         self,

--- a/antarest/study/business/study_interface.py
+++ b/antarest/study/business/study_interface.py
@@ -16,6 +16,7 @@ from antares.study.version import StudyVersion
 from typing_extensions import override
 
 from antarest.core.exceptions import CommandApplicationError
+from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.dao.api.study_dao import ReadOnlyStudyDao
 from antarest.study.dao.file.file_study_dao import FileStudyTreeDao
 from antarest.study.dao.memory.in_memory_study_dao import InMemoryStudyDao
@@ -71,9 +72,9 @@ class InMemoryStudyInterface(StudyInterface):
     Only used for test purposes, currently.
     """
 
-    def __init__(self, id: str, version: StudyVersion):
+    def __init__(self, id: str, version: StudyVersion, matrix_service: ISimpleMatrixService):
         self._id = id
-        self._study_dao = InMemoryStudyDao(version)
+        self._study_dao = InMemoryStudyDao(version, matrix_service)
 
     @override
     @property

--- a/antarest/study/dao/api/study_dao.py
+++ b/antarest/study/dao/api/study_dao.py
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+from abc import abstractmethod
 from typing import Sequence
 
 from antares.study.version import StudyVersion
@@ -22,7 +23,7 @@ from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
 
 class ReadOnlyStudyDao(ReadOnlyLinkDao, ReadOnlyThermalDao):
-    @override
+    @abstractmethod
     def get_version(self) -> StudyVersion:
         raise NotImplementedError()
 
@@ -40,7 +41,7 @@ class StudyDao(ReadOnlyStudyDao, LinkDao, ThermalDao):
         """
         return ReadOnlyAdapter(self)
 
-    @override
+    @abstractmethod
     def get_file_study(self) -> FileStudy:
         """
         To ease transition, to be removed when all goes through other methods

--- a/antarest/study/dao/api/study_dao.py
+++ b/antarest/study/dao/api/study_dao.py
@@ -74,8 +74,8 @@ class ReadOnlyAdapter(ReadOnlyStudyDao):
         return self._adaptee.link_exists(area1_id, area2_id)
 
     @override
-    def get_thermals(self) -> Sequence[ThermalCluster]:
-        return self._adaptee.get_thermals()
+    def get_thermals(self, area_id: str) -> Sequence[ThermalCluster]:
+        return self._adaptee.get_thermals(area_id)
 
     @override
     def get_thermal(self, area_id: str, thermal_id: str) -> ThermalCluster:

--- a/antarest/study/dao/api/study_dao.py
+++ b/antarest/study/dao/api/study_dao.py
@@ -92,20 +92,20 @@ class ReadOnlyAdapter(ReadOnlyStudyDao):
 
     @override
     def get_thermal_prepro(self, area_id: str, thermal_id: str) -> pd.DataFrame:
-        raise NotImplementedError()
+        return self._adaptee.get_thermal_prepro(area_id, thermal_id)
 
     @override
     def get_thermal_modulation(self, area_id: str, thermal_id: str) -> pd.DataFrame:
-        raise NotImplementedError()
+        return self._adaptee.get_thermal_modulation(area_id, thermal_id)
 
     @override
     def get_thermal_series(self, area_id: str, thermal_id: str) -> pd.DataFrame:
-        raise NotImplementedError()
+        return self._adaptee.get_thermal_series(area_id, thermal_id)
 
     @override
     def get_thermal_fuel_cost(self, area_id: str, thermal_id: str) -> pd.DataFrame:
-        raise NotImplementedError()
+        return self._adaptee.get_thermal_fuel_cost(area_id, thermal_id)
 
     @override
     def get_thermal_co2_cost(self, area_id: str, thermal_id: str) -> pd.DataFrame:
-        raise NotImplementedError()
+        return self._adaptee.get_thermal_co2_cost(area_id, thermal_id)

--- a/antarest/study/dao/api/study_dao.py
+++ b/antarest/study/dao/api/study_dao.py
@@ -9,24 +9,25 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from abc import abstractmethod
 from typing import Sequence
 
 from antares.study.version import StudyVersion
 from typing_extensions import override
 
 from antarest.study.business.model.link_model import Link
+from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.link_dao import LinkDao, ReadOnlyLinkDao
+from antarest.study.dao.api.thermal_dao import ReadOnlyThermalDao, ThermalDao
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
 
-class ReadOnlyStudyDao(ReadOnlyLinkDao):
-    @abstractmethod
+class ReadOnlyStudyDao(ReadOnlyLinkDao, ReadOnlyThermalDao):
+    @override
     def get_version(self) -> StudyVersion:
         raise NotImplementedError()
 
 
-class StudyDao(ReadOnlyStudyDao, LinkDao):
+class StudyDao(ReadOnlyStudyDao, LinkDao, ThermalDao):
     """
     Abstraction for access to study data. Handles all reading
     and writing from underlying storage format.
@@ -39,7 +40,7 @@ class StudyDao(ReadOnlyStudyDao, LinkDao):
         """
         return ReadOnlyAdapter(self)
 
-    @abstractmethod
+    @override
     def get_file_study(self) -> FileStudy:
         """
         To ease transition, to be removed when all goes through other methods
@@ -70,3 +71,15 @@ class ReadOnlyAdapter(ReadOnlyStudyDao):
     @override
     def link_exists(self, area1_id: str, area2_id: str) -> bool:
         return self._adaptee.link_exists(area1_id, area2_id)
+
+    @override
+    def get_thermals(self) -> Sequence[ThermalCluster]:
+        return self._adaptee.get_thermals()
+
+    @override
+    def get_thermal(self, area_id: str, thermal_id: str) -> ThermalCluster:
+        return self._adaptee.get_thermal(area_id, thermal_id)
+
+    @override
+    def thermal_exists(self, area_id: str, thermal_id: str) -> bool:
+        return self._adaptee.thermal_exists(area_id, thermal_id)

--- a/antarest/study/dao/api/study_dao.py
+++ b/antarest/study/dao/api/study_dao.py
@@ -12,6 +12,7 @@
 from abc import abstractmethod
 from typing import Sequence
 
+import pandas as pd
 from antares.study.version import StudyVersion
 from typing_extensions import override
 
@@ -88,3 +89,23 @@ class ReadOnlyAdapter(ReadOnlyStudyDao):
     @override
     def thermal_exists(self, area_id: str, thermal_id: str) -> bool:
         return self._adaptee.thermal_exists(area_id, thermal_id)
+
+    @override
+    def get_thermal_prepro(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        raise NotImplementedError()
+
+    @override
+    def get_thermal_modulation(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        raise NotImplementedError()
+
+    @override
+    def get_thermal_series(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        raise NotImplementedError()
+
+    @override
+    def get_thermal_fuel_cost(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        raise NotImplementedError()
+
+    @override
+    def get_thermal_co2_cost(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        raise NotImplementedError()

--- a/antarest/study/dao/api/study_dao.py
+++ b/antarest/study/dao/api/study_dao.py
@@ -74,8 +74,12 @@ class ReadOnlyAdapter(ReadOnlyStudyDao):
         return self._adaptee.link_exists(area1_id, area2_id)
 
     @override
-    def get_thermals(self, area_id: str) -> Sequence[ThermalCluster]:
-        return self._adaptee.get_thermals(area_id)
+    def get_all_thermals(self) -> dict[str, dict[str, ThermalCluster]]:
+        return self._adaptee.get_all_thermals()
+
+    @override
+    def get_all_thermals_for_area(self, area_id: str) -> Sequence[ThermalCluster]:
+        return self._adaptee.get_all_thermals_for_area(area_id)
 
     @override
     def get_thermal(self, area_id: str, thermal_id: str) -> ThermalCluster:

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -88,3 +88,7 @@ class ThermalDao(ReadOnlyThermalDao):
     @abstractmethod
     def delete_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
         raise NotImplementedError()
+
+    @abstractmethod
+    def duplicate_thermal(self, area_id: str, source_id: str, new_cluster_name: str) -> ThermalCluster:
+        raise NotImplementedError()

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+from antarest.study.business.model.link_model import Link
+from antarest.study.business.model.thermal_cluster_model import ThermalCluster
+
+
+class ReadOnlyThermalDao(ABC):
+    @abstractmethod
+    def get_thermals(self) -> Sequence[ThermalCluster]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_thermal(self, area_id: str, cluster_id: str) -> ThermalCluster:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def thermal_exists(self, area_id: str, thermal_id: str) -> bool:
+        raise NotImplementedError()
+
+
+class ThermalDao(ReadOnlyThermalDao):
+    @abstractmethod
+    def save_thermal(self, thermal: ThermalCluster) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def save_link_indirect_capacities(self, area_from: str, area_to: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def save_link_direct_capacities(self, area_from: str, area_to: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def save_thermal_series(self, area_from: str, area_to: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def delete_thermal(self, thermal: ThermalCluster) -> None:
+        raise NotImplementedError()

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -32,7 +32,7 @@ class ReadOnlyThermalDao(ABC):
 
 class ThermalDao(ReadOnlyThermalDao):
     @abstractmethod
-    def save_thermal(self, thermal: ThermalCluster) -> None:
+    def save_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
         raise NotImplementedError()
 
     @abstractmethod

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -56,5 +56,5 @@ class ThermalDao(ReadOnlyThermalDao):
         raise NotImplementedError()
 
     @abstractmethod
-    def delete_thermal(self, thermal: ThermalCluster) -> None:
+    def delete_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
         raise NotImplementedError()

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -18,7 +18,11 @@ from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 
 class ReadOnlyThermalDao(ABC):
     @abstractmethod
-    def get_thermals(self, area_id: str) -> Sequence[ThermalCluster]:
+    def get_all_thermals(self) -> dict[str, dict[str, ThermalCluster]]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_all_thermals_for_area(self, area_id: str) -> Sequence[ThermalCluster]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -40,6 +40,10 @@ class ThermalDao(ReadOnlyThermalDao):
         raise NotImplementedError()
 
     @abstractmethod
+    def save_thermals(self, area_id: str, thermals: Sequence[ThermalCluster]) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
     def save_thermal_prepro(self, area_id: str, thermal_id: str, series_id: str) -> None:
         raise NotImplementedError()
 

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -88,7 +88,3 @@ class ThermalDao(ReadOnlyThermalDao):
     @abstractmethod
     def delete_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
         raise NotImplementedError()
-
-    @abstractmethod
-    def duplicate_thermal(self, area_id: str, source_id: str, new_cluster_name: str) -> ThermalCluster:
-        raise NotImplementedError()

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -48,5 +48,13 @@ class ThermalDao(ReadOnlyThermalDao):
         raise NotImplementedError()
 
     @abstractmethod
+    def save_thermal_fuel_cost(self, area_id: str, thermal_id: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def save_thermal_co2_cost(self, area_id: str, thermal_id: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
     def delete_thermal(self, thermal: ThermalCluster) -> None:
         raise NotImplementedError()

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -13,6 +13,8 @@
 from abc import ABC, abstractmethod
 from typing import Sequence
 
+import pandas as pd
+
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 
 
@@ -31,6 +33,26 @@ class ReadOnlyThermalDao(ABC):
 
     @abstractmethod
     def thermal_exists(self, area_id: str, thermal_id: str) -> bool:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_thermal_prepro(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_thermal_modulation(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_thermal_series(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_thermal_fuel_cost(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_thermal_co2_cost(self, area_id: str, thermal_id: str) -> pd.DataFrame:
         raise NotImplementedError()
 
 

--- a/antarest/study/dao/api/thermal_dao.py
+++ b/antarest/study/dao/api/thermal_dao.py
@@ -18,7 +18,7 @@ from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 
 class ReadOnlyThermalDao(ABC):
     @abstractmethod
-    def get_thermals(self) -> Sequence[ThermalCluster]:
+    def get_thermals(self, area_id: str) -> Sequence[ThermalCluster]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/antarest/study/dao/file/file_study_dao.py
+++ b/antarest/study/dao/file/file_study_dao.py
@@ -15,10 +15,11 @@ from typing_extensions import override
 
 from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.dao.file.file_study_link_dao import FileStudyLinkDao
+from antarest.study.dao.file.file_study_thermal_dao import FileStudyThermalDao
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
 
-class FileStudyTreeDao(StudyDao, FileStudyLinkDao):
+class FileStudyTreeDao(StudyDao, FileStudyLinkDao, FileStudyThermalDao):
     """
     Implementation of study DAO over the simulator input format.
     """

--- a/antarest/study/dao/file/file_study_link_dao.py
+++ b/antarest/study/dao/file/file_study_link_dao.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Sequence
+from typing import List, Sequence
 
 from typing_extensions import override
 
@@ -18,13 +18,10 @@ from antarest.core.exceptions import LinkNotFound
 from antarest.study.business.model.link_model import (
     Link,
 )
-from antarest.study.storage.rawstudy.model.filesystem.config.link import parse_link, serialize_link
-from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-
-if TYPE_CHECKING:
-    pass
 from antarest.study.dao.api.link_dao import LinkDao
 from antarest.study.model import STUDY_VERSION_8_2
+from antarest.study.storage.rawstudy.model.filesystem.config.link import parse_link, serialize_link
+from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
 
 class FileStudyLinkDao(LinkDao, ABC):

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -17,6 +17,7 @@ from typing_extensions import override
 from antarest.core.exceptions import ThermalClusterConfigNotFound, ThermalClusterNotFound
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.thermal_dao import ThermalDao
+from antarest.study.model import STUDY_VERSION_8_7
 from antarest.study.storage.rawstudy.model.filesystem.config.thermal import (
     parse_thermal_cluster,
     serialize_thermal_cluster,
@@ -86,15 +87,34 @@ class FileStudyThermalDao(ThermalDao, ABC):
 
     @override
     def save_thermal_prepro(self, area_id: str, thermal_id: str, series_id: str) -> None:
-        raise NotImplementedError()
+        study_data = self.get_file_study()
+        study_data.tree.save(series_id, ["input", "thermal", "prepro", area_id, thermal_id, "data"])
 
     @override
     def save_thermal_modulation(self, area_id: str, thermal_id: str, series_id: str) -> None:
-        raise NotImplementedError()
+        study_data = self.get_file_study()
+        study_data.tree.save(series_id, ["input", "thermal", "prepro", area_id, thermal_id, "modulation"])
 
     @override
     def save_thermal_series(self, area_id: str, thermal_id: str, series_id: str) -> None:
-        raise NotImplementedError()
+        study_data = self.get_file_study()
+        study_data.tree.save(series_id, ["input", "thermal", "series", area_id, thermal_id, "series"])
+
+    @override
+    def save_thermal_fuel_cost(self, area_id: str, thermal_id: str, series_id: str) -> None:
+        study_data = self.get_file_study()
+        study_version = study_data.config.version
+        if study_version < STUDY_VERSION_8_7:
+            raise ValueError(f"fuelCost matrix is supported since version 8.7 and your study is in {study_version}")
+        study_data.tree.save(series_id, ["input", "thermal", "series", area_id, thermal_id, "fuelCost"])
+
+    @override
+    def save_thermal_co2_cost(self, area_id: str, thermal_id: str, series_id: str) -> None:
+        study_data = self.get_file_study()
+        study_version = study_data.config.version
+        if study_version < STUDY_VERSION_8_7:
+            raise ValueError(f"C02Cost matrix is supported since version 8.7 and your study is in {study_version}")
+        study_data.tree.save(series_id, ["input", "thermal", "series", area_id, thermal_id, "fuelCost"])
 
     @override
     def delete_thermal(self, thermal: ThermalCluster) -> None:

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -19,7 +19,6 @@ from antarest.core.exceptions import ThermalClusterConfigNotFound, ThermalCluste
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.thermal_dao import ThermalDao
 from antarest.study.model import STUDY_VERSION_8_7
-from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.config.thermal import (
     parse_thermal_cluster,
@@ -209,18 +208,6 @@ class FileStudyThermalDao(ThermalDao, ABC):
         self._remove_cluster_from_scenario_builder(study_data, area_id, thermal.id)
         # Deleting the thermal cluster in the configuration must be done AFTER deleting the files and folders.
         return self._remove_from_config(study_data.config, area_id, thermal)
-
-    @override
-    def duplicate_thermal(self, area_id: str, source_id: str, new_cluster_name: str) -> ThermalCluster:
-        source_thermal = self.get_thermal(area_id, source_id)
-        new_id = transform_name_to_id(new_cluster_name, lower=False)
-        source_thermal.name = new_cluster_name
-        source_thermal.id = new_id
-        self.save_thermal(area_id, source_thermal)
-
-        # Matrices
-
-        return source_thermal
 
     @staticmethod
     def _remove_cluster_from_scenario_builder(study_data: FileStudy, area_id: str, thermal_id: str) -> None:

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -9,44 +9,49 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-
 from abc import ABC, abstractmethod
 from typing import Sequence
 
+from typing_extensions import override
+
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
+from antarest.study.dao.api.thermal_dao import ThermalDao
+from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
 
-class ReadOnlyThermalDao(ABC):
+class FileStudyThermalDao(ThermalDao, ABC):
     @abstractmethod
+    def get_file_study(self) -> FileStudy:
+        pass
+
+    @override
     def get_thermals(self) -> Sequence[ThermalCluster]:
         raise NotImplementedError()
 
-    @abstractmethod
+    @override
     def get_thermal(self, area_id: str, thermal_id: str) -> ThermalCluster:
         raise NotImplementedError()
 
-    @abstractmethod
+    @override
     def thermal_exists(self, area_id: str, thermal_id: str) -> bool:
         raise NotImplementedError()
 
-
-class ThermalDao(ReadOnlyThermalDao):
-    @abstractmethod
+    @override
     def save_thermal(self, thermal: ThermalCluster) -> None:
         raise NotImplementedError()
 
-    @abstractmethod
+    @override
     def save_thermal_prepro(self, area_id: str, thermal_id: str, series_id: str) -> None:
         raise NotImplementedError()
 
-    @abstractmethod
+    @override
     def save_thermal_modulation(self, area_id: str, thermal_id: str, series_id: str) -> None:
         raise NotImplementedError()
 
-    @abstractmethod
+    @override
     def save_thermal_series(self, area_id: str, thermal_id: str, series_id: str) -> None:
         raise NotImplementedError()
 
-    @abstractmethod
+    @override
     def delete_thermal(self, thermal: ThermalCluster) -> None:
         raise NotImplementedError()

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -94,6 +94,15 @@ class FileStudyThermalDao(ThermalDao, ABC):
             ["input", "thermal", "clusters", "properties", area_id, "list", thermal.id],
         )
 
+    @override
+    def save_thermals(self, area_id: str, thermals: Sequence[ThermalCluster]) -> None:
+        study_data = self.get_file_study()
+        ini_content = {}
+        for thermal in thermals:
+            self._update_thermal_config(area_id, thermal)
+            ini_content.update(serialize_thermal_cluster(study_data.config.version, thermal))
+        study_data.tree.save(ini_content, ["input", "thermal", "clusters", "properties", area_id, "list"])
+
     def _update_thermal_config(self, area_id: str, thermal: ThermalCluster) -> None:
         study_data = self.get_file_study().config
         if area_id not in study_data.areas:

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -19,6 +19,7 @@ from antarest.core.exceptions import ThermalClusterConfigNotFound, ThermalCluste
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.thermal_dao import ThermalDao
 from antarest.study.model import STUDY_VERSION_8_7
+from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.config.thermal import (
     parse_thermal_cluster,
@@ -208,6 +209,18 @@ class FileStudyThermalDao(ThermalDao, ABC):
         self._remove_cluster_from_scenario_builder(study_data, area_id, thermal.id)
         # Deleting the thermal cluster in the configuration must be done AFTER deleting the files and folders.
         return self._remove_from_config(study_data.config, area_id, thermal)
+
+    @override
+    def duplicate_thermal(self, area_id: str, source_id: str, new_cluster_name: str) -> ThermalCluster:
+        source_thermal = self.get_thermal(area_id, source_id)
+        new_id = transform_name_to_id(new_cluster_name, lower=False)
+        source_thermal.name = new_cluster_name
+        source_thermal.id = new_id
+        self.save_thermal(area_id, source_thermal)
+
+        # Matrices
+
+        return source_thermal
 
     @staticmethod
     def _remove_cluster_from_scenario_builder(study_data: FileStudy, area_id: str, thermal_id: str) -> None:

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -14,9 +14,15 @@ from typing import Sequence
 
 from typing_extensions import override
 
+from antarest.core.exceptions import ThermalClusterConfigNotFound, ThermalClusterNotFound
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.thermal_dao import ThermalDao
+from antarest.study.storage.rawstudy.model.filesystem.config.thermal import parse_thermal_cluster
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
+
+_CLUSTER_PATH = "input/thermal/clusters/{area_id}/list/{cluster_id}"
+_CLUSTERS_PATH = "input/thermal/clusters/{area_id}/list"
+_ALL_CLUSTERS_PATH = "input/thermal/clusters"
 
 
 class FileStudyThermalDao(ThermalDao, ABC):
@@ -25,12 +31,24 @@ class FileStudyThermalDao(ThermalDao, ABC):
         pass
 
     @override
-    def get_thermals(self) -> Sequence[ThermalCluster]:
-        raise NotImplementedError()
+    def get_thermals(self, area_id: str) -> Sequence[ThermalCluster]:
+        file_study = self.get_file_study()
+        path = _CLUSTERS_PATH.format(area_id=area_id)
+        try:
+            clusters_data = file_study.tree.get(path.split("/"), depth=3)
+        except KeyError:
+            raise ThermalClusterConfigNotFound(path, area_id) from None
+        return [parse_thermal_cluster(file_study.config.version, c) for c in clusters_data.values()]
 
     @override
     def get_thermal(self, area_id: str, thermal_id: str) -> ThermalCluster:
-        raise NotImplementedError()
+        file_study = self.get_file_study()
+        path = _CLUSTER_PATH.format(area_id=area_id, cluster_id=thermal_id)
+        try:
+            cluster_data = file_study.tree.get(path.split("/"), depth=1)
+        except KeyError:
+            raise ThermalClusterNotFound(path, thermal_id) from None
+        return parse_thermal_cluster(file_study.config.version, cluster_data)
 
     @override
     def thermal_exists(self, area_id: str, thermal_id: str) -> bool:

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -19,6 +19,7 @@ from antarest.core.exceptions import ThermalClusterConfigNotFound, ThermalCluste
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.thermal_dao import ThermalDao
 from antarest.study.model import STUDY_VERSION_8_7
+from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.config.thermal import (
     parse_thermal_cluster,
@@ -53,7 +54,8 @@ class FileStudyThermalDao(ThermalDao, ABC):
         thermals_by_areas: dict[str, dict[str, ThermalCluster]] = {}
         for area_id, cluster_obj in clusters.items():
             for cluster_id, cluster in cluster_obj.items():
-                thermals_by_areas.setdefault(area_id, {})[cluster_id] = parse_thermal_cluster(version, cluster)
+                lowered_id = transform_name_to_id(cluster_id)
+                thermals_by_areas.setdefault(area_id, {})[lowered_id] = parse_thermal_cluster(version, cluster)
         return thermals_by_areas
 
     @override

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -18,6 +18,7 @@ from antarest.core.exceptions import ThermalClusterConfigNotFound, ThermalCluste
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.thermal_dao import ThermalDao
 from antarest.study.model import STUDY_VERSION_8_7
+from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.config.thermal import (
     parse_thermal_cluster,
     serialize_thermal_cluster,
@@ -117,5 +118,95 @@ class FileStudyThermalDao(ThermalDao, ABC):
         study_data.tree.save(series_id, ["input", "thermal", "series", area_id, thermal_id, "fuelCost"])
 
     @override
-    def delete_thermal(self, thermal: ThermalCluster) -> None:
-        raise NotImplementedError()
+    def delete_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
+        study_data = self.get_file_study()
+
+        paths = [
+            ["input", "thermal", "clusters", area_id, "list", thermal.id],
+            ["input", "thermal", "prepro", area_id, thermal.id],
+            ["input", "thermal", "series", area_id, thermal.id],
+        ]
+        if len(study_data.config.areas[area_id].thermals) == 1:
+            paths.append(["input", "thermal", "prepro", area_id])
+            paths.append(["input", "thermal", "series", area_id])
+
+        for path in paths:
+            study_data.tree.delete(path)
+
+        self._remove_cluster_from_binding_constraints(study_data, area_id, thermal.id)
+        self._remove_cluster_from_scenario_builder(study_data, area_id, thermal.id)
+        # Deleting the thermal cluster in the configuration must be done AFTER deleting the files and folders.
+        return self._remove_from_config(study_data.config, area_id, thermal)
+
+    def _remove_cluster_from_scenario_builder(self, study_data: FileStudy, area_id: str, thermal_id: str) -> None:
+        """
+        Update the scenario builder by removing the rows that correspond to the thermal cluster to remove.
+
+        NOTE: this update can be very long if the scenario builder configuration is large.
+        """
+        rulesets = study_data.tree.get(["settings", "scenariobuilder"])
+
+        for ruleset in rulesets.values():
+            for key in list(ruleset):
+                # The key is in the form "symbol,area,year,cluster"
+                symbol, *parts = key.split(",")
+                if symbol == "t" and parts[0] == area_id and parts[2] == thermal_id:
+                    del ruleset[key]
+
+        study_data.tree.save(rulesets, ["settings", "scenariobuilder"])
+
+    def _remove_cluster_from_binding_constraints(self, study_data: FileStudy, area_id: str, thermal_id: str) -> None:
+        """
+        Remove the binding constraints that are related to the thermal cluster.
+
+        Notes:
+            A binding constraint has properties, a list of terms (which form a linear equation) and
+            a right-hand side (which is the matrix of the binding constraint).
+            The terms are of the form `area1%area2` or `area.cluster` where `area` is the ID of the area
+            and `cluster` is the ID of the cluster.
+
+            When a thermal cluster is removed, it has an impact on the terms of the binding constraints.
+            At first, we could decide to remove the terms that are related to the area.
+            However, this would lead to a linear equation that is not valid anymore.
+
+            Instead, we decide to remove the binding constraints that are related to the cluster.
+        """
+        # See also `RemoveCluster`
+        # noinspection SpellCheckingInspection
+        url = ["input", "bindingconstraints", "bindingconstraints"]
+        binding_constraints = study_data.tree.get(url)
+
+        # Collect the binding constraints that are related to the area to remove
+        # by searching the terms that contain the ID of the area.
+        bc_to_remove = []
+        for bc_index, bc in list(binding_constraints.items()):
+            for key in bc:
+                if "." not in key:
+                    # This key identifies a link or belongs to the set of properties.
+                    # It isn't a cluster ID, so we skip it.
+                    continue
+                # Term IDs are in the form `area1%area2` or `area.cluster`
+                # noinspection PyTypeChecker
+                related_area_id, related_cluster_id = map(str.lower, key.split("."))
+                if (area_id, thermal_id) == (related_area_id, related_cluster_id):
+                    bc_to_remove.append(binding_constraints.pop(bc_index)["id"])
+                    break
+
+        matrix_suffixes = ["_lt", "_gt", "_eq"] if study_data.config.version >= 870 else [""]
+
+        existing_files = study_data.tree.get(["input", "bindingconstraints"], depth=1)
+        for bc_id, suffix in zip(bc_to_remove, matrix_suffixes):
+            matrix_id = f"{bc_id}{suffix}"
+            if matrix_id in existing_files:
+                study_data.tree.delete(["input", "bindingconstraints", matrix_id])
+
+        study_data.tree.save(binding_constraints, url)
+
+    def _remove_from_config(self, study_data: FileStudyTreeConfig, area_id: str, thermal: ThermalCluster) -> None:
+        study_data.areas[area_id].thermals.remove(thermal)
+
+        # Also removes thermal cluster from constraint terms
+        # Cluster IDs are stored in lower case in the binding constraints file.
+        selection = [b for b in study_data.bindings if f"{area_id}.{thermal.id}" in b.clusters]
+        for binding in selection:
+            study_data.bindings.remove(binding)

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -138,7 +138,8 @@ class FileStudyThermalDao(ThermalDao, ABC):
         # Deleting the thermal cluster in the configuration must be done AFTER deleting the files and folders.
         return self._remove_from_config(study_data.config, area_id, thermal)
 
-    def _remove_cluster_from_scenario_builder(self, study_data: FileStudy, area_id: str, thermal_id: str) -> None:
+    @staticmethod
+    def _remove_cluster_from_scenario_builder(study_data: FileStudy, area_id: str, thermal_id: str) -> None:
         """
         Update the scenario builder by removing the rows that correspond to the thermal cluster to remove.
 
@@ -155,7 +156,8 @@ class FileStudyThermalDao(ThermalDao, ABC):
 
         study_data.tree.save(rulesets, ["settings", "scenariobuilder"])
 
-    def _remove_cluster_from_binding_constraints(self, study_data: FileStudy, area_id: str, thermal_id: str) -> None:
+    @staticmethod
+    def _remove_cluster_from_binding_constraints(study_data: FileStudy, area_id: str, thermal_id: str) -> None:
         """
         Remove the binding constraints that are related to the thermal cluster.
 
@@ -202,7 +204,8 @@ class FileStudyThermalDao(ThermalDao, ABC):
 
         study_data.tree.save(binding_constraints, url)
 
-    def _remove_from_config(self, study_data: FileStudyTreeConfig, area_id: str, thermal: ThermalCluster) -> None:
+    @staticmethod
+    def _remove_from_config(study_data: FileStudyTreeConfig, area_id: str, thermal: ThermalCluster) -> None:
         study_data.areas[area_id].thermals.remove(thermal)
 
         # Also removes thermal cluster from constraint terms

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -134,7 +134,7 @@ class FileStudyThermalDao(ThermalDao, ABC):
 
         study_data.tree.save(
             serialize_thermal_cluster(study_data.config.version, thermal),
-            ["input", "thermal", "clusters", "properties", area_id, "list", thermal.id],
+            ["input", "thermal", "clusters", area_id, "list", thermal.id],
         )
 
     @override
@@ -143,8 +143,8 @@ class FileStudyThermalDao(ThermalDao, ABC):
         ini_content = {}
         for thermal in thermals:
             self._update_thermal_config(area_id, thermal)
-            ini_content.update(serialize_thermal_cluster(study_data.config.version, thermal))
-        study_data.tree.save(ini_content, ["input", "thermal", "clusters", "properties", area_id, "list"])
+            ini_content[thermal.id] = serialize_thermal_cluster(study_data.config.version, thermal)
+        study_data.tree.save(ini_content, ["input", "thermal", "clusters", area_id, "list"])
 
     def _update_thermal_config(self, area_id: str, thermal: ThermalCluster) -> None:
         study_data = self.get_file_study().config

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -52,7 +52,13 @@ class FileStudyThermalDao(ThermalDao, ABC):
 
     @override
     def thermal_exists(self, area_id: str, thermal_id: str) -> bool:
-        raise NotImplementedError()
+        file_study = self.get_file_study()
+        path = _CLUSTER_PATH.format(area_id=area_id, cluster_id=thermal_id)
+        try:
+            file_study.tree.get(path.split("/"), depth=1)
+            return True
+        except KeyError:
+            return False
 
     @override
     def save_thermal(self, thermal: ThermalCluster) -> None:

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -94,7 +94,7 @@ class InMemoryStudyDao(StudyDao):
         del self._links[link_key(link.area1, link.area2)]
 
     @override
-    def get_thermals(self) -> Sequence[ThermalCluster]:
+    def get_thermals(self, area_id: str) -> Sequence[ThermalCluster]:
         raise NotImplementedError()
 
     @override

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -13,10 +13,12 @@
 from dataclasses import dataclass
 from typing import Dict, Sequence
 
+import pandas as pd
 from antares.study.version import StudyVersion
 from typing_extensions import override
 
 from antarest.core.exceptions import LinkNotFound
+from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.link_model import Link
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.study_dao import StudyDao
@@ -50,8 +52,9 @@ class InMemoryStudyDao(StudyDao):
     TODO, warning: no version handling, no check on areas, no checks on matrices ...
     """
 
-    def __init__(self, version: StudyVersion) -> None:
+    def __init__(self, version: StudyVersion, matrix_service: ISimpleMatrixService) -> None:
         self._version = version
+        self._matrix_service = matrix_service
         # Links
         self._links: Dict[LinkKey, Link] = {}
         self._link_capacities: Dict[LinkKey, str] = {}
@@ -129,6 +132,31 @@ class InMemoryStudyDao(StudyDao):
     @override
     def thermal_exists(self, area_id: str, thermal_id: str) -> bool:
         return cluster_key(area_id, thermal_id) in self._thermals
+
+    @override
+    def get_thermal_prepro(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        matrix_id = self._thermal_prepro[cluster_key(area_id, thermal_id)]
+        return self._matrix_service.get(matrix_id)
+
+    @override
+    def get_thermal_modulation(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        matrix_id = self._thermal_modulation[cluster_key(area_id, thermal_id)]
+        return self._matrix_service.get(matrix_id)
+
+    @override
+    def get_thermal_series(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        matrix_id = self._thermal_series[cluster_key(area_id, thermal_id)]
+        return self._matrix_service.get(matrix_id)
+
+    @override
+    def get_thermal_fuel_cost(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        matrix_id = self._thermal_fuel_cost[cluster_key(area_id, thermal_id)]
+        return self._matrix_service.get(matrix_id)
+
+    @override
+    def get_thermal_co2_cost(self, area_id: str, thermal_id: str) -> pd.DataFrame:
+        matrix_id = self._thermal_co2_cost[cluster_key(area_id, thermal_id)]
+        return self._matrix_service.get(matrix_id)
 
     @override
     def save_thermal(self, area_id: str, thermal: ThermalCluster) -> None:

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -130,5 +130,5 @@ class InMemoryStudyDao(StudyDao):
         raise NotImplementedError()
 
     @override
-    def delete_thermal(self, thermal: ThermalCluster) -> None:
+    def delete_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
         raise NotImplementedError()

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -18,6 +18,7 @@ from typing_extensions import override
 
 from antarest.core.exceptions import LinkNotFound
 from antarest.study.business.model.link_model import Link
+from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
@@ -91,3 +92,35 @@ class InMemoryStudyDao(StudyDao):
     @override
     def delete_link(self, link: Link) -> None:
         del self._links[link_key(link.area1, link.area2)]
+
+    @override
+    def get_thermals(self) -> Sequence[ThermalCluster]:
+        raise NotImplementedError()
+
+    @override
+    def get_thermal(self, area_id: str, thermal_id: str) -> ThermalCluster:
+        raise NotImplementedError()
+
+    @override
+    def thermal_exists(self, area_id: str, thermal_id: str) -> bool:
+        raise NotImplementedError()
+
+    @override
+    def save_thermal(self, thermal: ThermalCluster) -> None:
+        raise NotImplementedError()
+
+    @override
+    def save_thermal_prepro(self, area_id: str, thermal_id: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @override
+    def save_thermal_modulation(self, area_id: str, thermal_id: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @override
+    def save_thermal_series(self, area_id: str, thermal_id: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @override
+    def delete_thermal(self, thermal: ThermalCluster) -> None:
+        raise NotImplementedError()

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -22,7 +22,6 @@ from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.link_model import Link
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.study_dao import StudyDao
-from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
 
@@ -191,12 +190,3 @@ class InMemoryStudyDao(StudyDao):
     @override
     def delete_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
         del self._thermals[cluster_key(area_id, thermal.id)]
-
-    @override
-    def duplicate_thermal(self, area_id: str, source_id: str, new_cluster_name: str) -> ThermalCluster:
-        source_thermal = self.get_thermal(area_id, source_id)
-        new_id = transform_name_to_id(new_cluster_name, lower=False)
-        source_thermal.name = new_cluster_name
-        source_thermal.id = new_id
-        self.save_thermal(area_id, source_thermal)
-        return source_thermal

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -123,7 +123,7 @@ class InMemoryStudyDao(StudyDao):
 
     @override
     def get_all_thermals_for_area(self, area_id: str) -> Sequence[ThermalCluster]:
-        return list(self._thermals.values())
+        return [thermal for key, thermal in self._thermals.items() if key.area_id == area_id]
 
     @override
     def get_thermal(self, area_id: str, thermal_id: str) -> ThermalCluster:

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -112,7 +112,14 @@ class InMemoryStudyDao(StudyDao):
         del self._links[link_key(link.area1, link.area2)]
 
     @override
-    def get_thermals(self, area_id: str) -> Sequence[ThermalCluster]:
+    def get_all_thermals(self) -> dict[str, dict[str, ThermalCluster]]:
+        all_thermals: dict[str, dict[str, ThermalCluster]] = {}
+        for key, thermal_cluster in self._thermals.items():
+            all_thermals.setdefault(key.area_id, {})[key.cluster_id] = thermal_cluster
+        return all_thermals
+
+    @override
+    def get_all_thermals_for_area(self, area_id: str) -> Sequence[ThermalCluster]:
         return list(self._thermals.values())
 
     @override

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -29,9 +29,19 @@ class LinkKey:
     area2_id: str
 
 
+@dataclass(frozen=True)
+class ClusterKey:
+    area_id: str
+    cluster_id: str
+
+
 def link_key(area1_id: str, area2_id: str) -> LinkKey:
     area1_id, area2_id = sorted((area1_id, area2_id))
     return LinkKey(area1_id, area2_id)
+
+
+def cluster_key(area_id: str, cluster_id: str) -> ClusterKey:
+    return ClusterKey(area_id, cluster_id)
 
 
 class InMemoryStudyDao(StudyDao):
@@ -42,10 +52,18 @@ class InMemoryStudyDao(StudyDao):
 
     def __init__(self, version: StudyVersion) -> None:
         self._version = version
+        # Links
         self._links: Dict[LinkKey, Link] = {}
         self._link_capacities: Dict[LinkKey, str] = {}
         self._link_direct_capacities: Dict[LinkKey, str] = {}
         self._link_indirect_capacities: Dict[LinkKey, str] = {}
+        # Thermals
+        self._thermals: Dict[ClusterKey, ThermalCluster] = {}
+        self._thermal_prepro: Dict[ClusterKey, str] = {}
+        self._thermal_modulation: Dict[ClusterKey, str] = {}
+        self._thermal_series: Dict[ClusterKey, str] = {}
+        self._thermal_fuel_cost: Dict[ClusterKey, str] = {}
+        self._thermal_co2_cost: Dict[ClusterKey, str] = {}
 
     @override
     def get_file_study(self) -> FileStudy:
@@ -95,40 +113,40 @@ class InMemoryStudyDao(StudyDao):
 
     @override
     def get_thermals(self, area_id: str) -> Sequence[ThermalCluster]:
-        raise NotImplementedError()
+        return list(self._thermals.values())
 
     @override
     def get_thermal(self, area_id: str, thermal_id: str) -> ThermalCluster:
-        raise NotImplementedError()
+        return self._thermals[cluster_key(area_id, thermal_id)]
 
     @override
     def thermal_exists(self, area_id: str, thermal_id: str) -> bool:
-        raise NotImplementedError()
+        return cluster_key(area_id, thermal_id) in self._thermals
 
     @override
     def save_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
-        raise NotImplementedError()
+        self._thermals[cluster_key(area_id, thermal.id)] = thermal
 
     @override
     def save_thermal_prepro(self, area_id: str, thermal_id: str, series_id: str) -> None:
-        raise NotImplementedError()
+        self._thermal_prepro[cluster_key(area_id, thermal_id)] = series_id
 
     @override
     def save_thermal_modulation(self, area_id: str, thermal_id: str, series_id: str) -> None:
-        raise NotImplementedError()
+        self._thermal_modulation[cluster_key(area_id, thermal_id)] = series_id
 
     @override
     def save_thermal_series(self, area_id: str, thermal_id: str, series_id: str) -> None:
-        raise NotImplementedError()
+        self._thermal_series[cluster_key(area_id, thermal_id)] = series_id
 
     @override
     def save_thermal_fuel_cost(self, area_id: str, thermal_id: str, series_id: str) -> None:
-        raise NotImplementedError()
+        self._thermal_fuel_cost[cluster_key(area_id, thermal_id)] = series_id
 
     @override
     def save_thermal_co2_cost(self, area_id: str, thermal_id: str, series_id: str) -> None:
-        raise NotImplementedError()
+        self._thermal_co2_cost[cluster_key(area_id, thermal_id)] = series_id
 
     @override
     def delete_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
-        raise NotImplementedError()
+        del self._thermals[cluster_key(area_id, thermal.id)]

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -106,7 +106,7 @@ class InMemoryStudyDao(StudyDao):
         raise NotImplementedError()
 
     @override
-    def save_thermal(self, thermal: ThermalCluster) -> None:
+    def save_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
         raise NotImplementedError()
 
     @override

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -22,6 +22,7 @@ from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.link_model import Link
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.study_dao import StudyDao
+from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
 
@@ -190,3 +191,12 @@ class InMemoryStudyDao(StudyDao):
     @override
     def delete_thermal(self, area_id: str, thermal: ThermalCluster) -> None:
         del self._thermals[cluster_key(area_id, thermal.id)]
+
+    @override
+    def duplicate_thermal(self, area_id: str, source_id: str, new_cluster_name: str) -> ThermalCluster:
+        source_thermal = self.get_thermal(area_id, source_id)
+        new_id = transform_name_to_id(new_cluster_name, lower=False)
+        source_thermal.name = new_cluster_name
+        source_thermal.id = new_id
+        self.save_thermal(area_id, source_thermal)
+        return source_thermal

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -135,6 +135,11 @@ class InMemoryStudyDao(StudyDao):
         self._thermals[cluster_key(area_id, thermal.id)] = thermal
 
     @override
+    def save_thermals(self, area_id: str, thermals: Sequence[ThermalCluster]) -> None:
+        for thermal in thermals:
+            self.save_thermal(area_id, thermal)
+
+    @override
     def save_thermal_prepro(self, area_id: str, thermal_id: str, series_id: str) -> None:
         self._thermal_prepro[cluster_key(area_id, thermal_id)] = series_id
 

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -122,5 +122,13 @@ class InMemoryStudyDao(StudyDao):
         raise NotImplementedError()
 
     @override
+    def save_thermal_fuel_cost(self, area_id: str, thermal_id: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @override
+    def save_thermal_co2_cost(self, area_id: str, thermal_id: str, series_id: str) -> None:
+        raise NotImplementedError()
+
+    @override
     def delete_thermal(self, thermal: ThermalCluster) -> None:
         raise NotImplementedError()

--- a/antarest/study/storage/rawstudy/model/filesystem/config/thermal.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/thermal.py
@@ -92,4 +92,4 @@ def parse_thermal_cluster(study_version: StudyVersion, data: Any) -> ThermalClus
 
 def serialize_thermal_cluster(study_version: StudyVersion, cluster: ThermalCluster) -> dict[str, Any]:
     validate_thermal_cluster_against_version(study_version, cluster)
-    return ThermalClusterFileData.from_model(cluster).model_dump(by_alias=True, exclude_none=True)
+    return ThermalClusterFileData.from_model(cluster).model_dump(mode="json", by_alias=True, exclude_none=True)

--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -102,13 +102,13 @@ class CreateCluster(ICommand):
     @override
     def _apply_dao(self, study_data: StudyDao, listener: Optional[ICommandListener] = None) -> CommandOutput:
         thermal = parse_thermal_cluster(self.study_version, self.parameters.model_dump(mode="json"))
-        if study_data.thermal_exists(self.area_id, thermal.id):
+        lower_thermal_id = thermal.id.lower()
+        if study_data.thermal_exists(self.area_id, lower_thermal_id):
             return command_failed(f"Thermal cluster '{thermal.id}' in area '{self.area_id}' already exists")
 
         study_data.save_thermal(self.area_id, thermal)
 
         # Matrices
-        lower_thermal_id = thermal.id.lower()
         null_matrix = self.command_context.generator_matrix_constants.get_null_matrix()
         study_data.save_thermal_series(self.area_id, lower_thermal_id, null_matrix)
         assert isinstance(self.prepro, str)

--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -119,7 +119,7 @@ class CreateCluster(ICommand):
             study_data.save_thermal_fuel_cost(self.area_id, lower_thermal_id, null_matrix)
             study_data.save_thermal_co2_cost(self.area_id, lower_thermal_id, null_matrix)
 
-        return command_succeeded(f"Thermal cluster '{thermal.id}' added to area '{self.area_id}'")
+        return command_succeeded(f"Thermal cluster '{thermal.id}' added to area '{self.area_id}'.")
 
     @override
     def to_dto(self) -> CommandDTO:

--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -101,22 +101,23 @@ class CreateCluster(ICommand):
 
     @override
     def _apply_dao(self, study_data: StudyDao, listener: Optional[ICommandListener] = None) -> CommandOutput:
-        thermal = parse_thermal_cluster(self.study_version, self.parameters.model_dump(mode="json", by_alias=True))
+        thermal = parse_thermal_cluster(self.study_version, self.parameters.model_dump(mode="json"))
         if study_data.thermal_exists(self.area_id, thermal.id):
             return command_failed(f"Thermal cluster '{thermal.id}' in area '{self.area_id}' already exists")
 
         study_data.save_thermal(self.area_id, thermal)
 
         # Matrices
+        lower_thermal_id = thermal.id.lower()
         null_matrix = self.command_context.generator_matrix_constants.get_null_matrix()
-        study_data.save_thermal_series(self.area_id, thermal.id, null_matrix)
+        study_data.save_thermal_series(self.area_id, lower_thermal_id, null_matrix)
         assert isinstance(self.prepro, str)
         assert isinstance(self.modulation, str)
-        study_data.save_thermal_prepro(self.area_id, thermal.id, self.prepro)
-        study_data.save_thermal_modulation(self.area_id, thermal.id, self.modulation)
+        study_data.save_thermal_prepro(self.area_id, lower_thermal_id, self.prepro)
+        study_data.save_thermal_modulation(self.area_id, lower_thermal_id, self.modulation)
         if self.study_version >= STUDY_VERSION_8_7:
-            study_data.save_thermal_fuel_cost(self.area_id, thermal.id, null_matrix)
-            study_data.save_thermal_co2_cost(self.area_id, thermal.id, null_matrix)
+            study_data.save_thermal_fuel_cost(self.area_id, lower_thermal_id, null_matrix)
+            study_data.save_thermal_co2_cost(self.area_id, lower_thermal_id, null_matrix)
 
         return command_succeeded(f"Thermal cluster '{thermal.id}' inside area '{self.area_id}' created")
 

--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -104,7 +104,7 @@ class CreateCluster(ICommand):
         thermal = parse_thermal_cluster(self.study_version, self.parameters.model_dump(mode="json"))
         lower_thermal_id = thermal.id.lower()
         if study_data.thermal_exists(self.area_id, lower_thermal_id):
-            return command_failed(f"Thermal cluster '{thermal.id}' in area '{self.area_id}' already exists")
+            return command_failed(f"Thermal cluster '{thermal.id}' already exists in the area '{self.area_id}'")
 
         study_data.save_thermal(self.area_id, thermal)
 
@@ -119,7 +119,7 @@ class CreateCluster(ICommand):
             study_data.save_thermal_fuel_cost(self.area_id, lower_thermal_id, null_matrix)
             study_data.save_thermal_co2_cost(self.area_id, lower_thermal_id, null_matrix)
 
-        return command_succeeded(f"Thermal cluster '{thermal.id}' inside area '{self.area_id}' created")
+        return command_succeeded(f"Thermal cluster '{thermal.id}' added to area '{self.area_id}'")
 
     @override
     def to_dto(self) -> CommandDTO:

--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -10,32 +10,32 @@
 #
 # This file is part of the Antares project.
 import typing as t
-from typing import Any, Dict, Final, List, Optional, Self, Tuple
+from typing import Any, Dict, Final, List, Optional, Self
 
 from antares.study.version import StudyVersion
 from pydantic import Field, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import override
 
-from antarest.core.model import JSON
 from antarest.core.utils.utils import assert_this
 from antarest.matrixstore.model import MatrixData
 from antarest.study.business.model.thermal_cluster_model import (
-    ThermalCluster,
     ThermalClusterCreation,
-    create_thermal_cluster,
     validate_thermal_cluster_against_version,
 )
+from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.model import STUDY_VERSION_8_7
-from antarest.study.storage.rawstudy.model.filesystem.config.model import Area, FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.config.thermal import (
     parse_thermal_cluster,
-    serialize_thermal_cluster,
 )
 from antarest.study.storage.rawstudy.model.filesystem.config.validation import AreaId
-from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.business.utils import strip_matrix_protocol, validate_matrix
-from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput
+from antarest.study.storage.variantstudy.model.command.common import (
+    CommandName,
+    CommandOutput,
+    command_failed,
+    command_succeeded,
+)
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.command_listener.command_listener import ICommandListener
 from antarest.study.storage.variantstudy.model.model import CommandDTO
@@ -64,10 +64,6 @@ class CreateCluster(ICommand):
     # version 2: remove cluster_name and type parameters as ThermalPropertiesType
     # version 3: type parameters as ThermalClusterCreation
     _SERIALIZATION_VERSION: Final[int] = 3
-
-    @property
-    def cluster_name(self) -> str:
-        return self.parameters.name
 
     @model_validator(mode="before")
     @classmethod
@@ -103,76 +99,26 @@ class CreateCluster(ICommand):
         validate_thermal_cluster_against_version(self.study_version, self.parameters)
         return self
 
-    def update_in_config(self, study_data: FileStudyTreeConfig) -> Tuple[CommandOutput, str]:
-        # Search the Area in the configuration
-        if self.area_id not in study_data.areas:
-            return (
-                CommandOutput(
-                    status=False,
-                    message=f"Area '{self.area_id}' does not exist in the study configuration.",
-                ),
-                "",
-            )
-        area: Area = study_data.areas[self.area_id]
-
-        # Check if the cluster already exists in the area
-        cluster = ThermalCluster.model_validate({"name": self.cluster_name})
-        if any(cl.id == cluster.id for cl in area.thermals):
-            return (
-                CommandOutput(
-                    status=False,
-                    message=f"Thermal cluster '{cluster.id}' already exists in the area '{self.area_id}'.",
-                ),
-                "",
-            )
-
-        area.thermals.append(cluster)
-
-        return (
-            CommandOutput(
-                status=True,
-                message=f"Thermal cluster '{cluster.id}' added to area '{self.area_id}'.",
-            ),
-            cluster.id,
-        )
-
     @override
-    def _apply(self, study_data: FileStudy, listener: Optional[ICommandListener] = None) -> CommandOutput:
-        output, cluster_id = self.update_in_config(study_data.config)
-        if not output.status:
-            return output
+    def _apply_dao(self, study_data: StudyDao, listener: Optional[ICommandListener] = None) -> CommandOutput:
+        thermal = parse_thermal_cluster(self.study_version, self.parameters.model_dump(mode="json", by_alias=True))
+        if study_data.thermal_exists(self.area_id, thermal.id):
+            return command_failed(f"Thermal cluster '{thermal.id}' in area '{self.area_id}' already exists")
 
-        version = study_data.config.version
+        study_data.save_thermal(self.area_id, thermal)
 
-        config = study_data.tree.get(["input", "thermal", "clusters", self.area_id, "list"])
-        cluster = create_thermal_cluster(self.parameters, version)
-        config[cluster_id] = serialize_thermal_cluster(version, cluster)
-
-        # Series identifiers are in lower case.
-        series_id = cluster_id.lower()
+        # Matrices
         null_matrix = self.command_context.generator_matrix_constants.get_null_matrix()
-        new_cluster_data: JSON = {
-            "input": {
-                "thermal": {
-                    "clusters": {self.area_id: {"list": config}},
-                    "prepro": {
-                        self.area_id: {
-                            series_id: {
-                                "data": self.prepro,
-                                "modulation": self.modulation,
-                            }
-                        }
-                    },
-                    "series": {self.area_id: {series_id: {"series": null_matrix}}},
-                }
-            }
-        }
-        if version >= STUDY_VERSION_8_7:
-            new_cluster_data["input"]["thermal"]["series"][self.area_id][series_id]["CO2Cost"] = null_matrix
-            new_cluster_data["input"]["thermal"]["series"][self.area_id][series_id]["fuelCost"] = null_matrix
-        study_data.tree.save(new_cluster_data)
+        study_data.save_thermal_series(self.area_id, thermal.id, null_matrix)
+        assert isinstance(self.prepro, str)
+        assert isinstance(self.modulation, str)
+        study_data.save_thermal_prepro(self.area_id, thermal.id, self.prepro)
+        study_data.save_thermal_modulation(self.area_id, thermal.id, self.modulation)
+        if self.study_version >= STUDY_VERSION_8_7:
+            study_data.save_thermal_fuel_cost(self.area_id, thermal.id, null_matrix)
+            study_data.save_thermal_co2_cost(self.area_id, thermal.id, null_matrix)
 
-        return output
+        return command_succeeded(f"Thermal cluster '{thermal.id}' inside area '{self.area_id}' created")
 
     @override
     def to_dto(self) -> CommandDTO:

--- a/antarest/study/storage/variantstudy/model/command/remove_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_cluster.py
@@ -14,13 +14,13 @@ from typing import List, Optional
 
 from typing_extensions import override
 
-from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
-from antarest.study.storage.rawstudy.model.filesystem.config.model import Area, FileStudyTreeConfig
-from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-from antarest.study.storage.variantstudy.business.utils_binding_constraint import (
-    remove_area_cluster_from_binding_constraints,
+from antarest.study.dao.api.study_dao import StudyDao
+from antarest.study.storage.variantstudy.model.command.common import (
+    CommandName,
+    CommandOutput,
+    command_failed,
+    command_succeeded,
 )
-from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.command_listener.command_listener import ICommandListener
 from antarest.study.storage.variantstudy.model.model import CommandDTO
@@ -42,99 +42,15 @@ class RemoveCluster(ICommand):
     area_id: str
     cluster_id: str
 
-    def remove_from_config(self, study_data: FileStudyTreeConfig) -> CommandOutput:
-        """
-        Remove the thermal clusters from the storages list.
-
-        Args:
-            study_data: The study data configuration.
-
-        Returns:
-            A tuple containing the command output and a dictionary of extra data.
-            On success, the dictionary is empty.
-        """
-        # Search the Area in the configuration
-        if self.area_id not in study_data.areas:
-            message = f"Area '{self.area_id}' does not exist in the study configuration."
-            return CommandOutput(status=False, message=message)
-        area: Area = study_data.areas[self.area_id]
-
-        # Search the Thermal cluster in the area
-        cluster_id = transform_name_to_id(self.cluster_id)
-        thermal = next(
-            iter(thermal for thermal in area.thermals if transform_name_to_id(thermal.id) == cluster_id),
-            None,
-        )
-        if thermal is None:
-            message = f"Thermal cluster '{self.cluster_id}' does not exist in the area '{self.area_id}'."
-            return CommandOutput(status=False, message=message)
-
-        # Remove the Thermal cluster from the configuration
-        area.thermals.remove(thermal)
-
-        remove_area_cluster_from_binding_constraints(study_data, self.area_id, self.cluster_id)
-
-        message = f"Thermal cluster '{self.cluster_id}' removed from the area '{self.area_id}'."
-        return CommandOutput(status=True, message=message)
-
-    def _remove_cluster_from_scenario_builder(self, study_data: FileStudy) -> None:
-        """
-        Update the scenario builder by removing the rows that correspond to the thermal cluster to remove.
-
-        NOTE: this update can be very long if the scenario builder configuration is large.
-        """
-        rulesets = study_data.tree.get(["settings", "scenariobuilder"])
-
-        for ruleset in rulesets.values():
-            for key in list(ruleset):
-                # The key is in the form "symbol,area,year,cluster"
-                symbol, *parts = key.split(",")
-                if symbol == "t" and parts[0] == self.area_id and parts[2] == self.cluster_id.lower():
-                    del ruleset[key]
-
-        study_data.tree.save(rulesets, ["settings", "scenariobuilder"])
-
     @override
-    def _apply(self, study_data: FileStudy, listener: Optional[ICommandListener] = None) -> CommandOutput:
-        """
-        Applies the study data to update thermal cluster configurations and saves the changes:
-        remove corresponding the configuration and remove the attached time series.
+    def _apply_dao(self, study_data: StudyDao, listener: Optional[ICommandListener] = None) -> CommandOutput:
+        if not study_data.thermal_exists(self.area_id, self.cluster_id):
+            return command_failed(f"Thermal cluster '{self.cluster_id}' in area '{self.area_id}' does not exists")
 
-        Args:
-            study_data: The study data to be applied.
+        thermal = study_data.get_thermal(self.area_id, self.cluster_id)
+        study_data.delete_thermal(self.area_id, thermal)
 
-        Returns:
-            The output of the command execution.
-        """
-        # Search the Area in the configuration
-        if self.area_id not in study_data.config.areas:
-            message = f"Area '{self.area_id}' does not exist in the study configuration."
-            return CommandOutput(status=False, message=message)
-
-        # It is required to delete the files and folders that correspond to the thermal cluster
-        # BEFORE updating the configuration, as we need the configuration to do so.
-        # Specifically, deleting the time series uses the list of thermal clusters from the configuration.
-
-        series_id = self.cluster_id.lower()
-        paths = [
-            ["input", "thermal", "clusters", self.area_id, "list", self.cluster_id],
-            ["input", "thermal", "prepro", self.area_id, series_id],
-            ["input", "thermal", "series", self.area_id, series_id],
-        ]
-        area: Area = study_data.config.areas[self.area_id]
-        if len(area.thermals) == 1:
-            paths.append(["input", "thermal", "prepro", self.area_id])
-            paths.append(["input", "thermal", "series", self.area_id])
-
-        for path in paths:
-            study_data.tree.delete(path)
-
-        self._remove_cluster_from_binding_constraints(study_data)
-        self._remove_cluster_from_scenario_builder(study_data)
-
-        # Deleting the renewable cluster in the configuration must be done AFTER
-        # deleting the files and folders.
-        return self.remove_from_config(study_data.config)
+        return command_succeeded(f"Thermal cluster '{self.cluster_id}' inside area '{self.area_id}' deleted")
 
     @override
     def to_dto(self) -> CommandDTO:
@@ -147,52 +63,3 @@ class RemoveCluster(ICommand):
     @override
     def get_inner_matrices(self) -> List[str]:
         return []
-
-    def _remove_cluster_from_binding_constraints(self, study_data: FileStudy) -> None:
-        """
-        Remove the binding constraints that are related to the thermal cluster.
-
-        Notes:
-            A binding constraint has properties, a list of terms (which form a linear equation) and
-            a right-hand side (which is the matrix of the binding constraint).
-            The terms are of the form `area1%area2` or `area.cluster` where `area` is the ID of the area
-            and `cluster` is the ID of the cluster.
-
-            When a thermal cluster is removed, it has an impact on the terms of the binding constraints.
-            At first, we could decide to remove the terms that are related to the area.
-            However, this would lead to a linear equation that is not valid anymore.
-
-            Instead, we decide to remove the binding constraints that are related to the cluster.
-        """
-        # See also `RemoveCluster`
-        # noinspection SpellCheckingInspection
-        url = ["input", "bindingconstraints", "bindingconstraints"]
-        binding_constraints = study_data.tree.get(url)
-
-        # Collect the binding constraints that are related to the area to remove
-        # by searching the terms that contain the ID of the area.
-        bc_to_remove = []
-        lower_area_id = self.area_id.lower()
-        lower_cluster_id = self.cluster_id.lower()
-        for bc_index, bc in list(binding_constraints.items()):
-            for key in bc:
-                if "." not in key:
-                    # This key identifies a link or belongs to the set of properties.
-                    # It isn't a cluster ID, so we skip it.
-                    continue
-                # Term IDs are in the form `area1%area2` or `area.cluster`
-                # noinspection PyTypeChecker
-                related_area_id, related_cluster_id = map(str.lower, key.split("."))
-                if (lower_area_id, lower_cluster_id) == (related_area_id, related_cluster_id):
-                    bc_to_remove.append(binding_constraints.pop(bc_index)["id"])
-                    break
-
-        matrix_suffixes = ["_lt", "_gt", "_eq"] if study_data.config.version >= 870 else [""]
-
-        existing_files = study_data.tree.get(["input", "bindingconstraints"], depth=1)
-        for bc_id, suffix in zip(bc_to_remove, matrix_suffixes):
-            matrix_id = f"{bc_id}{suffix}"
-            if matrix_id in existing_files:
-                study_data.tree.delete(["input", "bindingconstraints", matrix_id])
-
-        study_data.tree.save(binding_constraints, url)

--- a/antarest/study/storage/variantstudy/model/command/remove_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_cluster.py
@@ -45,7 +45,7 @@ class RemoveCluster(ICommand):
     @override
     def _apply_dao(self, study_data: StudyDao, listener: Optional[ICommandListener] = None) -> CommandOutput:
         if not study_data.thermal_exists(self.area_id, self.cluster_id):
-            return command_failed(f"Thermal cluster '{self.cluster_id}' in area '{self.area_id}' does not exists")
+            return command_failed(f"Thermal cluster '{self.cluster_id}' in area '{self.area_id}' does not exist")
 
         thermal = study_data.get_thermal(self.area_id, self.cluster_id)
         study_data.delete_thermal(self.area_id, thermal)

--- a/antarest/study/storage/variantstudy/model/command/update_thermal_clusters.py
+++ b/antarest/study/storage/variantstudy/model/command/update_thermal_clusters.py
@@ -65,7 +65,7 @@ class UpdateThermalClusters(ICommand):
             for cluster_id, new_properties in value.items():
                 lowered_id = cluster_id.lower()
                 if lowered_id not in all_thermals[area_id]:
-                    return command_failed(f"Thermal cluster '{cluster_id}' in area '{area_id}' does not exist")
+                    return command_failed(f"The thermal cluster '{cluster_id}' in the area '{area_id}' is not found.")
 
                 current_cluster = all_thermals[area_id][lowered_id]
                 new_cluster = update_thermal_cluster(current_cluster, new_properties)

--- a/antarest/study/storage/variantstudy/model/command/update_thermal_clusters.py
+++ b/antarest/study/storage/variantstudy/model/command/update_thermal_clusters.py
@@ -63,10 +63,11 @@ class UpdateThermalClusters(ICommand):
 
             new_clusters = []
             for cluster_id, new_properties in value.items():
-                if cluster_id not in all_thermals[area_id]:
+                lowered_id = cluster_id.lower()
+                if lowered_id not in all_thermals[area_id]:
                     return command_failed(f"Thermal cluster '{cluster_id}' in area '{area_id}' does not exist")
 
-                current_cluster = all_thermals[area_id][cluster_id]
+                current_cluster = all_thermals[area_id][lowered_id]
                 new_cluster = update_thermal_cluster(current_cluster, new_properties)
                 new_clusters.append(new_cluster)
 

--- a/antarest/study/storage/variantstudy/model/command/update_thermal_clusters.py
+++ b/antarest/study/storage/variantstudy/model/command/update_thermal_clusters.py
@@ -14,21 +14,18 @@ from typing import Any, List, Optional, Self
 from pydantic import model_validator
 from typing_extensions import override
 
-from antarest.core.exceptions import ChildNotFoundError
 from antarest.study.business.model.thermal_cluster_model import (
-    ThermalCluster,
     ThermalClusterUpdates,
     update_thermal_cluster,
     validate_thermal_cluster_against_version,
 )
-from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
-from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
-from antarest.study.storage.rawstudy.model.filesystem.config.thermal import (
-    parse_thermal_cluster,
-    serialize_thermal_cluster,
+from antarest.study.dao.api.study_dao import StudyDao
+from antarest.study.storage.variantstudy.model.command.common import (
+    CommandName,
+    CommandOutput,
+    command_failed,
+    command_succeeded,
 )
-from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput, IdMapping
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.command_listener.command_listener import ICommandListener
 from antarest.study.storage.variantstudy.model.model import CommandDTO
@@ -56,59 +53,26 @@ class UpdateThermalClusters(ICommand):
                 validate_thermal_cluster_against_version(self.study_version, cluster)
         return self
 
-    def update_in_config(self, study_data: FileStudyTreeConfig) -> CommandOutput:
-        for area_id, value in self.cluster_properties.items():
-            if area_id not in study_data.areas:
-                return CommandOutput(status=False, message=f"The area '{area_id}' is not found.")
-
-            thermal_mapping: dict[str, tuple[int, ThermalCluster]] = {}
-            for index, thermal in enumerate(study_data.areas[area_id].thermals):
-                thermal_mapping[transform_name_to_id(thermal.id)] = (index, thermal)
-
-            for cluster_id, update in value.items():
-                if cluster_id not in thermal_mapping:
-                    return CommandOutput(
-                        status=False,
-                        message=f"The thermal cluster '{cluster_id}' in the area '{area_id}' is not found.",
-                    )
-
-                index, thermal = thermal_mapping[cluster_id]
-                study_data.areas[area_id].thermals[index] = update_thermal_cluster(thermal, update)
-
-        return CommandOutput(status=True, message="The thermal clusters were successfully updated.")
-
     @override
-    def _apply(self, study_data: FileStudy, listener: Optional[ICommandListener] = None) -> CommandOutput:
+    def _apply_dao(self, study_data: StudyDao, listener: Optional[ICommandListener] = None) -> CommandOutput:
+        all_thermals = study_data.get_all_thermals()
+
         for area_id, value in self.cluster_properties.items():
-            ini_path = ["input", "thermal", "clusters", area_id, "list"]
+            if area_id not in all_thermals:
+                return command_failed(f"Area '{area_id}' does not exist")
 
-            try:
-                all_clusters_for_area = study_data.tree.get(ini_path)
-            except ChildNotFoundError:
-                return CommandOutput(status=False, message=f"The area '{area_id}' is not found.")
+            new_clusters = []
+            for cluster_id, new_properties in value.items():
+                if cluster_id not in all_thermals[area_id]:
+                    return command_failed(f"Thermal cluster '{cluster_id}' in area '{area_id}' does not exist")
 
-            # Validates the Ini file
-            clusters_by_id = IdMapping(parse_thermal_cluster, all_clusters_for_area, self.study_version)
+                current_cluster = all_thermals[area_id][cluster_id]
+                new_cluster = update_thermal_cluster(current_cluster, new_properties)
+                new_clusters.append(new_cluster)
 
-            for cluster_id, update in value.items():
-                if not clusters_by_id.asserts_id_exists(cluster_id):
-                    return CommandOutput(
-                        status=False,
-                        message=f"The thermal cluster '{cluster_id}' in the area '{area_id}' is not found.",
-                    )
+            study_data.save_thermals(area_id, new_clusters)
 
-                # Performs the update
-                cluster_key, cluster = clusters_by_id.get_key_and_properties(cluster_id)
-                updated_cluster = update_thermal_cluster(cluster, update)
-                all_clusters_for_area[cluster_key] = serialize_thermal_cluster(
-                    study_data.config.version, updated_cluster
-                )
-
-            study_data.tree.save(data=all_clusters_for_area, url=ini_path)
-
-        output = self.update_in_config(study_data.config)
-
-        return output
+        return command_succeeded("All thermal clusters updated")
 
     @override
     def to_dto(self) -> CommandDTO:

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -1633,28 +1633,6 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         # We cannot perform redirection, because we have a PUT, where a PATCH is required.
         return update_thermal_cluster(uuid, area_id, cluster_id, cluster_data)
 
-    @bp.get(
-        path="/studies/{uuid}/areas/{area_id}/clusters/thermal/{cluster_id}/validate",
-        tags=[APITag.study_data],
-        summary="Validates the thermal cluster series",
-    )
-    def validate_cluster_series(uuid: str, area_id: str, cluster_id: str) -> bool:
-        """
-        Validate the consistency of all time series for the given thermal cluster.
-
-        Args:
-        - `uuid`: The UUID of the study.
-        - `area_id`: the area ID.
-        - `cluster_id`: the ID of the thermal cluster.
-
-        Permissions:
-        - User must have READ permission on the study.
-        """
-        logger.info(f"Validating thermal series values for study {uuid} and cluster {cluster_id}")
-        study = study_service.check_study_access(uuid, StudyPermissionType.READ)
-        study_interface = study_service.get_study_interface(study)
-        return study_service.thermal_manager.validate_series(study_interface, area_id, cluster_id)
-
     @bp.delete(
         path="/studies/{uuid}/areas/{area_id}/clusters/thermal",
         tags=[APITag.study_data],

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -718,11 +718,7 @@ class TestThermal:
             },
         )
         assert res.status_code == 500, res.json()
-        obj = res.json()
-        description = obj["description"]
-        assert bad_area_id in description
-        assert re.search(r"Area ", description, flags=re.IGNORECASE)
-        assert re.search(r"does not exist ", description, flags=re.IGNORECASE)
+        assert f"The area '{bad_area_id}' does not exist" in res.json()["description"]
 
         # Check POST with wrong `group`
         res = client.post(
@@ -749,7 +745,7 @@ class TestThermal:
             },
         )
         assert res.status_code == 404, res.json()
-        assert bad_area_id in obj["description"]["description"]
+        assert bad_area_id in res.json()["description"]
 
         # Check PATCH with the wrong `cluster_id`
         bad_cluster_id = "bad_cluster"

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -567,71 +567,6 @@ class TestThermal:
         assert res.json()["data"] == matrix
 
         # =============================
-        #  THERMAL CLUSTER VALIDATION
-        # =============================
-
-        # Everything is fine at the beginning
-        res = client.get(
-            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate"
-        )
-        assert res.status_code == 200
-        assert res.json() is True
-
-        # Modifies series matrix with wrong length (!= 8760)
-        _upload_matrix(
-            client,
-            user_access_token,
-            internal_study_id,
-            f"input/thermal/series/{area_id}/{fr_gas_conventional_id.lower()}/series",
-            pd.DataFrame(np.random.randint(0, 10, size=(4, 1))),
-        )
-
-        # Validation should fail
-        res = client.get(
-            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate"
-        )
-        assert res.status_code == 422
-        obj = res.json()
-        assert obj["exception"] == "WrongMatrixHeightError"
-        assert obj["description"] == "The matrix series should have 8760 rows, currently: 4"
-
-        # Update with the right length
-        _upload_matrix(
-            client,
-            user_access_token,
-            internal_study_id,
-            f"input/thermal/series/{area_id}/{fr_gas_conventional_id.lower()}/series",
-            pd.DataFrame(np.random.randint(0, 10, size=(8760, 4))),
-        )
-
-        # Validation should succeed again
-        res = client.get(
-            f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate"
-        )
-        assert res.status_code == 200
-        assert res.json() is True
-
-        if version >= 870:
-            # Adds a CO2Cost matrix with different columns size
-            _upload_matrix(
-                client,
-                user_access_token,
-                internal_study_id,
-                f"input/thermal/series/{area_id}/{fr_gas_conventional_id.lower()}/CO2Cost",
-                pd.DataFrame(np.random.randint(0, 10, size=(8760, 3))),
-            )
-
-            # Validation should fail
-            res = client.get(
-                f"/v1/studies/{internal_study_id}/areas/{area_id}/clusters/thermal/{fr_gas_conventional_id}/validate"
-            )
-            assert res.status_code == 422
-            obj = res.json()
-            assert obj["exception"] == "MatrixWidthMismatchError"
-            pattern = r".*'series'.*4.*'CO2Cost'.*3"
-            assert re.match(pattern, obj["description"])
-
-        # =============================
         #  THERMAL CLUSTER DELETION
         # =============================
 
@@ -814,10 +749,7 @@ class TestThermal:
             },
         )
         assert res.status_code == 404, res.json()
-        obj = res.json()
-        description = obj["description"]
-        assert bad_area_id in description
-        assert re.search(r"is not found", description, flags=re.IGNORECASE)
+        assert bad_area_id in obj["description"]["description"]
 
         # Check PATCH with the wrong `cluster_id`
         bad_cluster_id = "bad_cluster"

--- a/tests/variantstudy/model/command/test_create_cluster.py
+++ b/tests/variantstudy/model/command/test_create_cluster.py
@@ -54,7 +54,6 @@ class TestCreateCluster:
         prepro_id = command_context.matrix_service.create(pd.DataFrame(prepro))
         modulation_id = command_context.matrix_service.create(pd.DataFrame(modulation))
         assert cl.area_id == "foo"
-        assert cl.cluster_name == "Cluster1"
         assert cl.parameters == ThermalClusterCreation(
             name="Cluster1", group=ThermalClusterGroup.NUCLEAR, unit_count=2, nominal_capacity=2400
         )
@@ -152,13 +151,14 @@ class TestCreateCluster:
         ).apply(empty_study)
         assert output.status is False
         assert re.match(
-            r"Thermal cluster 'cluster-1' already exists in the area 'de'",
+            r"Thermal cluster 'Cluster-1' already exists in the area 'de'",
             output.message,
             flags=re.IGNORECASE,
         )
 
+        fake_area_id = "non_existent_area"
         output = CreateCluster(
-            area_id="non_existent_area",
+            area_id=fake_area_id,
             parameters=parameters,
             prepro=prepro,
             modulation=modulation,
@@ -166,11 +166,7 @@ class TestCreateCluster:
             study_version=STUDY_VERSION_8_8,
         ).apply(empty_study)
         assert output.status is False
-        assert re.match(
-            r"Area 'non_existent_area' does not exist",
-            output.message,
-            flags=re.IGNORECASE,
-        )
+        assert f"The area '{fake_area_id}' does not exist" in output.message
 
     def test_to_dto(self, command_context: CommandContext):
         prepro = GEN.random((365, 6)).tolist()

--- a/tests/variantstudy/model/command/test_create_link_in_memory.py
+++ b/tests/variantstudy/model/command/test_create_link_in_memory.py
@@ -13,6 +13,7 @@
 import pytest
 from pydantic import ValidationError
 
+from antarest.matrixstore.in_memory import InMemorySimpleMatrixService
 from antarest.study.dao.memory.in_memory_study_dao import InMemoryStudyDao
 from antarest.study.model import STUDY_VERSION_8_8
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
@@ -36,7 +37,7 @@ class TestCreateLink:
             )
 
     def test_apply(self, command_context: CommandContext):
-        study_dao = InMemoryStudyDao(STUDY_VERSION_8_8)
+        study_dao = InMemoryStudyDao(STUDY_VERSION_8_8, InMemorySimpleMatrixService())
         area1 = "Area1"
         area1_id = transform_name_to_id(area1)
 


### PR DESCRIPTION
**Breaking change:**
- Removal of the unused endpoint GET `/v1/studies/{uuid}/areas/{area_id}/clusters/thermal/{cluster_id}/validate`

For information: the diagram of the DAO implementation for the links. White arrow means inheritance and black arrow means composition
![link_dao drawio](https://github.com/user-attachments/assets/59219b89-9264-452a-8f40-14cc81ea57b4)
