### PR TITLE
feat(matrix): normalize study at import and copy

### DIFF
--- a/antarest/core/serde/matrix_export.py
+++ b/antarest/core/serde/matrix_export.py
@@ -57,15 +57,7 @@ def _write_dataframes_stream_csv(path: Path, sep: str, decimal: str, dataframes:
     headers = True
     append = False
     for df in _checked_dataframes_generator(dataframes):
-        df.to_csv(
-            path,
-            mode="a" if append else "w",
-            sep=sep,
-            decimal=decimal,
-            index=False,
-            header=headers,
-            float_format="%.6f",
-        )
+        df.to_csv(path, mode="a" if append else "w", sep=sep, decimal=decimal, index=False, header=headers)
         headers = False
         append = True
 
@@ -176,30 +168,11 @@ class TableExportFormat(EnumIgnoreCase):
                     engine="xlsxwriter",
                 )
             case TableExportFormat.TSV:
-                return df.to_csv(
-                    export_path,
-                    sep="\t",
-                    index=with_index,
-                    header=with_header,
-                    float_format="%.6f",
-                )
+                return df.to_csv(export_path, sep="\t", index=with_index, header=with_header)
             case TableExportFormat.CSV:
-                return df.to_csv(
-                    export_path,
-                    sep=",",
-                    index=with_index,
-                    header=with_header,
-                    float_format="%.6f",
-                )
+                return df.to_csv(export_path, sep=",", index=with_index, header=with_header)
             case TableExportFormat.CSV_SEMICOLON:
