### PR TITLE
fix(ui): preserve tab state by passing ReactNode to TabsView content

### DIFF
--- a/webapp/src/components/App/Settings/index.tsx
+++ b/webapp/src/components/App/Settings/index.tsx
@@ -12,20 +12,20 @@
  * This file is part of the Antares project.
  */
 
+import About from "@/components/App/Settings/About";
+import ViewWrapper from "@/components/common/page/ViewWrapper";
+import TabsView from "@/components/common/TabsView";
+import { useAppMode } from "@/hooks/useAppMode";
+import SettingsIcon from "@mui/icons-material/Settings";
 import { useTranslation } from "react-i18next";
+import useAppSelector from "../../../redux/hooks/useAppSelector";
+import { isAuthUserAdmin, isAuthUserInGroupAdmin } from "../../../redux/selectors";
 import RootPage from "../../common/page/RootPage";
+import General from "./General";
 import Groups from "./Groups";
 import Maintenance from "./Maintenance";
 import Tokens from "./Tokens";
 import Users from "./Users";
-import General from "./General";
-import useAppSelector from "../../../redux/hooks/useAppSelector";
-import { isAuthUserAdmin, isAuthUserInGroupAdmin } from "../../../redux/selectors";
-import TabsView from "@/components/common/TabsView";
-import SettingsIcon from "@mui/icons-material/Settings";
-import ViewWrapper from "@/components/common/page/ViewWrapper";
-import About from "@/components/App/Settings/About";
-import { useAppMode } from "@/hooks/useAppMode";
 
 function Settings() {
   const { t } = useTranslation();
@@ -44,27 +44,27 @@ function Settings() {
           items={[
             {
               label: t("global.general"),
-              content: General,
+              content: <General />,
             },
             isUserAdmin && {
               label: t("global.users"),
-              content: Users,
+              content: <Users />,
             },
             (isUserAdmin || isUserInGroupAdmin) && {
               label: t("global.group"),
-              content: Groups,
+              content: <Groups />,
             },
             isWebMode && {
               label: t("global.tokens"),
-              content: Tokens,
+              content: <Tokens />,
             },
             isUserAdmin && {
               label: t("global.maintenance"),
-              content: Maintenance,
+              content: <Maintenance />,
             },
             {
               label: t("global.about"),
-              content: About,
+              content: <About />,
             },
           ].filter(Boolean)}
         />

--- a/webapp/src/components/App/Singlestudy/explore/Configuration/AdequacyPatch/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Configuration/AdequacyPatch/index.tsx
@@ -12,19 +12,19 @@
  * This file is part of the Antares project.
  */
 
-import { useOutletContext } from "react-router";
-import { useTranslation } from "react-i18next";
 import type { StudyMetadata } from "@/types/types";
+import { useTranslation } from "react-i18next";
+import { useOutletContext } from "react-router";
 import Form from "../../../../../common/Form";
 import type { SubmitHandlerPlus } from "../../../../../common/Form/types";
+import TableMode from "../../../../../common/TableMode";
+import TabsView from "../../../../../common/TabsView";
 import Fields from "./Fields";
 import {
   getAdequacyPatchFormFields,
   setAdequacyPatchFormFields,
   type AdequacyPatchFormFields,
 } from "./utils";
-import TableMode from "../../../../../common/TableMode";
-import TabsView from "../../../../../common/TabsView";
 
 function AdequacyPatch() {
   const { study } = useOutletContext<{ study: StudyMetadata }>();
@@ -47,7 +47,7 @@ function AdequacyPatch() {
       items={[
         {
           label: t("study.configuration.adequacyPatch.tab.general"),
-          content: () => (
+          content: (
             <Form
               key={study.id}
               config={{
@@ -62,9 +62,7 @@ function AdequacyPatch() {
         },
         {
           label: t("study.configuration.adequacyPatch.tab.perimeter"),
-          content: () => (
-            <TableMode studyId={study.id} type="areas" columns={["adequacyPatchMode"]} />
-          ),
+          content: <TableMode studyId={study.id} type="areas" columns={["adequacyPatchMode"]} />,
         },
       ]}
     />

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/StorageMatrices.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/StorageMatrices.tsx
@@ -35,14 +35,10 @@ interface Props {
 function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
   const { t } = useTranslation();
 
-  ////////////////////////////////////////////////////////////////
-  // JSX
-  ////////////////////////////////////////////////////////////////
-
   const matricesAllVersions = [
     {
       label: t("study.modelization.storages.modulation"),
-      content: () => (
+      content: (
         <SplitView id="storage-injectionModulation-withdrawalModulation" sizes={[50, 50]}>
           <Box sx={{ p: 2 }}>
             {/* TODO: Remove isTimeSeries={false} and customColumns when simulator development is complete */}
@@ -67,7 +63,7 @@ function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
     },
     {
       label: t("study.modelization.storages.ruleCurves"),
-      content: () => (
+      content: (
         <SplitView id="storage-lowerRuleCurve-upperRuleCurve" sizes={[50, 50]}>
           <Box sx={{ p: 2 }}>
             {/* TODO: Remove isTimeSeries={false} and customColumns when simulator development is complete */}
@@ -92,7 +88,7 @@ function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
     },
     {
       label: t("study.modelization.storages.inflows"),
-      content: () => (
+      content: (
         <Matrix
           url={`input/st-storage/series/${areaId}/${storageId}/inflows`}
           // Since v9.3 this matrix supports the resize functionality
@@ -105,7 +101,7 @@ function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
   const matrices920 = [
     {
       label: t("study.modelization.storages.costs"),
-      content: () => (
+      content: (
         <SplitView id="storage-injectionCost-withdrawalCost" sizes={[50, 50]}>
           <Box sx={{ p: 2 }}>
             {/* TODO: Remove isTimeSeries={false} and customColumns when simulator development is complete */}
@@ -130,7 +126,7 @@ function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
     },
     {
       label: t("study.modelization.storages.variationCosts"),
-      content: () => (
+      content: (
         <SplitView id="storage-variationInjectionCost-variationWithdrawalCost" sizes={[50, 50]}>
           <Box sx={{ p: 2 }}>
             {/* TODO: Remove isTimeSeries={false} and customColumns when simulator development is complete */}
@@ -155,7 +151,7 @@ function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
     },
     {
       label: t("study.modelization.storages.levelCost"),
-      content: () => (
+      content: (
         <Matrix
           title={t("study.modelization.storages.levelCost")}
           url={`input/st-storage/series/${areaId}/${storageId}/cost_level`}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/index.tsx
@@ -16,7 +16,6 @@ import TabsView from "@/components/common/TabsView";
 import { getCurrentAreaId } from "@/redux/selectors";
 import { nameToId } from "@/services/utils";
 import type { StudyMetadata } from "@/types/types";
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import useAppSelector from "../../../../../../../../redux/hooks/useAppSelector";
@@ -33,13 +32,14 @@ function StorageConfig() {
   const studyId = study.id;
   const studyVersion = Number(study.version);
 
-  // Memoize items to preserve the active tab when saving a matrix
-  const items = useMemo(
-    () =>
-      [
+  return (
+    <TabsView
+      onBack={() => navigate("../storages")}
+      divider
+      items={[
         {
           label: t("study.modelization.storages.operatingParameters"),
-          content: () => (
+          content: (
             <StorageForm
               studyId={studyId}
               studyVersion={studyVersion}
@@ -50,13 +50,13 @@ function StorageConfig() {
         },
         {
           label: t("global.timeSeries"),
-          content: () => (
+          content: (
             <StorageMatrices studyVersion={studyVersion} areaId={areaId} storageId={storageId} />
           ),
         },
         studyVersion >= 920 && {
           label: t("study.modelization.storages.additionalConstraints"),
-          content: () => (
+          content: (
             <AdditionalConstraints
               studyId={studyId}
               areaId={areaId}
@@ -65,15 +65,9 @@ function StorageConfig() {
             />
           ),
         },
-      ].filter(Boolean),
-    [studyId, areaId, storageId, studyVersion, t],
+      ].filter(Boolean)}
+    />
   );
-
-  ////////////////////////////////////////////////////////////////
-  // JSX
-  ////////////////////////////////////////////////////////////////
-
-  return <TabsView onBack={() => navigate("../storages")} divider items={items} />;
 }
 
 export default StorageConfig;

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Thermal/ThermalConfig/ThermalMatrices.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Thermal/ThermalConfig/ThermalMatrices.tsx
@@ -38,7 +38,7 @@ function ThermalMatrices({ study, areaId, clusterId }: Props) {
       items={[
         {
           label: t("study.modelization.clusters.matrix.common"),
-          content: () => (
+          content: (
             <Matrix
               url={`input/thermal/prepro/${areaId}/${clusterId}/modulation`}
               customColumns={COMMON_MATRIX_COLS}
@@ -48,7 +48,7 @@ function ThermalMatrices({ study, areaId, clusterId }: Props) {
         },
         {
           label: t("study.modelization.clusters.matrix.tsGen"),
-          content: () => (
+          content: (
             <Matrix
               url={`input/thermal/prepro/${areaId}/${clusterId}/data`}
               customColumns={TS_GEN_MATRIX_COLS}
@@ -58,7 +58,7 @@ function ThermalMatrices({ study, areaId, clusterId }: Props) {
         },
         {
           label: t("study.modelization.clusters.matrix.availability"),
-          content: () => (
+          content: (
             <Matrix
               url={`input/thermal/series/${areaId}/${clusterId}/series`}
               aggregateColumns="stats" // avg, min, max
@@ -67,11 +67,11 @@ function ThermalMatrices({ study, areaId, clusterId }: Props) {
         },
         studyVersion >= 870 && {
           label: t("study.modelization.clusters.matrix.fuelCosts"),
-          content: () => <Matrix url={`input/thermal/series/${areaId}/${clusterId}/fuelCost`} />,
+          content: <Matrix url={`input/thermal/series/${areaId}/${clusterId}/fuelCost`} />,
         },
         studyVersion >= 870 && {
           label: t("study.modelization.clusters.matrix.co2Costs"),
-          content: () => <Matrix url={`input/thermal/series/${areaId}/${clusterId}/CO2Cost`} />,
+          content: <Matrix url={`input/thermal/series/${areaId}/${clusterId}/CO2Cost`} />,
         },
       ].filter(Boolean)}
     />

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Links/LinkConfig/LinkMatrices.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Links/LinkConfig/LinkMatrices.tsx
@@ -53,7 +53,7 @@ function LinkMatrices({ area1, area2, isOldStudy }: Props) {
       items={[
         {
           label: t("study.modelization.links.matrix.parameters"),
-          content: () => (
+          content: (
             <Matrix
               url={`input/links/${area1.toLowerCase()}/${area2.toLowerCase()}_parameters`}
               title={t("study.modelization.links.matrix.parameters")}
@@ -75,7 +75,7 @@ function LinkMatrices({ area1, area2, isOldStudy }: Props) {
         },
         {
           label: t("study.modelization.links.matrix.capacities"),
-          content: () => (
+          content: (
             <SplitView id="link-transCapaDirect-transCapaIndirect" sizes={[50, 50]}>
               <Box sx={{ pr: 2 }}>
                 <Matrix

--- a/webapp/src/components/common/TabsView.tsx
+++ b/webapp/src/components/common/TabsView.tsx
@@ -20,7 +20,7 @@ import { useState } from "react";
 interface TabsViewProps {
   items: Array<{
     label: string;
-    content: React.FunctionComponent;
+    content: React.ReactNode;
     disabled?: boolean;
   }>;
   onChange?: TabListProps["onChange"];
@@ -77,7 +77,7 @@ function TabsView({
             ))}
           </TabList>
         </Box>
-        {items.map(({ content: Content, label }, index) => (
+        {items.map(({ content, label }, index) => (
           <TabPanel
             key={label + index}
             value={index}
@@ -96,7 +96,7 @@ function TabsView({
               disableGutters && { px: 0 },
             ]}
           >
-            <Content />
+            {content}
           </TabPanel>
         ))}
       </TabContext>

--- a/webapp/src/components/common/dialogs/DigestDialog/DigestTabs.tsx
+++ b/webapp/src/components/common/dialogs/DigestDialog/DigestTabs.tsx
@@ -24,19 +24,19 @@ function DigestTabs({ matrices }: DigestTabsProps) {
   const tabItems = [
     {
       label: "Area",
-      content: () => <DigestMatrix matrix={matrices.area} />,
+      content: <DigestMatrix matrix={matrices.area} />,
     },
     {
       label: "Districts",
-      content: () => <DigestMatrix matrix={matrices.districts} />,
+      content: <DigestMatrix matrix={matrices.districts} />,
     },
     {
       label: "Flow Linear",
-      content: () => <DigestMatrix matrix={matrices.flowLinear} />,
+      content: <DigestMatrix matrix={matrices.flowLinear} />,
     },
     {
       label: "Flow Quadratic",
-      content: () => <DigestMatrix matrix={matrices.flowQuadratic} />,
+      content: <DigestMatrix matrix={matrices.flowQuadratic} />,
     },
   ];
 


### PR DESCRIPTION
using `content: React.FunctionComponent` causes tab content to be recreated on each render, resulting in unnecessary unmounting and remounting of tab components. This leads to loss of internal state and a less consistent user experience when switching tabs or updating items.