### PR TITLE
fix(scenario): fix scenario builder API regressions

### DIFF
--- a/antarest/study/business/model/sts_model.py
+++ b/antarest/study/business/model/sts_model.py
@@ -292,7 +292,8 @@ class STStorageAdditionalConstraint(AntaresBaseModel):
     @model_validator(mode="before")
     @classmethod
     def set_id(cls, data: dict[str, Any]) -> dict[str, Any]:
-        data["id"] = transform_name_to_id(data["name"])
+        if isinstance(data, dict) and "id" not in data and "name" in data:
+            data["id"] = transform_name_to_id(data["name"])
         return data
 
     id: str

--- a/antarest/study/business/scenario_builder_management.py
+++ b/antarest/study/business/scenario_builder_management.py
@@ -77,7 +77,7 @@ def _read_ruleset(file_study: FileStudy, scenario_type: ScenarioType) -> Ruleset
     ruleset_config = extract_ruleset_data(file_study, ruleset_name, scenario_type)
 
     complete_ruleset = initialize_ruleset(
-        years=[str(y) for y in range(1, nb_years + 1)],
+        years=[str(y) for y in range(0, nb_years)],
         index=file_study.tree.config.to_study_index(),
         scenario_types={scenario_type},
     )

--- a/antarest/study/dao/file/file_study_st_storage_dao.py
+++ b/antarest/study/dao/file/file_study_st_storage_dao.py
@@ -261,6 +261,9 @@ class FileStudySTStorageDao(STStorageDao, ABC):
             ["input", "st-storage", "clusters", area_id, "list", storage_id],
             ["input", "st-storage", "series", area_id, storage_id],
         ]
+        if study_data.config.version >= STUDY_VERSION_9_2:
+            paths.append(["input", "st-storage", "constraints", area_id, storage_id])
+
         if len(study_data.config.areas[area_id].st_storages) == 1:
             paths.append(["input", "st-storage", "series", area_id])
 
@@ -269,6 +272,8 @@ class FileStudySTStorageDao(STStorageDao, ABC):
 
         # Deleting the short-term storage in the configuration must be done AFTER deleting the files and folders.
         study_data.config.areas[area_id].st_storages.remove(storage)
+        if study_data.config.version >= STUDY_VERSION_9_2:
+            study_data.config.areas[area_id].st_storages_additional_constraints.pop(storage.id)
 
     @override
     def get_all_st_storage_additional_constraints(self) -> STStorageAdditionalConstraintsMap:
@@ -388,6 +393,8 @@ class FileStudySTStorageDao(STStorageDao, ABC):
                 study_data.areas[area_id].st_storages[k] = storage
                 return
         study_data.areas[area_id].st_storages.append(storage)
