### PR TITLE
fix(layer): bug update layer

### DIFF
--- a/antarest/study/business/layer_management.py
+++ b/antarest/study/business/layer_management.py
@@ -28,13 +28,17 @@ class LayerManager:
         return list(study.get_study_dao().get_layers())
 
     def create_layer(self, study: StudyInterface, layer_name: str) -> str:
+        current_layers = list(study.get_study_dao().get_layers())
+        layer_id = str(max((int(layer.id) for layer in current_layers if layer.id is not None), default=0) + 1)
+
         command = CreateLayer(
-            parameters=LayerCreation(name=layer_name),
+            parameters=LayerCreation(id=layer_id, name=layer_name),
             command_context=self._command_context,
             study_version=study.version,
         )
         study.add_commands([command])
-        return layer_name
+
+        return layer_id
 
     def update_layer_name(self, study: StudyInterface, layer_id: str, layer_name: str) -> None:
         command = UpdateLayer(

--- a/antarest/study/business/model/layer_model.py
+++ b/antarest/study/business/model/layer_model.py
@@ -28,6 +28,7 @@ class Layer(AntaresBaseModel):
 class LayerCreation(AntaresBaseModel):
     model_config = ConfigDict(alias_generator=to_camel_case, populate_by_name=True, extra="forbid")
 
+    id: str | None = None
     name: str
 
 
@@ -40,8 +41,18 @@ class LayerUpdate(AntaresBaseModel):
 
 
 def create_layer(current_layers: list[Layer], layer: LayerCreation) -> Layer:
-    new_id = max((int(layer.id) for layer in current_layers if layer.id is not None), default=0) + 1
-    return Layer(id=str(new_id), name=layer.name)
+    # Use the provided ID if available, otherwise calculate the next available ID
+    if layer.id is not None:
+        new_id = layer.id
+    else:
+        new_id = str(
+            max(
+                (int(existing_layer.id) for existing_layer in current_layers if existing_layer.id is not None),
+                default=0,
+            )
+            + 1
+        )
+    return Layer(id=new_id, name=layer.name)
 
 
 def update_layer_name(layers: List[Layer], data: LayerUpdate) -> Layer:

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -277,7 +277,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         "/studies/{uuid}/layers/{layer_id}",
         summary="Update layer",
     )
-    def update_layer(uuid: str, layer_id: str, name: str = "", areas: Optional[List[str]] = None) -> None:
+    def update_layer(uuid: str, layer_id: str, name: str = Query(""), areas: Optional[List[str]] = None) -> None:
         logger.info(f"Updating layer {layer_id} for study {uuid} with name {name}")
         study = study_service.check_study_access(uuid, StudyPermissionType.WRITE)
         study_interface = study_service.get_study_interface(study)

--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -277,7 +277,7 @@ def create_study_data_routes(study_service: StudyService, config: Config) -> API
         "/studies/{uuid}/layers/{layer_id}",
         summary="Update layer",
     )
-    def update_layer(uuid: str, layer_id: str, name: str = Query(""), areas: Optional[List[str]] = None) -> None:
+    def update_layer(uuid: str, layer_id: str, name: str = "", areas: Optional[List[str]] = None) -> None:
         logger.info(f"Updating layer {layer_id} for study {uuid} with name {name}")
         study = study_service.check_study_access(uuid, StudyPermissionType.WRITE)
         study_interface = study_service.get_study_interface(study)

