### PR TITLE
chore(web): remove rate limiter

### DIFF
--- a/antarest/core/requests.py
+++ b/antarest/core/requests.py
@@ -14,17 +14,7 @@ from collections import OrderedDict
 from typing import Any, Generator, Mapping, MutableMapping, Tuple
 
 from fastapi import HTTPException
-from ratelimit import Rule  # type: ignore
 from typing_extensions import override
-
-RATE_LIMIT_CONFIG = {
-    r"^/v1/launcher/run": [
-        Rule(second=1, minute=20),
-    ],
-    r"^/v1/watcher/_scan": [
-        Rule(minute=2),
-    ],
-}
 
 
 class CaseInsensitiveDict(MutableMapping[str, Any]):  # copy of the requests class to avoid importing the package

--- a/antarest/login/auth.py
+++ b/antarest/login/auth.py
@@ -12,11 +12,9 @@
 
 import logging
 from datetime import timedelta
-from typing import Annotated, Any, AsyncGenerator, Callable, Coroutine, Optional, Tuple, TypeAlias, Union
+from typing import Annotated, Any, AsyncGenerator, Callable, Optional, Tuple, TypeAlias, Union
 
 from fastapi import Depends
-from ratelimit.types import Scope  # type: ignore
-from starlette.requests import Request
 
 from antarest.core.config import Config
 from antarest.core.jwt import DEFAULT_ADMIN_USER, JWTUser
@@ -51,16 +49,6 @@ class Auth:
     ):
         self.disabled = config.security.disabled
         self.validate_identity = validate_identity
-
-    def create_auth_function(
-        self,
-    ) -> Callable[[Scope], Coroutine[Any, Any, Tuple[str, str]]]:
-        async def auth(scope: Scope) -> Tuple[str, str]:
-            auth_jwt = AuthJWT(Request(scope))
-            user = self._get_current_user(auth_jwt)
-            return str(user.id), "admin" if user.is_site_admin() else "default"
-
-        return auth
 
     def _get_current_user(self, auth_jwt: AuthJWT) -> JWTUser:
         """

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -23,9 +23,6 @@ import uvicorn.config
 from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
-from ratelimit import RateLimitMiddleware  # type: ignore
-from ratelimit.backends.redis import RedisBackend  # type: ignore
-from ratelimit.backends.simple import MemoryBackend  # type: ignore
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -38,7 +35,6 @@ from antarest.core.core_blueprint import create_utils_routes
 from antarest.core.filesystem_blueprint import create_file_system_blueprint
 from antarest.core.logging.utils import LoggingMiddleware, configure_logger
 from antarest.core.metrics import add_metrics
-from antarest.core.requests import RATE_LIMIT_CONFIG
 from antarest.core.swagger import customize_openapi
 from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware
 from antarest.core.utils.utils import get_local_path
@@ -257,19 +253,6 @@ def fastapi_app(
             },
             status_code=500,
         )
-
-    # rate limiter
-    auth_manager = Auth(config)
-    application.add_middleware(
-        RateLimitMiddleware,
-        authenticate=auth_manager.create_auth_function(),
-        backend=(
-            MemoryBackend()
-            if config.redis is None
-            else RedisBackend(config.redis.host, config.redis.port, 1, config.redis.password)
-        ),
-        config=RATE_LIMIT_CONFIG,
-    )
 
     init_admin_user(engine=engine, session_args=SESSION_ARGS, admin_password=config.security.admin_pwd)
     services = create_services(config, app_ctxt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ httpx~=0.27.0
 python-multipart~=0.0.20
 
 alembic~=1.16.5
-asgi-ratelimit[redis]==0.7.0
 bcrypt~=5.0.0
 click~=8.3.0
 contextvars~=2.4


### PR DESCRIPTION
Removes the marginal rate limiting feature that exists now. As is, it's:
- inactive in https
- broken with python 3.11 (see https://github.com/AntaresSimulatorTeam/AntaREST/pull/2809 by @insatomcat )
- not configurable (config is hard-coded, hidden)

If need arises, we will restore it with more care.