### PR TITLE
feat(launcher): add versions in the /launchers endpoint

### DIFF
--- a/antarest/launcher/model.py
+++ b/antarest/launcher/model.py
@@ -306,7 +306,7 @@ class LauncherInfoDTO(AntaresBaseModel):
     name: str
     nb_cores: LauncherResourceRangeDTO
     time_limit: LauncherResourceRangeDTO
-    versions: list[str]
+    versions: list[SolverVersionStr]
 
 
 class LauncherListDTO(AntaresBaseModel):

--- a/antarest/launcher/model.py
+++ b/antarest/launcher/model.py
@@ -306,7 +306,7 @@ class LauncherInfoDTO(AntaresBaseModel):
     name: str
     nb_cores: LauncherResourceRangeDTO
     time_limit: LauncherResourceRangeDTO
-    versions: list[str]  # List of solver versions supported by this launcher (e.g., ["700", "880", "920"])
+    versions: list[str]
 
 
 class LauncherListDTO(AntaresBaseModel):

--- a/antarest/launcher/model.py
+++ b/antarest/launcher/model.py
@@ -306,6 +306,7 @@ class LauncherInfoDTO(AntaresBaseModel):
     name: str
     nb_cores: LauncherResourceRangeDTO
     time_limit: LauncherResourceRangeDTO
+    versions: list[str]  # List of solver versions supported by this launcher (e.g., ["700", "880", "920"])
 
 
 class LauncherListDTO(AntaresBaseModel):

--- a/antarest/launcher/service.py
+++ b/antarest/launcher/service.py
@@ -161,6 +161,7 @@ class LauncherService:
                         max=launcher_config.time_limit.max,
                         default=launcher_config.time_limit.default,
                     ),
+                    versions=self.get_solver_versions(launcher_config.id),
                 )
             )
         default_launcher = self.config.launcher.default

--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -160,12 +160,15 @@ def create_launcher_api(service: LauncherService, config: Config) -> APIRouter:
         "/versions",
         summary="Get list of supported solver versions for the specified launcher",
         response_description='List of supported solver versions formatted as "880" for 8.8.',
+        deprecated=True,
     )
     def get_solver_versions(
         launcher_id: str | None = None, solver: Annotated[str | None, Query(deprecated=True)] = None
     ) -> Annotated[list[str], Field(examples=[["820", "880", "920"]])]:
         """
         Get list of supported solver versions for the specified launcher.
+
+        **DEPRECATED**: Use GET /launchers instead, which includes versions for each launcher.
 
         Args:
            launcher_id: ID of the considered launcher. If no launcher is specified, returns solvers

--- a/tests/integration/assets/config.template.yml
+++ b/tests/integration/assets/config.template.yml
@@ -31,6 +31,7 @@ launcher:
       name: local
       binaries:
         700: {{launcher_mock}}
+        880: {{launcher_mock}}
       enable_nb_cores_detection: True
 
 debug: false

--- a/tests/integration/launcher_blueprint/test_launcher_local.py
+++ b/tests/integration/launcher_blueprint/test_launcher_local.py
@@ -44,7 +44,7 @@ class TestLauncherConfiguration:
                     "max": local_config.time_limit.max,
                     "default": local_config.time_limit.default,
                 },
-                "versions": ["700", "880"],
+                "versions": ["7.0", "8.8"],
             }
         ]
 

--- a/tests/integration/launcher_blueprint/test_launcher_local.py
+++ b/tests/integration/launcher_blueprint/test_launcher_local.py
@@ -44,6 +44,7 @@ class TestLauncherConfiguration:
                     "max": local_config.time_limit.max,
                     "default": local_config.time_limit.default,
                 },
+                "versions": ["700", "880"],
             }
         ]
 

--- a/tests/integration/launcher_blueprint/test_solver_versions.py
+++ b/tests/integration/launcher_blueprint/test_solver_versions.py
@@ -26,7 +26,7 @@ def test_get_solver_versions(
     )
     res.raise_for_status()
     actual = res.json()
-    assert actual == ["700"]
+    assert actual == ["700", "880"]
 
     res = client.get(
         "/v1/launcher/versions",
@@ -34,7 +34,7 @@ def test_get_solver_versions(
     )
     res.raise_for_status()
     actual = res.json()
-    assert actual == ["700"]
+    assert actual == ["700", "880"]
 
     res = client.get(
         "/v1/launcher/versions?launcher_id=local_id",
@@ -42,7 +42,7 @@ def test_get_solver_versions(
     )
     res.raise_for_status()
     actual = res.json()
-    assert actual == ["700"]
+    assert actual == ["700", "880"]
 
     res = client.get(
         "/v1/launcher/versions?launcher_id=slurm",
@@ -65,4 +65,4 @@ def test_get_solver_versions__default(
     )
     res.raise_for_status()
     actual = res.json()
-    assert actual == ["700"]
+    assert actual == ["700", "880"]


### PR DESCRIPTION
The front-end client want to be able to call only one endpoint to get both de launchers and the associated versions. Instead of calling `GET /launchers` then `GET /versions`
`GET /versions` is now deprecated