--- a/tests/integration/study_data_blueprint/test_layer.py
+++ b/tests/integration/study_data_blueprint/test_layer.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+import pytest
+from starlette.testclient import TestClient
+
+from tests.integration.prepare_proxy import PreparerProxy
+
+
+class TestLayer:
+    @pytest.mark.parametrize("study_type", ["raw", "variant"])
+    def test_layer_endpoints(self, client: TestClient, user_access_token: str, study_type: str) -> None:
+        """Test layer CRUD operations via HTTP endpoints"""
+        client.headers = {"Authorization": f"Bearer {user_access_token}"}  # type: ignore
+
+        preparer = PreparerProxy(client, user_access_token)
+        study_id = preparer.create_study("foo", version=880)
+        if study_type == "variant":
+            study_id = preparer.create_variant(study_id, name="Variant 1")
+
+        # Create some areas for layer assignment tests
+        client.post(f"/v1/studies/{study_id}/areas", json={"name": "area1", "type": "AREA"})
+        client.post(f"/v1/studies/{study_id}/areas", json={"name": "area2", "type": "AREA"})
+
+        # Test GET layers - should have default layer "0" (All)
+        res = client.get(f"/v1/studies/{study_id}/layers")
+        assert res.status_code == 200
+        layers = res.json()
+        assert len(layers) == 1
+        assert layers[0]["id"] == "0"
+        assert layers[0]["name"] == "All"
+        # Layer "0" (All) contains all areas by default
+        assert sorted(layers[0]["areas"]) == ["area1", "area2"]
+
+        # Test POST - Create a new layer
+        res = client.post(f"/v1/studies/{study_id}/layers?name=Layer%20One")
+        assert res.status_code == 200
+        layer_name_1 = res.json()
+        assert layer_name_1 == "Layer One"
+
+        # Test GET layers - should now have 2 layers
+        res = client.get(f"/v1/studies/{study_id}/layers")
+        assert res.status_code == 200
+        layers = res.json()
+        assert len(layers) == 2
+        assert layers[1]["id"] == "1"
+        assert layers[1]["name"] == "Layer One"
+        assert layers[1]["areas"] == []
+        layer_id_1 = layers[1]["id"]
+
+        # Test POST - Create another layer
+        res = client.post(f"/v1/studies/{study_id}/layers?name=Layer%20Two")
+        assert res.status_code == 200
+        layer_name_2 = res.json()
+        assert layer_name_2 == "Layer Two"
+
+        # Get the ID of the second layer
+        res = client.get(f"/v1/studies/{study_id}/layers")
+        assert res.status_code == 200
+        layers = res.json()
+        layer_id_2 = layers[2]["id"]
+        assert layer_id_2 == "2"
+
+        # Test PUT - Update layer name (this is the critical test for the bug fix)
+        # Verify that layer_id from path and name from query parameter are correctly distinguished
+        res = client.put(f"/v1/studies/{study_id}/layers/{layer_id_1}?name=Updated%20Layer%20One")
+        assert res.status_code == 200
+
+        # Verify the layer name was updated
+        res = client.get(f"/v1/studies/{study_id}/layers")
+        assert res.status_code == 200
+        layers = res.json()
+        layer_1 = next(layer for layer in layers if layer["id"] == layer_id_1)
+        assert layer_1["name"] == "Updated Layer One"
+
+        # Test PUT - Update layer areas
+        res = client.put(
+            f"/v1/studies/{study_id}/layers/{layer_id_1}?name=Updated%20Layer%20One", json=["area1", "area2"]
+        )
+        assert res.status_code == 200
+
+        # Verify the layer areas were updated
+        res = client.get(f"/v1/studies/{study_id}/layers")
+        assert res.status_code == 200
+        layers = res.json()
+        layer_1 = next(layer for layer in layers if layer["id"] == layer_id_1)
+        assert sorted(layer_1["areas"]) == ["area1", "area2"]
+
+        # Test PUT - Update only areas (name empty)
+        res = client.put(f"/v1/studies/{study_id}/layers/{layer_id_2}", json=["area1"])
+        assert res.status_code == 200
+
+        # Verify only areas were updated, name should still be "Layer Two"
+        res = client.get(f"/v1/studies/{study_id}/layers")
+        assert res.status_code == 200
+        layers = res.json()
+        layer_2 = next(layer for layer in layers if layer["id"] == layer_id_2)
+        assert layer_2["name"] == "Layer Two"
+        assert layer_2["areas"] == ["area1"]
+
+        res = client.put(f"/v1/studies/{study_id}/layers/1?name=FinalName")
+        assert res.status_code == 200
+
+        res = client.get(f"/v1/studies/{study_id}/layers")
+        assert res.status_code == 200
+        layers = res.json()
+        layer_1 = next(layer for layer in layers if layer["id"] == "1")
+        # The name should be "FinalName", NOT "1" (which was the bug)
+        assert layer_1["name"] == "FinalName"
+        assert layer_1["id"] == "1"
+
+        # Test DELETE - Remove a layer
+        res = client.delete(f"/v1/studies/{study_id}/layers/{layer_id_2}")
+        assert res.status_code == 204
+
+        # Verify the layer was deleted
+        res = client.get(f"/v1/studies/{study_id}/layers")
+        assert res.status_code == 200
+        layers = res.json()
+        assert len(layers) == 2  # Should have layer "0" and layer "1" only
+        layer_ids = [layer["id"] for layer in layers]
+        assert "2" not in layer_ids

--- a/tests/integration/study_data_blueprint/test_layer.py
+++ b/tests/integration/study_data_blueprint/test_layer.py
@@ -70,8 +70,6 @@ class TestLayer:
         layer_id_2 = layers[2]["id"]
         assert layer_id_2 == "2"
 
-        # Test PUT - Update layer name (this is the critical test for the bug fix)
-        # Verify that layer_id from path and name from query parameter are correctly distinguished
         res = client.put(f"/v1/studies/{study_id}/layers/{layer_id_1}?name=Updated%20Layer%20One")
         assert res.status_code == 200
 

--- a/tests/integration/study_data_blueprint/test_layer.py
+++ b/tests/integration/study_data_blueprint/test_layer.py
@@ -44,8 +44,8 @@ class TestLayer:
         # Test POST - Create a new layer
         res = client.post(f"/v1/studies/{study_id}/layers?name=Layer%20One")
         assert res.status_code == 200
