### PR TITLE
fix(db,metrics): always explicitly close transactions on session exit

### DIFF
--- a/antarest/core/filetransfer/repository.py
+++ b/antarest/core/filetransfer/repository.py
@@ -24,8 +24,9 @@ class FileDownloadRepository:
         db.session.commit()
 
     def get(self, download_id: str) -> Optional[FileDownload]:
-        file_download: Optional[FileDownload] = db.session.get(FileDownload, download_id)
-        return file_download
+        download = db.session.get(FileDownload, download_id)
+        db.session.refresh(download)
+        return download
 
     def save(self, download: FileDownload) -> None:
         db.session.merge(download)

--- a/antarest/core/filetransfer/service.py
+++ b/antarest/core/filetransfer/service.py
@@ -35,7 +35,6 @@ from antarest.core.interfaces.eventbus import Event, EventType, IEventBus
 from antarest.core.model import PermissionInfo, PublicMode
 from antarest.core.requests import UserHasNotPermissionError
 from antarest.core.tasks.service import DEFAULT_AWAIT_MAX_TIMEOUT
-from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import current_time
 from antarest.login.utils import get_current_user, require_current_user
 
@@ -230,9 +229,8 @@ class FileTransferManager:
 
             # disable download variable typing since it will always be defined
             while time.time() < end and not download.ready and not download.failed:
-                with db():  # needs db context to refresh download
-                    download = self.repository.get(download_id)
-                    assert download is not None
+                download = self.repository.get(download_id)
+                assert download is not None
                 time.sleep(2)
 
         if download.failed:

--- a/antarest/core/utils/fastapi_sqlalchemy/middleware.py
+++ b/antarest/core/utils/fastapi_sqlalchemy/middleware.py
@@ -1,5 +1,5 @@
 from contextvars import ContextVar, Token
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
@@ -10,7 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.types import ASGIApp
-from typing_extensions import override
+from typing_extensions import TypeAlias, override
 
 from antarest.core.utils.fastapi_sqlalchemy.exceptions import MissingSessionError, SessionNotInitialisedError
 
@@ -85,32 +85,45 @@ class DBSessionMeta(type):
         return session
 
 
+SessionFactory: TypeAlias = Callable[[], Session]
+
+
+def _default_create_session() -> Session:
+    if isinstance(_Session, sessionmaker):
+        return _Session()
+    raise SessionNotInitialisedError()
+
+
 class DBSession(metaclass=DBSessionMeta):
     def __init__(
         self,
-        session_args: Optional[Dict[str, Any]] = None,
+        session_factory: SessionFactory = _default_create_session,
         commit_on_exit: bool = False,
     ) -> None:
         self.token: Optional[Token[Optional[Any]]] = None
-        self.session_args = session_args or {}
+        self.session_factory = session_factory
         self.commit_on_exit = commit_on_exit
 
     def __enter__(self) -> Type["DBSession"]:
-        if not isinstance(_Session, sessionmaker):
-            raise SessionNotInitialisedError
-        self.token = _session.set(_Session(**self.session_args))
+        self.token = _session.set(self.session_factory())
         return type(self)
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        sess: Optional[Session] = _session.get()
+        sess = _session.get()
         if sess is not None:
-            if exc_type is not None:
-                sess.rollback()
+            try:
+                # it's important to either commit or rollback in all cases.
+                # this correctly closes the ongoing transaction. Otherwise,
+                # closing the session may raise an error (for example on server disconnect)
+                # without correctly closing the transaction. It can result in particular
+                # in wrong metrics.
+                if self.commit_on_exit and exc_value is None:
+                    sess.commit()
+                else:
+                    sess.rollback()
+            finally:
+                sess.close()
 
-            if self.commit_on_exit:
-                sess.commit()
-
-            sess.close()
         if self.token is not None:
             _session.reset(self.token)
 

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -28,6 +28,7 @@ from antarest.core.metrics import (
     _add_metrics_middleware,
 )
 from antarest.core.tasks.model import TaskStatus, TaskType
+from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.main import add_exception_handlers
 
 
@@ -288,6 +289,29 @@ def test_db_connection_metrics_preping():
 
     assert _get_value(registry, "db_connections_used") == 0
     assert _get_value(registry, "db_connections_idle") == 1
