### PR TITLE
fix(ui-commons): remove the column name from the copy on DataGrid

### DIFF
--- a/webapp/src/components/common/DataGrid.tsx
+++ b/webapp/src/components/common/DataGrid.tsx
@@ -304,7 +304,6 @@ function DataGrid({
       gridSelection={gridSelection}
       onGridSelectionChange={handleGridSelectionChange}
       freezeColumns={adjustedFreezeColumns}
-      copyHeaders
       {...rest}
     />
   );


### PR DESCRIPTION
it causes issue when pasting back