### PR TITLE
perf(matrix): return matrices as integers when possible inside endpoint

### DIFF
--- a/antarest/core/serde/matrix_export.py
+++ b/antarest/core/serde/matrix_export.py
@@ -26,19 +26,23 @@ except ImportError:
     raise ImportError("The 'xlsxwriter', 'openpyxl' and 'tables' packages are required") from None
 
 
-def write_dataframe_in_tsv_format(df: pd.DataFrame, path: Path, headers: bool = False) -> None:
+def simplify_dataframe(dataframe: pd.DataFrame, np_type: type[np.int32] | type[np.int64] = np.int64) -> pd.DataFrame:
     """
     Checks if the dataFrame could be represented with integer values.
-    If so, writes it this way as it is quicker and the file takes less place on the filesystem.
+    If so, returns it this way as it will be quicker to write or to return.
     """
 
-    # Ignores errors if conversion fails as if it happens, `df_as_int` will simply be `df`.
-    df_as_int = df.astype(np.int64, errors="ignore")
     try:
-        pd.testing.assert_frame_equal(df, df_as_int, check_dtype=False, check_exact=True)
-        df_as_int.to_csv(path, sep="\t", header=headers, index=False)
-    except AssertionError:
-        df.to_csv(path, sep="\t", header=headers, index=False)
+        df_as_int = dataframe.astype(np_type)
+        pd.testing.assert_frame_equal(dataframe, df_as_int, check_dtype=False, check_exact=True)
+        return df_as_int
+    except Exception:
+        return dataframe
+
+
+def write_dataframe_in_tsv_format(df: pd.DataFrame, path: Path, headers: bool = False) -> None:
+    df = simplify_dataframe(df)
+    df.to_csv(path, sep="\t", header=headers, index=False)
 
 
 class DataframeStreamWriter(Protocol):

--- a/antarest/study/web/raw_studies_blueprint.py
+++ b/antarest/study/web/raw_studies_blueprint.py
@@ -82,6 +82,8 @@ class MatrixFormat(EnumIgnoreCase):
 
     def serialize_dataframe(self, dataframe: pd.DataFrame) -> Response:
         np_type: type[np.int32] | type[np.int64] = np.int64
+        # For textual formats, int64 and int32 are represented in the same way, so we use int64 to catch bigger numbers.
+        # For the arrow format, on the other hand, the size of an int32 is half the size of an int64 so we prefer int32.
         if self in {MatrixFormat.ARROW_COMPRESSED, MatrixFormat.ARROW_UNCOMPRESSED}:
             np_type = np.int32
         dataframe = simplify_dataframe(dataframe, np_type)

--- a/antarest/study/web/raw_studies_blueprint.py
+++ b/antarest/study/web/raw_studies_blueprint.py
@@ -16,6 +16,7 @@ import logging
 from pathlib import Path, PurePosixPath
 from typing import Annotated, Any, List
 
+import numpy as np
 import pandas as pd
 from fastapi import APIRouter, Body, File, HTTPException
 from fastapi.params import Query
@@ -25,7 +26,7 @@ from antarest.core.config import Config
 from antarest.core.exceptions import IncorrectPathError
 from antarest.core.model import SUB_JSON
 from antarest.core.serde.json import from_json, to_json
-from antarest.core.serde.matrix_export import TableExportFormat
+from antarest.core.serde.matrix_export import TableExportFormat, simplify_dataframe
 from antarest.core.swagger import get_path_examples
 from antarest.core.utils.utils import sanitize_string, sanitize_uuid
 from antarest.core.utils.web import APITag
@@ -80,6 +81,11 @@ class MatrixFormat(EnumIgnoreCase):
     PLAIN = "plain"
 
     def serialize_dataframe(self, dataframe: pd.DataFrame) -> Response:
+        np_type: type[np.int32] | type[np.int64] = np.int64
+        if self in {MatrixFormat.ARROW_COMPRESSED, MatrixFormat.ARROW_UNCOMPRESSED}:
+            np_type = np.int32
+        dataframe = simplify_dataframe(dataframe, np_type)
+
         if self == MatrixFormat.PLAIN:
             if dataframe.empty:
                 return Response(content=b"", media_type="application/octet-stream")


### PR DESCRIPTION
**We've reached a point where we cannot have performance gains using better parsing / serializing methods. 
But we can still increase our perfs by transmitting lighter data.**

Benchmark performed on my local env with integers matrices (first value is time and second is size of the response):
 
**Current code**

    '8760*1 json': (0.02, 95284),
    '8760*1 plain': (0.02, 35040),
    '8760*1 arrow compressed': (0.01, 1714),
    '8760*1 arrow uncompressed': (0.01, 71450),

    '8760*200 json': (0.14, 13306546),
    '8760*200 plain': (0.8, 13245614),
    '8760*200 arrow compressed': (0.06, 7139250),
    '8760*200 arrow uncompressed': (0.06, 14086586),
          
    '8760*60 json': (0.04, 3739612),
    '8760*60 plain': (0.2, 3679200),
    '8760*60 arrow compressed': (0.03, 41458),
    '8760*60 arrow uncompressed': (0.04, 4226554)
 
 
**With int64**
 

    '8760*1 json': (0.02, 77764),
    '8760*1 plain': (0.01, 17520),
    '8760*1 arrow compressed': (0.01, 1730),
    '8760*1 arrow uncompressed': (0.01, 71466),
       
    '8760*200 json': (0.16, 9802546),
    '8760*200 plain': (0.4, 9741614),
    '8760*200 arrow compressed': (0.1, 6709210),
    '8760*200 arrow uncompressed': (0.1, 14086602),
           
    '8760*60 json': (0.05, 2688412),
    '8760*60 plain': (0.1, 2628000),
    '8760*60 arrow compressed': (0.03, 41922),
    '8760*60 arrow uncompressed': (0.04, 4226554)
 
**With int32**
 
    '8760*1 json': (0.02, 77764),
    '8760*1 plain': (0.01, 17520),
    '8760*1 arrow compressed': (0.01, 1578),
    '8760*1 arrow uncompressed': (0.01, 36426),
       
    '8760*200 json': (0.1, 9802546),
    '8760*200 plain': (0.4, 9741614),
    '8760*200 arrow compressed': (0.08, 5754930),
    '8760*200 arrow uncompressed': (0.08, 7078602),
           
    '8760*60 json': (0.05, 2688412),
    '8760*60 plain': (0.1, 2628000),
    '8760*60 arrow compressed': (0.04, 32330),
    '8760*60 arrow uncompressed': (0.03, 2124154)
 

# Conclusion
For `arrow compressed` and `arrow uncompressed`: perform the INT32 check
For `PLAIN` and `JSON`: perform the INT64 check (or INT32 to simplify the code)