+
+
+@pytest.mark.skip(reason="to be run manually with a local postgres server in debug mode")
+def test_db_transaction_is_closed_on_server_disconnect():
+    engine = create_engine("postgresql+psycopg2://postgres:somepass@127.0.0.1:5432/postgres", pool_pre_ping=True)
+
+    session_factory = sessionmaker(bind=engine)
+
+    registry = CollectorRegistry()
+    _add_db_session_metrics(registry, session_factory)
+
+    try:
+        with db(session_factory):
+            db.session.execute(text("DROP TABLE IF EXISTS test"))
+            db.session.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
+
+            # Put a breakpoint here and restart postgres server before continuing
+            assert _get_value(registry, "db_transactions_current") == 1
+    except Exception:
+        pass
+
+    # check that the DB transaction count is correctly decreased
+    assert _get_value(registry, "db_transactions_current") == 0
 
 
 def test_db_session_metrics():

--- a/tests/core/utils/test_db_session_middleware.py
+++ b/tests/core/utils/test_db_session_middleware.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2025, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+from dataclasses import dataclass
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.event import listens_for
+from sqlalchemy.orm import sessionmaker
+
+from antarest.core.utils.fastapi_sqlalchemy import db
+
+
+@dataclass
+class EventCounter:
+    transaction_start: int = 0
+    transaction_end: int = 0
+    begin: int = 0
+    rollback: int = 0
+    commit: int = 0
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    return sessionmaker(bind=engine)
+
+
+@pytest.fixture
+def events_counter(session_factory):
+    counter = EventCounter()
+
+    @listens_for(session_factory, "after_begin")
+    def after_begin(session, transaction, connection):
+        counter.begin = counter.begin + 1
+
+    @listens_for(session_factory, "after_rollback")
+    def after_rollback(session):
+        counter.rollback = counter.rollback + 1
+
+    @listens_for(session_factory, "after_commit")
+    def after_commit(session):
+        counter.commit = counter.commit + 1
+
+    @listens_for(session_factory, "after_transaction_create")
+    def on_transaction_start(session, transaction):
+        counter.transaction_start = counter.transaction_start + 1
+
+    @listens_for(session_factory, "after_transaction_end")
+    def on_transaction_end(session, transaction):
+        counter.transaction_end = counter.transaction_end + 1
+
+    return counter
+
+
+def test_db_session_is_rollbacked_on_exit(session_factory, events_counter):
+    # it's important that transactions are rollbacked on exit, otherwise some
+    # transactions can be seen as unclosed (in case an exception happens on close)
+
+    with db(session_factory):
+        db.session.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
+        assert events_counter.begin == 1
+        assert events_counter.transaction_start == 1
+
+    assert events_counter.transaction_end == 1
+    assert events_counter.rollback == 1
+    assert events_counter.commit == 0
+
+
+@pytest.mark.parametrize("commit_on_exit", [False, True])
+def test_db_session_is_rollbacked_on_exception(session_factory, events_counter, commit_on_exit):
+    with db(session_factory):
+        db.session.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
+        assert events_counter.begin == 1
+        assert events_counter.transaction_start == 1
+
+    assert events_counter.transaction_end == 1
+    assert events_counter.rollback == 1
+    assert events_counter.commit == 0
+
+
+def test_db_session_is_committed_on_autocommit(session_factory, events_counter):
+    with db(session_factory, commit_on_exit=True):
+        db.session.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
+        assert events_counter.begin == 1
+        assert events_counter.transaction_start == 1
+
+    assert events_counter.transaction_end == 1
+    assert events_counter.rollback == 0
+    assert events_counter.commit == 1

--- a/tests/matrixstore/test_service.py
+++ b/tests/matrixstore/test_service.py
@@ -82,11 +82,11 @@ class TestMatrixService:
         # A matrix object is stored in the database
         with db():
             obj = matrix_service.repo.get(matrix_id)
