### PR TITLE
feat(ui-matrix-filter): enable granular removal of filter values via separate chips

### DIFF
--- a/webapp/eslint.config.js
+++ b/webapp/eslint.config.js
@@ -145,6 +145,7 @@ export default [
       ],
       "require-await": "warn", // TODO: switch to "error" when the quantity of warning will be low
       eqeqeq: ["error"],
+      "array-callback-return": ["error", { checkForEach: true }],
     },
   },
 ];

--- a/webapp/src/components/common/DynamicDataTable/index.tsx
+++ b/webapp/src/components/common/DynamicDataTable/index.tsx
@@ -109,7 +109,7 @@ function DynamicDataTable({
     // Add items without group to rows
     items
       .filter((item) => !item.group)
-      .forEach((item) =>
+      .forEach((item) => {
         rowsArr.push(
           <TableRowItem
             key={item.id}
@@ -118,8 +118,8 @@ function DynamicDataTable({
             selected={selected}
             onClick={handleSelect}
           />,
-        ),
-      );
+        );
+      });
 
     return rowsArr;
   }, [items, itemsByGroup, columns, selected, handleSelect]);

--- a/webapp/src/components/common/Matrix/components/MatrixFilter/ColumnFilter.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/ColumnFilter.tsx
@@ -25,8 +25,8 @@ import {
   type SelectChangeEvent,
   Typography,
 } from "@mui/material";
-import { useTranslation } from "react-i18next";
 import { produce } from "immer";
+import { useTranslation } from "react-i18next";
 import ListFilterControl from "./components/ListFilterControl";
 import RangeFilterControl from "./components/RangeFilterControl";
 import { FILTER_TYPES } from "./constants";
@@ -42,7 +42,7 @@ function ColumnFilter({ filter, setFilter, columnCount }: ColumnFilterProps) {
     handleListChange,
     addValueToColumnFilter,
     addValuesToColumnFilter,
-    removeValueFromColumnFilter,
+    removeValuesFromColumnFilter,
     clearColumnFilterValues,
     handleKeyPress,
     handleTypeChange,
@@ -129,7 +129,7 @@ function ColumnFilter({ filter, setFilter, columnCount }: ColumnFilterProps) {
             onKeyPress={handleKeyPress}
             onAddValue={addValueToColumnFilter}
             onAddValues={addValuesToColumnFilter}
-            onRemoveValue={removeValueFromColumnFilter}
+            onRemoveValues={removeValuesFromColumnFilter}
             onOperatorChange={handleOperatorChangeEvent}
             onClearAll={clearColumnFilterValues}
           />

--- a/webapp/src/components/common/Matrix/components/MatrixFilter/RowFilter.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/RowFilter.tsx
@@ -277,8 +277,8 @@ function RowFilter({
           selectedValues={state.rowFilter.list || []}
           onAddValue={() => filterControls.addValueToRowFilter(state.rowFilter.id)}
           onAddValues={(values) => filterControls.addValuesToRowFilter(values, state.rowFilter.id)}
-          onRemoveValue={(value) =>
-            filterControls.removeValueFromRowFilter(value, state.rowFilter.id)
+          onRemoveValues={(values) =>
+            filterControls.removeValuesFromRowFilter(values, state.rowFilter.id)
           }
           onCheckboxChange={(value) => filterControls.handleCheckboxChange(value, filterId)}
           inputValue={filterControls.inputValue}

--- a/webapp/src/components/common/Matrix/components/MatrixFilter/components/ListFilterControl.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/components/ListFilterControl.tsx
@@ -40,7 +40,14 @@ import {
   TYPOGRAPHY_STYLES,
 } from "../styles";
 import type { FilterOperatorType } from "../types";
-import { parseRangeInput } from "../utils";
+import {
+  compactSelections,
+  selectionsToNumbers,
+  selectionToString,
+  stringToSelections,
+  type NumberOrRange,
+} from "../../../../../../utils/numberSelectionsUtils";
+import { buildKey } from "@/utils/reactUtils";
 
 const isValidFilterOperator = (value: string): value is FilterOperatorType => {
   return Object.values(FILTER_OPERATORS).includes(value as FilterOperatorType);
@@ -54,7 +61,7 @@ interface ListFilterControlProps {
   onKeyPress: (event: React.KeyboardEvent) => void;
   onAddValue: () => void;
   onAddValues?: (values: number[]) => void;
-  onRemoveValue: (value: number) => void;
+  onRemoveValues: (values: number[]) => void;
   onOperatorChange?: (operator: FilterOperatorType) => void;
   onClearAll?: () => void;
   placeholder?: string;
@@ -69,6 +76,7 @@ function ListFilterControl({
   onKeyPress,
   onAddValue,
   onAddValues,
+  onRemoveValues,
   onOperatorChange,
   onClearAll,
   placeholder,
@@ -76,46 +84,25 @@ function ListFilterControl({
 }: ListFilterControlProps) {
   const { t } = useTranslation();
 
-  // Format selected values as ranges (e.g., "1-5, 7, 10-15")
-  const formattedValues = useMemo(() => {
+  // Format selected values as separate ranges with their values
+  const formattedRanges = useMemo(() => {
     if (selectedValues.length === 0) {
-      return "";
+      return [];
     }
 
-    const sorted = [...selectedValues].sort((a, b) => a - b);
+    const compacted = compactSelections(selectedValues);
 
-    const formatRange = (start: number, end: number): string => {
-      if (start === end) {
-        return start.toString();
-      }
+    return compacted.map((selection: NumberOrRange) => {
+      const label = selectionToString(selection);
+      const values = Array.isArray(selection)
+        ? Array.from({ length: selection[1] - selection[0] + 1 }, (_, i) => selection[0] + i)
+        : [selection];
 
-      if (end === start + 1) {
-        return `${start}, ${end}`;
-      }
-
-      return `${start}-${end}`;
-    };
-
-    const ranges = sorted.reduce<Array<[number, number]>>((acc, curr, idx) => {
-      if (idx === 0) {
-        return [[curr, curr]];
-      }
-
-      const lastRange = acc[acc.length - 1];
-      const [, lastEnd] = lastRange;
-
-      if (curr === lastEnd + 1) {
-        // Extend the current range
-        lastRange[1] = curr;
-      } else {
-        // Start a new range
-        acc.push([curr, curr]);
-      }
-
-      return acc;
-    }, []);
-
-    return ranges.map(([start, end]) => formatRange(start, end)).join(", ");
+      return {
+        label,
+        values,
+      };
+    });
   }, [selectedValues]);
 
   ////////////////////////////////////////////////////////////////
@@ -133,7 +120,8 @@ function ListFilterControl({
   };
 
   const handleAddValue = () => {
-    const values = parseRangeInput(inputValue);
+    const selections = stringToSelections(inputValue);
+    const values = selectionsToNumbers(selections);
 
     if (values.length > 1 && onAddValues) {
       // Use onAddValues for multiple values (ranges)
@@ -156,6 +144,10 @@ function ListFilterControl({
     } else {
       onKeyPress(event);
     }
+  };
+
+  const handleRemoveRange = (values: number[]) => {
+    onRemoveValues(values);
   };
 
   ////////////////////////////////////////////////////////////////
@@ -263,13 +255,19 @@ function ListFilterControl({
               </Button>
             )}
           </Box>
-          <Chip
-            label={formattedValues}
-            size="small"
-            color="primary"
-            disabled={disabled}
-            sx={CHIP_SELECTOR_STYLES.dense}
-          />
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: DESIGN_TOKENS.spacing.xs }}>
+            {formattedRanges.map((range, index) => (
+              <Chip
+                key={buildKey(range.label, index)}
+                label={range.label}
+                size="small"
+                color="primary"
+                disabled={disabled}
+                onDelete={disabled ? undefined : () => handleRemoveRange(range.values)}
+                sx={CHIP_SELECTOR_STYLES.dense}
+              />
+            ))}
+          </Box>
         </Box>
       )}
     </>

--- a/webapp/src/components/common/Matrix/components/MatrixFilter/components/ListFilterControl.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/components/ListFilterControl.tsx
@@ -31,6 +31,15 @@ import {
 } from "@mui/material";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { buildKey } from "@/utils/reactUtils";
+import {
+  compactSelections,
+  type NumberOrRange,
+  selectionsToNumbers,
+  selectionToString,
+  stringToSelections,
+  selectionToNumbers,
+} from "../../../../../../utils/numberSelectionsUtils";
 import { FILTER_OPERATORS } from "../constants";
 import {
   CHIP_SELECTOR_STYLES,
@@ -40,14 +49,6 @@ import {
   TYPOGRAPHY_STYLES,
 } from "../styles";
 import type { FilterOperatorType } from "../types";
-import {
-  compactSelections,
-  selectionsToNumbers,
-  selectionToString,
-  stringToSelections,
-  type NumberOrRange,
-} from "../../../../../../utils/numberSelectionsUtils";
-import { buildKey } from "@/utils/reactUtils";
 
 const isValidFilterOperator = (value: string): value is FilterOperatorType => {
   return Object.values(FILTER_OPERATORS).includes(value as FilterOperatorType);
@@ -94,9 +95,7 @@ function ListFilterControl({
 
     return compacted.map((selection: NumberOrRange) => {
       const label = selectionToString(selection);
-      const values = Array.isArray(selection)
-        ? Array.from({ length: selection[1] - selection[0] + 1 }, (_, i) => selection[0] + i)
-        : [selection];
+      const values = selectionToNumbers(selection);
 
       return {
         label,
@@ -144,10 +143,6 @@ function ListFilterControl({
     } else {
       onKeyPress(event);
     }
-  };
-
-  const handleRemoveRange = (values: number[]) => {
-    onRemoveValues(values);
   };
 
   ////////////////////////////////////////////////////////////////
@@ -256,14 +251,14 @@ function ListFilterControl({
             )}
           </Box>
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: DESIGN_TOKENS.spacing.xs }}>
-            {formattedRanges.map((range, index) => (
+            {formattedRanges.map((range) => (
               <Chip
-                key={buildKey(range.label, index)}
+                key={buildKey(range.label)}
                 label={range.label}
                 size="small"
                 color="primary"
                 disabled={disabled}
-                onDelete={disabled ? undefined : () => handleRemoveRange(range.values)}
+                onDelete={disabled ? undefined : () => onRemoveValues(range.values)}
                 sx={CHIP_SELECTOR_STYLES.dense}
               />
             ))}

--- a/webapp/src/components/common/Matrix/components/MatrixFilter/components/TemporalFilterRenderer.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/components/TemporalFilterRenderer.tsx
@@ -37,7 +37,7 @@ interface TemporalFilterRendererProps {
   selectedValues: number[];
   onAddValue: () => void;
   onAddValues?: (values: number[]) => void;
-  onRemoveValue: (value: number) => void;
+  onRemoveValues: (values: number[]) => void;
   onCheckboxChange: (value: number) => void;
   onClearAll: () => void;
   inputValue: string;
@@ -58,7 +58,7 @@ function TemporalFilterRenderer({
   selectedValues,
   onAddValue,
   onAddValues,
-  onRemoveValue,
+  onRemoveValues,
   onCheckboxChange,
   onClearAll,
   inputValue,
@@ -253,7 +253,7 @@ function TemporalFilterRenderer({
         onKeyPress={onKeyPress}
         onAddValue={onAddValue}
         onAddValues={onAddValues}
-        onRemoveValue={onRemoveValue}
+        onRemoveValues={onRemoveValues}
         onOperatorChange={onOperatorChange}
         onClearAll={onClearAll}
         disabled={disabled}

--- a/webapp/src/components/common/Matrix/components/MatrixFilter/hooks/useFilterControls.ts
+++ b/webapp/src/components/common/Matrix/components/MatrixFilter/hooks/useFilterControls.ts
@@ -30,8 +30,8 @@ interface UseFilterControlsReturn {
   addValueToColumnFilter: () => void;
   addValuesToRowFilter: (values: number[], filterId: string) => void;
   addValuesToColumnFilter: (values: number[]) => void;
-  removeValueFromRowFilter: (valueToRemove: number, filterId: string) => void;
-  removeValueFromColumnFilter: (valueToRemove: number) => void;
+  removeValuesFromRowFilter: (valuesToRemove: number[], filterId: string) => void;
+  removeValuesFromColumnFilter: (valuesToRemove: number[]) => void;
   clearRowFilterValues: (filterId: string) => void;
   clearColumnFilterValues: () => void;
   handleKeyPress: (event: React.KeyboardEvent) => void;
@@ -168,14 +168,14 @@ export function useFilterControls({
     [setFilter],
   );
 
-  const removeValueFromRowFilter = useCallback(
-    (valueToRemove: number, filterId: string) => {
+  const removeValuesFromRowFilter = useCallback(
+    (valuesToRemove: number[], filterId: string) => {
       setFilter(
         produce((draft) => {
           const rowFilter = draft.rowsFilters.find((rf) => rf.id === filterId);
 
           if (rowFilter?.list) {
-            rowFilter.list = rowFilter.list.filter((value) => value !== valueToRemove);
+            rowFilter.list = rowFilter.list.filter((value) => !valuesToRemove.includes(value));
           }
         }),
       );
@@ -183,13 +183,13 @@ export function useFilterControls({
     [setFilter],
   );
 
-  const removeValueFromColumnFilter = useCallback(
-    (valueToRemove: number) => {
+  const removeValuesFromColumnFilter = useCallback(
+    (valuesToRemove: number[]) => {
       setFilter(
         produce((draft) => {
           if (draft.columnsFilter.list) {
             draft.columnsFilter.list = draft.columnsFilter.list.filter(
-              (value) => value !== valueToRemove,
+              (value) => !valuesToRemove.includes(value),
             );
           }
         }),
@@ -371,8 +371,8 @@ export function useFilterControls({
     addValueToColumnFilter,
     addValuesToRowFilter,
     addValuesToColumnFilter,
-    removeValueFromRowFilter,
-    removeValueFromColumnFilter,
+    removeValuesFromRowFilter,
+    removeValuesFromColumnFilter,
     clearRowFilterValues,
     clearColumnFilterValues,
     handleKeyPress,

--- a/webapp/src/services/webSocket/ws.ts
+++ b/webapp/src/services/webSocket/ws.ts
@@ -72,7 +72,9 @@ export function initWs(dispatch: AppDispatch, user?: UserInfo): WebSocket {
   webSocket.onmessage = (event: MessageEvent): void => {
     const message = JSON.parse(event.data) as WsEvent;
     logInfo("WebSocket message received", message);
-    eventListeners.forEach((listener) => listener(message));
+    eventListeners.forEach((listener) => {
+      listener(message);
+    });
   };
 
   webSocket.onerror = (event): void => {

--- a/webapp/src/utils/reactUtils.ts
+++ b/webapp/src/utils/reactUtils.ts
@@ -20,7 +20,9 @@ export function isDependencyList(value: unknown): value is React.DependencyList 
 
 export function composeRefs(...refs: Array<React.Ref<unknown> | undefined | null>) {
   return function refCallback(instance: unknown): void {
-    refs.forEach((ref) => setRef(ref, instance));
+    refs.forEach((ref) => {
+      setRef(ref, instance);
+    });
   };
 }
 


### PR DESCRIPTION
## Overview

The `ListFilterControl` component has been enhanced to display separate, deletable chips for each value or range of values instead of a single concatenated chip.

## Changes Made

### Before

- When entering values like "3" and then "6-9", the component would display a single chip: `"3, 6-9"`
- The entire chip could only be cleared using the "Clear All" button
- Individual values or ranges could not be removed

### After

- When entering values like "3" and then "6-9", the component now displays:
    - Chip 1: `"3"` with its own delete button (×)
    - Chip 2: `"6-9"` with its own delete button (×)
- Each chip can be individually deleted by clicking its delete button
- The "Clear All" button still removes all chips at once