### PR TITLE
fix(watcher): watcher should not be started when not asked for

### DIFF
--- a/antarest/main.py
+++ b/antarest/main.py
@@ -276,13 +276,15 @@ def fastapi_app(
 
     application.include_router(api_root)
 
-    if services.watcher:
+    # Important note:
+    # those singleton services must be "started" ONLY when explictly asked.
+    # Typically for a production multi-process deployment, they should not be started
+    # for each HTTP worker, but only for one dedicated background worker.
+    if services.watcher and Module.WATCHER in config.server.services:
         services.watcher.start()
-
-    if services.matrix_gc:
+    if services.matrix_gc and Module.MATRIX_GC in config.server.services:
         services.matrix_gc.start()
-
-    if services.auto_archiver:
+    if services.auto_archiver and Module.AUTO_ARCHIVER in config.server.services:
         services.auto_archiver.start()
 
     customize_openapi(application)

--- a/antarest/service_creator.py
+++ b/antarest/service_creator.py
@@ -252,7 +252,7 @@ def create_archive_worker(
     return ArchiveWorker(event_bus, workspace, local_root, config)
 
 
-@dataclass
+@dataclass(frozen=True)
 class Services:
     watcher: Watcher
     explorer: Explorer


### PR DESCRIPTION

In multi-process deployments, the watcher is currently started for all workers, which should not be the case.