-        layer_name_1 = res.json()
-        assert layer_name_1 == "Layer One"
+        layer_id_1 = res.json()
+        assert layer_id_1 == "1"
 
         # Test GET layers - should now have 2 layers
         res = client.get(f"/v1/studies/{study_id}/layers")
@@ -55,19 +55,11 @@ class TestLayer:
         assert layers[1]["id"] == "1"
         assert layers[1]["name"] == "Layer One"
         assert layers[1]["areas"] == []
-        layer_id_1 = layers[1]["id"]
 
         # Test POST - Create another layer
         res = client.post(f"/v1/studies/{study_id}/layers?name=Layer%20Two")
         assert res.status_code == 200
-        layer_name_2 = res.json()
-        assert layer_name_2 == "Layer Two"
-
-        # Get the ID of the second layer
-        res = client.get(f"/v1/studies/{study_id}/layers")
-        assert res.status_code == 200
-        layers = res.json()
-        layer_id_2 = layers[2]["id"]
+        layer_id_2 = res.json()
         assert layer_id_2 == "2"
 
         res = client.put(f"/v1/studies/{study_id}/layers/{layer_id_1}?name=Updated%20Layer%20One")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -604,7 +604,7 @@ def test_area_management(client: TestClient, admin_access_token: str) -> None:
     assert res.json() == [Layer(id="0", name="All", areas=["area 1", "area 2"]).model_dump(mode="json")]
 
     res = client.post(f"/v1/studies/{study_id}/layers?name=test")
-    assert res.json() == "test"
+    assert res.json() == "1"
 
     res = client.get(f"/v1/studies/{study_id}/layers")
     assert res.json() == [
@@ -636,7 +636,7 @@ def test_area_management(client: TestClient, admin_access_token: str) -> None:
 
     # Create the layer again without areas
     res = client.post(f"/v1/studies/{study_id}/layers?name=test2")
-    assert res.json() == "test2"
+    assert res.json() == "1"
 
     # Delete the layer with no areas
     res = client.delete(f"/v1/studies/{study_id}/layers/1")

--- a/tests/variantstudy/model/command/test_create_layer.py
+++ b/tests/variantstudy/model/command/test_create_layer.py
@@ -53,3 +53,23 @@ class TestCreateLayer:
         link = IniReader()
         layers = link.read(empty_study.config.study_path / "layers/layers.ini")["layers"]
         assert layers == {"0": "All", "1": "Test Layer1", "2": "Test Layer2"}
+
+    def test_create_layer_with_explicit_id(self, empty_study_880: FileStudy, command_context: CommandContext) -> None:
+        empty_study = empty_study_880
+
+        # Create a layer with an explicit ID
+        command = CreateLayer(
+            parameters=LayerCreation(name="Test Layer with ID", id="5"),
+            command_context=command_context,
+            study_version=empty_study.config.version,
+        )
+
+        output = command.apply(
+            study_data=empty_study,
+        )
+
+        assert output.status
+
+        link = IniReader()
+        layers = link.read(empty_study.config.study_path / "layers/layers.ini")["layers"]
+        assert layers == {"0": "All", "5": "Test Layer with ID"}

--- a/webapp/src/services/api/studydata.ts
+++ b/webapp/src/services/api/studydata.ts
@@ -17,7 +17,7 @@ import {
   bindingConstraintModelAdapter,
 } from "../../components/App/Singlestudy/explore/Modelization/BindingConstraints/BindingConstView/utils";
 import type { StudyMapNode } from "../../redux/ducks/studyMaps";
-import type { UpdateAreaUi } from "../../types/types";
+import type { AreaUIUpdatePayload, UpdateAreaUi } from "../../types/types";
 import client from "./client";
 
 export const createArea = async (uuid: string, name: string): Promise<StudyMapNode> => {
@@ -34,7 +34,12 @@ export const updateAreaUI = async (
   layerId: string,
   areaUi: UpdateAreaUi,
 ): Promise<string> => {
-  const res = await client.put(`/v1/studies/${uuid}/areas/${areaId}/ui?layer=${layerId}`, areaUi);
+  const payload: AreaUIUpdatePayload = {
+    x: areaUi.x,
+    y: areaUi.y,
+    color_rgb: areaUi.color_rgb,
+  };
+  const res = await client.put(`/v1/studies/${uuid}/areas/${areaId}/ui?layer=${layerId}`, payload);
   return res.data;
 };
 

--- a/webapp/src/types/types.ts
+++ b/webapp/src/types/types.ts
@@ -501,6 +501,12 @@ export interface UpdateAreaUi {
   layerColor: AreaLayerColor;
 }
 
+export interface AreaUIUpdatePayload {
+  x: number;
+  y: number;
+  color_rgb: number[];
+}
+
 export interface AreaCreationDTO {
   name: string;
   type: object;


### PR DESCRIPTION
## Bug Fixes

- `POST /layers` now returns the id instead of the name. Fixing a bug where you would update a layer right after creating it. It needed the ID but was using the name that was previously returned.
- `PUT /areas/{area_id}/ui`: Frontend sent extra fields rejected by backend