### PR TITLE
fix(sts-matrix): restore deprecated enpoint as a security net

### DIFF
--- a/antarest/study/business/areas/st_storage_management.py
+++ b/antarest/study/business/areas/st_storage_management.py
@@ -76,8 +76,6 @@ class STStorageMatrix(AntaresBaseModel):
         array = np.array(data)
         if array.size == 0:
             raise ValueError("time series must not be empty")
-        if array.shape != (8760, 1):
-            raise ValueError(f"time series must have shape ({8760}, 1)")
         if np.any(np.isnan(array)):
             raise ValueError("time series must not contain NaN values")
         return data

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -31,6 +31,8 @@ from antarest.study.business.allocation_management import AllocationField, Alloc
 from antarest.study.business.areas.renewable_management import RenewableManager
 from antarest.study.business.areas.st_storage_management import (
     STStorageManager,
+    STStorageMatrix,
+    STStorageTimeSeries,
 )
 from antarest.study.business.areas.thermal_management import (
     ThermalManager,
@@ -1842,5 +1844,64 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
 
         study_interface = study_service.get_study_interface(study)
         return manager.duplicate_cluster(study_interface, area_id, source_cluster_id, new_cluster_name)
+
+    @bp.get(
+        path="/studies/{uuid}/areas/{area_id}/storages/{storage_id}/series/{ts_name}",
+        tags=[APITag.study_data],
+        summary="Get a short-term storage time series",
+        response_model=STStorageMatrix,
+        deprecated=True,
+    )
+    def get_st_storage_matrix(
+        uuid: str, area_id: str, storage_id: str, ts_name: STStorageTimeSeries
+    ) -> STStorageMatrix:
+        """
+        Retrieve the matrix of the specified time series for the given short-term storage.
+
+        Args:
+        - `uuid`: The UUID of the study.
+        - `area_id`: the area ID.
+        - `storage_id`: the ID of the short-term storage.
+        - `ts_name`: the name of the time series to retrieve.
+
+        Returns: The time series matrix with the following attributes:
+        - `index`: a list of 0-indexed time series lines (8760 lines).
+        - `columns`: a list of 0-indexed time series columns (1 column).
+        - `data`: a 2D-array matrix representing the time series.
+
+        Permissions:
+        - User must have READ permission on the study.
+        """
+        logger.info(f"Retrieving time series for study {uuid} and short-term storage {storage_id}")
+        study = study_service.check_study_access(uuid, StudyPermissionType.READ)
+        study_interface = study_service.get_study_interface(study)
+        return study_service.st_storage_manager.get_matrix(study_interface, area_id, storage_id, ts_name)
+
+    @bp.put(
+        path="/studies/{uuid}/areas/{area_id}/storages/{storage_id}/series/{ts_name}",
+        tags=[APITag.study_data],
+        summary="Update a short-term storage time series",
+        deprecated=True,
+    )
+    def update_st_storage_matrix(
+        uuid: str, area_id: str, storage_id: str, ts_name: STStorageTimeSeries, ts: STStorageMatrix
+    ) -> None:
+        """
+        Update the matrix of the specified time series for the given short-term storage.
+
+        Args:
+        - `uuid`: The UUID of the study.
+        - `area_id`: the area ID.
+        - `storage_id`: the ID of the short-term storage.
+        - `ts_name`: the name of the time series to retrieve.
+        - `ts`: the time series matrix to update.
+
+        Permissions:
+        - User must have WRITE permission on the study.
+        """
+        logger.info(f"Update time series for study {uuid} and short-term storage {storage_id}")
+        study = study_service.check_study_access(uuid, StudyPermissionType.WRITE)
+        study_interface = study_service.get_study_interface(study)
+        study_service.st_storage_manager.update_matrix(study_interface, area_id, storage_id, ts_name, ts)
 
     return bp

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -1848,7 +1848,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
     @bp.get(
         path="/studies/{uuid}/areas/{area_id}/storages/{storage_id}/series/{ts_name}",
         tags=[APITag.study_data],
-        summary="Get a short-term storage time series",
+        summary="Get a short-term storage time series (deprecated)",
         response_model=STStorageMatrix,
         deprecated=True,
     )
@@ -1880,7 +1880,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
     @bp.put(
         path="/studies/{uuid}/areas/{area_id}/storages/{storage_id}/series/{ts_name}",
         tags=[APITag.study_data],
-        summary="Update a short-term storage time series",
+        summary="Update a short-term storage time series (deprecated)",
         deprecated=True,
     )
     def update_st_storage_matrix(


### PR DESCRIPTION
We restore temporarily the STS matrix modification endpoint, as deprecated.
This is a security net to give more time to client to adapt.
