### PR TITLE
fix(tasks): task status update on restart must be done only once

### DIFF
--- a/antarest/core/tasks/model.py
+++ b/antarest/core/tasks/model.py
@@ -11,14 +11,13 @@
 # This file is part of the Antares project.
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum, StrEnum
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from pydantic import field_validator
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Sequence, String, update
-from sqlalchemy.engine.base import Engine
-from sqlalchemy.orm import Mapped, mapped_column, relationship, sessionmaker
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, Sequence, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing_extensions import override
 
 from antarest.core.persistence import Base
@@ -253,30 +252,3 @@ class TaskJob(Base):
             f" result_msg={self.result_msg},"
             f" result_status={self.result_status}"
         )
-
-
-def cancel_orphan_tasks(engine: Engine, session_args: Mapping[str, Any]) -> None:
-    """
-    Cancel all tasks that are currently running or pending.
-
-    When the web application restarts, such as after a new deployment, any pending or running tasks may be lost.
-    To mitigate this, it is preferable to set these tasks to a "FAILED" status.
-    This ensures that users can easily identify the tasks that were affected by the restart and take appropriate
-    actions, such as restarting the tasks manually.
-
-    Args:
-        engine: The database engine (SQLAlchemy connection to SQLite or PostgreSQL).
-        session_args: The session arguments (SQLAlchemy session arguments).
-    """
-    updated_values = {
-        TaskJob.status: TaskStatus.FAILED.value,
-        TaskJob.result_status: False,
-        TaskJob.result_msg: "Task was interrupted due to server restart",
-        TaskJob.completion_date: datetime.now(timezone.utc).replace(tzinfo=None),
-    }
-    orphan_status = [TaskStatus.RUNNING.value, TaskStatus.PENDING.value]
-    make_session = sessionmaker(bind=engine, **session_args)
-    with make_session() as session:
-        stmt = update(TaskJob).where(TaskJob.status.in_(orphan_status)).values(updated_values)
-        session.execute(stmt)
-        session.commit()

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -40,7 +40,6 @@ from antarest.core.logging.utils import LoggingMiddleware, configure_logger
 from antarest.core.metrics import add_metrics
 from antarest.core.requests import RATE_LIMIT_CONFIG
 from antarest.core.swagger import customize_openapi
-from antarest.core.tasks.model import cancel_orphan_tasks
 from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware
 from antarest.core.utils.utils import get_local_path
 from antarest.core.utils.web import tags_metadata
