### PR TITLE
fix(matrix-filter): incorrect callback signatures for column filter controls

### DIFF
--- a/webapp/src/components/common/Matrix/components/MatrixFilter/ColumnFilter.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/ColumnFilter.tsx
@@ -40,10 +40,10 @@ function ColumnFilter({ filter, setFilter, columnCount }: ColumnFilterProps) {
   const {
     inputValue,
     handleListChange,
-    addValueToList,
-    addValuesToList,
-    removeValueFromList,
-    clearAllValues,
+    addValueToColumnFilter,
+    addValuesToColumnFilter,
+    removeValueFromColumnFilter,
+    clearColumnFilterValues,
     handleKeyPress,
     handleTypeChange,
     handleOperatorChange,
@@ -127,11 +127,11 @@ function ColumnFilter({ filter, setFilter, columnCount }: ColumnFilterProps) {
             operator={filter.columnsFilter.operator}
             onInputChange={handleListChange}
             onKeyPress={handleKeyPress}
-            onAddValue={() => addValueToList()}
-            onAddValues={(values) => addValuesToList(values)}
-            onRemoveValue={(value) => removeValueFromList(value)}
+            onAddValue={addValueToColumnFilter}
+            onAddValues={addValuesToColumnFilter}
+            onRemoveValue={removeValueFromColumnFilter}
             onOperatorChange={handleOperatorChangeEvent}
-            onClearAll={() => clearAllValues()}
+            onClearAll={clearColumnFilterValues}
           />
         )}
       </AccordionDetails>

--- a/webapp/src/components/common/Matrix/components/MatrixFilter/ColumnFilter.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/ColumnFilter.tsx
@@ -127,11 +127,11 @@ function ColumnFilter({ filter, setFilter, columnCount }: ColumnFilterProps) {
             operator={filter.columnsFilter.operator}
             onInputChange={handleListChange}
             onKeyPress={handleKeyPress}
-            onAddValue={addValueToList}
-            onAddValues={addValuesToList}
-            onRemoveValue={removeValueFromList}
+            onAddValue={() => addValueToList()}
+            onAddValues={(values) => addValuesToList(values)}
+            onRemoveValue={(value) => removeValueFromList(value)}
             onOperatorChange={handleOperatorChangeEvent}
-            onClearAll={clearAllValues}
+            onClearAll={() => clearAllValues()}
           />
         )}
       </AccordionDetails>

--- a/webapp/src/components/common/Matrix/components/MatrixFilter/RowFilter.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/RowFilter.tsx
@@ -280,14 +280,16 @@ function RowFilter({
           rangeValue={state.rangeValue}
           onRangeChange={handleRangeChange}
           selectedValues={state.rowFilter.list || []}
-          onAddValue={() => filterControls.addValueToList(filterId)}
-          onAddValues={(values) => filterControls.addValuesToList(values, filterId)}
-          onRemoveValue={(value) => filterControls.removeValueFromList(value, filterId)}
+          onAddValue={() => filterControls.addValueToRowFilter(state.rowFilter.id)}
+          onAddValues={(values) => filterControls.addValuesToRowFilter(values, state.rowFilter.id)}
+          onRemoveValue={(value) =>
+            filterControls.removeValueFromRowFilter(value, state.rowFilter.id)
+          }
           onCheckboxChange={(value) => filterControls.handleCheckboxChange(value, filterId)}
           inputValue={filterControls.inputValue}
           onInputChange={filterControls.handleListChange}
           onKeyPress={filterControls.handleKeyPress}
-          onClearAll={() => filterControls.clearAllValues(filterId)}
+          onClearAll={() => filterControls.clearRowFilterValues(state.rowFilter.id)}
           sliderMarks={state.sliderMarks}
           operator={state.rowFilter.operator}
           onOperatorChange={handleOperatorChange}


### PR DESCRIPTION
The "Clear All" button was not functioning for column filters in the matrix filter component, while it worked correctly for row filters. After this refactor: https://github.com/AntaresSimulatorTeam/AntaREST/pull/2522#discussion_r2174751260

### Solution
Added inline arrow functions when passing callbacks from `useFilterControls` to `ListFilterControl` in the `ColumnFilter` component:

```tsx
// Before - functions passed directly
onClearAll={clearAllValues}

// After - wrapped in arrow functions  
onClearAll={() => clearAllValues()}
```

The `useFilterControls` hook functions accept an optional `filterId` parameter:
- When called WITH `filterId` → updates row filters
- When called WITHOUT `filterId` → updates column filters