### PR TITLE
fix(launcher): fix launcher argument naming in /versions endpoint

### DIFF
--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -14,7 +14,7 @@ import logging
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 
 from antarest.core.config import Config
 from antarest.core.filetransfer.model import FileDownloadTaskDTO
@@ -157,18 +157,22 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
 
     @bp.get(
         "/versions",
-        summary="Get list of supported solver versions",
+        summary="Get list of supported solver versions for the specified launcher",
     )
-    def get_solver_versions(solver: Optional[str] = None) -> List[str]:
+    def get_solver_versions(
+        launcher_id: str | None = None, solver: str | None = Query(deprecated=True, default=None)
+    ) -> List[str]:
         """
-        Get list of supported solver versions defined in the configuration.
+        Get list of supported solver versions for the specified launcher.
 
         Args:
-        - `solver`: name of the configuration to read.
-          If no solver is specified, retrieve the configuration of the default launcher.
+           launcher_id: name of the configuration to read. If no launcher is specified, returns solvers
+                        of the default launcher.
         """
-        logger.info(f"Fetching the list of solver versions for the '{solver}' configuration")
-        return service.get_solver_versions(solver)
+        launcher_id = launcher_id or solver
+        launcher_msg = f"launcher '{launcher_id}'" if launcher_id else "default launcher"
+        logger.info(f"Fetching the list of solver versions for {launcher_msg}")
+        return service.get_solver_versions(launcher_id)
 
     @bp.post(
         "/solver-presets",

--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -166,7 +166,7 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
         Get list of supported solver versions for the specified launcher.
 
         Args:
-           launcher_id: name of the configuration to read. If no launcher is specified, returns solvers
+           launcher_id: ID of the considered launcher. If no launcher is specified, returns solvers
                         of the default launcher.
         """
         launcher_id = launcher_id or solver

--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -11,10 +11,11 @@
 # This file is part of the Antares project.
 
 import logging
-from typing import List, Optional
+from typing import Annotated, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Query
+from pydantic import Field
 
 from antarest.core.config import Config
 from antarest.core.filetransfer.model import FileDownloadTaskDTO
@@ -158,10 +159,11 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
     @bp.get(
         "/versions",
         summary="Get list of supported solver versions for the specified launcher",
+        response_description='List of supported solver versions formatted as "880" for 8.8.',
     )
     def get_solver_versions(
-        launcher_id: str | None = None, solver: str | None = Query(deprecated=True, default=None)
-    ) -> List[str]:
+        launcher_id: str | None = None, solver: Annotated[str | None, Query(deprecated=True)] = None
+    ) -> Annotated[list[str], Field(examples=[["820", "880", "920"]])]:
         """
         Get list of supported solver versions for the specified launcher.
 

--- a/tests/integration/launcher_blueprint/test_solver_versions.py
+++ b/tests/integration/launcher_blueprint/test_solver_versions.py
@@ -59,11 +59,6 @@ def test_get_solver_versions__default(
     client: TestClient,
     user_access_token: str,
 ) -> None:
-    """
-    This unit test checks that the default value
-    of the `solver` parameter is indeed "default".
-    """
-
     res = client.get(
         "/v1/launcher/versions",
         headers={"Authorization": f"Bearer {user_access_token}"},

--- a/tests/integration/launcher_blueprint/test_solver_versions.py
+++ b/tests/integration/launcher_blueprint/test_solver_versions.py
@@ -14,66 +14,60 @@
 from starlette.testclient import TestClient
 
 
-class TestSolverVersions:
+def test_get_solver_versions(
+    client: TestClient,
+    user_access_token: str,
+) -> None:
+    # Fetch the default server version from the configuration file.
+    # NOTE: the value is defined in `tests/integration/assets/config.template.yml`.
+    res = client.get(
+        "/v1/launcher/versions",
+        headers={"Authorization": f"Bearer {user_access_token}"},
+    )
+    res.raise_for_status()
+    actual = res.json()
+    assert actual == ["700"]
+
+    res = client.get(
+        "/v1/launcher/versions",
+        headers={"Authorization": f"Bearer {user_access_token}"},
+    )
+    res.raise_for_status()
+    actual = res.json()
+    assert actual == ["700"]
+
+    res = client.get(
+        "/v1/launcher/versions?launcher_id=local_id",
+        headers={"Authorization": f"Bearer {user_access_token}"},
+    )
+    res.raise_for_status()
+    actual = res.json()
+    assert actual == ["700"]
+
+    res = client.get(
+        "/v1/launcher/versions?launcher_id=slurm",
+        headers={"Authorization": f"Bearer {user_access_token}"},
+    )
+    assert res.status_code == 500
+    assert res.json() == {
+        "description": "Unexpected server error: Configuration is not available for the 'slurm' launcher",
+        "exception": "InvalidConfigurationError",
+    }
+
+
+def test_get_solver_versions__default(
+    client: TestClient,
+    user_access_token: str,
+) -> None:
     """
-    The purpose of this unit test is to check the `/v1/launcher/versions` endpoint.
+    This unit test checks that the default value
+    of the `solver` parameter is indeed "default".
     """
 
-    def test_get_solver_versions(
-        self,
-        client: TestClient,
-        user_access_token: str,
-    ) -> None:
-        # Fetch the default server version from the configuration file.
-        # NOTE: the value is defined in `tests/integration/assets/config.template.yml`.
-        res = client.get(
-            "/v1/launcher/versions",
-            headers={"Authorization": f"Bearer {user_access_token}"},
-        )
-        res.raise_for_status()
-        actual = res.json()
-        assert actual == ["700"]
-
-        res = client.get(
-            "/v1/launcher/versions",
-            headers={"Authorization": f"Bearer {user_access_token}"},
-        )
-        res.raise_for_status()
-        actual = res.json()
-        assert actual == ["700"]
-
-        res = client.get(
-            "/v1/launcher/versions?solver=local_id",
-            headers={"Authorization": f"Bearer {user_access_token}"},
-        )
-        res.raise_for_status()
-        actual = res.json()
-        assert actual == ["700"]
-
-        res = client.get(
-            "/v1/launcher/versions?solver=slurm",
-            headers={"Authorization": f"Bearer {user_access_token}"},
-        )
-        assert res.status_code == 500
-        assert res.json() == {
-            "description": "Unexpected server error: Configuration is not available for the 'slurm' launcher",
-            "exception": "InvalidConfigurationError",
-        }
-
-    def test_get_solver_versions__default(
-        self,
-        client: TestClient,
-        user_access_token: str,
-    ) -> None:
-        """
-        This unit test checks that the default value
-        of the `solver` parameter is indeed "default".
-        """
-
-        res = client.get(
-            "/v1/launcher/versions",
-            headers={"Authorization": f"Bearer {user_access_token}"},
-        )
-        res.raise_for_status()
-        actual = res.json()
-        assert actual == ["700"]
+    res = client.get(
+        "/v1/launcher/versions",
+        headers={"Authorization": f"Bearer {user_access_token}"},
+    )
+    res.raise_for_status()
+    actual = res.json()
+    assert actual == ["700"]

--- a/tests/launcher/test_web.py
+++ b/tests/launcher/test_web.py
@@ -11,7 +11,6 @@
 # This file is part of the Antares project.
 
 import http
-from typing import List, Union
 from unittest.mock import Mock, call
 from uuid import uuid4
 
@@ -138,34 +137,32 @@ def test_get_solver_versions() -> None:
 
 
 @pytest.mark.parametrize(
-    "solver, status_code, expected",
+    "launcher",
     [
-        pytest.param("default", http.HTTPStatus.OK, ["1", "2", "3"], id="default"),
-        pytest.param("slurm", http.HTTPStatus.OK, ["1", "2", "3"], id="slurm"),
-        pytest.param("local", http.HTTPStatus.OK, ["1", "2", "3"], id="local"),
+        "default",
+        "slurm",
+        "local",
+    ],
+)
+@pytest.mark.parametrize(
+    "param_name",
+    [
+        "solver",  # deprecated
+        "launcher_id",
     ],
 )
 def test_get_solver_versions__with_query_string(
-    solver: str,
-    status_code: http.HTTPStatus,
-    expected: Union[List[str], str],
+    launcher: str,
+    param_name: str,
 ) -> None:
     service = Mock()
-    if status_code == http.HTTPStatus.OK:
-        service.get_solver_versions.return_value = ["1", "2", "3"]
-    else:
-        service.get_solver_versions.side_effect = KeyError(solver)
+    service.get_solver_versions.return_value = ["1", "2", "3"]
 
     app = create_app(service)
     client = TestClient(app)
-    res = client.get(f"/v1/launcher/versions?solver={solver}")
-    assert res.status_code == status_code  # OK or UNPROCESSABLE_ENTITY
-    if status_code == http.HTTPStatus.OK:
-        assert res.json() == expected
-    else:
-        actual = res.json()["detail"][0]
-        assert actual["type"] == "enum"
-        assert actual["msg"] == expected
+    res = client.get(f"/v1/launcher/versions?{param_name}={launcher}")
+    assert res.status_code == http.HTTPStatus.OK  # OK or UNPROCESSABLE_ENTITY
+    assert res.json() == ["1", "2", "3"]
 
 
 def test_get_job_log() -> None:


### PR DESCRIPTION
The `/launcher/versions` endpoint allows to retrieve solver versions available for a given launcher.

This "launcher" argument is wrongly named as "solver", this PR fixes that.