### PR TITLE
fix(matrix-gc): reduce matrix gc memory usage

### DIFF
--- a/antarest/matrixstore/matrix_usage_provider.py
+++ b/antarest/matrixstore/matrix_usage_provider.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 from abc import ABC, abstractmethod
+from typing import Iterable
 
 from antarest.matrixstore.model import MatrixReference
 
@@ -20,5 +21,5 @@ class IMatrixUsageProvider(ABC):
     """
 
     @abstractmethod
-    def get_matrix_usage(self) -> list[MatrixReference]:
+    def get_matrix_usage(self) -> Iterable[MatrixReference]:
         raise NotImplementedError()

--- a/antarest/matrixstore/service.py
+++ b/antarest/matrixstore/service.py
@@ -18,7 +18,7 @@ import zipfile
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Sequence, Set
+from typing import Iterable, List, Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -567,11 +567,10 @@ class MatrixService(ISimpleMatrixService):
         matrix = self.get(matrix_id)
         save_matrix(InternalMatrixFormat.TSV, matrix, filepath)
 
-    def get_used_matrices(self) -> Set[MatrixReference]:
+    def get_used_matrices(self) -> Iterable[MatrixReference]:
         """Return all matrices used in raw studies, variant studies, constants hashes and datasets"""
-        return {
-            matrix_reference for provider in self.usage_providers for matrix_reference in provider.get_matrix_usage()
-        }
+        for provider in self.usage_providers:
+            yield from provider.get_matrix_usage()
 
     def _create_dataset_usage_provider(self) -> "IMatrixUsageProvider":
         repo_dataset = self.repo_dataset
@@ -581,15 +580,15 @@ class MatrixService(ISimpleMatrixService):
                 matrix_service.register_usage_provider(self)
 
             @override
-            def get_matrix_usage(self) -> list[MatrixReference]:
+            def get_matrix_usage(self) -> Iterable[MatrixReference]:
                 logger.info("Getting all matrices used in datasets")
                 datasets = repo_dataset.get_all_datasets()
 
-                return [
-                    MatrixReference(matrix_id=matrix.matrix_id, use_description=f"Used by dataset {dataset.id}")
-                    for dataset in datasets
-                    for matrix in dataset.matrices
-                ]
+                for dataset in datasets:
+                    for matrix in dataset.matrices:
+                        yield MatrixReference(
+                            matrix_id=matrix.matrix_id, use_description=f"Used by dataset {dataset.id}"
+                        )
 
         return DatasetUsageProvider(self)
 

--- a/antarest/study/storage/rawstudy/raw_study_matrix_usage_provider.py
+++ b/antarest/study/storage/rawstudy/raw_study_matrix_usage_provider.py
@@ -12,7 +12,7 @@
 import logging
 from pathlib import Path
 
-from typing_extensions import override
+from typing_extensions import Iterable, override
 
 from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.matrixstore.matrix_usage_provider import IMatrixUsageProvider
@@ -29,9 +29,8 @@ class RawStudyMatrixUsageProvider(IMatrixUsageProvider):
         matrix_service.register_usage_provider(self)
 
     @override
-    def get_matrix_usage(self) -> list[MatrixReference]:
+    def get_matrix_usage(self) -> Iterable[MatrixReference]:
         logger.info("Getting all matrices used in raw studies")
-        matrices_references = []
 
         study_filter = StudyFilter(managed=True, variant=False, access_permissions=AccessPermissions(is_admin=True))
 
@@ -43,6 +42,4 @@ class RawStudyMatrixUsageProvider(IMatrixUsageProvider):
                 matrix_reference = MatrixReference(
                     matrix_id=f"{matrix_id}", use_description=f"Used by raw study {study_id}"
                 )
-                matrices_references.append(matrix_reference)
-
-        return matrices_references
+                yield matrix_reference

--- a/antarest/study/storage/variantstudy/business/matrix_constants/matrix_constants_usage_provider.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/matrix_constants_usage_provider.py
@@ -9,6 +9,8 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+from typing import Iterable
+
 from typing_extensions import TYPE_CHECKING, override
 
 from antarest.matrixstore.matrix_usage_provider import IMatrixUsageProvider
@@ -25,10 +27,6 @@ class ConstantsMatrixUsageProvider(IMatrixUsageProvider):
         matrix_service.register_usage_provider(self)
 
     @override
-    def get_matrix_usage(self) -> list[MatrixReference]:
-        matrices_references = []
+    def get_matrix_usage(self) -> Iterable[MatrixReference]:
         for value in self.matrix_constants.hashes.values():
-            matrix_reference = MatrixReference(matrix_id=value, use_description="Constant matrix")
-            matrices_references.append(matrix_reference)
-
-        return matrices_references
+            yield MatrixReference(matrix_id=value, use_description="Constant matrix")

--- a/antarest/study/storage/variantstudy/command_matrix_usage_provider.py
+++ b/antarest/study/storage/variantstudy/command_matrix_usage_provider.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 import logging
-from typing import List
+from typing import Iterable, List
 
 from typing_extensions import override
 
@@ -37,10 +37,9 @@ class CommandMatrixUsageProvider(IMatrixUsageProvider):
         self.matrix_service.register_usage_provider(self)
 
     @override
-    def get_matrix_usage(self) -> list[MatrixReference]:
+    def get_matrix_usage(self) -> Iterable[MatrixReference]:
         logger.info("Getting all matrices used in variant studies")
         command_blocks: List[CommandBlock] = self.variant_study_repo.get_all_command_blocks()
-        matrices_references = []
 
         def transform_to_command(command_dto: CommandDTO, study_ref: str) -> List[ICommand]:
             try:
@@ -62,6 +61,4 @@ class CommandMatrixUsageProvider(IMatrixUsageProvider):
                         matrix_id=command_id,
                         use_description=f"Used by command {command_id} from variant study {study_id}",
                     )
-                    matrices_references.append(mat_reference)
-
-        return matrices_references
+                    yield mat_reference

--- a/tests/matrixstore/test_matrix_usage_providers.py
+++ b/tests/matrixstore/test_matrix_usage_providers.py
@@ -154,7 +154,7 @@ def test_command_matrix_usage_provider(
         db.session.add(command_block2)
         db.session.commit()
 
-        matrices_references = command_matrix_usage_provider.get_matrix_usage()
+        matrices_references = list(command_matrix_usage_provider.get_matrix_usage())
 
         assert matrices_references == [MatrixReference(matrix_id=matrices_id, use_description=use_description)] * 4
 


### PR DESCRIPTION
Try to reduce memory usage of the GC by streaming matrices references and
keeping only their ID, not the description which can be a pretty large string for each reference.

