### PR TITLE
fix(build): add explicit type

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/date_serializer.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/date_serializer.py
@@ -146,7 +146,7 @@ class DailyMatrixSerializer(IDateMatrixSerializer):
         df_date = df.iloc[:, 2:4]
         df_date.columns = pd.Index(["day", "month"])
         df_date["month"] = df_date["month"].map(IDateMatrixSerializer._MONTHS)
-        date = df_date["month"].astype(str) + "/" + df_date["day"].astype(str).str.zfill(2)
+        date: pd.Series[str] = df_date["month"].astype(str) + "/" + df_date["day"].astype(str).str.zfill(2)
 
         # Extract right part with data
         to_remove = cast(Sequence[Hashable], df.columns[0:4])


### PR DESCRIPTION
On windows mypy fails on  date_serializer.py

```sh
$ mypy antarest/study/storage/rawstudy/model/filesystem/matrix/date_serializer.py
antarest\study\storage\rawstudy\model\filesystem\matrix\date_serializer.py:155: error: Incompatible return value type (got "tuple[Index[int], DataFrame]", expected "tuple[Index[str], DataFrame]")  [return-value]
Found 1 error in 1 file (checked 1 source file)
```

