### PR TITLE
fix(adequacy-criterion): fix simulation calls

### DIFF
--- a/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
+++ b/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
@@ -94,12 +94,13 @@ class LauncherArgs(argparse.Namespace):
 
     def apply_xpansion_mode(self, launcher_params: LauncherParametersDTO) -> None:
         if launcher_params.xpansion:  # not None and not False
-            self.xpansion_mode = {True: "r", False: "cpp"}[launcher_params.xpansion_r_version]
-            if isinstance(launcher_params.xpansion, XpansionParametersDTO):
-                if launcher_params.xpansion.sensitivity_mode:
-                    self._append_other_option("xpansion_sensitivity")
-                if launcher_params.xpansion.adequacy_criterion:
-                    self._append_other_option("adequacy_criterion")
+            if launcher_params.xpansion.enabled:
+                self.xpansion_mode = {True: "r", False: "cpp"}[launcher_params.xpansion_r_version]
+                if isinstance(launcher_params.xpansion, XpansionParametersDTO):
+                    if launcher_params.xpansion.sensitivity_mode:
+                        self._append_other_option("xpansion_sensitivity")
+                    if launcher_params.xpansion.adequacy_criterion:
+                        self._append_other_option("adequacy_criteri&on")
 
     def apply_time_limit(self, launcher_params: LauncherParametersDTO, time_limit_cfg: TimeLimitConfig) -> None:
         # The `time_limit` parameter could be `None`, in that case, the default value is used.

--- a/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
+++ b/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
@@ -93,14 +93,18 @@ class LauncherArgs(argparse.Namespace):
         self.other_options = f"{self.other_options} {option}" if self.other_options else option
 
     def apply_xpansion_mode(self, launcher_params: LauncherParametersDTO) -> None:
-        if launcher_params.xpansion:  # not None and not False
-            if launcher_params.xpansion.enabled:
-                self.xpansion_mode = {True: "r", False: "cpp"}[launcher_params.xpansion_r_version]
-                if isinstance(launcher_params.xpansion, XpansionParametersDTO):
-                    if launcher_params.xpansion.sensitivity_mode:
-                        self._append_other_option("xpansion_sensitivity")
-                    if launcher_params.xpansion.adequacy_criterion:
-                        self._append_other_option("adequacy_criteri&on")
+        if isinstance(launcher_params.xpansion, XpansionParametersDTO):
+            should_run_xpansion = launcher_params.xpansion.enabled
+        else:
+            should_run_xpansion = launcher_params.xpansion is True
+
+        if should_run_xpansion:
+            self.xpansion_mode = {True: "r", False: "cpp"}[launcher_params.xpansion_r_version]
+            if isinstance(launcher_params.xpansion, XpansionParametersDTO):
+                if launcher_params.xpansion.sensitivity_mode:
+                    self._append_other_option("xpansion_sensitivity")
+                if launcher_params.xpansion.adequacy_criterion:
+                    self._append_other_option("adequacy_criterion")
 
     def apply_time_limit(self, launcher_params: LauncherParametersDTO, time_limit_cfg: TimeLimitConfig) -> None:
         # The `time_limit` parameter could be `None`, in that case, the default value is used.

--- a/antarest/launcher/model.py
+++ b/antarest/launcher/model.py
@@ -31,7 +31,7 @@ from antarest.login.model import Identity, UserInfo
 class XpansionParametersDTO(AntaresBaseModel, extra="forbid"):
     output_id: Optional[str] = None
     sensitivity_mode: bool = False
-    enabled: bool = False
+    enabled: bool = True
     adequacy_criterion: bool = False
 
     @model_validator(mode="after")

--- a/antarest/launcher/model.py
+++ b/antarest/launcher/model.py
@@ -31,7 +31,7 @@ from antarest.login.model import Identity, UserInfo
 class XpansionParametersDTO(AntaresBaseModel, extra="forbid"):
     output_id: Optional[str] = None
     sensitivity_mode: bool = False
-    enabled: bool = True
+    enabled: bool = False
     adequacy_criterion: bool = False
 
     @model_validator(mode="after")

--- a/antarest/launcher/model.py
+++ b/antarest/launcher/model.py
@@ -28,7 +28,7 @@ from antarest.core.serde.json import from_json
 from antarest.login.model import Identity, UserInfo
 
 
-class XpansionParametersDTO(AntaresBaseModel):
+class XpansionParametersDTO(AntaresBaseModel, extra="forbid"):
     output_id: Optional[str] = None
     sensitivity_mode: bool = False
     enabled: bool = True
@@ -41,7 +41,7 @@ class XpansionParametersDTO(AntaresBaseModel):
         return self
 
 