-        assert obj is not None, f"Missing Matrix object {matrix_id}"
-        assert obj.width == len(data[0])
-        assert obj.height == len(data)
-        now = current_time()
-        assert now - datetime.timedelta(seconds=1) <= obj.created_at <= now
+            assert obj is not None, f"Missing Matrix object {matrix_id}"
+            assert obj.width == len(data[0])
+            assert obj.height == len(data)
+            now = current_time()
+            assert now - datetime.timedelta(seconds=1) <= obj.created_at <= now
 
     def test_create__side_effect(self, matrix_service: MatrixService) -> None:
         """Creates a new matrix object with the specified data, but fail during saving."""
@@ -336,11 +336,11 @@ class TestMatrixService:
         # A matrix object is stored in the database
         with db():
             obj = matrix_service.repo.get(info.id)
-        assert obj is not None, f"Missing Matrix object {info.id}"
-        assert obj.width == matrix.shape[1]
-        assert obj.height == matrix.shape[0]
-        now = current_time()
-        assert now - datetime.timedelta(seconds=1) <= obj.created_at <= now
+            assert obj is not None, f"Missing Matrix object {info.id}"
+            assert obj.width == matrix.shape[1]
+            assert obj.height == matrix.shape[0]
+            now = current_time()
+            assert now - datetime.timedelta(seconds=1) <= obj.created_at <= now
 
     @pytest.mark.parametrize("content_type", ["application/json", "text/plain"])
     def test_create_by_importation__zip_file(self, matrix_service: MatrixService, content_type: str) -> None:
@@ -405,11 +405,11 @@ class TestMatrixService:
             # A matrix object is stored in the database
             with db():
                 obj = matrix_service.repo.get(info.id)
-            assert obj is not None, f"Missing Matrix object {info.id}"
-            assert obj.width == (matrix.shape[1] if matrix.size else 0)
-            assert obj.height == matrix.shape[0]
-            now = current_time()
-            assert now - datetime.timedelta(seconds=1) <= obj.created_at <= now
+                assert obj is not None, f"Missing Matrix object {info.id}"
+                assert obj.width == (matrix.shape[1] if matrix.size else 0)
+                assert obj.height == matrix.shape[0]
+                now = current_time()
+                assert now - datetime.timedelta(seconds=1) <= obj.created_at <= now
 
 
 def test_dataset_lifecycle() -> None:

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -790,13 +790,13 @@ class TestSnapshotGenerator:
             variant_study_service.repository.save(root_study)
         return root_study_id
 
-    @pytest.fixture(name="variant_study")
+    @pytest.fixture(name="variant_study_id")
     def variant_study_fixture(
         self,
         root_study_id: str,
         variant_study_service: VariantStudyService,
         jwt_user: JWTUser,
-    ) -> VariantStudy:
+    ) -> str:
         with db():
             # Create un new variant
             name = "my-variant"
@@ -825,7 +825,7 @@ class TestSnapshotGenerator:
                         ),
                     ],
                 )
-            return variant_study
+            return variant_study.id
 
     def test_init(self, variant_study_service: VariantStudyService) -> None:
         """
@@ -847,7 +847,9 @@ class TestSnapshotGenerator:
     @with_admin_user
     @with_db_context
     def test_generate__nominal_case(
-        self, variant_study: VariantStudy, variant_study_service: VariantStudyService
+        self,
+        variant_study_id: str,
+        variant_study_service: VariantStudyService,
     ) -> None:
         """
         Test the generation of a variant study based on a raw study.
@@ -880,7 +882,7 @@ class TestSnapshotGenerator:
 
         with DBStatementRecorder(db.session.bind) as db_recorder:
             results = generator.generate_snapshot(
-                variant_study.id,
+                variant_study_id,
                 denormalize=False,
                 from_scratch=False,
                 notifier=notifier,
@@ -929,6 +931,8 @@ class TestSnapshotGenerator:
         }
 
         # Check: the variant is correctly generated and all commands are applied.
+        variant_study = variant_study_service.repository.get(variant_study_id)
+        assert isinstance(variant_study, VariantStudy)
         snapshot_dir = variant_study.snapshot_dir
         assert snapshot_dir.exists()
         assert (snapshot_dir / "study.antares").exists()
