### PR TITLE
fix(output): fix issue inside links variables retrieval

### DIFF
--- a/antarest/study/business/output/variables_management.py
+++ b/antarest/study/business/output/variables_management.py
@@ -158,12 +158,11 @@ def extract_variables_list(output_path: Path) -> OutputVariablesList:
         links_folder = mc_path / "links"
         file_type_klass = MCIndLinksQueryFile if mc_root == MCRoot.MC_IND else MCAllLinksQueryFile
         if links_folder.exists():
-            for link_name in sorted(links_folder.iterdir()):
-                area1, area2 = link_name.name.split("-")
+            for link_path in sorted(links_folder.iterdir()):
+                area1, area2 = link_path.name.split(" - ")
                 links_dict: dict[str, Any] = {"area_1_name": area1, "area_2_name": area2}
-                parent_path = links_folder / link_name
 
-                for col_headers, _ in _get_all_headers_and_file_type(mc_root, parent_path, file_type_klass):
+                for col_headers, _ in _get_all_headers_and_file_type(mc_root, link_path, file_type_klass):
                     links_dict["variables"] = links_dict.get("variables", set()) | {col.name for col in col_headers}
 
                 variables[mc_root_key]["links"].append(links_dict)

--- a/tests/integration/raw_studies_blueprint/assets/output_variables_list/res1.json
+++ b/tests/integration/raw_studies_blueprint/assets/output_variables_list/res1.json
@@ -217,8 +217,8 @@
             ],
             "links": [
                 {
-                    "area1Name": "de ",
-                    "area2Name": " fr",
+                    "area1Name": "de",
+                    "area2Name": "fr",
                     "variables": [
                         "CONG. FEE (ABS.)",
                         "CONG. FEE (ALG.)",
@@ -233,8 +233,8 @@
                     ]
                 },
                 {
-                    "area1Name": "es ",
-                    "area2Name": " fr",
+                    "area1Name": "es",
+                    "area2Name": "fr",
                     "variables": [
                         "CONG. FEE (ABS.)",
                         "CONG. FEE (ALG.)",
@@ -249,8 +249,8 @@
                     ]
                 },
                 {
-                    "area1Name": "fr ",
-                    "area2Name": " it",
+                    "area1Name": "fr",
+                    "area2Name": "it",
                     "variables": [
                         "CONG. FEE (ABS.)",
                         "CONG. FEE (ALG.)",
@@ -564,9 +564,9 @@
                 }
             ],
             "links": [
-                {"area1Name": "de ", "area2Name": " fr", "variables": []},
-                {"area1Name": "es ", "area2Name": " fr", "variables": []},
-                {"area1Name": "fr ", "area2Name": " it", "variables": []}
+                {"area1Name": "de", "area2Name": "fr", "variables": []},
+                {"area1Name": "es", "area2Name": "fr", "variables": []},
+                {"area1Name": "fr", "area2Name": "it", "variables": []}
             ]
         }
     }

--- a/tests/integration/raw_studies_blueprint/test_output_variables.py
+++ b/tests/integration/raw_studies_blueprint/test_output_variables.py
@@ -39,6 +39,55 @@ def test_get_output_variables_list(client: TestClient, user_access_token: str, i
         assert db_content.variables_list_version == 1
         assert db_content.to_model().model_dump(by_alias=True) == expected_content
 
+    # Checks mc-all links work properly as we didn't have any info in the first output
+    output_id = "20241807-1540eco-extra-outputs"
+    res = client.get(f"/v1/studies/{internal_study_id}/output/{output_id}/variables-list")
+    assert res.json()["mcAll"]["links"] == [
+        {
+            "area1Name": "de",
+            "area2Name": "fr",
+            "variables": [
+                "CONG. FEE (ABS.) EXP",
+                "CONG. FEE (ABS.) MAX",
+                "CONG. FEE (ABS.) MIN",
+                "CONG. FEE (ABS.) STD",
+                "CONG. FEE (ALG.) EXP",
+                "CONG. FEE (ALG.) MAX",
+                "CONG. FEE (ALG.) MIN",
+                "CONG. FEE (ALG.) STD",
+                "CONG. PROB + VALUES",
+                "CONG. PROB - VALUES",
+                "FLOW LIN. EXP",
+                "FLOW LIN. MAX",
+                "FLOW LIN. MIN",
+                "FLOW LIN. STD",
+                "FLOW QUAD. VALUES",
+                "HURDLE COST EXP",
+                "HURDLE COST MAX",
+                "HURDLE COST MIN",
+                "HURDLE COST STD",
+                "LOOP FLOW VALUES",
+                "MARG. COST EXP",
+                "MARG. COST MAX",
+                "MARG. COST MIN",
+                "MARG. COST STD",
+                "UCAP LIN. EXP",
+                "UCAP LIN. MAX",
+                "UCAP LIN. MIN",
+                "UCAP LIN. STD",
+            ],
+        }
+    ]
+
+
+def test_get_output_variables_list_other_output(client: TestClient, user_access_token: str, internal_study_id: str):
+    client.headers = {"Authorization": f"Bearer {user_access_token}"}
+
+    # Checks the endpoint works correctly
+    output_id = "20241807-1540eco-extra-outputs"
+    res = client.get(f"/v1/studies/{internal_study_id}/output/{output_id}/variables-list")
+    print(res.json()["mcAll"]["links"])
+
 
 def test_get_output_variables_imagrid_endpoint(client: TestClient, user_access_token: str, internal_study_id: str):
     client.headers = {"Authorization": f"Bearer {user_access_token}"}

--- a/tests/integration/raw_studies_blueprint/test_output_variables.py
+++ b/tests/integration/raw_studies_blueprint/test_output_variables.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-
+from pathlib import Path
 
 from starlette.testclient import TestClient
 
@@ -80,13 +80,18 @@ def test_get_output_variables_list(client: TestClient, user_access_token: str, i
     ]
 
 
-def test_get_output_variables_list_other_output(client: TestClient, user_access_token: str, internal_study_id: str):
+def test_get_output_variables_list_limit_case(
+    client: TestClient, user_access_token: str, internal_study_id: str, tmp_path: Path
+) -> None:
     client.headers = {"Authorization": f"Bearer {user_access_token}"}
 
-    # Checks the endpoint works correctly
-    output_id = "20241807-1540eco-extra-outputs"
+    # Some areas have a `-` inside their ids. We need to ensure we're able to read their links' related variables
+    output_id = "20201014-1425eco-goodbye"
+    folder_path = tmp_path / "ext_workspace" / "STA-mini" / "output" / output_id / "economy" / "mc-all" / "links"
+    link_path = folder_path / "fr - psp-open"
+    link_path.mkdir()
     res = client.get(f"/v1/studies/{internal_study_id}/output/{output_id}/variables-list")
-    print(res.json()["mcAll"]["links"])
+    assert res.status_code == 200
 
 
 def test_get_output_variables_imagrid_endpoint(client: TestClient, user_access_token: str, internal_study_id: str):


### PR DESCRIPTION
Retrieving links variables for areas with a `-` in their names used to crash because we splitted on `-` instead of `  -  `