### PR TITLE
feat(metrics): add current requests gauge, fix exception handling

### DIFF
--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -13,10 +13,12 @@
 import logging
 import os
 import time
+from http import HTTPStatus
 from typing import Any
 
 import prometheus_client
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 from prometheus_client import (
     CollectorRegistry,
     Counter,
@@ -25,10 +27,12 @@ from prometheus_client import (
     make_asgi_app,
     multiprocess,
 )
+from pydantic import ValidationError
 from sqlalchemy import Engine, Pool, PoolProxiedConnection
 from sqlalchemy.event import listens_for
 from sqlalchemy.orm import Session, SessionTransaction, sessionmaker
 from sqlalchemy.pool import ConnectionPoolEntry
+from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from typing_extensions import override
 
@@ -196,7 +200,7 @@ def _add_db_session_metrics(registry: CollectorRegistry, session_factory: sessio
             del session.info["start_time"]
 
 
-def _add_metrics_middleware(application: FastAPI) -> None:
+def _add_metrics_middleware(registry: CollectorRegistry, application: FastAPI) -> None:
     """
     Registers an HTTP middleware to report metrics about requests count and duration
     """
@@ -205,20 +209,20 @@ def _add_metrics_middleware(application: FastAPI) -> None:
         "http_requests",
         "HTTP requests count",
         ["worker_id", "method", "endpoint", "http_status"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
     request_duration_histo = Histogram(
         "http_requests_duration_seconds",
         "HTTP requests duration",
         ["worker_id", "method", "endpoint", "http_status"],
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
     current_requests_gauge = Gauge(
         "http_requests_current",
         "Requests currently executing",
         ["worker_id", "method", "endpoint"],
         multiprocess_mode="liveall",
-        registry=prometheus_client.REGISTRY,
+        registry=registry,
     )
 
     @application.middleware("http")
@@ -231,15 +235,28 @@ def _add_metrics_middleware(application: FastAPI) -> None:
         current_requests_gauge.labels(WORKER_ID, request.method, request_path).inc()
 
         start_time = time.time()
-        response = await call_next(request)
-        process_time = time.time() - start_time
+        status_code = None
 
-        current_requests_gauge.labels(WORKER_ID, request.method, request_path).dec()
+        # In order to have the correct status code, we need to duplicate here the logic of exception handlers...
+        # Clearly this should be improved. However we have no reason to change that mapping soon.
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+        except HTTPException as exc:
+            status_code = exc.status_code
+            raise
+        except (ValidationError, RequestValidationError):
+            status_code = HTTPStatus.UNPROCESSABLE_ENTITY.value
+            raise
+        finally:
+            status_code = status_code or HTTPStatus.INTERNAL_SERVER_ERROR.value
 
-        request_counter.labels(WORKER_ID, request.method, request_path, response.status_code).inc()
-        request_duration_histo.labels(WORKER_ID, request.method, request_path, response.status_code).observe(
-            process_time
-        )
+            process_time = time.time() - start_time
+
+            current_requests_gauge.labels(WORKER_ID, request.method, request_path).dec()
+
+            request_counter.labels(WORKER_ID, request.method, request_path, status_code).inc()
+            request_duration_histo.labels(WORKER_ID, request.method, request_path, status_code).observe(process_time)
         return response
 
 
@@ -265,7 +282,7 @@ def add_metrics(application: FastAPI, config: Config) -> None:
     metrics_app = make_asgi_app(registry=global_registry)
     application.mount("/metrics", metrics_app)
 
-    _add_metrics_middleware(application)
+    _add_metrics_middleware(prometheus_client.REGISTRY, application)
 
 
 def _task_labels(task_type: TaskType, status: TaskStatus | None = None) -> list[str]:

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -213,17 +213,28 @@ def _add_metrics_middleware(application: FastAPI) -> None:
         ["worker_id", "method", "endpoint", "http_status"],
         registry=prometheus_client.REGISTRY,
     )
+    current_requests_gauge = Gauge(
+        "http_requests_current",
+        "Requests currently executing",
+        ["worker_id", "method", "endpoint"],
+        multiprocess_mode="liveall",
+        registry=prometheus_client.REGISTRY,
+    )
 
     @application.middleware("http")
     async def add_metrics(request: Request, call_next: Any) -> Any:
-        start_time = time.time()
-        response = await call_next(request)
-        process_time = time.time() - start_time
-
         if "route" in request.scope:
             request_path = request.scope["root_path"] + request.scope["route"].path
         else:
             request_path = request.url.path
+
+        current_requests_gauge.labels(WORKER_ID, request.method, request_path).inc()
+
+        start_time = time.time()
+        response = await call_next(request)
+        process_time = time.time() - start_time
+
+        current_requests_gauge.labels(WORKER_ID, request.method, request_path).dec()
 
         request_counter.labels(WORKER_ID, request.method, request_path, response.status_code).inc()
         request_duration_histo.labels(WORKER_ID, request.method, request_path, response.status_code).observe(

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -98,72 +98,7 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def fastapi_app(
-    config_file: Path,
-    resource_path: Optional[Path] = None,
-    mount_front: bool = True,
-    auto_upgrade_db: bool = False,
-) -> Tuple[FastAPI, Services]:
-    res = resource_path or get_local_path() / "resources"
-    config = Config.from_yaml_file(res=res, file=config_file)
-    configure_logger(config)
-
-    logger.info("Initiating application")
-
-    @asynccontextmanager
-    async def set_default_executor(app: FastAPI) -> AsyncGenerator[None, None]:
-        import asyncio
-        from concurrent.futures import ThreadPoolExecutor
-
-        loop = asyncio.get_running_loop()
-        loop.set_default_executor(ThreadPoolExecutor(max_workers=config.server.worker_threadpool_size))
-        yield
-
-    application = FastAPI(
-        title="AntaREST",
-        version=__version__,
-        docs_url=None,
-        root_path=config.root_path,
-        openapi_tags=tags_metadata,
-        lifespan=set_default_executor,
-        openapi_url=f"{config.api_prefix}/openapi.json",
-    )
-
-    api_root = APIRouter(prefix=config.api_prefix)
-
-    app_ctxt = AppBuildContext(application, api_root)
-
-    # Database
-    engine = init_db_engine(config_file, config, auto_upgrade_db)
-    application.add_middleware(DBSessionMiddleware, custom_engine=engine, session_args=SESSION_ARGS)
-    # Since Starlette Version 0.24.0, the middlewares are lazily built inside this function
-    # But we need to instantiate this middleware as it's needed for the study service.
-    # So we manually instantiate it here.
-    DBSessionMiddleware(None, custom_engine=engine, session_args=cast(Dict[str, bool], SESSION_ARGS))
-
-    application.add_middleware(LoggingMiddleware)
-
-    # TODO move that elsewhere
-    @AuthJWT.load_config  # type: ignore
-    def get_config() -> JwtSettings:
-        return JwtSettings(
-            authjwt_secret_key=config.security.jwt_key,
-            authjwt_token_location=("headers", "cookies"),
-            authjwt_access_token_expires=Auth.ACCESS_TOKEN_DURATION,
-            authjwt_refresh_token_expires=Auth.REFRESH_TOKEN_DURATION,
-            authjwt_cookie_csrf_protect=False,
-        )
-
-    application.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
-    api_root.include_router(create_utils_routes(config))
-    api_root.include_router(create_file_system_blueprint(config))
-
+def add_exception_handlers(application: FastAPI) -> None:
     # noinspection PyUnusedLocal
     @application.exception_handler(HTTPException)
     def handle_http_exception(request: Request, exc: HTTPException) -> Any:
@@ -257,6 +192,75 @@ def fastapi_app(
             },
             status_code=500,
         )
+
+
+def fastapi_app(
+    config_file: Path,
+    resource_path: Optional[Path] = None,
+    mount_front: bool = True,
+    auto_upgrade_db: bool = False,
+) -> Tuple[FastAPI, Services]:
+    res = resource_path or get_local_path() / "resources"
+    config = Config.from_yaml_file(res=res, file=config_file)
+    configure_logger(config)
+
+    logger.info("Initiating application")
+
+    @asynccontextmanager
+    async def set_default_executor(app: FastAPI) -> AsyncGenerator[None, None]:
+        import asyncio
+        from concurrent.futures import ThreadPoolExecutor
+
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(ThreadPoolExecutor(max_workers=config.server.worker_threadpool_size))
+        yield
+
+    application = FastAPI(
+        title="AntaREST",
+        version=__version__,
+        docs_url=None,
+        root_path=config.root_path,
+        openapi_tags=tags_metadata,
+        lifespan=set_default_executor,
+        openapi_url=f"{config.api_prefix}/openapi.json",
+    )
+
+    api_root = APIRouter(prefix=config.api_prefix)
+
+    app_ctxt = AppBuildContext(application, api_root)
+
+    # Database
+    engine = init_db_engine(config_file, config, auto_upgrade_db)
+    application.add_middleware(DBSessionMiddleware, custom_engine=engine, session_args=SESSION_ARGS)
+    # Since Starlette Version 0.24.0, the middlewares are lazily built inside this function
+    # But we need to instantiate this middleware as it's needed for the study service.
+    # So we manually instantiate it here.
+    DBSessionMiddleware(None, custom_engine=engine, session_args=cast(Dict[str, bool], SESSION_ARGS))
+
+    application.add_middleware(LoggingMiddleware)
+
+    # TODO move that elsewhere
+    @AuthJWT.load_config  # type: ignore
+    def get_config() -> JwtSettings:
+        return JwtSettings(
+            authjwt_secret_key=config.security.jwt_key,
+            authjwt_token_location=("headers", "cookies"),
+            authjwt_access_token_expires=Auth.ACCESS_TOKEN_DURATION,
+            authjwt_refresh_token_expires=Auth.REFRESH_TOKEN_DURATION,
+            authjwt_cookie_csrf_protect=False,
+        )
+
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    api_root.include_router(create_utils_routes(config))
+    api_root.include_router(create_file_system_blueprint(config))
+
+    add_exception_handlers(application)
 
     # rate limiter
     auth_manager = Auth(config)

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -13,16 +13,22 @@ import time
 
 import prometheus_client
 import pytest
+from fastapi import FastAPI
 from prometheus_client import CollectorRegistry, Metric
+from pydantic import BaseModel
 from sqlalchemy import QueuePool, create_engine, text
 from sqlalchemy.orm import sessionmaker
+from starlette.exceptions import HTTPException
+from starlette.testclient import TestClient
 
 from antarest.core.metrics import (
     TasksMetricsRecorder,
     _add_db_connection_metrics,
     _add_db_session_metrics,
+    _add_metrics_middleware,
 )
 from antarest.core.tasks.model import TaskStatus, TaskType
+from antarest.main import add_exception_handlers
 
 
 def _is_subset(small_dict: dict[str, str], big_dict: dict[str, str]) -> bool:
@@ -334,3 +340,52 @@ def test_db_session_metrics():
         assert _get_value(registry, "db_session_events", labels={"event_type": "commit"}) == 1
         assert _get_value(registry, "db_transactions_current") == 0
         assert _get_histo_count(registry, "db_transactions_duration_seconds") == 2
+
+
+class TestModel(BaseModel):
+    value: int
+
+
+def test_http_request_metrics() -> None:
+    registry = CollectorRegistry()
+
+    app = FastAPI()
+
+    @app.get("/ok")
+    def ok() -> None:
+        pass
+
+    @app.get("/notfound")
+    def notfound() -> None:
+        raise HTTPException(status_code=404)
+
+    @app.get("/error")
+    def error() -> None:
+        raise Exception()
+
+    @app.post("/validation")
+    def validation(input: TestModel) -> int:
+        return input.value
+
+    add_exception_handlers(app)
+
+    _add_metrics_middleware(registry=registry, application=app)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    res = client.get("/ok")
+    assert res.status_code == 200
+
+    assert _get_histo_count(registry, "http_requests_duration_seconds", labels={"http_status": "200"}) == 1
+
+    res = client.get("/error")
+    assert res.status_code == 500
+
+    assert _get_histo_count(registry, "http_requests_duration_seconds", labels={"http_status": "500"}) == 1
+
+    res = client.get("/notfound")
+    assert res.status_code == 404
+    assert _get_histo_count(registry, "http_requests_duration_seconds", labels={"http_status": "404"}) == 1
+
+    res = client.post("/validation", json={"value": "invalid"})
+    assert res.status_code == 422
+    assert _get_histo_count(registry, "http_requests_duration_seconds", labels={"http_status": "422"}) == 1


### PR DESCRIPTION
This PR implements:
 - correct handling of exceptions by the http metrics middleware
 - addition of a gauge for http requests

Note that the handling of exceptions is not great because it duplicates some logic from exception handlers.
It's not obvious to implement it another way, because the fact that exceptions are translated to status code
only after middleware action is hard coded in starlette.