### PR TITLE
chore(patch): remove "patch" related dead code

### DIFF
--- a/alembic/versions/d2942741ae68_drop_patch_data.py
+++ b/alembic/versions/d2942741ae68_drop_patch_data.py
@@ -1,0 +1,26 @@
+"""drop_patch_data
+
+Revision ID: d2942741ae68
+Revises: 6c3d9dbf678c
+Create Date: 2025-08-12 10:50:39.475561
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d2942741ae68"
+down_revision = "6c3d9dbf678c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("study_additional_data", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_study_additional_data_patch"))
+        batch_op.drop_column(batch_op.f("patch"))
+
+
+def downgrade():
+    # Cannot restore deleted data
+    pass

--- a/alembic/versions/d2942741ae68_drop_patch_data.py
+++ b/alembic/versions/d2942741ae68_drop_patch_data.py
@@ -6,6 +6,8 @@ Create Date: 2025-08-12 10:50:39.475561
 
 """
 
+import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -23,4 +25,8 @@ def upgrade():
 
 def downgrade():
     # Cannot restore deleted data
-    pass
+    with op.batch_alter_table("study_additional_data", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("patch", sa.String(), nullable=True),
+        )
+        batch_op.create_index(batch_op.f("ix_study_additional_data_patch"), ["patch"], unique=False)

--- a/antarest/study/model.py
+++ b/antarest/study/model.py
@@ -215,7 +215,6 @@ class StudyAdditionalData(Base):  # type:ignore
     author: Mapped[str] = mapped_column(String(255), default="Unknown")
     editor: Mapped[str] = mapped_column(String(255), default="Unknown")
     horizon: Mapped[Optional[str]] = mapped_column(String)
-    patch: Mapped[Optional[str]] = mapped_column(String(), index=True, nullable=True)
 
     @override
     def __eq__(self, other: Any) -> bool:
@@ -223,7 +222,7 @@ class StudyAdditionalData(Base):  # type:ignore
             return False
         if not isinstance(other, StudyAdditionalData):
             return False
-        return bool(other.author == self.author and other.horizon == self.horizon and other.patch == self.patch)
+        return bool(other.author == self.author and other.horizon == self.horizon)
 
 
 class Study(Base):  # type: ignore
@@ -483,18 +482,6 @@ class WorkspaceDTO(AntaresBaseModel):
     name: str
     disk_name: Optional[str] = None
     model_config = ConfigDict(populate_by_name=True, alias_generator=alias_generators.to_camel)
-
-
-class PatchStudy(AntaresBaseModel):
-    scenario: Optional[str] = None
-    doc: Optional[str] = None
-    status: Optional[str] = None
-    comments: Optional[str] = None
-    tags: List[str] = []
-
-
-class Patch(AntaresBaseModel, extra="allow"):
-    study: Optional[PatchStudy] = None
 
 
 class OwnerInfo(AntaresBaseModel):

--- a/antarest/study/storage/abstract_storage_service.py
+++ b/antarest/study/storage/abstract_storage_service.py
@@ -24,15 +24,12 @@ from antarest.core.config import Config
 from antarest.core.exceptions import BadOutputError, StudyOutputNotFoundError
 from antarest.core.interfaces.cache import ICache, study_raw_cache_key
 from antarest.core.model import JSON, PublicMode
-from antarest.core.serde.json import from_json
 from antarest.core.utils.archives import ArchiveFormat, archive_dir, extract_archive, unzip
 from antarest.core.utils.utils import StopWatch
 from antarest.login.model import GroupDTO
 from antarest.study.model import (
     DEFAULT_WORKSPACE_NAME,
     OwnerInfo,
-    Patch,
-    PatchStudy,
     Study,
     StudyAdditionalData,
     StudyMetadataDTO,
@@ -68,16 +65,6 @@ class AbstractStorageService(IStudyStorage, IOutputStorage, ABC):
         study: Study,
     ) -> StudyMetadataDTO:
         additional_data = study.additional_data or StudyAdditionalData()
-
-        try:
-            patch = Patch.model_validate(from_json(additional_data.patch or "{}"))
-        except ValueError as e:
-            # The conversion to JSON and the parsing can fail if the patch is not valid
-            logger.warning(f"Failed to parse patch for study {study.id}", exc_info=e)
-            patch = Patch()
-
-        patch_metadata = patch.study or PatchStudy()
-
         study_workspace = getattr(study, "workspace", DEFAULT_WORKSPACE_NAME)
         folder: Optional[str] = None
         if hasattr(study, "folder"):
@@ -103,9 +90,6 @@ class AbstractStorageService(IStudyStorage, IOutputStorage, ABC):
             groups=[GroupDTO(id=group.id, name=group.name) for group in study.groups],
             public_mode=study.public_mode or PublicMode.NONE,
             horizon=additional_data.horizon,
-            scenario=patch_metadata.scenario,
-            status=patch_metadata.status,
-            doc=patch_metadata.doc,
             folder=folder,
             tags=[tag.label for tag in study.tags],
         )

