### PR TITLE
fix(output): dont scan whole output dir recursively

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/simulation.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/simulation.py
@@ -54,7 +54,7 @@ class OutputSimulation(FolderNode):
         }
 
         if not self.simulation.error:
-            for file in self.config.path.rglob("*.txt"):
+            for file in self.config.path.glob("*.txt"):
                 file_name = file.name
                 if (self.config.path / file_name).exists():
                     children[file.stem] = RawFileNode(self.matrix_mapper, self.config.next_file(file_name))


### PR DESCRIPTION
On large outputs, reading anything can now take as long as 10s +,
whereas we don't want to scan recursively.

Checked that the fix allow to go back down to < 1s