### PR TITLE
refactor(area-ui)!: adjust models and update logic for area UI properties

### DIFF
--- a/antarest/study/business/area_management.py
+++ b/antarest/study/business/area_management.py
@@ -18,7 +18,7 @@ from antarest.study.business.areas.area_utils import _get_area_layers, _get_ui_i
 from antarest.study.business.model.area_model import (
     Area,
     AreaCreation,
-    UpdateAreaUi,
+    AreaUIUpdate,
 )
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.business.study_interface import StudyInterface
@@ -168,11 +168,11 @@ class AreaManager:
             thermals=[],
         )
 
-    def update_area_ui(self, study: StudyInterface, area_id: str, area_ui: UpdateAreaUi, layer: str) -> None:
+    def update_area_ui(self, study: StudyInterface, area_id: str, area_ui: AreaUIUpdate, layer: str) -> None:
         command = UpdateAreaUI(
             area_id=area_id,
-            area_ui=area_ui,
             layer=layer,
+            parameters=area_ui,
             command_context=self._command_context,
             study_version=study.version,
         )

--- a/antarest/study/business/areas/area_utils.py
+++ b/antarest/study/business/areas/area_utils.py
@@ -12,7 +12,7 @@
 import re
 from typing import Any, Dict, List, Sequence
 
-from antarest.study.storage.rawstudy.model.filesystem.config.area import UIProperties
+from antarest.study.storage.rawstudy.model.filesystem.config.area import AreaUIFileData
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 
 
@@ -45,8 +45,8 @@ def _get_ui_info_map(file_study: FileStudy, area_ids: Sequence[str]) -> Dict[str
     if len(area_ids) == 1:
         ui_info_map = {area_ids[0]: ui_info_map}
 
-    # Convert to UIProperties to ensure that the UI object is valid.
-    ui_info_map = {area_id: UIProperties(**ui_info).to_config() for area_id, ui_info in ui_info_map.items()}
+    # Convert to AreaUIFileData to ensure that the UI object is valid.
+    ui_info_map = {area_id: AreaUIFileData(**ui_info).to_config() for area_id, ui_info in ui_info_map.items()}
 
     return ui_info_map
 

--- a/antarest/study/business/model/area_model.py
+++ b/antarest/study/business/model/area_model.py
@@ -56,7 +56,7 @@ class AreaUIUpdate(AntaresBaseModel):
     Partial update for Area UI properties.
     """
 
-    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     x: Optional[int] = None
     y: Optional[int] = None

--- a/antarest/study/business/model/area_model.py
+++ b/antarest/study/business/model/area_model.py
@@ -11,11 +11,12 @@
 # This file is part of the Antares project.
 
 import enum
-from typing import List, Mapping, Optional, Sequence
+from typing import List, Optional
 
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from antarest.core.serde import AntaresBaseModel
+from antarest.core.utils.string import to_camel_case
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 
 
@@ -38,10 +39,35 @@ class AreaCreation(AntaresBaseModel):
     )
 
 
-class UpdateAreaUi(AntaresBaseModel, extra="forbid", populate_by_name=True):
-    x: int = Field(title="X position")
-    y: int = Field(title="Y position")
-    color_rgb: Sequence[int] = Field(title="RGB color", alias="colorRgb")
-    layer_x: Mapping[int, int] = Field(default_factory=dict, title="X position of each layer", alias="layerX")
-    layer_y: Mapping[int, int] = Field(default_factory=dict, title="Y position of each layer", alias="layerY")
-    layer_color: Mapping[int, str] = Field(default_factory=dict, title="Color of each layer", alias="layerColor")
+class AreaUI(AntaresBaseModel):
+    """
+    Area UI properties for a specific layer.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel_case, populate_by_name=True, extra="forbid")
+
+    x: int = Field(description="X position")
+    y: int = Field(description="Y position")
+    color_rgb: tuple[int, int, int] = Field(description="RGB color")
+
+
+class AreaUIUpdate(AntaresBaseModel):
+    """
+    Partial update for Area UI properties.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    x: Optional[int] = None
+    y: Optional[int] = None
+    color_rgb: Optional[tuple[int, int, int]] = Field(default=None, alias="colorRgb")
+
+
+def update_area_ui(current: AreaUI, data: AreaUIUpdate) -> AreaUI:
+    """
+    Updates an area UI according to the provided update data.
+    """
+    current_properties = current.model_dump(mode="json")
+    new_properties = data.model_dump(mode="json", exclude_none=True)
+    current_properties.update(new_properties)
+    return AreaUI.model_validate(current_properties)

--- a/antarest/study/business/model/area_model.py
+++ b/antarest/study/business/model/area_model.py
@@ -56,8 +56,8 @@ class AreaUIUpdate(AntaresBaseModel):
     Partial update for Area UI properties.
     """
 
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+    model_config = ConfigDict(alias_generator=to_camel_case, populate_by_name=True, extra="forbid")
 
     x: Optional[int] = None
     y: Optional[int] = None