--- a/antarest/study/storage/rawstudy/raw_study_service.py
+++ b/antarest/study/storage/rawstudy/raw_study_service.py
@@ -29,7 +29,7 @@ from antarest.core.model import PublicMode
 from antarest.core.serde.ini_reader import read_ini
 from antarest.core.utils.archives import ArchiveFormat, extract_archive
 from antarest.matrixstore.matrix_uri_mapper import NormalizedMatrixUriMapper
-from antarest.study.model import DEFAULT_WORKSPACE_NAME, STUDY_VERSION_9_2, Patch, RawStudy, Study, StudyAdditionalData
+from antarest.study.model import DEFAULT_WORKSPACE_NAME, STUDY_VERSION_9_2, RawStudy, Study, StudyAdditionalData
 from antarest.study.storage.abstract_storage_service import AbstractStorageService
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig, FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy, StudyFactory
@@ -135,7 +135,6 @@ class RawStudyService(AbstractStorageService):
                 metadata.updated_at = metadata.updated_at or datetime.utcnow()
                 if metadata.additional_data is None:
                     metadata.additional_data = StudyAdditionalData()
-                metadata.additional_data.patch = metadata.additional_data.patch or Patch().model_dump_json()
                 metadata.additional_data.author = metadata.additional_data.author or "Unknown"
                 metadata.additional_data.editor = metadata.additional_data.editor or "Unknown"
 
@@ -297,7 +296,6 @@ class RawStudyService(AbstractStorageService):
             additional_data = StudyAdditionalData(
                 horizon=src_study.additional_data.horizon,
                 author=src_study.additional_data.author,
-                patch=src_study.additional_data.patch,
             )
         dest_id = str(uuid4())
         dest_study = RawStudy(

--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -617,7 +617,6 @@ class VariantStudyService(AbstractStorageService):
             additional_data = StudyAdditionalData(
                 horizon=study.additional_data.horizon,
                 author=study.additional_data.author,
-                patch=study.additional_data.patch,
             )
 
         variant_study = VariantStudy(

--- a/tests/storage/business/test_raw_study_service.py
+++ b/tests/storage/business/test_raw_study_service.py
@@ -536,7 +536,7 @@ def test_initialize_additional_data(tmp_path: Path) -> None:
     study_path.mkdir()
     (study_path / "study.antares").touch()
 
-    study_additional_data = StudyAdditionalData(horizon=10, author="foo", patch="bar")
+    study_additional_data = StudyAdditionalData(horizon=10, author="foo")
 
     cache = Mock()
 

--- a/tests/storage/business/test_variant_study_service.py
+++ b/tests/storage/business/test_variant_study_service.py
@@ -354,7 +354,7 @@ def test_initialize_additional_data(tmp_path: Path) -> None:
 
     md = create_variant_study(id=name, path=str(study_path))
 
-    additional_data = StudyAdditionalData(horizon=2050, patch="{}", author="Zoro")
+    additional_data = StudyAdditionalData(horizon=2050, author="Zoro")
 
     study_factory = Mock()
     study_factory.create_from_fs.return_value = md

--- a/tests/storage/repository/test_study.py
+++ b/tests/storage/repository/test_study.py
@@ -96,7 +96,6 @@ def test_study__additional_data(db_session: Session) -> None:
     user = User(id=0, name="admin")
     group = Group(id="my-group", name="group")
 
-    patch = {"foo": "bar"}
     a = create_raw_study(
         name="a",
         version="820",
@@ -109,7 +108,7 @@ def test_study__additional_data(db_session: Session) -> None:
         workspace=DEFAULT_WORKSPACE_NAME,
         path="study",
         content_status=StudyContentStatus.WARNING,
-        additional_data=StudyAdditionalData(author="John Smith", horizon="2024-2050", patch=json.dumps(patch)),
+        additional_data=StudyAdditionalData(author="John Smith", horizon="2024-2050"),
     )
 
     repo.save(a)
@@ -119,7 +118,6 @@ def test_study__additional_data(db_session: Session) -> None:
     additional_data = repo.get_additional_data(a_id)
     assert additional_data.author == "John Smith"
     assert additional_data.horizon == "2024-2050"
-    assert json.loads(additional_data.patch) == patch
 
     # Check that the additional data is correctly updated
     new_patch = {"foo": "baz"}

--- a/tests/study/test_model.py
+++ b/tests/study/test_model.py
@@ -72,12 +72,6 @@ class TestStudy:
         index_names = {index["name"] for index in indexes}
         assert not index_names
 
-    def test_index_on_study_additional_data(self, db_engine: Engine) -> None:
-        inspector = inspect(db_engine)
-        indexes = inspector.get_indexes("study_additional_data")
-        index_names = {index["name"] for index in indexes}
-        assert index_names == {"ix_study_additional_data_patch"}
-
     def test_study_tag_relationship(self, db_session: Session) -> None:
         study_id_1 = str(uuid.uuid4())
         study_id_2 = str(uuid.uuid4())


### PR DESCRIPTION
The data stored in patch column in database is actually not used anymore,
as well as related classes.

This PR cleans it up.