-class LauncherParametersDTO(AntaresBaseModel):
+class LauncherParametersDTO(AntaresBaseModel, extra="forbid"):
     # Warning ! This class must be retro-compatible (that's the reason for the weird bool/XpansionParametersDTO union)
     # The reason is that it's stored in json format in database and deserialized using the latest class version
     # If compatibility is to be broken, an (alembic) data migration script should be added

--- a/tests/integration/launcher_blueprint/test_launcher_local.py
+++ b/tests/integration/launcher_blueprint/test_launcher_local.py
@@ -75,11 +75,7 @@ class TestLauncherConfiguration:
         study_id = res.json()
 
         # launch a job with the admin user
-        res = client.post(
-            f"/v1/launcher/run/{study_id}",
-            headers={"Authorization": f"Bearer {admin_access_token}"},
-            json={"launcher": "local"},
-        )
+        res = client.post(f"/v1/launcher/run/{study_id}", headers={"Authorization": f"Bearer {admin_access_token}"})
         res.raise_for_status()
         job_id = res.json()["job_id"]
 

--- a/webapp/src/components/App/shared/studies/dialogs/StudyLaunchDialog/index.tsx
+++ b/webapp/src/components/App/shared/studies/dialogs/StudyLaunchDialog/index.tsx
@@ -48,7 +48,7 @@ function StudyLaunchDialog({ open, onClose, studyIds }: Props) {
       xpansion: values.xpansion
         ? {
             enabled: true,
-            adequacyCriterion: values.adequacyCriterions,
+            adequacyCriterions: values.adequacyCriterions,
             sensitivityMode: values.sensitivityMode,
             // `output_id` has to be provided only if `sensitivity_mode` is enabled.
             outputId: values.sensitivityMode ? values.output : undefined,

--- a/webapp/src/components/App/shared/studies/dialogs/StudyLaunchDialog/index.tsx
+++ b/webapp/src/components/App/shared/studies/dialogs/StudyLaunchDialog/index.tsx
@@ -48,7 +48,7 @@ function StudyLaunchDialog({ open, onClose, studyIds }: Props) {
       xpansion: values.xpansion
         ? {
             enabled: true,
-            adequacyCriterions: values.adequacyCriterions,
+            adequacyCriterion: values.adequacyCriterions,
             sensitivityMode: values.sensitivityMode,
             // `output_id` has to be provided only if `sensitivity_mode` is enabled.
             outputId: values.sensitivityMode ? values.output : undefined,

--- a/webapp/src/services/api/launcher/index.ts
+++ b/webapp/src/services/api/launcher/index.ts
@@ -22,7 +22,7 @@ export async function launchStudy({ studyId, launcherId, version, config }: Laun
     nb_cpu: config?.nbCores,
     xpansion: config?.xpansion && {
       enabled: config.xpansion?.enabled,
-      adequacy_criterions: config.xpansion?.adequacyCriterions,
+      adequacy_criterion: config.xpansion?.adequacyCriterion,
       sensitivity_mode: config.xpansion?.sensitivityMode,
       output_id: config.xpansion?.outputId,
     },

--- a/webapp/src/services/api/launcher/index.ts
+++ b/webapp/src/services/api/launcher/index.ts
@@ -22,7 +22,7 @@ export async function launchStudy({ studyId, launcherId, version, config }: Laun
     nb_cpu: config?.nbCores,
     xpansion: config?.xpansion && {
       enabled: config.xpansion?.enabled,
-      adequacy_criterion: config.xpansion?.adequacyCriterion,
+      adequacy_criterion: config.xpansion?.adequacyCriterions,
       sensitivity_mode: config.xpansion?.sensitivityMode,
       output_id: config.xpansion?.outputId,
     },

--- a/webapp/src/services/api/launcher/types.ts
+++ b/webapp/src/services/api/launcher/types.ts
@@ -19,7 +19,7 @@ export interface XpansionParamsDTO {
   enabled?: boolean;
   sensitivity_mode?: boolean;
   output_id?: string;
-  adequacy_criterions?: boolean;
+  adequacy_criterion?: boolean;
 }
 
 export interface LauncherParamsDTO {
@@ -37,7 +37,7 @@ export interface LauncherParamsDTO {
 
 interface XpansionConfig {
   enabled?: boolean;
-  adequacyCriterions?: boolean;
+  adequacyCriterion?: boolean;
   sensitivityMode?: boolean;
   outputId?: string;
 }

--- a/webapp/src/services/api/launcher/types.ts
+++ b/webapp/src/services/api/launcher/types.ts
@@ -37,7 +37,7 @@ export interface LauncherParamsDTO {
 
 interface XpansionConfig {
   enabled?: boolean;
-  adequacyCriterion?: boolean;
+  adequacyCriterions?: boolean;
   sensitivityMode?: boolean;
   outputId?: string;
 }


### PR DESCRIPTION

2 fixes:
- All simulation launch requests were considered as xpansion requests
- adequacy_criterion**s** was defined with an S, which is invalid,
  but was silently ignored by the back

