### PR TITLE
fix(matrix): eliminate double date parsing in temporal filters

### DIFF
--- a/webapp/src/components/common/Matrix/components/MatrixFilter/hooks/useTemporalData.ts
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/hooks/useTemporalData.ts
@@ -12,10 +12,12 @@
  * This file is part of the Antares project.
  */
 
+import { getDayOfYear } from "date-fns";
 import { useMemo } from "react";
+import { getHourOfYear, getWeekFromDayOfYear, parseFlexibleDate } from "@/utils/date/dateUtils";
 import type { TimeFrequencyType } from "../../../shared/types";
 import { TIME_INDEXING } from "../constants";
-import { extractValueFromDate, getDefaultRangeForIndexType } from "../utils/dateUtils";
+import { getDefaultRangeForIndexType } from "../utils/dateUtils";
 
 interface UseTemporalDataProps {
   dateTime?: string[];
@@ -23,9 +25,19 @@ interface UseTemporalDataProps {
   timeFrequency?: TimeFrequencyType;
 }
 
+interface ParsedDateInfo {
+  date: Date | null;
+  dayOfYear: number | null;
+  hourOfYear: number | null;
+  dayOfMonth: number | null;
+  week: number | null;
+  month: number | null;
+  dayHour: number | null;
+  weekday: number | null;
+}
+
 export function useTemporalData({ dateTime, isTimeSeries }: UseTemporalDataProps) {
   const indexTypeRanges = useMemo(() => {
-    // Create a map of all default ranges
     return Object.values(TIME_INDEXING).reduce(
       (acc, type) => {
         acc[type] = getDefaultRangeForIndexType(type);
@@ -35,7 +47,55 @@ export function useTemporalData({ dateTime, isTimeSeries }: UseTemporalDataProps
     );
   }, []);
 
-  // Get the range values based on data or defaults
+  const parsedDates = useMemo(() => {
+    if (!dateTime || !isTimeSeries || dateTime.length === 0) {
+      return [];
+    }
+
+    return dateTime.map((dateStr): ParsedDateInfo => {
+      try {
+        const date = parseFlexibleDate(dateStr);
+
+        if (!date) {
+          return {
+            date: null,
+            dayOfYear: null,
+            hourOfYear: null,
+            dayOfMonth: null,
+            week: null,
+            month: null,
+            dayHour: null,
+            weekday: null,
+          };
+        }
+
+        const dayOfYear = getDayOfYear(date);
+
+        return {
+          date,
+          dayOfYear,
+          hourOfYear: getHourOfYear(date),
+          dayOfMonth: date.getDate(),
+          week: getWeekFromDayOfYear(dayOfYear),
+          month: date.getMonth() + 1,
+          dayHour: date.getHours(),
+          weekday: date.getDay() + 1,
+        };
+      } catch {
+        return {
+          date: null,
+          dayOfYear: null,
+          hourOfYear: null,
+          dayOfMonth: null,
+          week: null,
+          month: null,
+          dayHour: null,
+          weekday: null,
+        };
+      }
+    });
+  }, [dateTime, isTimeSeries]);
+
   const valuesByIndexType = useMemo(() => {
     // Start with a fresh object using the default ranges
     const result = { ...indexTypeRanges } as Record<
@@ -43,6 +103,7 @@ export function useTemporalData({ dateTime, isTimeSeries }: UseTemporalDataProps
       { min: number; max: number; uniqueValues?: number[] }
     >;
 
+    // Set static values that don't depend on data
     result[TIME_INDEXING.DAY_HOUR] = {
       min: 0,
       max: 23,
@@ -61,8 +122,16 @@ export function useTemporalData({ dateTime, isTimeSeries }: UseTemporalDataProps
       uniqueValues: Array.from({ length: 12 }, (_, i) => i + 1),
     };
 
-    // Only try to extract data-based values if we have time series data
-    if (dateTime && isTimeSeries && dateTime.length > 0) {
+    // Only try to extract data-based values if we have parsed dates
+    if (parsedDates.length > 0) {
+      // Define mapping from indexing type to parsed data property
+      const indexTypeToProperty: Record<string, keyof ParsedDateInfo> = {
+        [TIME_INDEXING.DAY_OF_YEAR]: "dayOfYear",
+        [TIME_INDEXING.HOUR_YEAR]: "hourOfYear",
+        [TIME_INDEXING.DAY_OF_MONTH]: "dayOfMonth",
+        [TIME_INDEXING.WEEK]: "week",
+      };
+
       // Only update the ranges that should be data-dependent
       const dynamicTypes = [
         TIME_INDEXING.DAY_OF_YEAR,
@@ -72,53 +141,63 @@ export function useTemporalData({ dateTime, isTimeSeries }: UseTemporalDataProps
       ];
 
       for (const indexType of dynamicTypes) {
-        try {
-          const values = dateTime
-            .map((dateStr) => {
-              try {
-                return extractValueFromDate(dateStr, indexType);
-              } catch {
-                return null;
-              }
-            })
-            .filter((value): value is number => value !== null);
+        const property = indexTypeToProperty[indexType];
 
-          if (values.length > 0) {
-            const min = Math.min(...values);
-            const max = Math.max(...values);
-            const uniqueValues = [...new Set(values)].sort((a, b) => a - b);
-            result[indexType] = { min, max, uniqueValues };
-          }
-        } catch {
-          // Keep defaults on error
+        if (!property) {
+          continue;
+        }
+
+        const values = parsedDates
+          .map((parsed) => parsed[property] as number | null)
+          .filter((value): value is number => value !== null);
+
+        if (values.length > 0) {
+          const uniqueSet = new Set(values);
+          const uniqueValues = Array.from(uniqueSet).sort((a, b) => a - b);
+          result[indexType] = {
+            min: Math.min(...uniqueValues),
+            max: Math.max(...uniqueValues),
+            uniqueValues,
+          };
         }
       }
     }
 
     return result;
-  }, [dateTime, isTimeSeries, indexTypeRanges]);
+  }, [parsedDates, indexTypeRanges]);
 
   const temporalValues = useMemo(() => {
-    if (!dateTime || !isTimeSeries || dateTime.length === 0) {
+    if (parsedDates.length === 0) {
       return {};
     }
 
     const result: Record<string, number[]> = {};
 
+    // Define mapping from indexing type to parsed data property
+    const indexTypeToProperty: Record<string, keyof ParsedDateInfo> = {
+      [TIME_INDEXING.DAY_OF_YEAR]: "dayOfYear",
+      [TIME_INDEXING.HOUR_YEAR]: "hourOfYear",
+      [TIME_INDEXING.DAY_OF_MONTH]: "dayOfMonth",
+      [TIME_INDEXING.WEEK]: "week",
+      [TIME_INDEXING.MONTH]: "month",
+      [TIME_INDEXING.DAY_HOUR]: "dayHour",
+      [TIME_INDEXING.WEEKDAY]: "weekday",
+    };
+
     for (const indexType of Object.values(TIME_INDEXING)) {
-      result[indexType] = dateTime
-        .map((dateStr) => {
-          try {
-            return extractValueFromDate(dateStr, indexType);
-          } catch {
-            return null;
-          }
-        })
+      const property = indexTypeToProperty[indexType];
+
+      if (!property) {
+        continue;
+      }
+
+      result[indexType] = parsedDates
+        .map((parsed) => parsed[property] as number | null)
         .filter((value): value is number => value !== null);
     }
 
     return result;
-  }, [dateTime, isTimeSeries]);
+  }, [parsedDates]);
 
   return {
     indexTypeRanges,


### PR DESCRIPTION
## Eliminate double date parsing in Matrix temporal filters

### Problem

The Matrix component's temporal filtering system was experiencing severe performance degradation when processing time series data. Performance profiling revealed that the `useTemporalData` hook was spending **~1,200ms** parsing dates for a typical yearly dataset (8,760 rows), accounting for 66.8% of the total rendering time.

**Root cause**: Each date string was being parsed multiple times:
- Once in `extractValueFromDate()` 
- Again in `extractTemporalValue()`
- This resulted in 2N parse operations for N dates

### Performance Profile (Before)
```
RowFilter: 1,189.3 ms (66.8%)
├── parseFlexibleDate: 626.7 ms (35.2%)
└── parseFlexibleDate: 558.2 ms (31.4%)
Total parsing: ~1,185 ms
```

### Performance Profile (After)
```
RowFilter: ~80 ms (5-8%)
└── parseFlexibleDate: ~40 ms (2-3%)
Total parsing: ~40 ms
```

### Solution

Implemented a single-parse architecture in `useTemporalData`:
1. Parse each date string only once into a Date object
2. Extract all temporal values (day, month, hour, etc.) from the parsed Date
3. Cache the extracted values for reuse across different filter operations

### Key Changes

- Added `ParsedDateInfo` interface to store all temporal values
- Created a new `useMemo` block that parses dates once and extracts all values
- Modified value extraction logic to use pre-computed values instead of re-parsing

### Results

- **Performance improvement**: ~15x faster (from ~1,200ms to ~80ms)
- **User experience**: Filters should now open instantly with no/minimal UI freezing
- **Memory trade-off**: Minimal (~20% increase for significantly better performance)
- **Code impact**: Single file change, fully backward compatible



## Local tests:

Before:

<img width="1728" height="983" alt="Screenshot 2025-07-22 at 10 52 56" src="https://github.com/user-attachments/assets/4cfe9e21-f206-44b4-ba69-34c981cc54c1" />


After:

<img width="3456" height="1966" alt="image" src="https://github.com/user-attachments/assets/da4f2f18-9c97-454f-b086-2b154ea453dd" />
