### PR TITLE
fix(tests): fix random failure in matrix gc tests

### DIFF
--- a/antarest/matrixstore/matrix_garbage_collector.py
+++ b/antarest/matrixstore/matrix_garbage_collector.py
@@ -56,7 +56,7 @@ class MatrixGarbageCollector(IService):
             current_time = datetime.utcnow()  # We use this value to fit with the one inside the database.
             for matrix in unused_matrices:
                 matrix_lifetime = (current_time - saved_matrices[matrix]).total_seconds()
-                if matrix_lifetime > self.retention_time:
+                if matrix_lifetime >= self.retention_time:
                     matrices_to_remove.add(matrix)
 
             self._delete_unused_saved_matrices(unused_matrices=matrices_to_remove)

--- a/tests/matrixstore/test_matrix_garbage_collector.py
+++ b/tests/matrixstore/test_matrix_garbage_collector.py
@@ -82,8 +82,8 @@ def test_clean_matrices(matrix_garbage_collector: MatrixGarbageCollector):
     matrix_garbage_collector._delete_unused_saved_matrices.assert_called_once_with(unused_matrices={"matrix2"})
 
 
-@pytest.mark.parametrize("retention_time", [-1, 3600])
-def test_clean_matrices_actual_service(matrix_service: MatrixService, retention_time: int):
+@pytest.mark.parametrize("retention_time, expected_remove", [(-1, True), (3600, False)])
+def test_clean_matrices_actual_service(matrix_service: MatrixService, retention_time: int, expected_remove: bool):
     gc = MatrixGarbageCollector(
         matrix_service=matrix_service, sleeping_time=3600, dry_run=False, retention_time=retention_time
     )
@@ -100,7 +100,7 @@ def test_clean_matrices_actual_service(matrix_service: MatrixService, retention_
         gc.clean_matrices()
 
         matrices_after_clean = matrix_service.get_matrices()
-        if retention_time == 0:
+        if expected_remove:
             assert matrices_after_clean == []
         else:
             # Ensures the matrix wasn't deleted as it was created recently

--- a/tests/matrixstore/test_matrix_garbage_collector.py
+++ b/tests/matrixstore/test_matrix_garbage_collector.py
@@ -82,7 +82,7 @@ def test_clean_matrices(matrix_garbage_collector: MatrixGarbageCollector):
     matrix_garbage_collector._delete_unused_saved_matrices.assert_called_once_with(unused_matrices={"matrix2"})
 
 
-@pytest.mark.parametrize("retention_time", [0, 3600])
+@pytest.mark.parametrize("retention_time", [-1, 3600])
 def test_clean_matrices_actual_service(matrix_service: MatrixService, retention_time: int):
     gc = MatrixGarbageCollector(
         matrix_service=matrix_service, sleeping_time=3600, dry_run=False, retention_time=retention_time


### PR DESCRIPTION

If creation and GC happened in the same second, the unit test could fail.