@@ -980,12 +984,10 @@ class TestSnapshotGenerator:
         assert (snapshot_dir / "input/thermal/series/south/gas_cluster/series.txt.link").exists()
 
         # Check: the variant is updated in the database (snapshot and additional_data).
-        with db():
-            study = variant_study_service.repository.get(variant_study.id)
-            assert study is not None
-            assert study.snapshot is not None
-            assert study.snapshot.last_executed_command == study.commands[-1].id
-            assert study.additional_data.author == "john.doe"
+        assert variant_study is not None
+        assert variant_study.snapshot is not None
+        assert variant_study.snapshot.last_executed_command == variant_study.commands[-1].id
+        assert variant_study.additional_data.author == "john.doe"
 
         # Check: the cache is updated with the new variant configuration.
         # The cache is a mock created in the session's scope, so it is shared between all tests.
@@ -1041,7 +1043,7 @@ class TestSnapshotGenerator:
     @with_admin_user
     @with_db_context
     def test_generate__with_denormalize_true(
-        self, variant_study: VariantStudy, variant_study_service: VariantStudyService
+        self, variant_study_id: str, variant_study_service: VariantStudyService
     ) -> None:
         """
         Test the generation of a variant study with matrices de-normalization.
@@ -1056,7 +1058,7 @@ class TestSnapshotGenerator:
         )
 
         results = generator.generate_snapshot(
-            variant_study.id,
+            variant_study_id,
             denormalize=True,
             from_scratch=False,
         )
@@ -1095,6 +1097,8 @@ class TestSnapshotGenerator:
 
         # Check: the matrices are denormalized (we should have TSV files).
         # The matrices should be empty as they are default ones for the Simulator.
+        variant_study = variant_study_service.repository.get(variant_study_id)
+        assert isinstance(variant_study, VariantStudy)
         snapshot_dir = variant_study.snapshot_dir
         assert (snapshot_dir / "input/links/north/south_parameters.txt").exists()
         array = np.loadtxt(snapshot_dir / "input/links/north/south_parameters.txt", delimiter="\t")
@@ -1107,7 +1111,7 @@ class TestSnapshotGenerator:
     @with_admin_user
     @with_db_context
     def test_generate__with_invalid_command(
-        self, variant_study: VariantStudy, variant_study_service: VariantStudyService
+        self, variant_study_id: str, variant_study_service: VariantStudyService
     ) -> None:
         """
         Test the generation of a variant study with an invalid command.
@@ -1115,9 +1119,12 @@ class TestSnapshotGenerator:
         The snapshot directory must be removed (and no temporary directory must be left).
         """
         # Append an invalid command to the variant study.
+        variant_study = variant_study_service.repository.get(variant_study_id)
+        assert isinstance(variant_study, VariantStudy)
+
         study_version = StudyVersion.parse(variant_study.version)
         variant_study_service.append_commands(
-            variant_study.id,
+            variant_study_id,
             [
                 CommandDTO(action="create_area", args={"area_name": "North"}, study_version=study_version),  # duplicate
             ],
@@ -1154,7 +1161,7 @@ class TestSnapshotGenerator:
     @with_db_context
     def test_generate__notification_failure(
         self,
-        variant_study: VariantStudy,
+        variant_study_id: str,
         variant_study_service: VariantStudyService,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
@@ -1174,7 +1181,7 @@ class TestSnapshotGenerator:
 
         with caplog.at_level(logging.WARNING):
             results = generator.generate_snapshot(
-                variant_study.id,
+                variant_study_id,
                 denormalize=False,
                 from_scratch=False,
                 notifier=notifier,
@@ -1219,7 +1226,7 @@ class TestSnapshotGenerator:
     @with_db_context
     def test_generate__variant_of_variant(
         self,
-        variant_study: VariantStudy,
+        variant_study_id: str,
         variant_study_service: VariantStudyService,
     ) -> None:
         """
@@ -1235,13 +1242,13 @@ class TestSnapshotGenerator:
 
         # Generate the variant once.
         generator.generate_snapshot(
-            variant_study.id,
+            variant_study_id,
             denormalize=False,
             from_scratch=False,
         )
 
         # Create a new variant of the variant study
