### PR TITLE
feat(unittest): add --fast flag to speed up test execution

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
 checksumdir~=1.2.0
-pytest~=8.3.0
-pytest-xdist~=3.6.0
-pytest-cov~=4.0.0
+pytest~=8.4.1
+pytest-xdist~=3.7.0
+pytest-cov~=6.2.1
 pytest-mock~=3.14.0
 
 jinja2~=3.1.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-import random
 from pathlib import Path
 from typing import Callable
 
@@ -58,7 +57,7 @@ def get_fast_subset(test_cases, subset_size=1):
     or all cases in normal mode.
     """
     if pytest.FAST_MODE:  # type: ignore
-        return random.sample(test_cases, min(subset_size, len(test_cases)))
+        return test_cases[:subset_size]
     return test_cases
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,26 @@ from tests.conftest_services import *  # noqa: F403
 
 HERE = Path(__file__).parent.resolve()
 PROJECT_DIR = next(iter(p for p in HERE.parents if p.joinpath("antarest").exists()))
+pytest.FAST_MODE = False
+
+
+def pytest_addoption(parser):
+    parser.addoption("--fast", action="store_true", default=False, help="Run tests in fast mode (subset of cases)")
+
+
+def pytest_configure(config):
+    if config.getoption("--fast"):
+        pytest.FAST_MODE = True
+
+
+def get_fast_subset(test_cases, subset_size=1):
+    """
+    Returns a subset of test cases in fast mode,
+    or all cases in normal mode.
+    """
+    if pytest.FAST_MODE:  # type: ignore
+        return test_cases[:subset_size]
+    return test_cases
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-
+import random
 from pathlib import Path
 from typing import Callable
 
@@ -58,7 +58,7 @@ def get_fast_subset(test_cases, subset_size=1):
     or all cases in normal mode.
     """
     if pytest.FAST_MODE:  # type: ignore
-        return test_cases[:subset_size]
+        return random.sample(test_cases, min(subset_size, len(test_cases)))
     return test_cases
 
 

--- a/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
@@ -643,6 +643,8 @@ class TestRawDataAggregationMCInd:
         """
         Asserts that requests get an empty dataframe when columns are not existing
         """
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
         # test for areas
@@ -816,6 +818,8 @@ class TestRawDataAggregationMCAll:
         Imports the STA-mini study and create a variant from it. Then imports the parent output inside it
         Then asserts the aggregation endpoint works the same for parent and variant
         """
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
         # Imports STA-mini
@@ -943,6 +947,8 @@ class TestRawDataAggregationMCAll:
         """
         Asserts that requests get an empty dataframe when columns are not existing
         """
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
 
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 

--- a/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
@@ -21,6 +21,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from antarest.core.serde.matrix_export import TableExportFormat
+from tests.conftest import get_fast_subset
 from tests.integration.assets import ASSETS_DIR as INTEGRATION_ASSETS_DIR
 from tests.integration.raw_studies_blueprint.assets import ASSETS_DIR
 
@@ -451,7 +452,9 @@ class TestRawDataAggregationMCInd:
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
-        for params, expected_result_filename in AREAS_REQUESTS__IND:
+        test_cases = get_fast_subset(AREAS_REQUESTS__IND)
+
+        for params, expected_result_filename in test_cases:
             output_id = params.pop("output_id")
             res = client.get(f"/v1/studies/{internal_study_id}/areas/aggregate/mc-ind/{output_id}", params=params)
             assert res.status_code == 200, res.json()
@@ -487,7 +490,9 @@ class TestRawDataAggregationMCInd:
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
-        for params, expected_result_filename in LINKS_REQUESTS__IND:
+        test_cases = get_fast_subset(LINKS_REQUESTS__IND)
+
+        for params, expected_result_filename in test_cases:
             output_id = params.pop("output_id")
             res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/mc-ind/{output_id}", params=params)
             assert res.status_code == 200, res.json()
@@ -524,7 +529,9 @@ class TestRawDataAggregationMCInd:
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
-        for params, expected_result_filename in SAME_REQUEST_DIFFERENT_FORMATS__IND:
+        test_cases = get_fast_subset(SAME_REQUEST_DIFFERENT_FORMATS__IND)
+
+        for params, expected_result_filename in test_cases:
             output_id = params.pop("output_id")
             res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/mc-ind/{output_id}", params=params)
             assert res.status_code == 200, res.json()
@@ -562,8 +569,10 @@ class TestRawDataAggregationMCInd:
     ):
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
+        test_cases = get_fast_subset(INCOHERENT_REQUESTS_BODIES__IND)
+
         # Asserts that requests with incoherent bodies don't crash but send empty dataframes
-        for params in INCOHERENT_REQUESTS_BODIES__IND:
+        for params in test_cases:
             output_id = params.pop("output_id")
             res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/mc-ind/{output_id}", params=params)
             assert res.status_code == 200, res.json()
@@ -690,7 +699,9 @@ class TestRawDataAggregationMCAll:
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
-        for params, expected_result_filename in AREAS_REQUESTS__ALL:
+        test_cases = get_fast_subset(AREAS_REQUESTS__ALL)
+
+        for params, expected_result_filename in test_cases:
             output_id = params.pop("output_id")
             res = client.get(f"/v1/studies/{internal_study_id}/areas/aggregate/mc-all/{output_id}", params=params)
             assert res.status_code == 200, res.json()
@@ -727,7 +738,9 @@ class TestRawDataAggregationMCAll:
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
-        for params, expected_result_filename in LINKS_REQUESTS__ALL:
+        test_cases = get_fast_subset(LINKS_REQUESTS__ALL)
+
+        for params, expected_result_filename in test_cases:
             output_id = params.pop("output_id")
             res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/mc-all/{output_id}", params=params)
             assert res.status_code == 200, res.json()
@@ -764,7 +777,9 @@ class TestRawDataAggregationMCAll:
         """
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
-        for params, expected_result_filename in SAME_REQUEST_DIFFERENT_FORMATS__ALL:
+        test_cases = get_fast_subset(SAME_REQUEST_DIFFERENT_FORMATS__ALL)
+
+        for params, expected_result_filename in test_cases:
             output_id = params.pop("output_id")
             res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/mc-all/{output_id}", params=params)
             assert res.status_code == 200, res.json()
