### PR TITLE
feat(metrics): add labels to task metrics

### DIFF
--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -34,6 +34,7 @@ from typing_extensions import override
 
 from antarest.core.config import Config
 from antarest.core.exceptions import ConfigurationError
+from antarest.core.tasks.model import TaskStatus, TaskType
 from antarest.core.tasks.service import TaskServiceListener
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,14 @@ logger = logging.getLogger(__name__)
 _PROMETHEUS_MULTIPROCESS_ENV_VAR = "PROMETHEUS_MULTIPROC_DIR"
 
 WORKER_ID = str(os.getpid())
+
+
+def add_db_metrics(config: Config) -> None:
+    """
+    Registers metrics related to database activity.
+    """
+    if config.metrics.prometheus:
+        _add_db_metrics(prometheus_client.REGISTRY)
 
 
 def _add_db_metrics(registry: CollectorRegistry = prometheus_client.REGISTRY) -> None:
@@ -232,8 +241,6 @@ def add_metrics(application: FastAPI, config: Config) -> None:
     if not prometheus_config:
         return
 
-    prometheus_client.disable_created_metrics()  # type: ignore
-
     if prometheus_config.multiprocess:
         if _PROMETHEUS_MULTIPROCESS_ENV_VAR not in os.environ:
             raise ConfigurationError(
@@ -248,7 +255,10 @@ def add_metrics(application: FastAPI, config: Config) -> None:
     application.mount("/metrics", metrics_app)
 
     _add_metrics_middleware(application)
-    _add_db_metrics()
+
+
+def _task_labels(task_type: TaskType, status: TaskStatus | None = None) -> list[str]:
+    return [WORKER_ID, task_type.value.lower()] + ([status.name.lower()] if status else [])
 
 
 class TasksMetricsRecorder(TaskServiceListener):
@@ -260,26 +270,26 @@ class TasksMetricsRecorder(TaskServiceListener):
         self._duration_histo = Histogram(
             "tasks_duration_seconds",
             "Tasks duration in seconds",
-            ["worker_id"],
+            ["worker_id", "type", "status"],
             registry=registry,
         )
         self._wait_time_histo = Histogram(
             "tasks_wait_seconds",
             "Tasks wait time in seconds",
-            ["worker_id"],
+            ["worker_id", "type"],
             registry=registry,
         )
         self._running_gauge = Gauge(
             "tasks_running",
             "Count of running tasks",
-            ["worker_id"],
+            ["worker_id", "type"],
             multiprocess_mode="liveall",
             registry=registry,
         )
         self._pending_gauge = Gauge(
             "tasks_pending",
             "Count of pending tasks",
-            ["worker_id"],
+            ["worker_id", "type"],
             multiprocess_mode="liveall",
             registry=registry,
         )
@@ -288,20 +298,24 @@ class TasksMetricsRecorder(TaskServiceListener):
         self._start_times: dict[str, float] = {}
 
     @override
-    def on_task_submit(self, task_id: str) -> None:
-        self._pending_gauge.labels(WORKER_ID).inc()
+    def on_task_submit(self, task_id: str, task_type: TaskType) -> None:
+        self._pending_gauge.labels(*_task_labels(task_type)).inc()
         self._submit_times[task_id] = time.time()
 
     @override
-    def on_task_start(self, task_id: str) -> None:
-        self._pending_gauge.labels(WORKER_ID).dec()
-        self._running_gauge.labels(WORKER_ID).inc()
-        self._wait_time_histo.labels(WORKER_ID).observe(time.time() - self._submit_times[task_id])
-        del self._submit_times[task_id]
+    def on_task_start(self, task_id: str, task_type: TaskType) -> None:
+        labels = _task_labels(task_type)
+        self._pending_gauge.labels(*labels).dec()
+        self._running_gauge.labels(*labels).inc()
+        if task_id in self._submit_times:
+            self._wait_time_histo.labels(*labels).observe(time.time() - self._submit_times[task_id])
+            del self._submit_times[task_id]
         self._start_times[task_id] = time.time()
 
     @override
-    def on_task_end(self, task_id: str) -> None:
-        self._running_gauge.labels(WORKER_ID).dec()
-        self._duration_histo.labels(WORKER_ID).observe(time.time() - self._start_times[task_id])
-        del self._start_times[task_id]
+    def on_task_end(self, task_id: str, task_type: TaskType, task_status: TaskStatus) -> None:
+        labels = _task_labels(task_type, task_status)
+        self._running_gauge.labels(*labels).dec()
+        if task_id in self._start_times:
+            self._duration_histo.labels(*labels).observe(time.time() - self._start_times[task_id])
+            del self._start_times[task_id]

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -303,6 +303,18 @@ class TasksMetricsRecorder(TaskServiceListener):
         self._submit_times[task_id] = time.time()
 
     @override
+    def on_task_cancel(self, task_id: str, task_type: TaskType) -> None:
+        labels = _task_labels(task_type)
+        if task_id in self._submit_times:
+            self._pending_gauge.labels(*labels).dec()
+            self._wait_time_histo.labels(*labels).observe(time.time() - self._submit_times[task_id])
+            del self._submit_times[task_id]
+
+            # Adding one observation to duration histo as well, so that we can get stats
+            # on actually cancelled tasks
+            self._duration_histo.labels(*_task_labels(task_type, TaskStatus.CANCELLED)).observe(0)
+
+    @override
     def on_task_start(self, task_id: str, task_type: TaskType) -> None:
         labels = _task_labels(task_type)
         self._pending_gauge.labels(*labels).dec()

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -314,8 +314,9 @@ class TasksMetricsRecorder(TaskServiceListener):
 
     @override
     def on_task_end(self, task_id: str, task_type: TaskType, task_status: TaskStatus) -> None:
-        labels = _task_labels(task_type, task_status)
-        self._running_gauge.labels(*labels).dec()
+        self._running_gauge.labels(*_task_labels(task_type)).dec()
         if task_id in self._start_times:
-            self._duration_histo.labels(*labels).observe(time.time() - self._start_times[task_id])
+            self._duration_histo.labels(*_task_labels(task_type, task_status)).observe(
+                time.time() - self._start_times[task_id]
+            )
             del self._start_times[task_id]

--- a/antarest/core/tasks/model.py
+++ b/antarest/core/tasks/model.py
@@ -180,6 +180,11 @@ class TaskJob(Base):
     # If the Study is deleted, all attached TaskJob must be deleted in cascade.
     study: Mapped["Study"] = relationship("Study", back_populates="jobs", uselist=False)
 
+    def get_type(self) -> TaskType:
+        if not self.type:
+            raise ValueError("Task type is not set")
+        return TaskType(self.type)
+
     def to_dto(self, with_logs: bool = False) -> TaskDTO:
         result = None
         if self.completion_date:

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -82,7 +82,7 @@ class ITaskService(ABC):
         self,
         action: Task,
         name: Optional[str],
-        task_type: Optional[TaskType],
+        task_type: TaskType,
         ref_id: Optional[str],
         progress: Optional[int],
         custom_event_messages: Optional[CustomTaskEventMessages],
@@ -161,15 +161,15 @@ class TaskLogAndProgressRecorder(ITaskNotifier):
 
 class TaskServiceListener(ABC):
     @abstractmethod
-    def on_task_submit(self, task_id: str) -> None:
+    def on_task_submit(self, task_id: str, task_type: TaskType) -> None:
         pass
 
     @abstractmethod
-    def on_task_start(self, task_id: str) -> None:
+    def on_task_start(self, task_id: str, task_type: TaskType) -> None:
         pass
 
     @abstractmethod
-    def on_task_end(self, task_id: str) -> None:
+    def on_task_end(self, task_id: str, task_type: TaskType, task_status: TaskStatus) -> None:
         pass
 
 
@@ -260,7 +260,7 @@ class TaskJobService(ITaskService):
         self,
         action: Task,
         name: Optional[str],
-        task_type: Optional[TaskType],
+        task_type: TaskType,
         ref_id: Optional[str],
         progress: Optional[int],
         custom_event_messages: Optional[CustomTaskEventMessages],
@@ -311,9 +311,9 @@ class TaskJobService(ITaskService):
         )
 
         for listener in self._listeners:
