### PR TITLE
fix(raw): fix getting link output data

### DIFF
--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -126,6 +126,7 @@ from antarest.study.repository import (
 from antarest.study.storage.matrix_profile import adjust_matrix_columns_index
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
+from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
 from antarest.study.storage.rawstudy.model.filesystem.ini_file_node import IniFileNode
 from antarest.study.storage.rawstudy.model.filesystem.inode import INode, OriginalFile
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
@@ -2424,4 +2425,13 @@ class StudyService:
         if isinstance(node, MatrixNode):
             return node.parse_as_dataframe()
 
+        # Minor optimization: in order to not restart the search from the root
+        # in the specific case of folders, we can assume there is no
+        # "remaining parts" in the URL.
+        # This is a technical debt because this is clearly an implicit contract.
+        # Should be solved by returning remaining parts after a search, for ex.
+        if isinstance(node, FolderNode):
+            return node.get(url=[], depth=depth)
+
+        # Else we have to restart from the root to guarantee the right behaviour
         return file_study.tree.get(url, depth=depth, formatted=formatted)

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -2424,9 +2424,4 @@ class StudyService:
         if isinstance(node, MatrixNode):
             return node.parse_as_dataframe()
 
-        relative_url: Sequence[str]
-        if node.config.archive_path:
-            relative_url = node.get_relative_path_inside_archive(node.config.archive_path).split("/")
-        else:
-            relative_url = node.config.path.relative_to(node.config.study_path).parts
-        return node.get(url=url[len(relative_url) :], depth=depth, formatted=formatted)
+        return file_study.tree.get(url, depth=depth, formatted=formatted)

--- a/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
@@ -277,6 +277,14 @@ class TestFetchRawData:
             res = client.get(raw_url, params={"path": path, "depth": depth})
             assert res.status_code == 200, f"Error for path={path} and depth={depth}"
 
+        # asserts that the GET /raw endpoint is able to read link URLs, which don't map
+        # 1 to 1 with filesystem path (which is "output/20201014-1427eco/economy/mc-all/links/de - fr/" for
+        # example)
+        if study_type == "raw":
+            res = client.get(raw_url, params={"path": "output/20201014-1427eco/economy/mc-all/links/de/"})
+            assert res.status_code == 200
+            assert res.json() == {"fr": {}}
+
         ####### Matrices #######
 
         # We should have a JSON content if formatted is True


### PR DESCRIPTION

This is a quick-fix to revert a regression on getting some raw data.
Not great because it will cause some searches to be performed twice,
but at least it works.

The issue is that the previous code was relying on filesystem paths to get
the relative "URL" of a node. This does not work, because paths and URLs
don't map 1 to 1. In particular, a link folder such as "de - fr" is mapped to
a 2-levels URL `["de", "fr" ]`.

If we want to have a more robust solution we'll need to add a URL member to
each node and update it correctly. Not sure it's worth it.