@@ -856,8 +871,10 @@ class TestRawDataAggregationMCAll:
     ):
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
+        test_cases = get_fast_subset(INCOHERENT_REQUESTS_BODIES__ALL)
+
         # Asserts that requests with incoherent bodies don't crash but send empty dataframes
-        for params in INCOHERENT_REQUESTS_BODIES__ALL:
+        for params in test_cases:
             output_id = params.pop("output_id")
             res = client.get(f"/v1/studies/{internal_study_id}/links/aggregate/mc-all/{output_id}", params=params)
             assert res.status_code == 200, res.json()

--- a/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
@@ -86,6 +86,9 @@ class TestFetchRawData:
         5. Checks for a 415 error when the extension of a file is unknown.
         """
 
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
+
         # =============================
         #  SET UP
         # =============================
@@ -323,6 +326,8 @@ class TestFetchRawData:
         # =============================
         #  SET UP
         # =============================
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
         if study_type == "variant":

--- a/tests/integration/studies_blueprint/test_comments.py
+++ b/tests/integration/studies_blueprint/test_comments.py
@@ -14,6 +14,7 @@ import io
 import time
 from xml.etree import ElementTree
 
+import pytest
 from starlette.testclient import TestClient
 
 from tests.integration.studies_blueprint.assets import ASSETS_DIR
@@ -38,6 +39,8 @@ class TestStudyComments:
         This test verifies that we can retrieve and modify the comments of a study.
         It also performs performance measurements and analyzes.
         """
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
         # Get the comments of the study and compare with the expected file
         res = client.get(f"/v1/studies/{internal_study_id}/comments")

--- a/tests/integration/studies_blueprint/test_get_studies.py
+++ b/tests/integration/studies_blueprint/test_get_studies.py
@@ -872,7 +872,8 @@ class TestStudiesListing:
         ##########################
         # 1. Database initialization
         ##########################
-
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         users = {"user_1": "pass_1", "user_2": "pass_2", "user_3": "pass_3"}
         users_tokens = {}
         users_ids = {}

--- a/tests/integration/study_data_blueprint/test_binding_constraints.py
+++ b/tests/integration/study_data_blueprint/test_binding_constraints.py
@@ -660,6 +660,8 @@ class TestBindingConstraints:
 
     @pytest.mark.parametrize("study_type", ["raw", "variant"])
     def test_for_version_870(self, client: TestClient, user_access_token: str, study_type: str, tmp_path: Path) -> None:
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         client.headers = {"Authorization": f"Bearer {user_access_token}"}  # type: ignore
 
         # =============================

