### PR TITLE
refactor(ui-common):  improve `SplitView` prop naming and fix decimal precision in localStorage

### DIFF
--- a/webapp/src/components/App/Data/index.tsx
+++ b/webapp/src/components/App/Data/index.tsx
@@ -153,7 +153,7 @@ function Data() {
   return (
     <RootPage title={t("data.title")} titleIcon={StorageIcon}>
       {loaded && (
-        <SplitView splitId="data" sizes={[15, 85]}>
+        <SplitView splitId="data">
           <DataPropsView
             dataset={dataList}
             onAdd={handleCreation}

--- a/webapp/src/components/App/Data/index.tsx
+++ b/webapp/src/components/App/Data/index.tsx
@@ -153,7 +153,7 @@ function Data() {
   return (
     <RootPage title={t("data.title")} titleIcon={StorageIcon}>
       {loaded && (
-        <SplitView id="data" sizes={[15, 85]}>
+        <SplitView splitId="data" sizes={[15, 85]}>
           <DataPropsView
             dataset={dataList}
             onAdd={handleCreation}

--- a/webapp/src/components/App/Singlestudy/HomeView/index.tsx
+++ b/webapp/src/components/App/Singlestudy/HomeView/index.tsx
@@ -28,7 +28,7 @@ function HomeView({ study, variantTree }: Props) {
   const navigate = useNavigate();
 
   return (
-    <SplitView id="study-home" gutterSize={4} sizes={[36, 64]}>
+    <SplitView storageId="study-home" gutterSize={4} sizes={[36, 64]}>
       {/* Left */}
       <Box
         height="100%"

--- a/webapp/src/components/App/Singlestudy/HomeView/index.tsx
+++ b/webapp/src/components/App/Singlestudy/HomeView/index.tsx
@@ -12,9 +12,9 @@
  * This file is part of the Antares project.
  */
 
-import SplitView from "@/components/common/SplitView";
 import { Box } from "@mui/material";
 import { useNavigate } from "react-router-dom";
+import SplitView from "@/components/common/SplitView";
 import type { StudyMetadata, VariantTree } from "../../../../types/types";
 import InformationView from "./InformationView";
 import StudyTreeView from "./StudyTreeView";
@@ -28,7 +28,7 @@ function HomeView({ study, variantTree }: Props) {
   const navigate = useNavigate();
 
   return (
-    <SplitView storageId="study-home" gutterSize={4} sizes={[36, 64]}>
+    <SplitView splitId="study-home" gutterSize={4} sizes={[30, 70]}>
       {/* Left */}
       <Box
         height="100%"

--- a/webapp/src/components/App/Singlestudy/explore/Configuration/General/dialogs/ScenarioBuilderDialog/withAreas.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Configuration/General/dialogs/ScenarioBuilderDialog/withAreas.tsx
@@ -80,7 +80,7 @@ function withAreas(
     }
 
     return (
-      <SplitView id="scenario-builder" sizes={[15, 85]}>
+      <SplitView storageId="scenario-builder" sizes={[15, 85]}>
         <PropertiesView
           sx={{ p: 1, ".SearchFE": { mx: 0 } }}
           mainContent={

--- a/webapp/src/components/App/Singlestudy/explore/Configuration/General/dialogs/ScenarioBuilderDialog/withAreas.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Configuration/General/dialogs/ScenarioBuilderDialog/withAreas.tsx
@@ -80,7 +80,7 @@ function withAreas(
     }
 
     return (
-      <SplitView storageId="scenario-builder" sizes={[15, 85]}>
+      <SplitView splitId="scenario-builder">
         <PropertiesView
           sx={{ p: 1, ".SearchFE": { mx: 0 } }}
           mainContent={

--- a/webapp/src/components/App/Singlestudy/explore/Configuration/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Configuration/index.tsx
@@ -53,7 +53,7 @@ function Configuration() {
   );
 
   return (
-    <SplitView id="configuration" sizes={[15, 85]}>
+    <SplitView storageId="configuration" sizes={[15, 85]}>
       {/* Left */}
       <PropertiesView
         mainContent={

--- a/webapp/src/components/App/Singlestudy/explore/Configuration/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Configuration/index.tsx
@@ -53,7 +53,7 @@ function Configuration() {
   );
 
   return (
-    <SplitView storageId="configuration" sizes={[15, 85]}>
+    <SplitView splitId="configuration">
       {/* Left */}
       <PropertiesView
         mainContent={

--- a/webapp/src/components/App/Singlestudy/explore/Debug/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Debug/index.tsx
@@ -112,7 +112,7 @@ function Debug() {
             response={treeDataResponse}
             ifPending={() =>
               Array.from({ length: 3 }).map((_, index) => (
-                <Skeleton key={buildKey(index)} height={32} />
+                <Skeleton key={buildKey("skeleton", index)} height={32} />
               ))
             }
             ifFulfilled={(data) => (

--- a/webapp/src/components/App/Singlestudy/explore/Debug/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Debug/index.tsx
@@ -104,7 +104,7 @@ function Debug() {
 
   return (
     <DebugContext.Provider value={contextValue}>
-      <SplitView id="debug" sizes={[20, 80]} minSize={150}>
+      <SplitView storageId="debug" sizes={[20, 80]} minSize={150}>
         <Box sx={{ p: 1, overflow: "auto", position: "relative" }}>
           <UsePromiseCond
             keepLastResolvedOnReload

--- a/webapp/src/components/App/Singlestudy/explore/Debug/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Debug/index.tsx
@@ -18,6 +18,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useOutletContext, useSearchParams } from "react-router-dom";
 import { useUpdateEffect } from "react-use";
+import { buildKey } from "@/utils/reactUtils";
 import usePromiseWithSnackbarError from "../../../../../hooks/usePromiseWithSnackbarError";
 import type { StudyMetadata } from "../../../../../types/types";
 import SplitView from "../../../../common/SplitView";
@@ -25,7 +26,7 @@ import UsePromiseCond from "../../../../common/utils/UsePromiseCond";
 import Data from "./Data";
 import DebugContext from "./DebugContext";
 import Tree from "./Tree";
-import { getFileType, getTreeData, type FileInfo, type TreeData } from "./utils";
+import { type FileInfo, getFileType, getTreeData, type TreeData } from "./utils";
 
 function Debug() {
   const { t } = useTranslation();
@@ -104,13 +105,15 @@ function Debug() {
 
   return (
     <DebugContext.Provider value={contextValue}>
-      <SplitView storageId="debug" sizes={[20, 80]} minSize={150}>
+      <SplitView splitId="debug">
         <Box sx={{ p: 1, overflow: "auto", position: "relative" }}>
           <UsePromiseCond
             keepLastResolvedOnReload
             response={treeDataResponse}
             ifPending={() =>
-              Array.from({ length: 3 }).map((_, index) => <Skeleton key={index} height={32} />)
+              Array.from({ length: 3 }).map((_, index) => (
+                <Skeleton key={buildKey(index)} height={32} />
+              ))
             }
             ifFulfilled={(data) => (
               <Tree

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/SplitHydroMatrix.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/SplitHydroMatrix.tsx
@@ -12,8 +12,8 @@
  * This file is part of the Antares project.
  */
 
-import { mergeSxProp } from "@/utils/muiUtils";
 import { Box, type SxProps, type Theme } from "@mui/material";
+import { mergeSxProp } from "@/utils/muiUtils";
 import SplitView, { type SplitViewProps } from "../../../../../../common/SplitView";
 import HydroMatrix from "./HydroMatrix";
 import type { HydroMatrixType } from "./utils";
@@ -30,7 +30,7 @@ function SplitHydroMatrix({ types, direction, sizes, form: Form, sx }: Props) {
   return (
     <Box sx={mergeSxProp({ width: 1, height: 1 }, sx)}>
       {Form && <Form />}
-      <SplitView storageId={`hydro-${types[0]}-${types[1]}`} direction={direction} sizes={sizes}>
+      <SplitView splitId={`hydro-${types[0]}-${types[1]}`} direction={direction} sizes={sizes}>
         <HydroMatrix type={types[0]} />
         <HydroMatrix type={types[1]} />
       </SplitView>

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/SplitHydroMatrix.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Hydro/SplitHydroMatrix.tsx
@@ -30,7 +30,7 @@ function SplitHydroMatrix({ types, direction, sizes, form: Form, sx }: Props) {
   return (
     <Box sx={mergeSxProp({ width: 1, height: 1 }, sx)}>
       {Form && <Form />}
-      <SplitView id={`hydro-${types[0]}-${types[1]}`} direction={direction} sizes={sizes}>
+      <SplitView storageId={`hydro-${types[0]}-${types[1]}`} direction={direction} sizes={sizes}>
         <HydroMatrix type={types[0]} />
         <HydroMatrix type={types[1]} />
       </SplitView>

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/AdditionalConstraints/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/AdditionalConstraints/index.tsx
@@ -161,7 +161,7 @@ function AdditionalConstraints({ studyId, areaId, storageId, studyVersion }: Pro
 
   return (
     <>
-      <SplitView id="storage-additionalConstraints" sizes={[15, 85]}>
+      <SplitView storageId="storage-additionalConstraints" sizes={[15, 85]}>
         {/* Left panel - Constraints list */}
         <Box>
           {isLoading ? (

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/AdditionalConstraints/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/AdditionalConstraints/index.tsx
@@ -161,7 +161,7 @@ function AdditionalConstraints({ studyId, areaId, storageId, studyVersion }: Pro
 
   return (
     <>
-      <SplitView storageId="storage-additionalConstraints" sizes={[15, 85]}>
+      <SplitView splitId="storage-additionalConstraints">
         {/* Left panel - Constraints list */}
         <Box>
           {isLoading ? (

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/StorageMatrices.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/StorageMatrices.tsx
@@ -39,7 +39,7 @@ function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
     {
       label: t("study.modelization.storages.modulation"),
       content: (
-        <SplitView id="storage-injectionModulation-withdrawalModulation" sizes={[50, 50]}>
+        <SplitView splitId="storage-injectionModulation-withdrawalModulation" sizes={[50, 50]}>
           <Box sx={{ p: 2 }}>
             {/* TODO: Remove isTimeSeries={false} and customColumns when simulator development is complete */}
             <Matrix
@@ -64,7 +64,7 @@ function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
     {
       label: t("study.modelization.storages.ruleCurves"),
       content: (
-        <SplitView id="storage-lowerRuleCurve-upperRuleCurve" sizes={[50, 50]}>
+        <SplitView splitId="storage-lowerRuleCurve-upperRuleCurve" sizes={[50, 50]}>
           <Box sx={{ p: 2 }}>
             {/* TODO: Remove isTimeSeries={false} and customColumns when simulator development is complete */}
             <Matrix
@@ -102,7 +102,7 @@ function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
     {
       label: t("study.modelization.storages.costs"),
       content: (
-        <SplitView id="storage-injectionCost-withdrawalCost" sizes={[50, 50]}>
+        <SplitView splitId="storage-injectionCost-withdrawalCost" sizes={[50, 50]}>
           <Box sx={{ p: 2 }}>
             {/* TODO: Remove isTimeSeries={false} and customColumns when simulator development is complete */}
             <Matrix
@@ -127,7 +127,10 @@ function StorageMatrices({ areaId, storageId, studyVersion }: Props) {
     {
       label: t("study.modelization.storages.variationCosts"),
       content: (
-        <SplitView id="storage-variationInjectionCost-variationWithdrawalCost" sizes={[50, 50]}>
+        <SplitView
+          splitId="storage-variationInjectionCost-variationWithdrawalCost"
+          sizes={[50, 50]}
+        >
           <Box sx={{ p: 2 }}>
             {/* TODO: Remove isTimeSeries={false} and customColumns when simulator development is complete */}
             <Matrix

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/index.tsx
@@ -96,7 +96,7 @@ function Areas() {
   ////////////////////////////////////////////////////////////////
 
   return (
-    <SplitView id="areas" sizes={[10, 90]}>
+    <SplitView splitId="areas" sizes={[10, 90]}>
       {/* Left */}
       <AreaPropsView studyId={study.id} onClick={handleAreaClick} currentArea={currentArea?.id} />
       {/* Right */}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/index.tsx
@@ -96,7 +96,7 @@ function Areas() {
   ////////////////////////////////////////////////////////////////
 
   return (
-    <SplitView splitId="areas" sizes={[10, 90]}>
+    <SplitView splitId="areas">
       {/* Left */}
       <AreaPropsView studyId={study.id} onClick={handleAreaClick} currentArea={currentArea?.id} />
       {/* Right */}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/Matrix.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/Matrix.tsx
@@ -74,7 +74,7 @@ function ConstraintMatrix({ study, operator, constraintId, open, onClose }: Prop
             />
           )}
           {operator === "both" && (
-            <SplitView id="binding-constraints-matrix" sizes={[50, 50]}>
+            <SplitView splitId="binding-constraints-matrix" sizes={[50, 50]}>
               <Box sx={{ px: 2 }}>
                 <Matrix
                   title={t("study.modelization.bindingConst.timeSeries.less")}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
@@ -71,7 +71,7 @@ function BindingConstraints() {
     <UsePromiseCond
       response={constraintsRes}
       ifFulfilled={(data) => (
-        <SplitView id="binding-constraints" sizes={[10, 90]}>
+        <SplitView splitId="binding-constraints" sizes={[10, 90]}>
           {/* Left */}
           <BindingConstPropsView // TODO rename ConstraintsList
             list={data}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/BindingConstraints/index.tsx
@@ -71,7 +71,7 @@ function BindingConstraints() {
     <UsePromiseCond
       response={constraintsRes}
       ifFulfilled={(data) => (
-        <SplitView splitId="binding-constraints" sizes={[10, 90]}>
+        <SplitView splitId="binding-constraints">
           {/* Left */}
           <BindingConstPropsView // TODO rename ConstraintsList
             list={data}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Links/LinkConfig/LinkMatrices.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Links/LinkConfig/LinkMatrices.tsx
@@ -76,7 +76,7 @@ function LinkMatrices({ area1, area2, isOldStudy }: Props) {
         {
           label: t("study.modelization.links.matrix.capacities"),
           content: (
-            <SplitView id="link-transCapaDirect-transCapaIndirect" sizes={[50, 50]}>
+            <SplitView splitId="link-transCapaDirect-transCapaIndirect" sizes={[50, 50]}>
               <Box sx={{ pr: 2 }}>
                 <Matrix
                   url={`input/links/${area1.toLowerCase()}/capacities/${area2.toLowerCase()}_direct`}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Links/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Links/index.tsx
@@ -62,7 +62,7 @@ function Links() {
   ////////////////////////////////////////////////////////////////
 
   return (
-    <SplitView splitId="links" sizes={[10, 90]}>
+    <SplitView splitId="links">
       {/* Left */}
       <LinkPropsView studyId={study.id} onClick={handleLinkClick} />
       {/* Right */}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Links/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Links/index.tsx
@@ -62,7 +62,7 @@ function Links() {
   ////////////////////////////////////////////////////////////////
 
   return (
-    <SplitView id="links" sizes={[10, 90]}>
+    <SplitView splitId="links" sizes={[10, 90]}>
       {/* Left */}
       <LinkPropsView studyId={study.id} onClick={handleLinkClick} />
       {/* Right */}

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/index.tsx
@@ -173,7 +173,7 @@ function Map() {
       response={mapNodesRes}
       ifFulfilled={(mapNodes) => (
         <>
-          <SplitView id="map" sizes={[10, 90]}>
+          <SplitView splitId="map" sizes={[10, 90]}>
             <Box>
               <Areas onAdd={() => setOpenDialog(true)} nodes={mapNodes} updateUI={updateUI} />
             </Box>

--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Map/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Map/index.tsx
@@ -173,7 +173,7 @@ function Map() {
       response={mapNodesRes}
       ifFulfilled={(mapNodes) => (
         <>
-          <SplitView splitId="map" sizes={[10, 90]}>
+          <SplitView splitId="map">
             <Box>
               <Areas onAdd={() => setOpenDialog(true)} nodes={mapNodes} updateUI={updateUI} />
             </Box>

--- a/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
@@ -244,7 +244,7 @@ function ResultDetails() {
   ////////////////////////////////////////////////////////////////
 
   return (
-    <SplitView id="results" sizes={[15, 85]} minSize={[200, 300]}>
+    <SplitView splitId="results" sizes={[10, 90]} minSize={[100, 1100]}>
       <ResultItemSelector
         itemType={itemType}
         onItemTypeChange={handleItemTypeChange}

--- a/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Results/ResultDetails/index.tsx
@@ -244,7 +244,7 @@ function ResultDetails() {
   ////////////////////////////////////////////////////////////////
 
   return (
-    <SplitView splitId="results" sizes={[10, 90]} minSize={[100, 1100]}>
+    <SplitView splitId="results" minSize={[150, 400]}>
       <ResultItemSelector
         itemType={itemType}
         onItemTypeChange={handleItemTypeChange}

--- a/webapp/src/components/App/Singlestudy/explore/TableModeList/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/TableModeList/index.tsx
@@ -110,7 +110,7 @@ function TableModeList() {
 
   return (
     <>
-      <SplitView id="tablemode" sizes={[10, 90]}>
+      <SplitView splitId="tablemode" sizes={[10, 90]}>
         {/* Left */}
         <PropertiesView
           mainContent={

--- a/webapp/src/components/App/Singlestudy/explore/TableModeList/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/TableModeList/index.tsx
@@ -110,7 +110,7 @@ function TableModeList() {
 
   return (
     <>
-      <SplitView splitId="tablemode" sizes={[10, 90]}>
+      <SplitView splitId="tablemode">
         {/* Left */}
         <PropertiesView
           mainContent={

--- a/webapp/src/components/App/Singlestudy/explore/Xpansion/Candidates/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Xpansion/Candidates/index.tsx
@@ -226,7 +226,7 @@ function Candidates() {
 
   return (
     <>
-      <SplitView id="xpansion" sizes={[10, 90]}>
+      <SplitView splitId="xpansion" sizes={[10, 90]}>
         <Box>
           <XpansionPropsView
             candidateList={candidates || []}

--- a/webapp/src/components/App/Singlestudy/explore/Xpansion/Candidates/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Xpansion/Candidates/index.tsx
@@ -226,7 +226,7 @@ function Candidates() {
 
   return (
     <>
-      <SplitView splitId="xpansion" sizes={[10, 90]}>
+      <SplitView splitId="xpansion">
         <Box>
           <XpansionPropsView
             candidateList={candidates || []}

--- a/webapp/src/components/App/Studies/index.tsx
+++ b/webapp/src/components/App/Studies/index.tsx
@@ -50,7 +50,7 @@ function Studies() {
       titleIcon={TravelExploreOutlinedIcon}
       headerActions={<HeaderActions onOpenFilterClick={() => setOpenFilter(true)} />}
     >
-      <SplitView id="studies" direction="horizontal" sizes={[30, 70]} minSize={[200, 400]}>
+      <SplitView splitId="studies" direction="horizontal" sizes={[30, 70]} minSize={[200, 400]}>
         {/* Left */}
         <SideNav />
         {/* Right */}

--- a/webapp/src/components/App/Studies/index.tsx
+++ b/webapp/src/components/App/Studies/index.tsx
@@ -50,7 +50,7 @@ function Studies() {
       titleIcon={TravelExploreOutlinedIcon}
       headerActions={<HeaderActions onOpenFilterClick={() => setOpenFilter(true)} />}
     >
-      <SplitView splitId="studies" direction="horizontal" sizes={[30, 70]} minSize={[200, 400]}>
+      <SplitView splitId="studies" minSize={[200, 400]}>
         {/* Left */}
         <SideNav />
         {/* Right */}

--- a/webapp/src/components/common/SplitView/index.tsx
+++ b/webapp/src/components/common/SplitView/index.tsx
@@ -73,7 +73,7 @@ function SplitView({
 
   // Update localStorage whenever `activeSizes` change.
   useUpdateEffect(() => {
-    storage.setItem(localStorageKey, activeSizes);
+    storage.setItem(localStorageKey, activeSizes?.map(Math.round));
   }, [activeSizes, localStorageKey]);
 
   ////////////////////////////////////////////////////////////////
@@ -87,11 +87,7 @@ function SplitView({
       direction={direction}
       sizes={activeSizes ?? defaultSizes}
       minSize={minSize}
-      onDragEnd={(sizes) => {
-        // Round to whole numbers to avoid excessive precision
-        const roundedSizes = sizes.map((size) => Math.round(size));
-        setActiveSizes(roundedSizes);
-      }}
+      onDragEnd={setActiveSizes}
       gutterSize={gutterSize}
       style={{
         display: "flex",

--- a/webapp/src/components/common/SplitView/index.tsx
+++ b/webapp/src/components/common/SplitView/index.tsx
@@ -87,7 +87,11 @@ function SplitView({
       direction={direction}
       sizes={activeSizes ?? defaultSizes}
       minSize={minSize}
-      onDragEnd={setActiveSizes} // Update sizes on drag end.
+      onDragEnd={(sizes) => {
+        // Round to whole numbers to avoid excessive precision
+        const roundedSizes = sizes.map((size) => Math.round(size));
+        setActiveSizes(roundedSizes);
+      }}
       gutterSize={gutterSize}
       style={{
         display: "flex",

--- a/webapp/src/components/common/SplitView/index.tsx
+++ b/webapp/src/components/common/SplitView/index.tsx
@@ -58,7 +58,7 @@ function SplitView({
   splitId,
   children,
   direction = "horizontal",
-  sizes,
+  sizes = [10, 90], // Most common split ratio: small sidebar (10%) + main content area (90%)
   minSize = [150, 150],
   gutterSize = 3,
 }: SplitViewProps) {

--- a/webapp/src/components/common/SplitView/index.tsx
+++ b/webapp/src/components/common/SplitView/index.tsx
@@ -19,7 +19,7 @@ import storage from "../../../services/utils/localStorage";
 import "./style.css";
 
 export interface SplitViewProps {
-  id: string;
+  splitId: string;
   children: React.ReactNode[];
   direction?: SplitProps["direction"];
   sizes?: SplitProps["sizes"];
@@ -46,7 +46,7 @@ function isValidSizes(sizes: unknown): sizes is number[] {
  * </SplitView>
  *
  * @param props - The component props.
- * @param props.id - Identifier to uniquely store the sizes of the panes.
+ * @param props.splitId - Identifier to uniquely store the sizes of the panes.
  * @param props.children - Child components to be rendered within the split views.
  * @param [props.direction=horizontal] - The orientation of the split view ("horizontal" or "vertical").
  * @param [props.sizes] - Initial sizes of each view in percentages. The array must sum to 100 and match the number of children.
@@ -55,7 +55,7 @@ function isValidSizes(sizes: unknown): sizes is number[] {
  * @returns A React component displaying a split layout view with resizable panes.
  */
 function SplitView({
-  id,
+  splitId,
   children,
   direction = "horizontal",
   sizes,
@@ -64,7 +64,7 @@ function SplitView({
 }: SplitViewProps) {
   const numberOfChildren = Children.count(children);
   const defaultSizes = Array(numberOfChildren).fill(100 / numberOfChildren);
-  const localStorageKey = `splitSizes.${id}.${direction}`;
+  const localStorageKey = `splitSizes.${splitId}.${direction}`;
 
   const [activeSizes, setActiveSizes] = useState<SplitProps["sizes"]>(() => {
     const savedSizes = storage.getItem(localStorageKey);

--- a/webapp/src/components/common/dialogs/DatabaseUploadDialog/index.tsx
+++ b/webapp/src/components/common/dialogs/DatabaseUploadDialog/index.tsx
@@ -127,7 +127,7 @@ function DatabaseUploadDialog({ studyId, path, open, onClose }: DatabaseUploadDi
       {isUploading ? (
         <SimpleLoader />
       ) : (
-        <SplitView storageId="matrix-assign" sizes={[20, 80]}>
+        <SplitView splitId="matrix-assign">
           <DataPropsView
             dataset={matrices || []}
             selectedItem={selectedItem}

--- a/webapp/src/components/common/dialogs/DatabaseUploadDialog/index.tsx
+++ b/webapp/src/components/common/dialogs/DatabaseUploadDialog/index.tsx
@@ -127,7 +127,7 @@ function DatabaseUploadDialog({ studyId, path, open, onClose }: DatabaseUploadDi
       {isUploading ? (
         <SimpleLoader />
       ) : (
-        <SplitView id="matrix-assign" sizes={[20, 80]}>
+        <SplitView storageId="matrix-assign" sizes={[20, 80]}>
           <DataPropsView
             dataset={matrices || []}
             selectedItem={selectedItem}


### PR DESCRIPTION
## Issues

**Prop Naming Issue**: The `id` prop name was misleading and could trigger linter warnings when conflicting with the standard HTML `id` attribute. React components should avoid prop names that shadow DOM properties.

**Precision Issue**: When users drag the splitter, `react-split` calculates percentages with high floating-point precision (e.g., `33.33333333333333`). These values were stored directly in localStorage, creating messy entries and potential serialization issues.

**Inconsistent Defaults**: No standardized default split ratio, leading to inconsistent UX across different instances.

## Changes
- **Renamed `id` → `splitId`**: 
  - Follows React naming conventions (component-specific props)
  - Avoids HTML attribute conflicts and linter warnings
  - More descriptive of its actual purpose

- **Round stored sizes to whole numbers**:
  - Converts `[33.33333333333333, 66.7777777777777]` → `[33,66]`
  - Cleaner localStorage entries
  - Maintains sufficient precision for UI layout

- **Standardized default to `[10, 90]`**:
  - Common sidebar/main content pattern
  - Consistent UX across the application
  - Avoid prop repetitions