-            listener.on_task_submit(task.id)
+            listener.on_task_submit(task.id, task_type=task.get_type())
 
-        future = self.threadpool.submit(self._run_task, action, task.id, user, custom_event_messages)
+        future = self.threadpool.submit(self._run_task, action, task.id, task.get_type(), user, custom_event_messages)
         self.tasks[task.id] = future
 
     def create_task_event_callback(self) -> Callable[[Event], Awaitable[None]]:
@@ -333,9 +333,12 @@ class TaskJobService(ITaskService):
     def _cancel_task(self, task_id: str, dispatch: bool = False) -> None:
         task = self.repo.get_or_raise(task_id)
         if task_id in self.tasks:
-            self.tasks[task_id].cancel()
-            task.status = TaskStatus.CANCELLED.value
-            self.repo.save(task)
+            cancelled = self.tasks[task_id].cancel()
+            if cancelled:
+                task.status = TaskStatus.CANCELLED.value
+                self.repo.save(task)
+                for listener in self._listeners:
+                    listener.on_task_end(task.id, task.get_type(), TaskStatus.CANCELLED)
         elif dispatch:
             self.event_bus.push(
                 Event(
@@ -409,14 +412,16 @@ class TaskJobService(ITaskService):
         self,
         callback: Task,
         task_id: str,
+        task_type: TaskType,
         jwt_user: JWTUser,
         custom_event_messages: Optional[CustomTaskEventMessages] = None,
     ) -> None:
         # We need to catch all exceptions so that the calling thread is guaranteed
         # to not die
         try:
+            status = TaskStatus.FAILED
             for listener in self._listeners:
-                listener.on_task_start(task_id)
+                listener.on_task_start(task_id, task_type)
 
             # attention: this function is executed in a thread, not in the main process
             with task_context(task_id=task_id, user=jwt_user):
@@ -424,7 +429,6 @@ class TaskJobService(ITaskService):
                     # Important to keep this retry for now,
                     # in case commit is not visible (read from replica ...)
                     task = retry(lambda: self.repo.get_or_raise(task_id))
-                    task_type = task.type
                     study_id = task.ref_id
 
                 self.event_bus.push(
@@ -534,7 +538,7 @@ class TaskJobService(ITaskService):
                 )
         finally:
             for listener in self._listeners:
-                listener.on_task_end(task_id)
+                listener.on_task_end(task_id, task_type, status)
 
     def get_task_progress(self, task_id: str) -> Optional[int]:
         task = self.repo.get_or_raise(task_id)

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -160,17 +160,43 @@ class TaskLogAndProgressRecorder(ITaskNotifier):
 
 
 class TaskServiceListener(ABC):
+    """
+    Allows to observe tasks lifecycle.
+
+    There are 2 alternative flows of operation:
+
+     - the standard flow is submit -> start -> end.
+     - If a task is cancelled before it starts executing, the flow will be
+       submit -> cancel.
+    """
+
     @abstractmethod
     def on_task_submit(self, task_id: str, task_type: TaskType) -> None:
-        pass
+        """
+        Called as soon as a new task has been submitted for execution.
+        """
 
     @abstractmethod
     def on_task_start(self, task_id: str, task_type: TaskType) -> None:
-        pass
+        """
+        Called when a task is actually started.
+
+        At that point, it is guaranteed that:
+          - the listener will also be notified of the end of the task
+          - the task cannot be cancelled anymore
+        """
+
+    @abstractmethod
+    def on_task_cancel(self, task_id: str, task_type: TaskType) -> None:
+        """
+        Called when a task is actually cancelled, which means it has not started.
+        """
 
     @abstractmethod
     def on_task_end(self, task_id: str, task_type: TaskType, task_status: TaskStatus) -> None:
-        pass
+        """
+        Called when a started task completes, either successfully or not.
+        """
 
 
 class TaskJobService(ITaskService):
@@ -334,11 +360,13 @@ class TaskJobService(ITaskService):
         task = self.repo.get_or_raise(task_id)
         if task_id in self.tasks:
             cancelled = self.tasks[task_id].cancel()
+            task.status = TaskStatus.CANCELLED.value
+            self.repo.save(task)
+            # Only notifying listeners when the task is actually cancelled,
+            # otherwise the listeners will be notified again when the task is done.
             if cancelled:
-                task.status = TaskStatus.CANCELLED.value
-                self.repo.save(task)
                 for listener in self._listeners:
-                    listener.on_task_end(task.id, task.get_type(), TaskStatus.CANCELLED)
+                    listener.on_task_cancel(task.id, task.get_type())
         elif dispatch:
             self.event_bus.push(
                 Event(

--- a/antarest/service_creator.py
+++ b/antarest/service_creator.py
@@ -33,6 +33,7 @@ from antarest.core.interfaces.cache import ICache
 from antarest.core.interfaces.eventbus import IEventBus
 from antarest.core.maintenance.main import build_maintenance_manager
 from antarest.core.maintenance.service import MaintenanceService
+from antarest.core.metrics import add_db_metrics
 from antarest.core.persistence import upgrade_db
 from antarest.core.tasks.main import build_taskjob_manager
 from antarest.core.tasks.service import ITaskService
@@ -110,6 +111,8 @@ def init_db_engine(
             extra["pool_use_lifo"] = config.db.pool_use_lifo
 
     engine = create_engine(config.db.db_url, echo=config.debug, connect_args=connect_args, **extra)
+
+    add_db_metrics(config)
 
     return engine
 

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -22,6 +22,7 @@ from antarest.core.metrics import (
     _add_db_connection_metrics,
     _add_db_session_metrics,
 )
+from antarest.core.tasks.model import TaskStatus, TaskType
 
 
 def _is_subset(small_dict: dict[str, str], big_dict: dict[str, str]) -> bool:
@@ -52,7 +53,7 @@ def _get_value(registry: CollectorRegistry, name: str, labels: dict[str, str] | 
             return None
 
 
-def _get_histo_count(registry: CollectorRegistry, name: str) -> float | None:
+def _get_histo_count(registry: CollectorRegistry, name: str, labels: dict[str, str] | None = None) -> float | None:
     """
     Returns the count of values for a histogram metric.
     """
@@ -61,7 +62,8 @@ def _get_histo_count(registry: CollectorRegistry, name: str) -> float | None:
     if not metric:
         return None
     try:
-        sample = next(s for s in metric.samples if s.name == count_sample_name)
+        labels = labels or {}
+        sample = next(s for s in metric.samples if s.name == count_sample_name and _is_subset(labels, s.labels))
         return sample.value
     except StopIteration:
         return None
@@ -73,23 +75,23 @@ def test_task_metrics_recorder():
     metrics_names = {m.name for m in registry.collect()}
     assert metrics_names == {"tasks_duration_seconds", "tasks_wait_seconds", "tasks_running", "tasks_pending"}
 
-    recorder.on_task_submit("task1")
-    assert _get_value(registry, "tasks_running") is None
-    assert _get_value(registry, "tasks_pending") == 1
-    assert _get_histo_count(registry, "tasks_wait_seconds") is None
-    assert _get_histo_count(registry, "tasks_duration_seconds") is None
+    recorder.on_task_submit("task1", TaskType.ARCHIVE)
+    assert _get_value(registry, "tasks_running", {"type": "archive"}) is None
+    assert _get_value(registry, "tasks_pending", {"type": "archive"}) == 1
+    assert _get_histo_count(registry, "tasks_wait_seconds", {"type": "archive"}) is None
+    assert _get_histo_count(registry, "tasks_duration_seconds", {"type": "archive"}) is None
 
-    recorder.on_task_start("task1")
-    assert _get_value(registry, "tasks_running") == 1
-    assert _get_value(registry, "tasks_pending") == 0
-    assert _get_histo_count(registry, "tasks_wait_seconds") == 1
-    assert _get_histo_count(registry, "tasks_duration_seconds") is None
+    recorder.on_task_start("task1", TaskType.ARCHIVE)
+    assert _get_value(registry, "tasks_running", {"type": "archive"}) == 1
+    assert _get_value(registry, "tasks_pending", {"type": "archive"}) == 0
+    assert _get_histo_count(registry, "tasks_wait_seconds", {"type": "archive"}) == 1
+    assert _get_histo_count(registry, "tasks_duration_seconds", {"type": "archive"}) is None
 
-    recorder.on_task_end("task1")
-    assert _get_value(registry, "tasks_running") == 0
-    assert _get_value(registry, "tasks_pending") == 0
-    assert _get_histo_count(registry, "tasks_wait_seconds") == 1
-    assert _get_histo_count(registry, "tasks_duration_seconds") == 1
+    recorder.on_task_end("task1", TaskType.ARCHIVE, TaskStatus.COMPLETED)
+    assert _get_value(registry, "tasks_running", {"type": "archive"}) == 0
+    assert _get_value(registry, "tasks_pending", {"type": "archive"}) == 0
+    assert _get_histo_count(registry, "tasks_wait_seconds", {"type": "archive"}) == 1
+    assert _get_histo_count(registry, "tasks_duration_seconds", {"type": "archive", "status": "completed"}) == 1
 
 
 def test_db_connection_metrics():

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -94,6 +94,24 @@ def test_task_metrics_recorder():
     assert _get_histo_count(registry, "tasks_duration_seconds", {"type": "archive", "status": "completed"}) == 1
 
 
+def test_cancelled_task_metrics():
+    registry = CollectorRegistry()
+    recorder = TasksMetricsRecorder(registry)
+
+    recorder.on_task_submit("task1", TaskType.ARCHIVE)
+    assert _get_value(registry, "tasks_running", {"type": "archive"}) is None
+    assert _get_value(registry, "tasks_pending", {"type": "archive"}) == 1
+    assert _get_histo_count(registry, "tasks_wait_seconds", {"type": "archive"}) is None
+    assert _get_histo_count(registry, "tasks_duration_seconds", {"type": "archive"}) is None
+
+    recorder.on_task_cancel("task1", TaskType.ARCHIVE)
+    assert _get_value(registry, "tasks_running", {"type": "archive"}) is None
+    assert _get_value(registry, "tasks_pending", {"type": "archive"}) == 0
+    assert _get_histo_count(registry, "tasks_wait_seconds", {"type": "archive"}) == 1
+    # We get one observation for cancelled tasks.
+    assert _get_histo_count(registry, "tasks_duration_seconds", {"type": "archive", "status": "cancelled"}) == 1
+
+
 def test_db_connection_metrics():
     engine = create_engine("sqlite:///:memory:")
 


### PR DESCRIPTION
Mainly adding type and status labels to task metrics, to be able to monitor failed tasks and task stats by type.

Also, adding DB listeners as soon as the engine is created, to make sure we don't miss events of services
created early in the application startup process (task service etc).