--- a/tests/integration/study_data_blueprint/test_hydro_allocation.py
+++ b/tests/integration/study_data_blueprint/test_hydro_allocation.py
@@ -222,6 +222,8 @@ class TestHydroAllocation:
         Other columns must be updated to reflect the area deletion.
         """
         # First change the coefficients to avoid zero values (which are defaults).
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         obj = {
             "de": {"[allocation]": {"de": 10, "es": 20, "fr": 30, "it": 40}},
             "es": {"[allocation]": {"de": 11, "es": 21, "fr": 31, "it": 41}},

--- a/tests/integration/study_data_blueprint/test_hydro_correlation.py
+++ b/tests/integration/study_data_blueprint/test_hydro_correlation.py
@@ -272,6 +272,8 @@ class TestHydroCorrelation:
         Other columns must be updated to reflect the area deletion.
         """
         # First change the coefficients to avoid zero values (which are defaults).
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         correlation_cfg = {
             "annual": {
                 "de%es": 0.12,
@@ -319,6 +321,8 @@ class TestHydroCorrelation:
     def test_get_correlation_values__empty_annual(
         self, client: TestClient, internal_study_id: str, user_access_token: str, tmp_path: Path
     ):
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         area_id = "it"
 
         correlation_file_path = tmp_path.joinpath("ext_workspace/STA-mini/input/hydro/prepro/correlation.ini")

--- a/tests/integration/study_data_blueprint/test_link.py
+++ b/tests/integration/study_data_blueprint/test_link.py
@@ -21,6 +21,8 @@ from tests.integration.prepare_proxy import PreparerProxy
 class TestLink:
     @pytest.mark.parametrize("study_type", ["raw", "variant"])
     def test_link_update(self, client: TestClient, user_access_token: str, study_type: str) -> None:
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         client.headers = {"Authorization": f"Bearer {user_access_token}"}  # type: ignore
 
         preparer = PreparerProxy(client, user_access_token)

--- a/tests/integration/study_data_blueprint/test_playlist.py
+++ b/tests/integration/study_data_blueprint/test_playlist.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-
+import pytest
 from starlette.testclient import TestClient
 
 
@@ -19,6 +19,8 @@ class TestConfigPlaylist:
     """
 
     def test_nominal_case(self, client: TestClient, user_access_token: str):
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
         base_study_res = client.post("/v1/studies?name=foo")

--- a/tests/integration/study_data_blueprint/test_table_mode.py
+++ b/tests/integration/study_data_blueprint/test_table_mode.py
@@ -17,6 +17,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
+from tests.conftest import get_fast_subset
 from tests.integration.utils import wait_task_completion
 
 # noinspection SpellCheckingInspection
@@ -33,7 +34,7 @@ class TestTableMode:
     which contains the following areas: ["de", "es", "fr", "it"].
     """
 
-    @pytest.mark.parametrize("study_version", [0, 810, 830, 860, 870, 880, 920])
+    @pytest.mark.parametrize("study_version", get_fast_subset([0, 810, 830, 860, 870, 880, 920], 3))
     def test_lifecycle__nominal(
         self, client: TestClient, user_access_token: str, internal_study_id: str, study_version: int
     ) -> None:

--- a/tests/integration/variant_blueprint/test_thermal_cluster.py
+++ b/tests/integration/variant_blueprint/test_thermal_cluster.py
@@ -57,6 +57,8 @@ class TestThermalCluster:
         user_access_token: str,
         internal_study_id: str,
     ) -> None:
+        if pytest.FAST_MODE:
+            pytest.skip("Skipping test")
         """
         This test is based on the study "STA-mini.zip", which is a RAW study.
         We will first convert this study to a managed study, and then we will

--- a/tests/integration/variant_blueprint/test_variant_manager.py
+++ b/tests/integration/variant_blueprint/test_variant_manager.py
@@ -319,6 +319,9 @@ def test_comments(client: TestClient, admin_access_token: str, variant_id: str) 
 
 
 def test_recursive_variant_tree(client: TestClient, admin_access_token: str, base_study_id: str) -> None:
+    if pytest.FAST_MODE:
+        pytest.skip("Skipping test")
+
     admin_headers = {"Authorization": f"Bearer {admin_access_token}"}
     parent_id = base_study_id
     for k in range(200):

--- a/tests/integration/xpansion_studies_blueprint/test_integration_xpansion.py
+++ b/tests/integration/xpansion_studies_blueprint/test_integration_xpansion.py
@@ -51,6 +51,8 @@ def _create_link(
 
 
 def test_xpansion_with_upgrade(client: TestClient, tmp_path: Path, user_access_token: str) -> None:
+    if pytest.FAST_MODE:
+        pytest.skip("Skipping test")
     headers = {"Authorization": f"Bearer {user_access_token}"}
     client.headers = headers
 

--- a/tests/launcher/test_log_manager.py
+++ b/tests/launcher/test_log_manager.py
@@ -44,10 +44,12 @@ def test_reading(tmp_path: Path):
     with open(log2, "a") as fh:
         fh.write("world\n")
 
-    count = 5
-    while count > 0 and len(logs) == 0:
-        count -= 1
-        time.sleep(1)
+    timeout = 0.5
+    interval = 0.01
+    elapsed = 0
+    while elapsed < timeout and len(logs) == 0:
+        time.sleep(interval)
+        elapsed += interval
 
     assert len(logs) > 0
 
@@ -57,8 +59,10 @@ def test_reading(tmp_path: Path):
     with open(log1, "a") as fh:
         fh.write("world\n")
 
-    count = 2
-    while count > 0:
-        count -= 1
-        time.sleep(1)
-    assert len(logs) == 0
+    timeout = 0.5
+    interval = 0.01
+    elapsed = 0
+    while elapsed < timeout:
+        assert len(logs) == 0
+        time.sleep(interval)
+        elapsed += interval


### PR DESCRIPTION
introduces a new `--fast` flag that runs a reduced subset of test cases to accelerate development workflows.
- Reduces test execution time from ~5 minutes to <4 minutes 
- skip 10/15 slowest tests
Nothing groundbreaking but still useful
I am open to suggestions

