### PR TITLE
fix(ui-districts): update erase areas

### DIFF
--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Districts/UpdateDistrictDialog.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/MapConfig/Districts/UpdateDistrictDialog.tsx
@@ -65,12 +65,14 @@ function UpdateDistrictDialog(props: Props) {
 
   const handleSubmit = async (data: SubmitHandlerPlus<typeof defaultValues>) => {
     const { districtId, output, comments } = data.values;
+    const districtAreas = districtsById[districtId].areas;
     dispatch(
       updateStudyMapDistrict({
         studyId: study.id,
         districtId,
         output,
         comments,
+        areas: districtAreas,
       }),
     );
     onClose();

--- a/webapp/src/services/api/study.ts
+++ b/webapp/src/services/api/study.ts
@@ -465,7 +465,7 @@ export async function updateStudyDistrict(
   await client.put(`v1/studies/${studyId}/districts/${districtId}`, {
     output,
     comments,
-    areas: areas,
+    areas,
   });
 }
 

--- a/webapp/src/services/api/study.ts
+++ b/webapp/src/services/api/study.ts
@@ -465,7 +465,7 @@ export async function updateStudyDistrict(
   await client.put(`v1/studies/${studyId}/districts/${districtId}`, {
     output,
     comments,
-    areas: areas || [],
+    areas: areas,
   });
 }
 


### PR DESCRIPTION
When a ditrict has areas, if we update a district with the update district dialog, it will erase its areas. It's not easy to notice because the update happens on the backend but the front is not refreshed so we still see the areas in the table but if you check with the debug mode you'll see that the areas have been erased. 

<img width="1069" height="640" alt="image" src="https://github.com/user-attachments/assets/22a81a51-6ce9-462f-bf18-ba3ab20f61e5" />