-    color_rgb: Optional[tuple[int, int, int]] = Field(default=None, alias="colorRgb")
+    color_rgb: Optional[tuple[int, int, int]] = None

--- a/antarest/study/business/model/area_model.py
+++ b/antarest/study/business/model/area_model.py
@@ -61,13 +61,3 @@ class AreaUIUpdate(AntaresBaseModel):
     x: Optional[int] = None
     y: Optional[int] = None
     color_rgb: Optional[tuple[int, int, int]] = Field(default=None, alias="colorRgb")
-
-
-def update_area_ui(current: AreaUI, data: AreaUIUpdate) -> AreaUI:
-    """
-    Updates an area UI according to the provided update data.
-    """
-    current_properties = current.model_dump(mode="json")
-    new_properties = data.model_dump(mode="json", exclude_none=True)
-    current_properties.update(new_properties)
-    return AreaUI.model_validate(current_properties)

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -80,7 +80,7 @@ from antarest.study.business.general_management import GeneralManager
 from antarest.study.business.layer_management import LayerManager
 from antarest.study.business.link_management import LinkManager
 from antarest.study.business.matrix_management import MatrixManager, MatrixManagerError
-from antarest.study.business.model.area_model import Area, AreaCreation, UpdateAreaUi
+from antarest.study.business.model.area_model import Area, AreaCreation, AreaUIUpdate
 from antarest.study.business.model.binding_constraint_model import LinkTerm
 from antarest.study.business.model.link_model import Link, LinkUpdate
 from antarest.study.business.model.user_model import ResourceType, UserResourceDataCreation, UserResourceDataRemoval
@@ -1732,7 +1732,7 @@ class StudyService:
         self,
         uuid: str,
         area_id: str,
-        area_ui: UpdateAreaUi,
+        area_ui: AreaUIUpdate,
         layer: str,
     ) -> None:
         study = self.get_study(uuid)

--- a/antarest/study/storage/rawstudy/model/filesystem/config/area.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/area.py
@@ -35,7 +35,11 @@ from antarest.study.storage.rawstudy.model.filesystem.config.validation import (
 )
 
 
-class AreaUI(IniProperties):
+class AreaUIStyle(IniProperties):
+    """
+    Style properties for an area: position and color.
+    """
+
     x: int = Field(default=0, description="x coordinate of the area in the map")
     y: int = Field(default=0, description="y coordinate of the area in the map")
     color_r: int = Field(default=230, description="red component of the area color")
@@ -47,16 +51,21 @@ class AreaUI(IniProperties):
         return {"x": self.x, "y": self.y, "color_r": self.color_r, "color_g": self.color_g, "color_b": self.color_b}
 
 
