### PR TITLE
feat(xpansion): support `adequacy_criterion` option inside slurm launcher

### DIFF
--- a/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
+++ b/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
@@ -95,11 +95,11 @@ class LauncherArgs(argparse.Namespace):
     def apply_xpansion_mode(self, launcher_params: LauncherParametersDTO) -> None:
         if launcher_params.xpansion:  # not None and not False
             self.xpansion_mode = {True: "r", False: "cpp"}[launcher_params.xpansion_r_version]
-            if (
-                isinstance(launcher_params.xpansion, XpansionParametersDTO)
-                and launcher_params.xpansion.sensitivity_mode
-            ):
-                self._append_other_option("xpansion_sensitivity")
+            if isinstance(launcher_params.xpansion, XpansionParametersDTO):
+                if launcher_params.xpansion.sensitivity_mode:
+                    self._append_other_option("xpansion_sensitivity")
+                if launcher_params.xpansion.adequacy_criterion:
+                    self._append_other_option("xpansion_adequacy_criterion")
 
     def apply_time_limit(self, launcher_params: LauncherParametersDTO, time_limit_cfg: TimeLimitConfig) -> None:
         # The `time_limit` parameter could be `None`, in that case, the default value is used.

--- a/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
+++ b/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
@@ -99,7 +99,7 @@ class LauncherArgs(argparse.Namespace):
                 if launcher_params.xpansion.sensitivity_mode:
                     self._append_other_option("xpansion_sensitivity")
                 if launcher_params.xpansion.adequacy_criterion:
-                    self._append_other_option("xpansion_adequacy_criterion")
+                    self._append_other_option("adequacy_criterion")
 
     def apply_time_limit(self, launcher_params: LauncherParametersDTO, time_limit_cfg: TimeLimitConfig) -> None:
         # The `time_limit` parameter could be `None`, in that case, the default value is used.

--- a/antarest/launcher/model.py
+++ b/antarest/launcher/model.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import Any, Dict, List, MutableMapping, Optional
 from uuid import uuid4
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
 from sqlalchemy import DateTime, Enum, ForeignKey, Integer, Sequence, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -32,6 +32,13 @@ class XpansionParametersDTO(AntaresBaseModel):
     output_id: Optional[str] = None
     sensitivity_mode: bool = False
     enabled: bool = True
+    adequacy_criterion: bool = False
+
+    @model_validator(mode="after")
+    def check_coherence(self) -> "XpansionParametersDTO":
+        if self.sensitivity_mode and self.adequacy_criterion:
+            raise ValueError("Cannot launch a sensitivity analysis and an adequacy criterion one at the same time")
+        return self
 
 
 class LauncherParametersDTO(AntaresBaseModel):

--- a/tests/launcher/test_slurm_launcher.py
+++ b/tests/launcher/test_slurm_launcher.py
@@ -235,6 +235,19 @@ def test_extra_parameters(launcher_config: SlurmConfig) -> None:
     assert launcher_params.xpansion_mode == "cpp"
     assert launcher_params.other_options == "xpansion_sensitivity"
 
+    launcher_params = apply_params(LauncherParametersDTO(xpansion=XpansionParametersDTO(adequacy_criterion=False)))
+    assert launcher_params.xpansion_mode == "cpp"
+    assert launcher_params.other_options == ""
+
+    launcher_params = apply_params(LauncherParametersDTO(xpansion=XpansionParametersDTO(adequacy_criterion=True)))
+    assert launcher_params.xpansion_mode == "cpp"
+    assert launcher_params.other_options == "xpansion_adequacy_criterion"
+
+    with pytest.raises(
+        ValueError, match="Cannot launch a sensitivity analysis and an adequacy criterion one at the same time"
+    ):
+        XpansionParametersDTO(adequacy_criterion=True, sensitivity_mode=True)
+
     launcher_params = apply_params(LauncherParametersDTO(post_processing=False))
     assert launcher_params.post_processing is False
 

--- a/tests/launcher/test_slurm_launcher.py
+++ b/tests/launcher/test_slurm_launcher.py
@@ -241,7 +241,7 @@ def test_extra_parameters(launcher_config: SlurmConfig) -> None:
 
     launcher_params = apply_params(LauncherParametersDTO(xpansion=XpansionParametersDTO(adequacy_criterion=True)))
     assert launcher_params.xpansion_mode == "cpp"
-    assert launcher_params.other_options == "xpansion_adequacy_criterion"
+    assert launcher_params.other_options == "adequacy_criterion"
 
     with pytest.raises(
         ValueError, match="Cannot launch a sensitivity analysis and an adequacy criterion one at the same time"


### PR DESCRIPTION
[ANT-3738]