-        new_variant = variant_study_service.create_variant_study(variant_study.id, "my-variant")
+        new_variant = variant_study_service.create_variant_study(variant_study_id, "my-variant")
 
         # Append some commands to the new variant.
         study_version = StudyVersion.parse(new_variant.version)
@@ -1275,9 +1282,7 @@ class TestSnapshotGenerator:
 
     @with_admin_user
     @with_db_context
-    def test_generate_invalidate_cache(
-        self, variant_study_service: VariantStudyService, variant_study: VariantStudy
-    ) -> None:
+    def test_generate_invalidate_cache(self, variant_study_service: VariantStudyService, variant_study_id: str) -> None:
         cache = LocalCache()
         variant_study_service.cache = cache
         generator = SnapshotGenerator(
@@ -1289,19 +1294,19 @@ class TestSnapshotGenerator:
         )
 
         # Fill the cache for the test.
-        study = db.session.query(VariantStudy).get(variant_study.id)  #  `variant_study` isn't bound to the session yet.
+        study = db.session.query(VariantStudy).get(variant_study_id)  #  `variant_study` isn't bound to the session yet.
         study_interface = VariantStudyInterface(variant_study_service, study)
         file_study = study_interface.get_files()
         data = FileStudyTreeConfigDTO.from_build_config(file_study.config).model_dump()
-        update_cache(cache, variant_study.id, data)
+        update_cache(cache, variant_study_id, data)
 
         # Checks the cache content
-        cache_key = f"{CacheConstants.STUDY_FACTORY}/{variant_study.id}"
+        cache_key = f"{CacheConstants.STUDY_FACTORY}/{variant_study_id}"
         assert cache.get(cache_key) is not None
         starting_cache = cache.get(cache_key)
         assert starting_cache is not None
         # Generates the snapshot
-        results = generator.generate_snapshot(variant_study.id, denormalize=False)
+        results = generator.generate_snapshot(variant_study_id, denormalize=False)
         # Ensures we shouldn't have to invalidate the cache as all commands updated the config correctly
         assert not results.should_invalidate_cache
         generated_cache = cache.get(cache_key)
@@ -1310,9 +1315,10 @@ class TestSnapshotGenerator:
         assert generated_cache == starting_cache
 
         # Add a `create_cluster` command
+        variant_study = variant_study_service.repository.get(variant_study_id)
         version = StudyVersion.parse(variant_study.version)
         variant_study_service.append_commands(
-            variant_study.id,
+            variant_study_id,
             [
                 CommandDTO(
                     action="create_cluster",
@@ -1323,7 +1329,7 @@ class TestSnapshotGenerator:
         )
 
         # Generates the snapshot
-        results = generator.generate_snapshot(variant_study.id, denormalize=False)
+        results = generator.generate_snapshot(variant_study_id, denormalize=False)
         # Ensures we shouldn't have to invalidate the cache as the `create cluster` command updated the config correctly
         assert not results.should_invalidate_cache
         # Ensures the cache was modified accordingly
@@ -1334,7 +1340,7 @@ class TestSnapshotGenerator:
 
         # Add an `update_config` command
         variant_study_service.append_commands(
-            variant_study.id,
+            variant_study_id,
             [
                 CommandDTO(
                     action="update_config",
@@ -1347,7 +1353,7 @@ class TestSnapshotGenerator:
             ],
         )
 
-        results = generator.generate_snapshot(variant_study.id, denormalize=False)
+        results = generator.generate_snapshot(variant_study_id, denormalize=False)
         # Ensures we have to invalidate the cache as the `update_config` command couldn't (it's too generic)
         assert results.should_invalidate_cache
         assert cache.get(cache_key) is None


### PR DESCRIPTION

Currently, we don't explicitly rollback transactions before closing the session.

This does not make the behaviour very clear, and in particular it causes some
transactions to be incorrectly seen as "unclosed", when an exception occurs at
closing time.
This results, in prod env, in wrong metrics for "current transactions".

The new behaviour is to always explicitly either commit or rollback the current
transaction before closing the session. slqalchemy seems to hand errors at
rollback time better than errors at closing time.