### PR TITLE
feat(ui-matrix): add separate enable flags for `Matrix` filters and resize

### DIFF
--- a/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/AdditionalConstraints/ConstraintForm/index.tsx
+++ b/webapp/src/components/App/Singlestudy/explore/Modelization/Areas/Storages/StorageConfig/AdditionalConstraints/ConstraintForm/index.tsx
@@ -126,6 +126,7 @@ function ConstraintForm({
             {...(studyVersion < 930 && {
               isTimeSeries: false,
               customColumns: ["TS 1"],
+              enableFilters: true,
             })}
           />
         </OkDialog>

--- a/webapp/src/components/common/Matrix/components/MatrixActions/index.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixActions/index.tsx
@@ -12,18 +12,18 @@
  * This file is part of the Antares project.
  */
 
-import DownloadMatrixButton from "@/components/common/buttons/DownloadMatrixButton";
-import SplitButton, { type SplitButtonProps } from "@/components/common/buttons/SplitButton";
 import FileUploadIcon from "@mui/icons-material/FileUpload";
 import RedoIcon from "@mui/icons-material/Redo";
 import SaveIcon from "@mui/icons-material/Save";
 import UndoIcon from "@mui/icons-material/Undo";
 import { Button, Divider, IconButton, Tooltip } from "@mui/material";
 import { useTranslation } from "react-i18next";
+import DownloadMatrixButton from "@/components/common/buttons/DownloadMatrixButton";
+import SplitButton, { type SplitButtonProps } from "@/components/common/buttons/SplitButton";
 import { useMatrixContext } from "../../context/MatrixContext";
-import MatrixResize from "../MatrixResize";
-import MatrixFilter from "../MatrixFilter";
 import type { DateTimes, TimeFrequencyType } from "../../shared/types";
+import MatrixFilter from "../MatrixFilter";
+import MatrixResize from "../MatrixResize";
 
 interface MatrixActionsProps {
   studyId: string;

--- a/webapp/src/components/common/Matrix/components/MatrixActions/index.tsx
+++ b/webapp/src/components/common/Matrix/components/MatrixActions/index.tsx
@@ -36,6 +36,8 @@ interface MatrixActionsProps {
   timeFrequency?: TimeFrequencyType;
   onMatrixUpdated: VoidFunction;
   canImport?: boolean;
+  enableFilters?: boolean;
+  enableResize?: boolean;
 }
 
 function MatrixActions({
@@ -48,6 +50,8 @@ function MatrixActions({
   isTimeSeries,
   timeFrequency,
   canImport = false,
+  enableFilters = false,
+  enableResize = false,
 }: MatrixActionsProps) {
   const { t } = useTranslation();
   const { isSubmitting, updateCount, undo, redo, canUndo, canRedo, isDirty } = useMatrixContext();
@@ -88,14 +92,16 @@ function MatrixActions({
         </span>
       </Tooltip>
       <Divider sx={{ mx: 1 }} orientation="vertical" flexItem />
-      {isTimeSeries && (
+      {(enableResize || enableFilters) && (
         <>
-          <MatrixResize />
-          <MatrixFilter
-            dateTime={dateTime}
-            isTimeSeries={isTimeSeries}
-            timeFrequency={timeFrequency}
-          />
+          {enableResize && <MatrixResize />}
+          {enableFilters && (
+            <MatrixFilter
+              dateTime={dateTime}
+              isTimeSeries={isTimeSeries}
+              timeFrequency={timeFrequency}
+            />
+          )}
           <Divider sx={{ mx: 1 }} orientation="vertical" flexItem />
         </>
       )}

--- a/webapp/src/components/common/Matrix/index.tsx
+++ b/webapp/src/components/common/Matrix/index.tsx
@@ -12,12 +12,12 @@
  * This file is part of the Antares project.
  */
 
-import MatrixUpload from "@/components/common/Matrix/components/MatrixUpload";
 import GridOffIcon from "@mui/icons-material/GridOff";
 import { Box, Skeleton, Tooltip } from "@mui/material";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useOutletContext } from "react-router";
+import MatrixUpload from "@/components/common/Matrix/components/MatrixUpload";
 import type { StudyMetadata } from "../../../types/types";
 import type { fetchMatrixFn } from "../../App/Singlestudy/explore/Modelization/Areas/Hydro/utils";
 import CustomScrollbar from "../CustomScrollbar";
@@ -28,7 +28,7 @@ import { MatrixProvider } from "./context/MatrixContext";
 import { useMatrixColumns } from "./hooks/useMatrixColumns";
 import { useMatrixData } from "./hooks/useMatrixData";
 import { useMatrixMutations } from "./hooks/useMatrixMutations";
-import { isNonEmptyMatrix, type AggregateConfig, type RowCountSource } from "./shared/types";
+import { type AggregateConfig, isNonEmptyMatrix, type RowCountSource } from "./shared/types";
 import { getAggregateTypes } from "./shared/utils";
 import { MatrixContainer, MatrixHeader, MatrixTitle } from "./styles";
 
@@ -37,6 +37,10 @@ interface MatrixProps {
   title?: string;
   customRowHeaders?: string[];
   dateTimeColumn?: boolean;
+  /**
+   * Enables time series features like temporal filters, resize, and calculated columns.
+   * Note: For specific cases (e.g., hourly time series that shouldn't resize), use enableFilters/enableResize to override.
+   */
   isTimeSeries?: boolean;
   aggregateColumns?: AggregateConfig;
   rowHeaders?: boolean;
@@ -47,7 +51,15 @@ interface MatrixProps {
   fetchMatrixData?: fetchMatrixFn;
   canImport?: boolean;
   rowCountSource?: RowCountSource;
+  /**
+   * Feature flag for data filtering functionality.
+   * Useful for matrices that need filtering but can't be resized.
+   */
   enableFilters?: boolean;
+  /**
+   * Feature flag for data resizing functionality.
+   * Some matrices have temporal structure but fixed dimensions.
+   */
   enableResize?: boolean;
 }
 

--- a/webapp/src/components/common/Matrix/index.tsx
+++ b/webapp/src/components/common/Matrix/index.tsx
@@ -47,6 +47,8 @@ interface MatrixProps {
   fetchMatrixData?: fetchMatrixFn;
   canImport?: boolean;
   rowCountSource?: RowCountSource;
+  enableFilters?: boolean;
+  enableResize?: boolean;
 }
 
 function Matrix({
@@ -64,6 +66,8 @@ function Matrix({
   fetchMatrixData,
   canImport = true,
   rowCountSource,
+  enableFilters = isTimeSeries,
+  enableResize = isTimeSeries,
 }: MatrixProps) {
   const { t } = useTranslation();
   const { study } = useOutletContext<{ study: StudyMetadata }>();
@@ -161,6 +165,8 @@ function Matrix({
                 onSave={handleSaveUpdates}
                 onMatrixUpdated={reload}
                 canImport={canImport}
+                enableFilters={enableFilters}
+                enableResize={enableResize}
                 onImport={(_, index) => {
                   setUploadType(index === 0 ? "file" : "database");
                 }}


### PR DESCRIPTION
 ### Changes Made:

  1. Added two new optional props to Matrix component:
    - `enableFilters?`: boolean - Controls whether the filter feature is available
    - `enableResize?`: boolean - Controls whether the resize feature is available
    
  2. Set defaults:
    - Both props default to isTimeSeries value, maintaining current behavior
    - This means existing code won't break and timeseries matrices get both features by default
    
  3. Updated `MatrixActions` component:
    - Added the new props to the interface
    - Changed the conditional rendering logic to use separate enable flags
    - Each feature can now be enabled/disabled independently

  Usage Examples:

```tsx
  // Current behavior (unchanged) - both features enabled for timeseries
  <Matrix url="/path" isTimeSeries />

  // With filters but no resize 
  <Matrix url="/path" isTimeSeries={false} enableFilters />

  // With resize but no filters 
  <Matrix url="/path" isTimeSeries={false} enableResize />

  // Disable both features even for timeseries
  <Matrix url="/path" isTimeSeries enableFilters={false} enableResize={false} />
  ```

