### PR TITLE
fix(worker): fix unarchive worker build

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -23,8 +23,7 @@ jobs:
       - name: 🐍 Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pyinstaller==6.10.0
+          pip install -r requirements-dev.txt
 
       - name: 📦 Packaging AntaresWebWorker
         run: bash ./package_worker.sh

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -34,4 +34,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: AntaresWebWorker
-          path: dist/AntaresWebWorker.exe
+          path: dist/AntaresWebWorker

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -33,4 +33,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: AntaresWebWorker
-          path: dist/AntaresWebWorker
+          path: dist/AntaresWebWorker.exe

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pyinstaller==5.6.2
+          pip install pyinstaller==5.15.6
 
       - name: 📦 Packaging AntaresWebWorker
         run: bash ./package_worker.sh

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.11.3
 
       - name: 🐍 Install dependencies
         run: |

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11.3
+          python-version: 3.11
 
       - name: 🐍 Install dependencies
         run: |

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pyinstaller==5.15.6
+          pip install pyinstaller==6.10.0
 
       - name: 📦 Packaging AntaresWebWorker
         run: bash ./package_worker.sh

--- a/AntaresWebWorker.spec
+++ b/AntaresWebWorker.spec
@@ -34,12 +34,11 @@ exe = EXE(
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    console=False,
+    console=True,
     disable_windowed_traceback=False,
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon='resources/webapp/favicon.ico'
 )
 
 coll = COLLECT(exe,

--- a/AntaresWebWorker.spec
+++ b/AntaresWebWorker.spec
@@ -17,7 +17,6 @@ a = Analysis(
     cipher=block_cipher,
     noarchive=False,
 )
-
 pyz = PYZ(
     a.pure,
     a.zipped_data,
@@ -27,25 +26,20 @@ pyz = PYZ(
 exe = EXE(
     pyz,
     a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
     [],
-    exclude_binaries=True,
-    name='AntaresWebWorker',
+    name="AntaresWebWorker",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
     console=True,
     disable_windowed_traceback=False,
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
 )
-
-coll = COLLECT(exe,
-               a.binaries,
-               a.zipfiles,
-               a.datas,
-               strip=False,
-               upx=True,
-               upx_exclude=[],
-               name='AntaresWebWorker')

--- a/AntaresWebWorker.spec
+++ b/AntaresWebWorker.spec
@@ -17,6 +17,7 @@ a = Analysis(
     cipher=block_cipher,
     noarchive=False,
 )
+
 pyz = PYZ(
     a.pure,
     a.zipped_data,
@@ -26,20 +27,26 @@ pyz = PYZ(
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
     [],
-    name="AntaresWebWorker",
+    exclude_binaries=True,
+    name='AntaresWebWorker',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    upx_exclude=[],
-    runtime_tmpdir=None,
-    console=True,
+    console=False,
     disable_windowed_traceback=False,
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
+    icon='resources/webapp/favicon.ico'
 )
+
+coll = COLLECT(exe,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               strip=False,
+               upx=True,
+               upx_exclude=[],
+               name='AntaresWebWorker')

--- a/AntaresWebWorker.spec
+++ b/AntaresWebWorker.spec
@@ -3,7 +3,7 @@
 block_cipher = None
 
 a = Analysis(
-    ["antarest/worker/archive_worker_service.py"],
+    ["antarest/worker/archive_worker_main.py"],
     pathex=[],
     binaries=[],
     datas=[("resources", "resources")],

--- a/antarest/eventbus/business/redis_eventbus.py
+++ b/antarest/eventbus/business/redis_eventbus.py
@@ -11,8 +11,7 @@
 # This file is part of the Antares project.
 
 import logging
-import pathlib
-from typing import List, Optional, cast
+from typing import List, Optional
 
 from redis.client import Redis
 from typing_extensions import override
@@ -43,8 +42,7 @@ class RedisEventBus(IEventBusBackend):
     def pull_queue(self, queue: str) -> Optional[Event]:
         event = self.redis.lpop(queue)
         if event:
-            event_string = pathlib.Path(event).read_text()
-            return cast(Optional[Event], Event.model_validate_json(event_string))
+            return Event.model_validate_json(event)
         return None
 
     @override

--- a/antarest/worker/archive_worker_main.py
+++ b/antarest/worker/archive_worker_main.py
@@ -1,0 +1,9 @@
+import multiprocessing
+
+if __name__ == "__main__":
+    # Freeze support needed for pyinstaller
+    multiprocessing.freeze_support()
+
+    from antarest.worker.archive_worker_service import run_archive_worker
+
+    run_archive_worker()

--- a/antarest/worker/archive_worker_main.py
+++ b/antarest/worker/archive_worker_main.py
@@ -1,7 +1,8 @@
 import multiprocessing
 
 if __name__ == "__main__":
-    # Freeze support needed for pyinstaller
+    # Freeze support needed for pyinstaller. Important to run it before other imports,
+    # because some of them call multiprocessing functions.
     multiprocessing.freeze_support()
 
     from antarest.worker.archive_worker_service import run_archive_worker

--- a/antarest/worker/archive_worker_service.py
+++ b/antarest/worker/archive_worker_service.py
@@ -12,7 +12,6 @@
 
 import argparse
 import logging
-import multiprocessing
 from pathlib import Path
 from typing import Optional, Sequence, TypeAlias
 
@@ -75,8 +74,3 @@ def run_archive_worker(args: ArgsType = None) -> None:
     worker = create_archive_worker(config, workspace, Path(local_root))
     worker.start(threaded=False)
     logger.info("Archive Worker task is done, bye.")
-
-
-if __name__ == "__main__":
-    multiprocessing.freeze_support()
-    run_archive_worker()

--- a/antarest/worker/archive_worker_service.py
+++ b/antarest/worker/archive_worker_service.py
@@ -12,6 +12,7 @@
 
 import argparse
 import logging
+import multiprocessing
 from pathlib import Path
 from typing import Optional, Sequence, TypeAlias
 
@@ -77,4 +78,5 @@ def run_archive_worker(args: ArgsType = None) -> None:
 
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
     run_archive_worker()

--- a/scripts/package_worker.sh
+++ b/scripts/package_worker.sh
@@ -13,5 +13,3 @@ echo "INFO: Generating the Worker Application..."
 pushd ${PROJECT_DIR}
 pyinstaller --distpath ${DIST_DIR} AntaresWebWorker.spec
 popd
-
-chmod +x "${DIST_DIR}/AntaresWebWorker"


### PR DESCRIPTION
The unarchive worker for windows does not work anymore:
 - we use an outdated pyinstaller version to build it
 - it doesn't call `multiprocessing.freeze_support()`, which causes an endless loop on startup


Also fixes event parsing in redis backend, which was not working anymore.