### PR TITLE
fix(studies): make all managed studies folder end with id

### DIFF
--- a/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
+++ b/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
@@ -30,7 +30,7 @@ def upgrade():
 
     rawstudy_table = table("rawstudy", column("id"), column("workspace"))
 
-    # add id to folder, handle case whith and without a trailing slash
+    # add id to folder, handle case with and without a trailing slash
     add_id_exp = case(
         (
             study_table.c.folder.like("%/"),

--- a/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
+++ b/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
@@ -31,7 +31,7 @@ def upgrade():
             )
         WHERE
             s.folder IS NOT NULL
-            AND s.folder NOT LIKE concat('%', id)
+            AND s.folder NOT LIKE '%' || id
             AND (
                 EXISTS (
                     SELECT 1 FROM rawstudy r

--- a/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
+++ b/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
@@ -23,8 +23,10 @@ def upgrade():
         UPDATE study AS s SET
             folder = (
                 CASE
-                    WHEN folder LIKE '%/' THEN concat(folder, id)
-                    ELSE concat(concat(folder, '/'), id)
+                    WHEN folder LIKE '%/' THEN 
+                        folder || id
+                    ELSE 
+                        folder || '/' || id
                 END
             )
         WHERE

--- a/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
+++ b/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
@@ -18,6 +18,12 @@ depends_on = None
 
 
 def upgrade():
+    """
+    This update fixes an incident with the folder path of some managed studies.
+    Sometimes, a study's folder does not end with its own ID
+    (as seen in the top entry of the image below), even though this should always be
+    the case). So this function add the ID to the end of the folder path if it is not already there.
+    """
     op.execute(
         sa.text("""
         UPDATE study AS s SET
@@ -44,4 +50,8 @@ def upgrade():
 
 
 def downgrade():
+    """
+    We cannot downgrade this migration because we cannot make the difference between a folder path that was
+    correctly set and one that was incorrectly set.
+    """
     pass

--- a/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
+++ b/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
@@ -1,0 +1,45 @@
+"""Make all managed studies folder path end with id
+
+Revision ID: fa59340767b0
+Revises: 9ba7fc46d4a0
+Create Date: 2025-07-21 12:16:43.213036
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "fa59340767b0"
+down_revision = "9ba7fc46d4a0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        sa.text("""
+        UPDATE study AS s SET
+            folder = (
+                CASE
+                    WHEN folder LIKE '%/' THEN concat(folder, id)
+                    ELSE concat(concat(folder, '/'), id)
+                END
+            )
+        WHERE
+            s.folder IS NOT NULL
+            AND s.folder NOT LIKE concat('%', id)
+            AND (
+                EXISTS (
+                    SELECT 1 FROM rawstudy r
+                    WHERE s.id = r.id AND r.workspace = 'default'
+                )
+                OR s."type" = 'variantstudy'
+            );
+    """)
+    )
+
+
+def downgrade():
+    pass

--- a/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
+++ b/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
@@ -7,6 +7,7 @@ Create Date: 2025-07-21 12:16:43.213036
 """
 
 import sqlalchemy as sa
+from sqlalchemy.sql import and_, case, column, literal, not_, or_, select, table, update
 
 from alembic import op
 
@@ -20,33 +21,53 @@ depends_on = None
 def upgrade():
     """
     This update fixes an incident with the folder path of some managed studies.
-    Sometimes, a study's folder does not end with its own ID
-    (as seen in the top entry of the image below), even though this should always be
-    the case). So this function add the ID to the end of the folder path if it is not already there.
+    Sometimes, a study's folder does not end with its own ID.
+    So this function add the ID to the end of the folder path if it is not already there.
     """
-    op.execute(
-        sa.text("""
-        UPDATE study AS s SET
-            folder = (
-                CASE
-                    WHEN folder LIKE '%/' THEN 
-                        folder || id
-                    ELSE 
-                        folder || '/' || id
-                END
-            )
-        WHERE
-            s.folder IS NOT NULL
-            AND s.folder NOT LIKE '%' || id
-            AND (
-                EXISTS (
-                    SELECT 1 FROM rawstudy r
-                    WHERE s.id = r.id AND r.workspace = 'default'
-                )
-                OR s."type" = 'variantstudy'
-            );
-    """)
+    # Create db connection
+    bind = op.get_bind()
+
+    study_table = table(
+        "study",
+        column("id"),
+        column("folder"),
+        column("type"),
     )
+
+    rawstudy_table = table(
+        "rawstudy",
+        column("id"),
+        column("workspace"),
+    )
+
+    # add id to folder, handle case whith and without a trailing slash
+    add_id_exp = case(
+        (
+            study_table.c.folder.like("%/"),
+            study_table.c.folder + study_table.c.id,
+        ),
+        else_=study_table.c.folder + literal("/") + study_table.c.id,
+    )
+
+    is_in_default_workspace_subq = (
+        select(sa.literal(1))
+        .where(and_(rawstudy_table.c.id == study_table.c.id, rawstudy_table.c.workspace == "default"))
+        .exists()
+    )
+
+    # managed study = in default workspace or is variant
+    is_managed = or_(is_in_default_workspace_subq, study_table.c.type == "variantstudy")
+
+    # We're only interested in managed studies
+    # whose folder name doesn't end with their own ID.
+    where_clause = and_(
+        study_table.c.folder.isnot(None),
+        not_(study_table.c.folder.like("%" + study_table.c.id.cast(sa.String))),
+        is_managed,
+    )
+
+    stmt = update(study_table).where(where_clause).values(folder=add_id_exp)
+    bind.execute(stmt)
 
 
 def downgrade():


### PR DESCRIPTION
Fix [ANT-3640](https://gopro-tickets.rte-france.com/browse/ANT-3640)

Sometimes, a study's folder does not end with its own ID (as seen in the top entry of the image below), even though this should always be the case. 

This inconsistency was observed in both staging and production environments.

It is likely the result of a bug that was live for a few days several weeks ago. The query below fixes the issue by appending the study's ID to its folder path if it’s not already present.

One consequence of this inconsistency is that sometime, when the studies are processed by the front end to build the study tree, depending on the order on which they are processed some folders are marked a study folders, they are then ignored by the front and they're not shown in the study tree, for the user it seems that some folders are randomly missing from the study tree. As you can see in the screenshot bellow the uae folder isn't in the tree although it should.


<img width="1579" height="895" alt="image" src="https://github.com/user-attachments/assets/e73f4fb5-a436-41ff-85d4-7c0bbd88a0cc" />