-                return df.to_csv(
-                    export_path,
-                    sep=";",
-                    decimal=",",
-                    index=with_index,
-                    header=with_header,
-                    float_format="%.6f",
-                )
+                return df.to_csv(export_path, sep=";", decimal=",", index=with_index, header=with_header)
             case TableExportFormat.HDF5:
                 return df.to_hdf(
                     export_path,

--- a/antarest/matrixstore/parsing.py
+++ b/antarest/matrixstore/parsing.py
@@ -46,7 +46,7 @@ def load_matrix(matrix_format: InternalMatrixFormat, path: Path, matrix_version:
 
 def save_matrix(matrix_format: InternalMatrixFormat, dataframe: pd.DataFrame, path: Path) -> None:
     if matrix_format == InternalMatrixFormat.TSV:
-        dataframe.to_csv(path, sep="\t", float_format="%.6f", index=False)
+        dataframe.to_csv(path, sep="\t", index=False)
     elif matrix_format == InternalMatrixFormat.HDF:
         dataframe.to_hdf(str(path), key="data", index=False)
     elif matrix_format == InternalMatrixFormat.PARQUET:

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -1125,6 +1125,7 @@ class StudyService:
             )
 
             self._save_study(study, group_ids)
+            self.normalize_study(study)
 
             # Copying all jobs associated with the study
             jobs = self.job_result_repository.find_by_study_and_output_ids(origin_study.id, output_ids)
@@ -1336,6 +1337,7 @@ class StudyService:
         study.updated_at = datetime.utcnow()
 
         self._save_study(study, group_ids)
+        self.normalize_study(study)
         self.event_bus.push(
             Event(
                 type=EventType.STUDY_CREATED,
@@ -2382,3 +2384,10 @@ class StudyService:
         cache_id = study_raw_cache_key(study.id)
         updated_tree = file_study.tree.get()
         self.storage_service.get_storage(study).cache.put(cache_id, updated_tree)  # type: ignore
+
+    def normalize_study(self, study: Study) -> None:
+        """
+        Method used to normalize the study.
+        It will put every matrix in the study in the matrix-store.
+        """
+        self.storage_service.get_storage(study).get_raw(study).tree.normalize()

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -138,7 +138,7 @@ class InputSeriesMatrix(MatrixNode):
             target_path = self.config.path.with_suffix(".txt")
             buffer = io.BytesIO()
             df = self.parse_as_dataframe()
-            dump_dataframe(df, buffer, None)
+            dump_dataframe(df, buffer)
             content = buffer.getvalue()
             suffix = target_path.suffix
             filename = target_path.name

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -80,7 +80,7 @@ class InputSeriesMatrix(MatrixNode):
                     study_id = self.config.study_id
                     relpath = file_path.relative_to(self.config.study_path).as_posix()
                     raise ChildNotFoundError(f"File '{relpath}' not found in the study '{study_id}'") from e
-            stopwatch.log_elapsed(lambda x: logger.info(f"Matrix parsed in {x}s"))
+            stopwatch.log_elapsed(lambda x: logger.debug(f"Matrix parsed in {x}s"))
             final_matrix = matrix.dropna(how="any", axis=1)
             if final_matrix.empty:
                 raise EmptyDataError

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
@@ -46,17 +46,11 @@ class MatrixFrequency(StrEnum):
     HOURLY = "hourly"
 
 
-def dump_dataframe(df: pd.DataFrame, path_or_buf: Path | io.BytesIO, float_format: Optional[str] = "%.6f") -> None:
+def dump_dataframe(df: pd.DataFrame, path_or_buf: Path | io.BytesIO) -> None:
     if df.empty and isinstance(path_or_buf, Path):
         path_or_buf.write_bytes(b"")
     else:
-        df.to_csv(
-            path_or_buf,
-            sep="\t",
-            header=False,
-            index=False,
-            float_format=float_format,
-        )
+        df.to_csv(path_or_buf, sep="\t", header=False, index=False)
 
 
 def imports_matrix_from_bytes(data: bytes) -> Optional[npt.NDArray[np.float64]]:
@@ -184,7 +178,7 @@ class MatrixNode(LazyNode[bytes | JSON, bytes | JSON, JSON], ABC):
         if df.empty:
             return b""
         buffer = io.StringIO()
-        df.to_csv(buffer, sep="\t", header=False, index=False, float_format="%.6f")
+        df.to_csv(buffer, sep="\t", header=False, index=False)
         return buffer.getvalue()  # type: ignore
 
     @override

--- a/antarest/study/storage/variantstudy/model/command/generate_thermal_cluster_timeseries.py
+++ b/antarest/study/storage/variantstudy/model/command/generate_thermal_cluster_timeseries.py
@@ -129,7 +129,7 @@ class GenerateThermalClusterTimeSeries(ICommand):
                     df = pd.DataFrame(data=generated_matrix)
                     df = df[list(df.columns)].astype(int)
                     target_path = self._build_matrix_path(tmp_path / area_id / thermal.id.lower())
-                    dump_dataframe(df, target_path, None)
+                    dump_dataframe(df, target_path)
                     # 10- Notify the progress to the notifier
                     generation_performed += 1
                     if listener:

--- a/tests/integration/studies_blueprint/test_disk_usage.py
+++ b/tests/integration/studies_blueprint/test_disk_usage.py
@@ -73,7 +73,7 @@ class TestDiskUsage:
         res = client.put(
             f"/v1/studies/{variant_id}/generate",
             headers={"Authorization": f"Bearer {user_access_token}"},
-            params={"denormalize": True, "from_scratch": True},
+            params={"from_scratch": True},
         )
         res.raise_for_status()
         task_id = res.json()
@@ -92,8 +92,9 @@ class TestDiskUsage:
             headers=user_headers,
         )
         assert res.status_code == 200, res.json()
-        disk_usage = res.json()  # currently: 6.38 Mio on Ubuntu.
-        assert 6 * 1024 * 1024 < disk_usage < 7 * 1024 * 1024
+        disk_usage = res.json()
+        # currently: 850 Kio on Ubuntu because the parent study is normalized as it was imported.
+        assert 0.1 * 1024 * 1024 < disk_usage < 0.5 * 1024 * 1024
 
         # Create dummy outputs for the variant
         outputs_dir = tmp_path / "internal_workspace" / variant_id / "output"

--- a/tests/integration/studies_blueprint/test_study_version.py
+++ b/tests/integration/studies_blueprint/test_study_version.py
@@ -15,9 +15,11 @@ import os
 import zipfile
 from pathlib import Path
 
+from antares.study.version.upgrade_app import UpgradeApp
 from starlette.testclient import TestClient
 
 from antarest.core.serde.ini_reader import read_ini
+from antarest.study.model import STUDY_VERSION_9_2
 from tests.integration.assets import ASSETS_DIR
 
 
@@ -26,33 +28,21 @@ class TestStudyVersions:
     This class contains tests related to the handling of different study versions
     """
 
-    def test_nominal_case(self, client: TestClient, user_access_token: str, tmp_path: str) -> None:
+    def test_nominal_case(self, client: TestClient, user_access_token: str, tmp_path: Path) -> None:
         # =============================
         #  SET UP
         # =============================
         client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
-        data = """[antares]
-version = 9.0
-caption = test_version_90
-created = 1682506382.235618
-lastsave = 1682506382.23562
-author = Unknown
-"""
-        tmp_dir = Path(tmp_path)
         zip_path = ASSETS_DIR / "STA-mini.zip"
-        # Extract zip inside tmp_dir
-        new_zip_path = tmp_dir / "test_version_90"
+
+        # Creates a study in version 9.2 from the base study in version 7.0
+        new_zip_path = tmp_path / "test_version_92"
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
             zip_ref.extractall(new_zip_path)
-
-        # Change file content
-        target_path = os.path.join(new_zip_path, "STA-mini", "study.antares")
-        with open(target_path, "w") as file:
-            file.write(data)
-
-        final_path = tmp_dir / "test_version_90.zip"
-        # Rezip it
+        app = UpgradeApp(new_zip_path / "STA-mini", version=STUDY_VERSION_9_2)
+        app()
+        final_path = tmp_path / "test_version_92.zip"
         with zipfile.ZipFile(final_path, "w", zipfile.ZIP_DEFLATED) as zipf:
             for root, dirs, files in os.walk(new_zip_path):
                 for file in files:
@@ -63,7 +53,7 @@ author = Unknown
         #  LIFECYCLE
         # =============================
 
-        for f in [zip_path, final_path]:
+        for f in [zip_path, final_path]:  # zip path is the study in version 7.0 and final path the one in version 9.2
             # Imports a study
             res = client.post("/v1/studies/_import", files={"study": io.BytesIO(f.read_bytes())})
             res.raise_for_status()
@@ -72,13 +62,13 @@ author = Unknown
             # Gets study information
             res = client.get(f"v1/studies/{study_id}")
             res.raise_for_status()
-            assert res.json()["version"] == 900 if f == final_path else 700
+            assert res.json()["version"] == 920 if f == final_path else 700
 
             # Reads `study.version` file
             res = client.get(f"v1/studies/{study_id}/raw?path=study")
             res.raise_for_status()
             version = str(res.json()["antares"]["version"])
-            assert version == "9.0" if f == final_path else "700"
+            assert version == "9.2" if f == final_path else "700"
 
             # Delete the study
             res = client.delete(f"v1/studies/{study_id}")

--- a/tests/integration/studies_blueprint/test_study_version.py
+++ b/tests/integration/studies_blueprint/test_study_version.py
@@ -53,7 +53,7 @@ class TestStudyVersions:
         #  LIFECYCLE
         # =============================
 
-        for f in [zip_path, final_path]:  # zip path is the study in version 7.0 and final path the one in version 9.2
+        for f in [zip_path, final_path]:  # zip_path is the study in version 7.0 and final_path the one in version 9.2
             # Imports a study
             res = client.post("/v1/studies/_import", files={"study": io.BytesIO(f.read_bytes())})
             res.raise_for_status()

--- a/tests/storage/integration/conftest.py
+++ b/tests/storage/integration/conftest.py
@@ -39,8 +39,6 @@ from antarest.matrixstore.service import SimpleMatrixService
 from antarest.study.main import build_study_service
 from antarest.study.model import DEFAULT_WORKSPACE_NAME, RawStudy, StudyAdditionalData
 from antarest.study.service import StudyService
-from antarest.study.storage.output_service import OutputService
-from antarest.study.storage.storage_dispatchers import OutputStorageDispatcher
 
 UUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
@@ -149,17 +147,3 @@ def storage_service(tmp_path: Path, project_path: Path, sta_mini_zip_path: Path)
     )
 
     return storage_service
-
-
-@pytest.fixture(name="output_service")
-def output_service_fixture(storage_service: StudyService) -> OutputService:
-    storage = OutputStorageDispatcher(
-        storage_service.storage_service.raw_study_service, storage_service.storage_service.variant_study_service
-    )
-    return OutputService(
-        storage_service,
-        storage,
-        storage_service.task_service,
-        storage_service.file_transfer_manager,
-        storage_service.event_bus,
-    )

--- a/tests/storage/integration/conftest.py
+++ b/tests/storage/integration/conftest.py
@@ -39,6 +39,8 @@ from antarest.matrixstore.service import SimpleMatrixService
 from antarest.study.main import build_study_service
 from antarest.study.model import DEFAULT_WORKSPACE_NAME, RawStudy, StudyAdditionalData
 from antarest.study.service import StudyService
+from antarest.study.storage.output_service import OutputService
+from antarest.study.storage.storage_dispatchers import OutputStorageDispatcher
 
 UUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
@@ -147,3 +149,17 @@ def storage_service(tmp_path: Path, project_path: Path, sta_mini_zip_path: Path)
     )
 
     return storage_service
+
+
+@pytest.fixture(name="output_service")
+def output_service_fixture(storage_service: StudyService) -> OutputService:
+    storage = OutputStorageDispatcher(
+        storage_service.storage_service.raw_study_service, storage_service.storage_service.variant_study_service
+    )
+    return OutputService(
+        storage_service,
+        storage,
+        storage_service.task_service,
+        storage_service.file_transfer_manager,
+        storage_service.event_bus,
+    )

--- a/tests/storage/integration/test_STA_mini.py
+++ b/tests/storage/integration/test_STA_mini.py
@@ -26,11 +26,13 @@ from starlette.testclient import TestClient
 
 from antarest.core.application import create_app_ctxt
 from antarest.core.jwt import JWTGroup, JWTUser
-from antarest.core.model import JSON
 from antarest.core.roles import RoleType
-from antarest.matrixstore.service import MatrixService
+from antarest.matrixstore.matrix_uri_mapper import MatrixUriMapperFactory, NormalizedMatrixUriMapper
+from antarest.matrixstore.service import ISimpleMatrixService, MatrixService
 from antarest.study.main import build_study_service
 from antarest.study.service import StudyService
+from antarest.study.storage.rawstudy.model.filesystem.config.files import build
+from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
 from antarest.study.storage.study_download_utils import BadOutputFormat
 from tests.helpers import assert_study, with_admin_user
 from tests.storage.integration.conftest import UUID
@@ -488,7 +490,7 @@ def test_sta_mini_expansion(storage_service, url: str, expected_output: dict):
 
 @with_admin_user
 @pytest.mark.integration_test
-def test_sta_mini_copy(storage_service) -> None:
+def test_sta_mini_copy(storage_service, tmp_path: Path, matrix_service: ISimpleMatrixService) -> None:
     source_study_name = UUID
     destination_study_name = "copy-STA-mini"
 
@@ -510,20 +512,18 @@ def test_sta_mini_copy(storage_service) -> None:
     # The study is copied; therefore, it was normalized
     assert "matrix://ef73d0226d966d7c085e03bf37f26986fb7bfaba0977f8f60acfa9109ded8c1f" == link_url_destination
 
-    def replace_study_name(data: JSON) -> None:
-        if isinstance(data, dict):
-            for key, value in data.items():
-                if isinstance(value, str) and value.startswith("file/"):
-                    data[key] = value.replace(uuid, source_study_name)
-                else:
-                    replace_study_name(value)
+    # We should first denormalize the copied study to ensure it's the same exact study.
+    denormalized_path = tmp_path / "denormalized_study"
+    storage_service.export_study_flat(uuid, denormalized_path)
 
-    replace_study_name(data_destination)
+    config = build(denormalized_path, "")
+    mapper_factory = MatrixUriMapperFactory(matrix_service=matrix_service)
+    matrix_mapper = mapper_factory.create(NormalizedMatrixUriMapper.NORMALIZED)
+    tree = FileStudyTree(matrix_mapper=matrix_mapper, config=config)
+    data_destination = tree.get()
+
     del data_source["output"]
-    data_source["study"] = {}
-    data_destination["study"] = {}
 
-    # todo: We should first denormalize the copied study to ensure it's the same exact study.
     assert_study(data_source, data_destination)
 
 

--- a/tests/storage/integration/test_STA_mini.py
+++ b/tests/storage/integration/test_STA_mini.py
@@ -507,7 +507,8 @@ def test_sta_mini_copy(storage_service) -> None:
     assert "matrixfile://fr.txt" == link_url_source
 
     link_url_destination = data_destination["input"]["links"]["de"]["fr"]
-    assert "matrixfile://fr.txt" == link_url_destination
+    # The study is copied; therefore, it was normalized
+    assert "matrix://ef73d0226d966d7c085e03bf37f26986fb7bfaba0977f8f60acfa9109ded8c1f" == link_url_destination
 
     def replace_study_name(data: JSON) -> None:
         if isinstance(data, dict):
@@ -522,6 +523,7 @@ def test_sta_mini_copy(storage_service) -> None:
     data_source["study"] = {}
     data_destination["study"] = {}
 
+    # todo: We should first denormalize the copied study to ensure it's the same exact study.
     assert_study(data_source, data_destination)
 
 

--- a/tests/storage/integration/test_STA_mini.py
+++ b/tests/storage/integration/test_STA_mini.py
@@ -176,7 +176,7 @@ def test_sta_mini_study_antares(storage_service, url: str, expected_output: str)
 
 buffer = io.StringIO()
 df = pd.DataFrame(np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]] * 8760))
-df.to_csv(buffer, sep="\t", header=False, index=False, float_format="%.6f")
+df.to_csv(buffer, sep="\t", header=False, index=False)
 expected_min_gen_response = buffer.getvalue()
 
 

--- a/tests/storage/repository/filesystem/matrix/test_input_series_matrix.py
+++ b/tests/storage/repository/filesystem/matrix/test_input_series_matrix.py
@@ -71,7 +71,7 @@ class TestInputSeriesMatrix:
         # We cannot check the content as is as we're applying a transformation to the data
         df_binary = pd.DataFrame(data=expected["data"])
         buffer = io.StringIO()
-        df_binary.to_csv(buffer, sep="\t", header=False, index=False, float_format="%.6f")
+        df_binary.to_csv(buffer, sep="\t", header=False, index=False)
         actual_binary = node.load(formatted=False)
         assert actual_binary == buffer.getvalue()
 
@@ -100,7 +100,7 @@ class TestInputSeriesMatrix:
         # checks binary response
         actual = node.load(formatted=False)
         buffer = io.StringIO()
-        pd.DataFrame(default_matrix).to_csv(buffer, sep="\t", header=False, index=False, float_format="%.6f")
+        pd.DataFrame(default_matrix).to_csv(buffer, sep="\t", header=False, index=False)
         assert actual == buffer.getvalue()
 
     def test_load__file_not_found(self, my_study_config: FileStudyTreeConfig) -> None:


### PR DESCRIPTION
[ANT-3541]


**Benchmark performed on my local environment:**


Starting with a BP study of 2.27 Go

Copy without normalizing matrices : 0:06'
Copy with normalizing matrices (matrixstore in TSV) : 3:20'
Copy with normalizing matrices (matrixstore in feather) :1:20'
Copy with normalizing matrices (all matrices already in the matrixstore) :0:50'

Final size of the study if normalized: 37 Mo.