### PR TITLE
chore(node): clean normalization / denormalization methods

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/ini_file_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/ini_file_node.py
@@ -391,14 +391,6 @@ class IniFileNode(INode[SUB_JSON, SUB_JSON, JSON]):
 
         return errors
 
-    @override
-    def normalize(self) -> None:
-        pass  # no external store in this node
-
-    @override
-    def denormalize(self) -> None:
-        pass  # no external store in this node
-
     def _validate_param(
         self,
         section: str,

--- a/antarest/study/storage/rawstudy/model/filesystem/inode.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/inode.py
@@ -114,23 +114,21 @@ class INode(ABC, Generic[G, S, V]):
         """
         raise NotImplementedError()
 
-    @abstractmethod
     def normalize(self) -> None:
         """
         Scan tree to send matrix in matrix store and replace by its links
         Returns:
 
         """
-        raise NotImplementedError()
+        pass
 
-    @abstractmethod
     def denormalize(self) -> None:
         """
         Scan tree to fetch matrix by its links
         Returns:
 
         """
-        raise NotImplementedError()
+        pass
 
     def get_file_content(self) -> OriginalFile:
         suffix = self.config.path.suffix

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
@@ -153,7 +153,6 @@ class MatrixNode(LazyNode[bytes | JSON, bytes | JSON, JSON], ABC):
         and write the matrix data to the file specified by `self.config.path`
         before removing the link file.
         """
-        logger.info(f"Denormalizing matrix {self.config.path}")
         self.matrix_mapper.denormalize(self)
 
     @override

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
@@ -156,14 +156,6 @@ class OutputSeriesMatrix(LazyNode[Union[bytes, JSON], Union[bytes, JSON], JSON])
     def dump(self, data: Union[bytes, JSON], url: Optional[List[str]] = None) -> None:
         raise MustNotModifyOutputException(self.config.path.name)
 
-    @override
-    def normalize(self) -> None:
-        pass  # no external store in this node
-
-    @override
-    def denormalize(self) -> None:
-        pass  # no external store in this node
-
 
 class LinkOutputSeriesMatrix(OutputSeriesMatrix):
     def __init__(

--- a/antarest/study/storage/rawstudy/model/filesystem/raw_file_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/raw_file_node.py
@@ -73,11 +73,3 @@ class RawFileNode(LazyNode[bytes, bytes, str]):
                 raise ValueError(msg)
             return [msg]
         return []
-
-    @override
-    def normalize(self) -> None:
-        pass  # no external store in this node
-
-    @override
-    def denormalize(self) -> None:
-        pass  # no external store in this node

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/areas/list.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/areas/list.py
@@ -23,14 +23,6 @@ AREAS_LIST_RELATIVE_PATH = "input/areas/list.txt"
 
 
 class InputAreasList(INode[List[str], List[str], List[str]]):
-    @override
-    def normalize(self) -> None:
-        pass  # no external store in this node
-
-    @override
-    def denormalize(self) -> None:
-        pass  # no external store in this node
-
     def __init__(self, matrix_mapper: MatrixUriMapper, config: FileStudyTreeConfig):
         super().__init__(config)
         self.matrix_mapper = matrix_mapper

--- a/antarest/study/storage/rawstudy/model/filesystem/root/output/output.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/output/output.py
@@ -32,3 +32,11 @@ class Output(FolderNode):
         if (self.config.path / "logs").exists():
             children["logs"] = BucketNode(self.matrix_mapper, self.config.next_file("logs"))
         return children
+
+    @override
+    def normalize(self) -> None:
+        pass  # no external store in this node
+
+    @override
+    def denormalize(self) -> None:
+        pass  # no external store in this node

--- a/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/mode/mcall/grid.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/mode/mcall/grid.py
@@ -76,11 +76,3 @@ class OutputSynthesis(LazyNode[JSON, bytes, bytes]):
                 raise ValueError(msg)
             return [msg]
         return []
-
-    @override
-    def normalize(self) -> None:
-        pass  # shouldn't be normalized as it's an output file
-
-    @override
-    def denormalize(self) -> None:
-        pass  # shouldn't be denormalized as it's an output file

--- a/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/mode/mcall/synthesis.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/mode/mcall/synthesis.py
@@ -62,11 +62,3 @@ class OutputSynthesis(LazyNode[JSON, bytes, bytes]):
                 raise ValueError(msg)
             return [msg]
         return []
-
-    @override
-    def normalize(self) -> None:
-        pass  # shouldn't be normalized as it's an output file
-
-    @override
-    def denormalize(self) -> None:
-        pass  # shouldn't be denormalized as it's an output file

--- a/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/ts_numbers/ts_numbers_data.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/ts_numbers/ts_numbers_data.py
@@ -67,13 +67,3 @@ class TsNumbersVector(LazyNode[List[int], List[int], JSON]):
         raising: bool = False,
     ) -> List[str]:
         return []
-
-    @override
-    def normalize(self) -> None:
-        # this is not normalizable
-        pass
-
-    @override
-    def denormalize(self) -> None:
-        # this is not normalizable
-        pass

--- a/tests/storage/repository/filesystem/test_lazy_node.py
+++ b/tests/storage/repository/filesystem/test_lazy_node.py
@@ -21,12 +21,6 @@ from tests.storage.repository.filesystem.matrix.test_matrix_node import MockMatr
 
 
 class MockLazyNode(LazyNode[str, str, str]):
-    def normalize(self) -> None:
-        pass  # no external store in this node
-
-    def denormalize(self) -> None:
-        pass  # no external store in this node
-
     def __init__(self, matrix_mapper: MatrixUriMapper, config: FileStudyTreeConfig) -> None:
         super().__init__(
             config=config,

--- a/tests/storage/repository/filesystem/utils.py
+++ b/tests/storage/repository/filesystem/utils.py
@@ -21,12 +21,6 @@ from antarest.study.storage.rawstudy.model.filesystem.inode import TREE, INode
 
 
 class CheckSubNode(INode[int, int, int]):
-    def normalize(self) -> None:
-        pass
-
-    def denormalize(self) -> None:
-        pass
-
     def build(self, config: FileStudyTreeConfig) -> "TREE":
         pass
 


### PR DESCRIPTION
It also improves a little bit the performances when normalizing / denormalizing a study that has outputs as we don't iterate over these files anymore