-class UIProperties(IniProperties):
-    style: AreaUI = Field(
-        default_factory=AreaUI,
+class AreaUIFileData(IniProperties):
+    """
+    UI properties for an area, including layer-specific styles.
+    Handles serialization to/from INI file format.
+    """
+
+    style: AreaUIStyle = Field(
+        default_factory=AreaUIStyle,
         description="style of the area in the map: coordinates and color",
     )
     layers: Set[int] = Field(
         default_factory=lambda: {0},
         description="layers where the area is visible",
     )
-    layer_styles: Dict[int, AreaUI] = Field(
+    layer_styles: Dict[int, AreaUIStyle] = Field(
         default_factory=dict,
         description="style of the area in each layer",
         alias="layerStyles",
@@ -67,11 +76,11 @@ class UIProperties(IniProperties):
         """Defined the default style if missing."""
         style = values.get("style", None)
         if style is None:
-            values["style"] = AreaUI()
+            values["style"] = AreaUIStyle()
         elif isinstance(style, dict):
-            values["style"] = AreaUI(**style)
+            values["style"] = AreaUIStyle(**style)
         else:
-            values["style"] = AreaUI(**style.model_dump())
+            values["style"] = AreaUIStyle(**style.model_dump())
         return values
 
     @staticmethod
@@ -79,15 +88,15 @@ class UIProperties(IniProperties):
         """Define the default layer styles if missing."""
         layer_styles = values.get("layer_styles")
         if layer_styles is None:
-            values["layer_styles"] = {0: AreaUI()}
+            values["layer_styles"] = {0: AreaUIStyle()}
         elif isinstance(layer_styles, dict):
-            values["layer_styles"] = {0: AreaUI()}
+            values["layer_styles"] = {0: AreaUIStyle()}
             for key, style in layer_styles.items():
                 key = int(key)
                 if isinstance(style, dict):
-                    values["layer_styles"][key] = AreaUI(**style)
+                    values["layer_styles"][key] = AreaUIStyle(**style)
                 else:
-                    values["layer_styles"][key] = AreaUI(**style.model_dump())
+                    values["layer_styles"][key] = AreaUIStyle(**style.model_dump())
         else:
             raise TypeError(f"Invalid type for layer_styles: {type(layer_styles)}")
         return values
@@ -209,8 +218,8 @@ class AreaFileData(AntaresBaseModel):
         default_factory=AdequacyPatchFileData,
         description="adequacy patch configuration",
     )
-    ui: UIProperties = Field(
-        default_factory=UIProperties,
+    ui: AreaUIFileData = Field(
+        default_factory=AreaUIFileData,
         description="UI configuration",
     )
 

--- a/antarest/study/storage/variantstudy/model/command/update_area_ui.py
+++ b/antarest/study/storage/variantstudy/model/command/update_area_ui.py
@@ -14,8 +14,7 @@ import typing as t
 
 from typing_extensions import override
 
-from antarest.study.business.model.area_model import AreaUI, AreaUIUpdate, update_area_ui
-from antarest.study.storage.rawstudy.model.filesystem.config.area import AreaUIFileData, AreaUIStyle
+from antarest.study.business.model.area_model import AreaUIUpdate
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput, command_succeeded
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
@@ -42,40 +41,29 @@ class UpdateAreaUI(ICommand):
 
     @override
     def _apply(self, study_data: FileStudy, listener: t.Optional[ICommandListener] = None) -> CommandOutput:
-        # Retrieve current area UI data from file
-        current_area_data = study_data.tree.get(["input", "areas", self.area_id, "ui"])
-        area_ui_file_data = AreaUIFileData(**current_area_data)
-
-        # Get current style for the specified layer
+        current_area = study_data.tree.get(["input", "areas", self.area_id, "ui"])
         layer_int = int(self.layer)
-        current_style = area_ui_file_data.layer_styles.get(layer_int, area_ui_file_data.style)
 
-        # Convert to business model
-        current_ui = AreaUI(
-            x=current_style.x,
-            y=current_style.y,
-            color_rgb=(current_style.color_r, current_style.color_g, current_style.color_b),
-        )
+        # Apply updates if provided
+        if self.parameters.x is not None:
+            current_area["layerX"][self.layer] = self.parameters.x
+            if layer_int == 0:
+                current_area["ui"]["x"] = self.parameters.x
 
-        # Apply update
-        updated_ui = update_area_ui(current_ui, self.parameters)
+        if self.parameters.y is not None:
+            current_area["layerY"][self.layer] = self.parameters.y
+            if layer_int == 0:
+                current_area["ui"]["y"] = self.parameters.y
 
-        # Convert back to file data model
-        updated_style = AreaUIStyle(
-            x=updated_ui.x,
-            y=updated_ui.y,
-            color_r=updated_ui.color_rgb[0],
-            color_g=updated_ui.color_rgb[1],
-            color_b=updated_ui.color_rgb[2],
-        )
+        if self.parameters.color_rgb is not None:
+            r, g, b = self.parameters.color_rgb
+            current_area["layerColor"][self.layer] = f"{r}, {g}, {b}"
+            if layer_int == 0:
+                current_area["ui"]["color_r"] = r
+                current_area["ui"]["color_g"] = g
+                current_area["ui"]["color_b"] = b
 
-        # Update the appropriate style
-        if layer_int == 0:
-            area_ui_file_data.style = updated_style
-        area_ui_file_data.layer_styles[layer_int] = updated_style
-
-        # Save to file
-        study_data.tree.save(area_ui_file_data.to_config(), ["input", "areas", self.area_id, "ui"])
+        study_data.tree.save(current_area, ["input", "areas", self.area_id, "ui"])
 
         return command_succeeded(message=f"area '{self.area_id}' UI updated")
 

--- a/antarest/study/storage/variantstudy/model/command/update_area_ui.py
+++ b/antarest/study/storage/variantstudy/model/command/update_area_ui.py
@@ -11,7 +11,10 @@
 # This file is part of the Antares project.
 
 import typing as t
+from typing import Any
 
+from pydantic import model_validator
+from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import override
 
 from antarest.study.business.model.area_model import AreaUIUpdate
@@ -38,6 +41,37 @@ class UpdateAreaUI(ICommand):
     area_id: str
     layer: str
     parameters: AreaUIUpdate
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_parameters(cls, values: dict[str, Any], info: ValidationInfo) -> dict[str, Any]:
+        # Handle version 1 format: {"area_id": "x", "area_ui": {...}, "layer": "0"}
+        if "area_ui" in values:
+            area_ui = values.pop("area_ui")
+            # Extract only x, y, color_rgb from old UpdateAreaUi (ignore layer_x, layer_y, layer_color)
+            if isinstance(area_ui, dict):
+                parameters = {
+                    "x": area_ui.get("x"),
+                    "y": area_ui.get("y"),
+                    "color_rgb": area_ui.get("color_rgb") or area_ui.get("colorRgb"),
+                }
+                # Remove None values
+                parameters = {k: v for k, v in parameters.items() if v is not None}
+                values["parameters"] = parameters
+            else:
+                # If it's already a pydantic model
+                values["parameters"] = {
+                    "x": area_ui.x if hasattr(area_ui, "x") else None,
+                    "y": area_ui.y if hasattr(area_ui, "y") else None,
+                    "color_rgb": area_ui.color_rgb if hasattr(area_ui, "color_rgb") else None,
+                }
+                values["parameters"] = {k: v for k, v in values["parameters"].items() if v is not None}
+
+        # Ensure parameters exists
+        if "parameters" not in values:
+            values["parameters"] = AreaUIUpdate()
+
+        return values
 
     @override
     def _apply(self, study_data: FileStudy, listener: t.Optional[ICommandListener] = None) -> CommandOutput:
@@ -71,8 +105,13 @@ class UpdateAreaUI(ICommand):
     def to_dto(self) -> CommandDTO:
         return CommandDTO(
             action=CommandName.UPDATE_AREA_UI.value,
-            args={"area_id": self.area_id, "layer": self.layer, "parameters": self.parameters},
+            args={
+                "area_id": self.area_id,
+                "layer": self.layer,
+                "parameters": self.parameters.model_dump(mode="json", by_alias=True, exclude_none=True),
+            },
             study_version=self.study_version,
+            version=2,
         )
 
     @override

--- a/antarest/study/storage/variantstudy/model/command/update_area_ui.py
+++ b/antarest/study/storage/variantstudy/model/command/update_area_ui.py
@@ -14,7 +14,8 @@ import typing as t
 
 from typing_extensions import override
 
-from antarest.study.business.model.area_model import UpdateAreaUi
+from antarest.study.business.model.area_model import AreaUI, AreaUIUpdate, update_area_ui
+from antarest.study.storage.rawstudy.model.filesystem.config.area import AreaUIFileData, AreaUIStyle
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput, command_succeeded
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
@@ -24,7 +25,7 @@ from antarest.study.storage.variantstudy.model.model import CommandDTO
 
 class UpdateAreaUI(ICommand):
     """
-    Command used to move an area inside the map and to update its UI.
+    Command used to update an area's UI properties (position and color) for a specific layer.
     """
 
     # Overloaded metadata
@@ -36,23 +37,45 @@ class UpdateAreaUI(ICommand):
     # ==================
 
     area_id: str
-    area_ui: UpdateAreaUi
     layer: str
+    parameters: AreaUIUpdate
 
     @override
     def _apply(self, study_data: FileStudy, listener: t.Optional[ICommandListener] = None) -> CommandOutput:
-        current_area = study_data.tree.get(["input", "areas", self.area_id, "ui"])
+        # Retrieve current area UI data from file
+        current_area_data = study_data.tree.get(["input", "areas", self.area_id, "ui"])
+        area_ui_file_data = AreaUIFileData(**current_area_data)
 
-        if self.layer == "0":
-            ui = current_area["ui"]
-            ui["x"] = self.area_ui.x
-            ui["y"] = self.area_ui.y
-            ui["color_r"], ui["color_g"], ui["color_b"] = self.area_ui.color_rgb
-        current_area["layerX"][self.layer] = self.area_ui.x
-        current_area["layerY"][self.layer] = self.area_ui.y
-        current_area["layerColor"][self.layer] = ",".join(map(str, self.area_ui.color_rgb))
+        # Get current style for the specified layer
+        layer_int = int(self.layer)
+        current_style = area_ui_file_data.layer_styles.get(layer_int, area_ui_file_data.style)
 
-        study_data.tree.save(current_area, ["input", "areas", self.area_id, "ui"])
+        # Convert to business model
+        current_ui = AreaUI(
+            x=current_style.x,
+            y=current_style.y,
+            color_rgb=(current_style.color_r, current_style.color_g, current_style.color_b),
+        )
+
+        # Apply update
+        updated_ui = update_area_ui(current_ui, self.parameters)
+
+        # Convert back to file data model
+        updated_style = AreaUIStyle(
+            x=updated_ui.x,
+            y=updated_ui.y,
+            color_r=updated_ui.color_rgb[0],
+            color_g=updated_ui.color_rgb[1],
+            color_b=updated_ui.color_rgb[2],
+        )
+
+        # Update the appropriate style
+        if layer_int == 0:
+            area_ui_file_data.style = updated_style
+        area_ui_file_data.layer_styles[layer_int] = updated_style
+
+        # Save to file
+        study_data.tree.save(area_ui_file_data.to_config(), ["input", "areas", self.area_id, "ui"])
 
         return command_succeeded(message=f"area '{self.area_id}' UI updated")
 
@@ -60,7 +83,7 @@ class UpdateAreaUI(ICommand):
     def to_dto(self) -> CommandDTO:
         return CommandDTO(
             action=CommandName.UPDATE_AREA_UI.value,
-            args={"area_id": self.area_id, "area_ui": self.area_ui, "layer": self.layer},
+            args={"area_id": self.area_id, "layer": self.layer, "parameters": self.parameters},
             study_version=self.study_version,
         )
 

--- a/antarest/study/storage/variantstudy/model/command/update_area_ui.py
+++ b/antarest/study/storage/variantstudy/model/command/update_area_ui.py
@@ -13,7 +13,7 @@
 import typing as t
 from typing import Any
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import override
 
@@ -42,6 +42,16 @@ class UpdateAreaUI(ICommand):
     layer: str
     parameters: AreaUIUpdate
 
+    @field_validator("layer")
+    @classmethod
+    def _validate_layer(cls, v: str) -> str:
+        """Validate that layer is a valid integer string."""
+        try:
+            int(v)
+            return v
+        except ValueError:
+            raise ValueError(f"Layer must be a valid integer string, got: {v}")
+
     @model_validator(mode="before")
     @classmethod
     def _validate_parameters(cls, values: dict[str, Any], info: ValidationInfo) -> dict[str, Any]:
@@ -50,10 +60,15 @@ class UpdateAreaUI(ICommand):
             area_ui = values.pop("area_ui")
             # Extract only x, y, color_rgb from old UpdateAreaUi (ignore layer_x, layer_y, layer_color)
             if isinstance(area_ui, dict):
+                color_value = area_ui.get("color_rgb") or area_ui.get("colorRgb")
+                # Convert list to tuple if necessary
+                if color_value is not None and isinstance(color_value, list):
+                    color_value = tuple(color_value)
+
                 parameters = {
                     "x": area_ui.get("x"),
                     "y": area_ui.get("y"),
-                    "color_rgb": area_ui.get("color_rgb") or area_ui.get("colorRgb"),
+                    "color_rgb": color_value,
                 }
                 # Remove None values
                 parameters = {k: v for k, v in parameters.items() if v is not None}

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -42,7 +42,7 @@ from antarest.study.business.correlation_management import (
     CorrelationFormFields,
     CorrelationMatrix,
 )
-from antarest.study.business.model.area_model import Area, AreaCreation, AreaType, UpdateAreaUi
+from antarest.study.business.model.area_model import Area, AreaCreation, AreaType, AreaUIUpdate
 from antarest.study.business.model.area_properties_model import AreaProperties, AreaPropertiesUpdate
 from antarest.study.business.model.binding_constraint_model import (
     BindingConstraint,

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -43,7 +43,7 @@ from antarest.study.business.correlation_management import (
     CorrelationMatrix,
 )
 from antarest.study.business.district_manager import DistrictCreationDTO, DistrictInfoDTO, DistrictUpdateDTO
-from antarest.study.business.model.area_model import Area, AreaCreation, AreaType, UpdateAreaUi
+from antarest.study.business.model.area_model import Area, AreaCreation, AreaType, AreaUIUpdate
 from antarest.study.business.model.area_properties_model import AreaProperties, AreaPropertiesUpdate
 from antarest.study.business.model.binding_constraint_model import (
     BindingConstraint,
@@ -209,7 +209,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         summary="Update area information",
         response_model=None,
     )
-    def update_area_ui(uuid: str, area_id: str, area_ui: UpdateAreaUi, layer: str = "0") -> Any:
+    def update_area_ui(uuid: str, area_id: str, area_ui: AreaUIUpdate, layer: str = "0") -> Any:
         logger.info(f"Updating area ui {area_id} for study {uuid}")
         return study_service.update_area_ui(uuid, area_id, area_ui, layer)
 

--- a/tests/integration/study_data_blueprint/test_area.py
+++ b/tests/integration/study_data_blueprint/test_area.py
@@ -56,7 +56,7 @@ class TestArea:
                 "layerColor": {"0": "100, 100, 100"},
                 "layerX": {"0": 10},
                 "layerY": {"0": 10},
-                "color_rgb": (100, 100, 100),
+                "colorRgb": [100, 100, 100],
             },
         )
 

--- a/tests/integration/study_data_blueprint/test_area.py
+++ b/tests/integration/study_data_blueprint/test_area.py
@@ -53,9 +53,6 @@ class TestArea:
             json={
                 "x": 10,
                 "y": 10,
-                "layerColor": {"0": "100, 100, 100"},
-                "layerX": {"0": 10},
-                "layerY": {"0": 10},
                 "colorRgb": [100, 100, 100],
             },
         )

--- a/tests/storage/business/test_arealink_manager.py
+++ b/tests/storage/business/test_arealink_manager.py
@@ -14,8 +14,9 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from antarest.matrixstore.service import ISimpleMatrixService
-from antarest.study.business.area_management import AreaCreation, AreaManager, UpdateAreaUi
+from antarest.study.business.area_management import AreaCreation, AreaManager
 from antarest.study.business.link_management import LinkManager
+from antarest.study.business.model.area_model import AreaUIUpdate
 from antarest.study.business.model.link_model import AssetType, Link, TransmissionCapacity
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.business.study_interface import FileStudyInterface, StudyInterface
@@ -40,7 +41,7 @@ def test_area_crud(
     area_manager.create_area(study, AreaCreation(name="test"))
     assert len(file_study.config.areas.keys()) == 1
 
-    area_manager.update_area_ui(study, "test", UpdateAreaUi(x=100, y=200, color_rgb=(255, 0, 100)), layer="0")
+    area_manager.update_area_ui(study, "test", AreaUIUpdate(x=100, y=200, color_rgb=(255, 0, 100)), layer="0")
     assert file_study.tree.get(["input", "areas", "test", "ui", "ui"]) == {
         "x": 100,
         "y": 200,

--- a/tests/variantstudy/test_command_factory.py
+++ b/tests/variantstudy/test_command_factory.py
@@ -19,7 +19,6 @@ from unittest.mock import Mock
 import pytest
 
 from antarest.matrixstore.service import MatrixService
-from antarest.study.business.model.area_model import AreaUIUpdate
 from antarest.study.model import STUDY_VERSION_8_6, STUDY_VERSION_8_8, STUDY_VERSION_9_2, STUDY_VERSION_9_3
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import (
     GeneratorMatrixConstants,
@@ -63,9 +62,10 @@ COMMANDS = [
             args={
                 "area_id": "id",
                 "layer": "0",
-                "parameters": AreaUIUpdate(x=100, y=100, color_rgb=(100, 100, 100)),
+                "parameters": {"x": 100, "y": 100, "colorRgb": [100, 100, 100]},
             },
             study_version=STUDY_VERSION_8_8,
+            version=2,
         ),
         None,
         id="update_area_ui",
@@ -1387,6 +1387,38 @@ def test_parse_legacy_command_update_playlist(command_factory: CommandFactory):
     assert dto.action == "update_playlist"
     assert dto.version == 2
     assert dto.args == {"playlist": {"years": {1: {"status": True, "weight": 5.0}, 3: {"status": True}}}}
+
+
+def test_parse_update_area_ui_dto_v1(command_factory: CommandFactory):
+    """Test conversion from v1 format (area_ui) to v2 format (parameters)"""
+    dto = CommandDTO(
+        action=CommandName.UPDATE_AREA_UI.value,
+        args={
+            "area_id": "area1",
+            "area_ui": {
+                "x": 100,
+                "y": 200,
+                "color_rgb": [255, 128, 64],
+                "layer_x": {"0": 100},  # Should be ignored
+                "layer_y": {"0": 200},  # Should be ignored
+                "layer_color": {"0": "255, 128, 64"},  # Should be ignored
+            },
+            "layer": "0",
+        },
+        study_version=STUDY_VERSION_8_8,
+        version=1,
+    )
+    commands = command_factory.to_command(dto)
+    assert len(commands) == 1
+    command = commands[0]
+    dto = command.to_dto()
+    assert dto.action == "update_area_ui"
+    assert dto.version == 2
+    assert dto.args == {
+        "area_id": "area1",
+        "layer": "0",
+        "parameters": {"x": 100, "y": 200, "colorRgb": [255, 128, 64]},
+    }
 
 
 def test_parse_legacy_command_create_district(command_factory: CommandFactory):

--- a/tests/variantstudy/test_command_factory.py
+++ b/tests/variantstudy/test_command_factory.py
@@ -19,7 +19,7 @@ from unittest.mock import Mock
 import pytest
 
 from antarest.matrixstore.service import MatrixService
-from antarest.study.business.model.area_model import UpdateAreaUi
+from antarest.study.business.model.area_model import AreaUIUpdate
 from antarest.study.model import STUDY_VERSION_8_6, STUDY_VERSION_8_8, STUDY_VERSION_9_2, STUDY_VERSION_9_3
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import (
     GeneratorMatrixConstants,
@@ -62,10 +62,8 @@ COMMANDS = [
             action=CommandName.UPDATE_AREA_UI.value,
             args={
                 "area_id": "id",
-                "area_ui": UpdateAreaUi(
-                    x=100, y=100, color_rgb=(100, 100, 100), layer_x={}, layer_y={}, layer_color={}
-                ),
                 "layer": "0",
+                "parameters": AreaUIUpdate(x=100, y=100, color_rgb=(100, 100, 100)),
             },
             study_version=STUDY_VERSION_8_8,
         ),

--- a/tests/variantstudy/test_command_factory.py
+++ b/tests/variantstudy/test_command_factory.py
@@ -1419,6 +1419,27 @@ def test_parse_update_area_ui_dto_v1(command_factory: CommandFactory):
         "layer": "0",
         "parameters": {"x": 100, "y": 200, "colorRgb": [255, 128, 64]},
     }
+    # Verify old layer_* fields are not in the converted parameters
+    assert "layer_x" not in dto.args
+    assert "layer_y" not in dto.args
+    assert "layer_color" not in dto.args
+    assert "area_ui" not in dto.args
+
+
+def test_update_area_ui_invalid_layer(command_factory: CommandFactory):
+    """Test that invalid layer value raises validation error"""
+    dto = CommandDTO(
+        action=CommandName.UPDATE_AREA_UI.value,
+        args={
+            "area_id": "area1",
+            "layer": "invalid",  # Invalid: not an integer
+            "parameters": {"x": 100, "y": 200, "colorRgb": [255, 128, 64]},
+        },
+        study_version=STUDY_VERSION_8_8,
+        version=2,
+    )
+    with pytest.raises(ValueError, match="Layer must be a valid integer string"):
+        command_factory.to_command(dto)
 
 
 def test_parse_legacy_command_create_district(command_factory: CommandFactory):


### PR DESCRIPTION
Breaking change: 
- Layers related field (layerX, layerY, layerColor) are not accepted anymore in the `PUT "/studies/{uuid}/areas/{area_id}/ui"` endpoint