@@ -303,7 +302,6 @@ def fastapi_app(
         def home(request: Request) -> Any:
             return ""
 
-    cancel_orphan_tasks(engine=engine, session_args=SESSION_ARGS)
     return application, services
 
 

--- a/antarest/tools/admin.py
+++ b/antarest/tools/admin.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import click
 
 from antarest.tools.admin_lib import clean_locks as do_clean_locks
+from antarest.tools.admin_lib import fix_interrupted_tasks_status
 from antarest.tools.admin_lib import reindex_table as do_reindex_table
 
 logging.basicConfig(level=logging.INFO)
@@ -39,6 +40,22 @@ def commands() -> None:
 def clean_locks(config: str) -> None:
     """Clean app locks"""
     do_clean_locks(Path(config))
+
+
+@commands.command()
+@click.option(
+    "--config",
+    "-c",
+    nargs=1,
+    required=True,
+    type=click.Path(exists=True),
+    help="Application config",
+)
+def fix_tasks_status(config: str) -> None:
+    """
+    Set status of running or pending tasks to FAILED.
+    """
+    fix_interrupted_tasks_status(Path(config))
 
 
 @commands.command()

--- a/antarest/tools/admin_lib.py
+++ b/antarest/tools/admin_lib.py
@@ -11,16 +11,27 @@
 # This file is part of the Antares project.
 
 import logging
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
+from sqlalchemy import Engine, create_engine, update
+
 from antarest.core.config import Config
+from antarest.core.tasks.model import TaskJob, TaskStatus
 from antarest.core.utils.utils import get_local_path
 from antarest.launcher.adapters.slurm_launcher.slurm_launcher import WORKSPACE_LOCK_FILE_NAME
 
 logger = logging.getLogger(__name__)
 
 
-def get_config(config_path: Path) -> Config:
+def _create_engine(config: Config) -> Engine:
+    url = config.db.db_admin_url
+    assert url is not None, "db_admin_url can not be None"
+    return create_engine(url, echo=False)
+
+
+def _create_config(config_path: Path) -> Config:
     res = get_local_path() / "resources"
     config_obj = Config.from_yaml_file(res=res, file=config_path)
     return config_obj
@@ -39,7 +50,7 @@ def clean_locks_from_config(config: Config) -> None:
 
 def clean_locks(config: Path) -> None:
     """Clean app locks"""
-    config_obj = get_config(config)
+    config_obj = _create_config(config)
     clean_locks_from_config(config_obj)
 
 
@@ -47,7 +58,7 @@ def reindex_table(config: Path) -> None:
     import sqlalchemy
     from sqlalchemy import text
 
-    config_obj = get_config(config)
+    config_obj = _create_config(config)
     assert config_obj.db.db_admin_url is not None, "db_admin_url can not be None"
 
     engine = sqlalchemy.create_engine(str(config_obj.db.db_admin_url), echo=False)
@@ -61,3 +72,34 @@ def reindex_table(config: Path) -> None:
         connection.execute(text("REINDEX INDEX study_pkey"))
         connection.execute(text("VACUUM ANALYSE rawstudy"))
         connection.execute(text("REINDEX INDEX rawstudy_pkey"))
+
+
+def fix_interrupted_tasks_status(engine_or_config_path: Engine | Path) -> None:
+    """
+    Cancel all tasks that are currently running or pending.
+
+    When the web application restarts, such as after a new deployment, any pending or running tasks may be lost.
+    To mitigate this, it is preferable to set these tasks to a "FAILED" status.
+    This ensures that users can easily identify the tasks that were affected by the restart and take appropriate
+    actions, such as restarting the tasks manually.
+    """
+    if isinstance(engine_or_config_path, Engine):
+        engine = engine_or_config_path
+    else:
+        config = _create_config(engine_or_config_path)
+        engine = _create_engine(config)
+
+    updated_values = {
+        TaskJob.status: TaskStatus.FAILED.value,
+        TaskJob.result_status: False,
+        TaskJob.result_msg: "Task was interrupted due to server restart",
+        TaskJob.completion_date: datetime.now(timezone.utc).replace(tzinfo=None),
+    }
+    orphan_status = [TaskStatus.RUNNING.value, TaskStatus.PENDING.value]
+    logger.info("Setting status of interrupted tasks to FAILED.")
+    t0 = time.time()
+    with engine.connect() as connection:
+        stmt = update(TaskJob).where(TaskJob.status.in_(orphan_status)).values(updated_values)
+        connection.execute(stmt)
+        connection.commit()
+    logger.info(f"Tasks status correctly updated in {time.time() - t0}s.")

--- a/antarest/tools/admin_lib.py
+++ b/antarest/tools/admin_lib.py
@@ -74,21 +74,7 @@ def reindex_table(config: Path) -> None:
         connection.execute(text("REINDEX INDEX rawstudy_pkey"))
 
 
-def fix_interrupted_tasks_status(engine_or_config_path: Engine | Path) -> None:
-    """
-    Cancel all tasks that are currently running or pending.
-
-    When the web application restarts, such as after a new deployment, any pending or running tasks may be lost.
-    To mitigate this, it is preferable to set these tasks to a "FAILED" status.
-    This ensures that users can easily identify the tasks that were affected by the restart and take appropriate
-    actions, such as restarting the tasks manually.
-    """
-    if isinstance(engine_or_config_path, Engine):
-        engine = engine_or_config_path
-    else:
-        config = _create_config(engine_or_config_path)
-        engine = _create_engine(config)
-
+def _do_fix_interrupted_tasks_status(engine: Engine) -> None:
     updated_values = {
         TaskJob.status: TaskStatus.FAILED.value,
         TaskJob.result_status: False,
@@ -103,3 +89,17 @@ def fix_interrupted_tasks_status(engine_or_config_path: Engine | Path) -> None:
         connection.execute(stmt)
         connection.commit()
     logger.info(f"Tasks status correctly updated in {time.time() - t0}s.")
+
+
+def fix_interrupted_tasks_status(config_file: Path) -> None:
+    """
+    Cancel all tasks that are currently running or pending.
+
+    When the web application restarts, such as after a new deployment, any pending or running tasks may be lost.
+    To mitigate this, it is preferable to set these tasks to a "FAILED" status.
+    This ensures that users can easily identify the tasks that were affected by the restart and take appropriate
+    actions, such as restarting the tasks manually.
+    """
+    config = _create_config(config_file)
+    engine = _create_engine(config)
+    _do_fix_interrupted_tasks_status(engine)

--- a/scripts/pre-start.sh
+++ b/scripts/pre-start.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-
+# Executes some setup tasks before the actual start of the web application:
+# - database migration if needed
+# - cleaning up lock files
+# - fixing status of tasks that have been interrupted by previous shutdown
+#
 set -e
 
 CUR_DIR=$(cd "$(dirname "$0")" && pwd)
@@ -11,3 +15,4 @@ cd -
 
 export PYTHONPATH=$BASE_DIR
 python3 "$BASE_DIR/antarest/tools/admin.py" clean-locks -c "$ANTAREST_CONF"
+python3 "$BASE_DIR/antarest/tools/admin.py" fix-tasks-status -c "$ANTAREST_CONF"

--- a/tests/core/tasks/test_fix_tasks_status.py
+++ b/tests/core/tasks/test_fix_tasks_status.py
@@ -78,37 +78,37 @@ def test_fix_tasks_status(db_engine: Engine) -> None:
         )
         assert tasks_in_progress == 0
 
-        fixed_pending = session.query(TaskJob).get("pending")
+        fixed_pending = session.get(TaskJob, "pending")
         assert fixed_pending.status == TaskStatus.FAILED.value
         assert fixed_pending.result_status is False
         assert fixed_pending.result_msg == "Task was interrupted due to server restart"
         assert (now - fixed_pending.completion_date).seconds <= 1
 
-        fixed_running = session.query(TaskJob).get("running")
+        fixed_running = session.get(TaskJob, "running")
         assert fixed_running.status == TaskStatus.FAILED.value
         assert fixed_running.result_status is False
         assert fixed_running.result_msg == "Task was interrupted due to server restart"
         assert (now - fixed_running.completion_date).seconds <= 1
 
-        unchanged_completed = session.query(TaskJob).get("completed")
+        unchanged_completed = session.get(TaskJob, "completed")
         assert unchanged_completed.status == TaskStatus.COMPLETED.value
         assert unchanged_completed.result_status is True
         assert unchanged_completed.result_msg == "success"
         assert unchanged_completed.completion_date == datetime(2025, 6, 1, 12, 0, 0)
 
-        unchanged_failed = session.query(TaskJob).get("failed")
+        unchanged_failed = session.get(TaskJob, "failed")
         assert unchanged_failed.status == TaskStatus.FAILED.value
         assert unchanged_failed.result_status is False
         assert unchanged_failed.result_msg == "failed"
         assert unchanged_failed.completion_date == datetime(2025, 6, 1, 12, 0, 0)
 
-        unchanged_timeout = session.query(TaskJob).get("timeout")
+        unchanged_timeout = session.get(TaskJob, "timeout")
         assert unchanged_timeout.status == TaskStatus.TIMEOUT.value
         assert unchanged_timeout.result_status is False
         assert unchanged_timeout.result_msg == "timed out"
         assert unchanged_timeout.completion_date == datetime(2025, 6, 1, 12, 0, 0)
 
-        unchanged_cancelled = session.query(TaskJob).get("cancelled")
+        unchanged_cancelled = session.get(TaskJob, "cancelled")
         assert unchanged_cancelled.status == TaskStatus.CANCELLED.value
         assert unchanged_cancelled.result_status is False
         assert unchanged_cancelled.result_msg == "was cancelled"

--- a/tests/core/tasks/test_fix_tasks_status.py
+++ b/tests/core/tasks/test_fix_tasks_status.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import Engine
+from sqlalchemy.orm import sessionmaker
+
+from antarest.core.tasks.model import TaskJob, TaskStatus
+from antarest.tools.admin_lib import fix_interrupted_tasks_status
+
+
+@pytest.mark.parametrize(
+    ("status", "result_status", "result_msg"),
+    [
+        (TaskStatus.RUNNING.value, False, "task ongoing"),
+        (TaskStatus.PENDING.value, True, "task pending"),
+        (TaskStatus.FAILED.value, False, "task failed"),
+        (TaskStatus.COMPLETED.value, True, "task finished"),
+        (TaskStatus.TIMEOUT.value, False, "task timed out"),
+        (TaskStatus.CANCELLED.value, True, "task canceled"),
+    ],
+)
+def test_fix_tasks_status(
+    db_engine: Engine,
+    status: int,
+    result_status: bool,
+    result_msg: str,
+) -> None:
+    max_diff_seconds: int = 1
+    test_id: str = "2ea94758-9ea5-4015-a45f-b245a6ffc147"
+
+    completion_date: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
+    task_job = TaskJob(
+        id=test_id,
+        name="test",
+        status=status,
+        result_status=result_status,
+        result_msg=result_msg,
+        completion_date=completion_date,
+    )
+    make_session = sessionmaker(bind=db_engine)
+    with make_session() as session:
+        session.add(task_job)
+        session.commit()
+    fix_interrupted_tasks_status(db_engine)
+    with make_session() as session:
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        if status in [TaskStatus.RUNNING.value, TaskStatus.PENDING.value]:
+            update_tasks_count = (
+                session.query(TaskJob)
+                .filter(TaskJob.status.in_([TaskStatus.RUNNING.value, TaskStatus.PENDING.value]))
+                .count()
+            )
+            assert not update_tasks_count
+            updated_task_job = session.query(TaskJob).get(test_id)
+            assert updated_task_job.status == TaskStatus.FAILED.value
+            assert not updated_task_job.result_status
+            assert updated_task_job.result_msg == "Task was interrupted due to server restart"
+            assert (now - updated_task_job.completion_date).seconds <= max_diff_seconds
+        else:
+            updated_task_job = session.query(TaskJob).get(test_id)
+            assert updated_task_job.status == status
+            assert updated_task_job.result_status == result_status
+            assert updated_task_job.result_msg == result_msg
+            assert (now - updated_task_job.completion_date).seconds <= max_diff_seconds

--- a/tests/core/tasks/test_fix_tasks_status.py
+++ b/tests/core/tasks/test_fix_tasks_status.py
@@ -11,65 +11,105 @@
 # This file is part of the Antares project.
 from datetime import datetime, timezone
 
-import pytest
 from sqlalchemy import Engine
 from sqlalchemy.orm import sessionmaker
 
 from antarest.core.tasks.model import TaskJob, TaskStatus
-from antarest.tools.admin_lib import fix_interrupted_tasks_status
+from antarest.tools.admin_lib import _do_fix_interrupted_tasks_status
 
 
-@pytest.mark.parametrize(
-    ("status", "result_status", "result_msg"),
-    [
-        (TaskStatus.RUNNING.value, False, "task ongoing"),
-        (TaskStatus.PENDING.value, True, "task pending"),
-        (TaskStatus.FAILED.value, False, "task failed"),
-        (TaskStatus.COMPLETED.value, True, "task finished"),
-        (TaskStatus.TIMEOUT.value, False, "task timed out"),
-        (TaskStatus.CANCELLED.value, True, "task canceled"),
-    ],
-)
-def test_fix_tasks_status(
-    db_engine: Engine,
-    status: int,
-    result_status: bool,
-    result_msg: str,
-) -> None:
-    max_diff_seconds: int = 1
-    test_id: str = "2ea94758-9ea5-4015-a45f-b245a6ffc147"
-
-    completion_date: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
-    task_job = TaskJob(
-        id=test_id,
-        name="test",
-        status=status,
-        result_status=result_status,
-        result_msg=result_msg,
-        completion_date=completion_date,
+def test_fix_tasks_status(db_engine: Engine) -> None:
+    completed_task = TaskJob(
+        id="completed",
+        name="completed",
+        status=TaskStatus.COMPLETED.value,
+        result_status=True,
+        result_msg="success",
+        completion_date=datetime(2025, 6, 1, 12, 0, 0),
+    )
+    failed_task = TaskJob(
+        id="failed",
+        name="failed",
+        status=TaskStatus.FAILED.value,
+        result_status=False,
+        result_msg="failed",
+        completion_date=datetime(2025, 6, 1, 12, 0, 0),
+    )
+    running_task = TaskJob(
+        id="running",
+        name="running",
+        status=TaskStatus.RUNNING.value,
+    )
+    pending_task = TaskJob(
+        id="pending",
+        name="pending",
+        status=TaskStatus.PENDING.value,
+    )
+    timeout_task = TaskJob(
+        id="timeout",
+        name="timeout",
+        status=TaskStatus.TIMEOUT.value,
+        result_status=False,
+        result_msg="timed out",
+        completion_date=datetime(2025, 6, 1, 12, 0, 0),
+    )
+    cancelled_task = TaskJob(
+        id="cancelled",
+        name="cancelled",
+        status=TaskStatus.CANCELLED.value,
+        result_status=False,
+        result_msg="was cancelled",
+        completion_date=datetime(2025, 6, 1, 12, 0, 0),
     )
     make_session = sessionmaker(bind=db_engine)
     with make_session() as session:
-        session.add(task_job)
+        session.add_all([pending_task, running_task, failed_task, completed_task, timeout_task, cancelled_task])
         session.commit()
-    fix_interrupted_tasks_status(db_engine)
+
+    _do_fix_interrupted_tasks_status(db_engine)
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+
     with make_session() as session:
-        now = datetime.now(timezone.utc).replace(tzinfo=None)
-        if status in [TaskStatus.RUNNING.value, TaskStatus.PENDING.value]:
-            update_tasks_count = (
-                session.query(TaskJob)
-                .filter(TaskJob.status.in_([TaskStatus.RUNNING.value, TaskStatus.PENDING.value]))
-                .count()
-            )
-            assert not update_tasks_count
-            updated_task_job = session.query(TaskJob).get(test_id)
-            assert updated_task_job.status == TaskStatus.FAILED.value
-            assert not updated_task_job.result_status
-            assert updated_task_job.result_msg == "Task was interrupted due to server restart"
-            assert (now - updated_task_job.completion_date).seconds <= max_diff_seconds
-        else:
-            updated_task_job = session.query(TaskJob).get(test_id)
-            assert updated_task_job.status == status
-            assert updated_task_job.result_status == result_status
-            assert updated_task_job.result_msg == result_msg
-            assert (now - updated_task_job.completion_date).seconds <= max_diff_seconds
+        tasks_in_progress = (
+            session.query(TaskJob)
+            .filter(TaskJob.status.in_([TaskStatus.RUNNING.value, TaskStatus.PENDING.value]))
+            .count()
+        )
+        assert tasks_in_progress == 0
+
+        fixed_pending = session.query(TaskJob).get("pending")
+        assert fixed_pending.status == TaskStatus.FAILED.value
+        assert fixed_pending.result_status is False
+        assert fixed_pending.result_msg == "Task was interrupted due to server restart"
+        assert (now - fixed_pending.completion_date).seconds <= 1
+
+        fixed_running = session.query(TaskJob).get("running")
+        assert fixed_running.status == TaskStatus.FAILED.value
+        assert fixed_running.result_status is False
+        assert fixed_running.result_msg == "Task was interrupted due to server restart"
+        assert (now - fixed_running.completion_date).seconds <= 1
+
+        unchanged_completed = session.query(TaskJob).get("completed")
+        assert unchanged_completed.status == TaskStatus.COMPLETED.value
+        assert unchanged_completed.result_status is True
+        assert unchanged_completed.result_msg == "success"
+        assert unchanged_completed.completion_date == datetime(2025, 6, 1, 12, 0, 0)
+
+        unchanged_failed = session.query(TaskJob).get("failed")
+        assert unchanged_failed.status == TaskStatus.FAILED.value
+        assert unchanged_failed.result_status is False
+        assert unchanged_failed.result_msg == "failed"
+        assert unchanged_failed.completion_date == datetime(2025, 6, 1, 12, 0, 0)
+
+        unchanged_timeout = session.query(TaskJob).get("timeout")
+        assert unchanged_timeout.status == TaskStatus.TIMEOUT.value
+        assert unchanged_timeout.result_status is False
+        assert unchanged_timeout.result_msg == "timed out"
+        assert unchanged_timeout.completion_date == datetime(2025, 6, 1, 12, 0, 0)
+
+        unchanged_cancelled = session.query(TaskJob).get("cancelled")
+        assert unchanged_cancelled.status == TaskStatus.CANCELLED.value
+        assert unchanged_cancelled.result_status is False
+        assert unchanged_cancelled.result_msg == "was cancelled"
+        assert unchanged_cancelled.completion_date == datetime(2025, 6, 1, 12, 0, 0)

--- a/tests/core/tasks/test_tasks_service.py
+++ b/tests/core/tasks/test_tasks_service.py
@@ -22,7 +22,6 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine.base import Engine
-from sqlalchemy.orm import sessionmaker
 
 from antarest.core.config import Config
 from antarest.core.interfaces.eventbus import DummyEventBusService, EventType, IEventBus
@@ -37,7 +36,6 @@ from antarest.core.tasks.model import (
     TaskResult,
     TaskStatus,
     TaskType,
-    cancel_orphan_tasks,
 )
 from antarest.core.tasks.repository import TaskJobRepository
 from antarest.core.tasks.service import ITaskNotifier, TaskJobService
@@ -47,7 +45,6 @@ from antarest.eventbus.service import EventBusService
 from antarest.login.model import User
 from antarest.login.service import LoginService
 from antarest.login.utils import current_user_context, get_current_user
-from antarest.service_creator import SESSION_ARGS
 from antarest.study.repository import StudyMetadataRepository
 from antarest.study.service import ThermalClusterTimeSeriesGeneratorTask
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
@@ -88,7 +85,6 @@ def task_service(core_config: Config, event_bus: IEventBus, task_repo: TaskJobRe
 @with_admin_user
 @with_db_context
 def test_service(task_repo: TaskJobRepository, task_service: TaskJobService) -> None:
-    engine = db.session.bind
     service = task_service
 
     # Prepare a TaskJob in the database
@@ -96,15 +92,12 @@ def test_service(task_repo: TaskJobRepository, task_service: TaskJobService) -> 
     running_task = TaskJob(id="a", name="b", status=TaskStatus.RUNNING.value, creation_date=creation_date)
     task_repo.save(running_task)
 
-    # Cancel pending and running tasks
-    cancel_orphan_tasks(engine=engine, session_args=SESSION_ARGS)
-
     # Test Case: list tasks
     # =====================
 
     tasks = service.list_tasks(TaskListFilter())
     assert len(tasks) == 1
-    assert tasks[0].status == TaskStatus.FAILED
+    assert tasks[0].status == TaskStatus.RUNNING
     assert tasks[0].creation_date_utc == str(creation_date.replace(tzinfo=None))
 
     # Test Case: get task status
@@ -120,12 +113,8 @@ def test_service(task_repo: TaskJobRepository, task_service: TaskJobService) -> 
         "name": "b",
         "owner": None,
         "ref_id": None,
-        "result": {
-            "message": "Task was interrupted due to server restart",
-            "return_value": None,
-            "success": False,
-        },
-        "status": TaskStatus.FAILED,
+        "result": None,
+        "status": TaskStatus.RUNNING,
         "type": None,
         "progress": None,
     }
@@ -337,62 +326,6 @@ def test_cancel_not_started_task_should_update_status(
     task_a = task_job_repo.get("a")
     assert task_a is not None
     assert task_a.status == TaskStatus.CANCELLED.value
-
-
-@pytest.mark.parametrize(
-    ("status", "result_status", "result_msg"),
-    [
-        (TaskStatus.RUNNING.value, False, "task ongoing"),
-        (TaskStatus.PENDING.value, True, "task pending"),
-        (TaskStatus.FAILED.value, False, "task failed"),
-        (TaskStatus.COMPLETED.value, True, "task finished"),
-        (TaskStatus.TIMEOUT.value, False, "task timed out"),
-        (TaskStatus.CANCELLED.value, True, "task canceled"),
-    ],
-)
-def test_cancel_orphan_tasks(
-    db_engine: Engine,
-    status: int,
-    result_status: bool,
-    result_msg: str,
-) -> None:
-    max_diff_seconds: int = 1
-    test_id: str = "2ea94758-9ea5-4015-a45f-b245a6ffc147"
-
-    completion_date: datetime.datetime = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
-    task_job = TaskJob(
-        id=test_id,
-        name="test",
-        status=status,
-        result_status=result_status,
-        result_msg=result_msg,
-        completion_date=completion_date,
-    )
-    make_session = sessionmaker(bind=db_engine, **SESSION_ARGS)
-    with make_session() as session:
-        session.add(task_job)
-        session.commit()
-    cancel_orphan_tasks(engine=db_engine, session_args=SESSION_ARGS)
-    with make_session() as session:
-        now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
-        if status in [TaskStatus.RUNNING.value, TaskStatus.PENDING.value]:
-            update_tasks_count = (
-                session.query(TaskJob)
-                .filter(TaskJob.status.in_([TaskStatus.RUNNING.value, TaskStatus.PENDING.value]))
-                .count()
-            )
-            assert not update_tasks_count
-            updated_task_job = session.query(TaskJob).get(test_id)
-            assert updated_task_job.status == TaskStatus.FAILED.value
-            assert not updated_task_job.result_status
-            assert updated_task_job.result_msg == "Task was interrupted due to server restart"
-            assert (now - updated_task_job.completion_date).seconds <= max_diff_seconds
-        else:
-            updated_task_job = session.query(TaskJob).get(test_id)
-            assert updated_task_job.status == status
-            assert updated_task_job.result_status == result_status
-            assert updated_task_job.result_msg == result_msg
-            assert (now - updated_task_job.completion_date).seconds <= max_diff_seconds
 
 
 @with_db_context


### PR DESCRIPTION

Currently, each worker changes tasks status from RUNNING/PENDING to FAILED.

This cannot work well in a distributed environment, it must be done only once,
or some tasks could be erroneously set to FAILED.

This PR introduces a new "admin" operation which is performed on startup
after migration and locks cleanup.