### PR TITLE
fix(alembic): alembic merge heads

### DIFF
--- a/alembic/versions/6c3d9dbf678c_.py
+++ b/alembic/versions/6c3d9dbf678c_.py
@@ -1,0 +1,21 @@
+"""empty message
+
+Revision ID: 6c3d9dbf678c
+Revises: fa59340767b0, a8c6e9d47b12
+Create Date: 2025-07-28 11:07:02.181937
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "6c3d9dbf678c"
+down_revision = ("fa59340767b0", "a8c6e9d47b12")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/alembic/versions/6c3d9dbf678c_merge_divergent_heads.py
+++ b/alembic/versions/6c3d9dbf678c_merge_divergent_heads.py
@@ -1,4 +1,4 @@
-"""empty message
+"""resolves a divergence in the Alembic migration history by merging multiple head revisions
 
 Revision ID: 6c3d9dbf678c
 Revises: fa59340767b0, a8c6e9d47b12


### PR DESCRIPTION
This PR resolves a divergence in the Alembic migration history by merging multiple head revisions into a single lineage. 

<img width="2355" height="254" alt="image" src="https://github.com/user-attachments/assets/a6e38a04-e44b-4c6c-8f18-14a274896a02" />

