### PR TITLE
fix(tasks): fix a memory leak

### DIFF
--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -583,6 +583,10 @@ class TaskJobService(ITaskService):
             for listener in self._listeners:
                 listener.on_task_end(task_id, task_type, status)
 
+            # Task has been updated in database, we can safely remove it from running tasks
+            if task_id in self.tasks:
+                del self.tasks[task_id]
+
     def get_task_progress(self, task_id: str) -> Optional[int]:
         task = self.repo.get_or_raise(task_id)
         user = get_current_user()

--- a/tests/core/tasks/test_tasks_service.py
+++ b/tests/core/tasks/test_tasks_service.py
@@ -753,3 +753,20 @@ def test_task_timeout_this_worker(task_service: TaskJobService) -> None:
             task_service.await_task(task_id, 1)
 
             assert task_service.status_task("a").status == TaskStatus.RUNNING
+
+
+@with_admin_user
+def test_memory_leak_fix(task_service: TaskJobService) -> None:
+    with db():
+
+        def dummy_task(notifier: ITaskNotifier) -> TaskResult:
+            return TaskResult(success=True, message="success")
+
+        task_id = task_service.add_task(dummy_task, "a", TaskType.SCAN, None, None, None)
+
+    with db():
+        task_service.await_task(task_id, 1)
+
+        # accessing an implementation detail, but no other way to check it
+        assert task_id not in task_service.tasks
+        assert task_service.status_task(task_id).status == TaskStatus.COMPLETED


### PR DESCRIPTION
The dictionary we use for storing futures is never ever cleaned up.
It seems it has never been an issue in production, but it still can
be non-negligible, in particular because it probably stores a reference
to the function executed, which generally carry some state with them.

Removing the future from the dict at the end of the computation
should not hurt, since the status is updated in database, therefore
future "waiters" will see on first request that it has indeed completed.