### PR TITLE
fix(alembic): fix migration syntax for postgresql

### DIFF
--- a/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
+++ b/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
@@ -7,6 +7,7 @@ Create Date: 2025-07-21 12:16:43.213036
 """
 
 from sqlalchemy.sql import and_, case, column, exists, literal, not_, or_, table, update
+from sqlalchemy.sql.functions import concat
 
 from alembic import op
 
@@ -34,7 +35,7 @@ def upgrade():
     add_id_exp = case(
         (
             study_table.c.folder.like("%/"),
-            study_table.c.folder + study_table.c.id,
+            concat(study_table.c.folder + study_table.c.id),
         ),
         else_=study_table.c.folder + literal("/") + study_table.c.id,
     )

--- a/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
+++ b/alembic/versions/fa59340767b0_make_all_managed_studies_folder_path_.py
@@ -35,7 +35,7 @@ def upgrade():
     add_id_exp = case(
         (
             study_table.c.folder.like("%/"),
-            concat(study_table.c.folder + study_table.c.id),
+            concat(study_table.c.folder, study_table.c.id),
         ),
         else_=study_table.c.folder + literal("/") + study_table.c.id,
     )


### PR DESCRIPTION

It seems that sqlalchemy does not understand that the addition is between 2 strings,
and does not translate it correctly to concatenation.