+        if study_data.version >= STUDY_VERSION_9_2:
+            study_data.areas[area_id].st_storages_additional_constraints[storage.id] = []
 
     def _update_st_storage_additional_constraints_config(
         self, area_id: str, storage_id: str, constraints: list[STStorageAdditionalConstraint]

--- a/antarest/study/storage/rawstudy/model/filesystem/config/model.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/model.py
@@ -272,7 +272,10 @@ class FileStudyTreeConfig(DTO):
         return [grp for _, grp in sorted(lower_groups.items())]  # type: ignore
 
     def get_sts_constraint_ids(self, area: str, storage: str) -> List[str]:
-        return [c.id for c in self.areas[area].st_storages_additional_constraints[storage]]
+        if self.version >= STUDY_VERSION_9_2:
+            return [c.id for c in self.areas[area].st_storages_additional_constraints[storage]]
+        else:
+            return []
 
     def to_study_index(self) -> StudyIndex:
         areas = self.areas

--- a/antarest/study/storage/rawstudy/model/filesystem/config/model.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/model.py
@@ -27,7 +27,7 @@ from antarest.study.business.model.renewable_cluster_model import RenewableClust
 from antarest.study.business.model.sts_model import STStorage, STStorageAdditionalConstraint
 from antarest.study.business.model.study_index import StudyIndex
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
-from antarest.study.model import STUDY_VERSION_8_7, StudyVersionInt
+from antarest.study.model import STUDY_VERSION_9_2, StudyVersionInt
 
 from .validation import extract_filtering, study_version_context
 
@@ -267,8 +267,7 @@ class FileStudyTreeConfig(DTO):
         sorted alphabetically (case-insensitive).
         Note that groups are stored in lower case in the binding constraints file.
         """
-        if self.version < STUDY_VERSION_8_7:
-            return []
+
         lower_groups = {bc.group: bc.group for bc in self.bindings}
         return [grp for _, grp in sorted(lower_groups.items())]  # type: ignore
 
@@ -277,6 +276,11 @@ class FileStudyTreeConfig(DTO):
 
     def to_study_index(self) -> StudyIndex:
         areas = self.areas
+        sts_additional_constraints = {}
+        if self.version >= STUDY_VERSION_9_2:
+            sts_additional_constraints = {
+                a: {s: self.get_sts_constraint_ids(a, s) for s in self.get_st_storage_ids(a)} for a in areas
+            }
         return StudyIndex(
             areas=areas,
             links=((a1, a2) for a1 in areas for a2 in self.get_links(a1)),
@@ -284,9 +288,7 @@ class FileStudyTreeConfig(DTO):
             thermals={a: self.get_thermal_ids(a) for a in areas},
             renewables={a: self.get_renewable_ids(a) for a in areas},
             storages={a: self.get_st_storage_ids(a) for a in areas},
-            sts_additional_constraints={
-                a: {s: self.get_sts_constraint_ids(a, s) for s in self.get_st_storage_ids(a)} for a in areas
-            },
+            sts_additional_constraints=sts_additional_constraints,
         )
 
 

--- a/antarest/study/storage/rawstudy/model/filesystem/config/scenario_builder.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/scenario_builder.py
@@ -163,7 +163,7 @@ def _add_value_triple(
 
 def _to_percent(value: RuleValue) -> RuleValue:
     if isinstance(value, (int, float)):
-        return int(100 * value)
+        return 100 * value
     return value
 
 

--- a/tests/integration/study_data_blueprint/test_scenario_builder.py
+++ b/tests/integration/study_data_blueprint/test_scenario_builder.py
@@ -82,56 +82,56 @@ def test_scenario_builder_nominal_case(variant: bool, study_service: StudyServic
 
     res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/load")
     assert res.status_code == 200
-    assert res.json() == {"load": {"be": {"1": ""}, "fr": {"1": ""}}}
+    assert res.json() == {"load": {"be": {"0": ""}, "fr": {"0": ""}}}
 
-    scenarios: AreaScenarios = {"be": {"1": 2}}
+    scenarios: AreaScenarios = {"be": {"0": 2}}
     res = client.put(f"/v1/studies/{study_id}/config/scenariobuilder/load", json={"load": scenarios})
     assert res.status_code == 200, res.json()
 
     res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/load")
     assert res.status_code == 200
-    assert res.json() == {"load": {"be": {"1": 2}, "fr": {"1": ""}}}
+    assert res.json() == {"load": {"be": {"0": 2}, "fr": {"0": ""}}}
 
     # Thermal clusters tests
 
     res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/thermal")
     assert res.status_code == 200
-    assert res.json() == {"thermal": {"be": {}, "fr": {"nuclear": {"1": ""}}}}
+    assert res.json() == {"thermal": {"be": {}, "fr": {"nuclear": {"0": ""}}}}
 
-    scenarios: AreaItemsScenarios = {"be": {}, "fr": {"nuclear": {"1": 2}}}
+    scenarios: AreaItemsScenarios = {"be": {}, "fr": {"nuclear": {"0": 2}}}
     res = client.put(f"/v1/studies/{study_id}/config/scenariobuilder/thermal", json={"thermal": scenarios})
     assert res.status_code == 200
-    assert res.json() == {"thermal": {"be": {}, "fr": {"nuclear": {"1": 2}}}}
+    assert res.json() == {"thermal": {"be": {}, "fr": {"nuclear": {"0": 2}}}}
 
     res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/thermal")
     assert res.status_code == 200
-    assert res.json() == {"thermal": {"be": {}, "fr": {"nuclear": {"1": 2}}}}
+    assert res.json() == {"thermal": {"be": {}, "fr": {"nuclear": {"0": 2}}}}
 
     # Storages additional constraints
 
     res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/shortTermStorageAdditionalConstraints")
     assert res.status_code == 200
-    assert res.json() == {"shortTermStorageAdditionalConstraints": {"be": {}, "fr": {"battery": {"c1": {"1": ""}}}}}
+    assert res.json() == {"shortTermStorageAdditionalConstraints": {"be": {}, "fr": {"battery": {"c1": {"0": ""}}}}}
 
-    sts_ac_scenarios = {"fr": {"battery": {"c1": {"1": 2}}}}
+    sts_ac_scenarios = {"fr": {"battery": {"c1": {"0": 2}}}}
     res = client.put(
         f"/v1/studies/{study_id}/config/scenariobuilder/shortTermStorageAdditionalConstraints",
         json={"shortTermStorageAdditionalConstraints": sts_ac_scenarios},
     )
     assert res.status_code == 200
-    assert res.json() == {"shortTermStorageAdditionalConstraints": {"fr": {"battery": {"c1": {"1": 2}}}}}
+    assert res.json() == {"shortTermStorageAdditionalConstraints": {"fr": {"battery": {"c1": {"0": 2}}}}}
 
     res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/shortTermStorageAdditionalConstraints")
     assert res.status_code == 200
-    assert res.json() == {"shortTermStorageAdditionalConstraints": {"be": {}, "fr": {"battery": {"c1": {"1": 2}}}}}
+    assert res.json() == {"shortTermStorageAdditionalConstraints": {"be": {}, "fr": {"battery": {"c1": {"0": 2}}}}}
 
     # Hydro tests
 
     res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/hydroInitialLevels")
     assert res.status_code == 200
-    assert res.json() == {"hydroInitialLevels": {"be": {"1": ""}, "fr": {"1": ""}}}
+    assert res.json() == {"hydroInitialLevels": {"be": {"0": ""}, "fr": {"0": ""}}}
 
-    hydro_scenarios = {"be": {"1": 0.5}}
+    hydro_scenarios = {"be": {"0": 0.5}}
     res = client.put(
         f"/v1/studies/{study_id}/config/scenariobuilder/hydroInitialLevels",
         json={"hydroInitialLevels": hydro_scenarios},
@@ -140,4 +140,4 @@ def test_scenario_builder_nominal_case(variant: bool, study_service: StudyServic
 
     res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/hydroInitialLevels")
     assert res.status_code == 200
-    assert res.json() == {"hydroInitialLevels": {"be": {"1": 0.5}, "fr": {"1": ""}}}
+    assert res.json() == {"hydroInitialLevels": {"be": {"0": 0.5}, "fr": {"0": ""}}}

--- a/tests/integration/study_data_blueprint/test_scenario_builder.py
+++ b/tests/integration/study_data_blueprint/test_scenario_builder.py
@@ -124,3 +124,20 @@ def test_scenario_builder_nominal_case(variant: bool, study_service: StudyServic
     res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/shortTermStorageAdditionalConstraints")
     assert res.status_code == 200
     assert res.json() == {"shortTermStorageAdditionalConstraints": {"be": {}, "fr": {"battery": {"c1": {"1": 2}}}}}
+
+    # Hydro tests
+
+    res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/hydroInitialLevels")
+    assert res.status_code == 200
+    assert res.json() == {"hydroInitialLevels": {"be": {"1": ""}, "fr": {"1": ""}}}
+
+    hydro_scenarios = {"be": {"1": 0.5}}
+    res = client.put(
+        f"/v1/studies/{study_id}/config/scenariobuilder/hydroInitialLevels",
+        json={"hydroInitialLevels": hydro_scenarios},
+    )
+    assert res.status_code == 200, res.json()
+
+    res = client.get(f"/v1/studies/{study_id}/config/scenariobuilder/hydroInitialLevels")
+    assert res.status_code == 200
+    assert res.json() == {"hydroInitialLevels": {"be": {"1": 0.5}, "fr": {"1": ""}}}

--- a/tests/storage/repository/filesystem/config/test_config_files.py
+++ b/tests/storage/repository/filesystem/config/test_config_files.py
@@ -628,8 +628,9 @@ def test_parse_st_storage_additional_constraints(study_path: Path) -> None:
     config_dir.joinpath("additional-constraints.ini").write_text(ADDITIONAL_CONSTRAINTS_INI)
 
     storage = STStorage(**{"name": "sts_test"})
+    storage2 = STStorage(**{"name": "sts_test_2"})
     # Check values
-    assert _parse_st_storage_additional_constraints(study_path, "fr", [storage]) == {
+    assert _parse_st_storage_additional_constraints(study_path, "fr", [storage, storage2]) == {
         "sts_test": [
             STStorageAdditionalConstraint(
                 id="withdrawal-1",
@@ -650,7 +651,8 @@ def test_parse_st_storage_additional_constraints(study_path: Path) -> None:
                 occurrences=[Occurrence(hours=[1, 168])],
                 enabled=True,
             ),
-        ]
+        ],
+        "sts_test_2": [],
     }
 
     # With a study version anterior to 9.2, it should always return an empty list
@@ -777,6 +779,16 @@ def test_config_to_study_index_9_2_additional_constraints():
                 links={},
                 thermals=[ThermalCluster(name="Nuclear")],
                 renewables=[RenewableCluster(name="Wind")],
+                filters_synthesis=[],
+                filters_year=[],
+                st_storages=[STStorage(name="Battery")],
+                st_storages_additional_constraints={"battery": [STStorageAdditionalConstraint(name="STSConstraint")]},
+            ),
+            "fr": Area(
+                name="FR",
+                links={},
+                thermals=[],
+                renewables=[],
                 filters_synthesis=[],
                 filters_year=[],
                 st_storages=[STStorage(name="Battery")],

--- a/tests/storage/repository/filesystem/config/test_config_files.py
+++ b/tests/storage/repository/filesystem/config/test_config_files.py
@@ -37,7 +37,7 @@ from antarest.study.business.model.sts_model import (
     STStorageGroup,
 )
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster, ThermalCostGeneration
-from antarest.study.model import STUDY_VERSION_8_8
+from antarest.study.model import STUDY_VERSION_8_8, STUDY_VERSION_9_2
 from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint import BindingConstraintFrequency
 from antarest.study.storage.rawstudy.model.filesystem.config.files import (
     _parse_bindings,
@@ -643,7 +643,7 @@ def test_parse_st_storage_additional_constraints(study_path: Path) -> None:
                 enabled=True,
             ),
             STStorageAdditionalConstraint(
-                id="netting-1",
+                id="netting -1",
                 name="nettinG?-1",
                 variable=AdditionalConstraintVariable.NETTING,
                 operator=AdditionalConstraintOperator.LESS,
@@ -770,27 +770,27 @@ def test_config_to_study_index_9_2_additional_constraints():
         study_path=Path(),
         path=Path(),
         study_id="my-study",
-        version=STUDY_VERSION_8_8,
+        version=STUDY_VERSION_9_2,
         areas={
             "be": Area(
                 name="BE",
-                links={"fr": LinkConfig()},
+                links={},
                 thermals=[ThermalCluster(name="Nuclear")],
                 renewables=[RenewableCluster(name="Wind")],
                 filters_synthesis=[],
                 filters_year=[],
                 st_storages=[STStorage(name="Battery")],
-                st_storages_additional_constraints={"battery": STStorageAdditionalConstraint(name="STSConstraint")},
+                st_storages_additional_constraints={"battery": [STStorageAdditionalConstraint(name="STSConstraint")]},
             ),
         },
     )
 
     index = config.to_study_index()
-    assert list(index.area_ids) == ["be", "fr"]
-    assert list(index.link_ids) == ["be / fr"]
-    _assert_mapping_equals(index.thermal_ids, {"be": ["nuclear"], "fr": []})
-    _assert_mapping_equals(index.renewable_ids, {"be": ["wind"], "fr": []})
-    _assert_mapping_equals(index.storage_ids, {"be": ["battery"], "fr": ["battery"]})
+    assert list(index.area_ids) == ["be"]
+    assert list(index.link_ids) == []
+    _assert_mapping_equals(index.thermal_ids, {"be": ["nuclear"]})
+    _assert_mapping_equals(index.renewable_ids, {"be": ["wind"]})
+    _assert_mapping_equals(index.storage_ids, {"be": ["battery"]})
     assert list(index.bc_group_ids) == []
     assert list(index.sts_constraint_ids) == ["be"]
     assert list(index.sts_constraint_ids["be"]) == ["battery"]

--- a/tests/storage/repository/filesystem/config/test_config_files.py
+++ b/tests/storage/repository/filesystem/config/test_config_files.py
@@ -784,16 +784,6 @@ def test_config_to_study_index_9_2_additional_constraints():
                 st_storages=[STStorage(name="Battery")],
                 st_storages_additional_constraints={"battery": [STStorageAdditionalConstraint(name="STSConstraint")]},
             ),
-            "fr": Area(
-                name="FR",
-                links={},
-                thermals=[],
-                renewables=[],
-                filters_synthesis=[],
-                filters_year=[],
-                st_storages=[STStorage(name="Battery")],
-                st_storages_additional_constraints={"battery": [STStorageAdditionalConstraint(name="STSConstraint")]},
-            ),
         },
     )
 
@@ -804,6 +794,7 @@ def test_config_to_study_index_9_2_additional_constraints():
     _assert_mapping_equals(index.renewable_ids, {"be": ["wind"]})
     _assert_mapping_equals(index.storage_ids, {"be": ["battery"]})
     assert list(index.bc_group_ids) == []
+
     assert list(index.sts_constraint_ids) == ["be"]
     assert list(index.sts_constraint_ids["be"]) == ["battery"]
     assert list(index.sts_constraint_ids["be"]["battery"]) == ["stsconstraint"]

--- a/tests/storage/repository/filesystem/config/test_config_files.py
+++ b/tests/storage/repository/filesystem/config/test_config_files.py
@@ -14,6 +14,7 @@ import logging
 import textwrap
 import typing as t
 from pathlib import Path
+from typing import Iterable, Mapping
 from zipfile import ZipFile
 
 import pytest
@@ -36,6 +37,7 @@ from antarest.study.business.model.sts_model import (
     STStorageGroup,
 )
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster, ThermalCostGeneration
+from antarest.study.model import STUDY_VERSION_8_8
 from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint import BindingConstraintFrequency
 from antarest.study.storage.rawstudy.model.filesystem.config.files import (
     _parse_bindings,
@@ -711,3 +713,85 @@ def test_parse_expansion_output(empty_study_880: FileStudy) -> None:
     assert "file_3" not in output_tree[output_id]
     # Asserts the `economy` folder is scanned
     assert "economy" in output_tree[output_id]
+
+
+def _assert_mapping_equals(left: Mapping[str, Iterable[str]], right: Mapping[str, Iterable[str]]) -> None:
+    """Custom comparator to compare just the mapping, content, when the exact iterable type can be different."""
+    for k, v in left.items():
+        assert k in right
+        assert list(v) == list(right[k])
+    for k, v in right.items():
+        assert k in left
+
+
+def test_config_to_study_index_8_8():
+    config = FileStudyTreeConfig(
+        study_path=Path(),
+        path=Path(),
+        study_id="my-study",
+        version=STUDY_VERSION_8_8,
+        areas={
+            "be": Area(
+                name="BE",
+                links={"fr": LinkConfig()},
+                thermals=[ThermalCluster(name="Nuclear")],
+                renewables=[RenewableCluster(name="Wind")],
+                filters_synthesis=[],
+                filters_year=[],
+                st_storages=[STStorage(name="Battery")],
+                st_storages_additional_constraints={},
+            ),
+            "fr": Area(
+                name="FR",
+                links={},
+                thermals=[],
+                renewables=[],
+                filters_synthesis=[],
+                filters_year=[],
+                st_storages=[STStorage(name="Battery")],
+                st_storages_additional_constraints={},
+            ),
+        },
+        bindings=[BindingConstraint(name="Constraint", group="BCGroup")],
+    )
+
+    index = config.to_study_index()
+    assert list(index.area_ids) == ["be", "fr"]
+    assert list(index.link_ids) == ["be / fr"]
+    _assert_mapping_equals(index.thermal_ids, {"be": ["nuclear"], "fr": []})
+    _assert_mapping_equals(index.renewable_ids, {"be": ["wind"], "fr": []})
+    _assert_mapping_equals(index.storage_ids, {"be": ["battery"], "fr": ["battery"]})
+    assert list(index.bc_group_ids) == ["bcgroup"]
+    assert list(index.sts_constraint_ids) == []
+
+
+def test_config_to_study_index_9_2_additional_constraints():
+    config = FileStudyTreeConfig(
+        study_path=Path(),
+        path=Path(),
+        study_id="my-study",
+        version=STUDY_VERSION_8_8,
+        areas={
+            "be": Area(
+                name="BE",
+                links={"fr": LinkConfig()},
+                thermals=[ThermalCluster(name="Nuclear")],
+                renewables=[RenewableCluster(name="Wind")],
+                filters_synthesis=[],
+                filters_year=[],
+                st_storages=[STStorage(name="Battery")],
+                st_storages_additional_constraints={"battery": STStorageAdditionalConstraint(name="STSConstraint")},
+            ),
+        },
+    )
+
+    index = config.to_study_index()
+    assert list(index.area_ids) == ["be", "fr"]
+    assert list(index.link_ids) == ["be / fr"]
+    _assert_mapping_equals(index.thermal_ids, {"be": ["nuclear"], "fr": []})
+    _assert_mapping_equals(index.renewable_ids, {"be": ["wind"], "fr": []})
+    _assert_mapping_equals(index.storage_ids, {"be": ["battery"], "fr": ["battery"]})
+    assert list(index.bc_group_ids) == []
+    assert list(index.sts_constraint_ids) == ["be"]
+    assert list(index.sts_constraint_ids["be"]) == ["battery"]
+    assert list(index.sts_constraint_ids["be"]["battery"]) == ["stsconstraint"]

--- a/tests/storage/repository/filesystem/config/test_scenario_builder.py
+++ b/tests/storage/repository/filesystem/config/test_scenario_builder.py
@@ -32,7 +32,7 @@ def test_ruleset_parsing_hydro():
     rules = {
         "h,be,1": 2,
         "h,be,2": 1,
-        "hl,be,1": 0.2,
+        "hl,be,1": 0.002,
         "hl,be,2": 0.1,
         "hfl,be,1": 0.4,
         "hfl,be,2": 0.2,
@@ -42,7 +42,7 @@ def test_ruleset_parsing_hydro():
     ruleset = parse_ruleset(rules)
     assert ruleset == Ruleset(
         hydro={"be": {"1": 2, "2": 1}},
-        hydro_initial_levels={"be": {"1": 20.0, "2": 10.0}},
+        hydro_initial_levels={"be": {"1": 0.2, "2": 10.0}},
         hydro_final_levels={"be": {"1": 40.0, "2": 20.0}},
         hydro_generation_power={"be": {"1": 10, "2": 20}},
     )

--- a/tests/variantstudy/model/command/test_create_st_storage.py
+++ b/tests/variantstudy/model/command/test_create_st_storage.py
@@ -374,6 +374,8 @@ class TestCreateSTStorage:
         }
         assert config == expected
 
+        assert recent_study.config.get_sts_constraint_ids("area fr", "storage1") == []
+
     # noinspection SpellCheckingInspection
     def test_to_dto(self, command_context: CommandContext):
         cmd = CreateSTStorage(
@@ -445,6 +447,8 @@ class TestCreateSTStorage:
             }
         }
         assert ini_content == expected_content
+
+        assert study.config.get_sts_constraint_ids("area fr", "storage1") == []
 
         # Create new st storage by specifying 9.2 properties
         parameters_9_2 = copy.deepcopy(PARAMETERS)

--- a/tests/variantstudy/model/command/test_remove_st_storage.py
+++ b/tests/variantstudy/model/command/test_remove_st_storage.py
@@ -13,12 +13,18 @@
 import pytest
 from pydantic import ValidationError
 
+from antarest.core.exceptions import STStorageNotFound
+from antarest.study.business.model.sts_model import STStorageAdditionalConstraintCreation, STStorageCreation
+from antarest.study.dao.file.file_study_dao import FileStudyTreeDao
 from antarest.study.model import STUDY_VERSION_8_8
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.study_upgrader import StudyUpgrader
 from antarest.study.storage.variantstudy.model.command.common import CommandName
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command.create_st_storage import CreateSTStorage
+from antarest.study.storage.variantstudy.model.command.create_st_storage_constraints import (
+    CreateSTStorageAdditionalConstraints,
+)
 from antarest.study.storage.variantstudy.model.command.remove_st_storage import REQUIRED_VERSION, RemoveSTStorage
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.model.model import CommandDTO
@@ -138,3 +144,48 @@ class TestRemoveSTStorage:
         output = cmd.apply(study)
         assert not output.status
         assert output.message == "Short-term storage 'fake_storage' in area 'fr' does not exist"
+
+    def test_apply(self, empty_study_920: FileStudy, command_context: CommandContext):
+        # Create an area and a short-term storage inside it
+        study = empty_study_920
+        version = study.config.version
+        cmd = CreateArea(command_context=command_context, area_name="fr", study_version=version)
+        cmd.apply(study_data=study)
+
+        cmd = CreateSTStorage(
+            area_id="fr",
+            parameters=STStorageCreation(name="STS"),
+            command_context=command_context,
+            study_version=version,
+        )
+        cmd.apply(study_data=study)
+
+        cmd = CreateSTStorageAdditionalConstraints(
+            command_context=command_context,
+            area_id="fr",
+            storage_id="sts",
+            constraints=[
+                STStorageAdditionalConstraintCreation(name="Constraint"),
+            ],
+            study_version=version,
+        )
+        output = cmd.apply(study)
+        assert output.status
+
+        assert "sts" in study.config.get_st_storage_ids("fr")
+        assert "constraint" in study.config.get_sts_constraint_ids("fr", "sts")
+
+        study_dao = FileStudyTreeDao(study)
+        assert study_dao.get_st_storage("fr", "sts") is not None
+
+        cmd = RemoveSTStorage(command_context=command_context, area_id="fr", storage_id="sts", study_version=version)
+        output = cmd.apply(study)
+        assert output.status
+
+        study_dao = FileStudyTreeDao(study)
+        with pytest.raises(STStorageNotFound):
+            study_dao.get_st_storage("fr", "sts")
+
+        assert "sts" not in study.config.get_st_storage_ids("fr")
+        with pytest.raises(KeyError):
+            study.config.get_sts_constraint_ids("fr", "sts")


### PR DESCRIPTION
Fixes 3 regressions of https://github.com/AntaresSimulatorTeam/AntaREST/pull/2679 : 

- MC year number must start at 0
- fixes a KeyError for studies <= 9.2 which have short term storages
- hydro levels must not be rounded as integers, float values are allowed

Also fixes existing issues in additional constraint management:
- the study config was not correctly updated when creating / removing storages
- constraint files must be removed when a storage is removed

