### PR TITLE
chore(logging): log server errors with request or task context

### DIFF
--- a/antarest/core/logging/utils.py
+++ b/antarest/core/logging/utils.py
@@ -179,7 +179,13 @@ class LoggingMiddleware(BaseHTTPMiddleware):
     @override
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         with RequestContext(request):
-            response = await call_next(request)
+            try:
+                response = await call_next(request)
+            except Exception as exc:
+                # Logging here and not in outer exception handler, so that we get the request context
+                # into the logs. Otherwise, the log will not get the proper trace_id, in particular.
+                logger.error("Unexpected Exception", exc_info=exc)
+                raise
         return response
 
 

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -466,81 +466,81 @@ class TaskJobService(ITaskService):
                 for listener in self._listeners:
                     listener.on_task_start(task_id, task_type)
 
-                    # attention: this function is executed in a thread, not in the main process
-                    with db():
-                        # Important to keep this retry for now,
-                        # in case commit is not visible (read from replica ...)
-                        task = retry(lambda: self.repo.get_or_raise(task_id))
-                        study_id = task.ref_id
+                # attention: this function is executed in a thread, not in the main process
+                with db():
+                    # Important to keep this retry for now,
+                    # in case commit is not visible (read from replica ...)
+                    task = retry(lambda: self.repo.get_or_raise(task_id))
+                    study_id = task.ref_id
 
-                    self.event_bus.push(
-                        Event(
-                            type=EventType.TASK_RUNNING,
-                            payload=TaskEventPayload(
-                                id=task_id,
-                                message=(
-                                    custom_event_messages.running
-                                    if custom_event_messages is not None
-                                    else f"Task {task_id} is running"
-                                ),
-                                type=task_type,
-                                study_id=study_id,
-                            ).model_dump(),
-                            permissions=PermissionInfo(public_mode=PublicMode.READ),
-                            channel=EventChannelDirectory.TASK + task_id,
+                self.event_bus.push(
+                    Event(
+                        type=EventType.TASK_RUNNING,
+                        payload=TaskEventPayload(
+                            id=task_id,
+                            message=(
+                                custom_event_messages.running
+                                if custom_event_messages is not None
+                                else f"Task {task_id} is running"
+                            ),
+                            type=task_type,
+                            study_id=study_id,
+                        ).model_dump(),
+                        permissions=PermissionInfo(public_mode=PublicMode.READ),
+                        channel=EventChannelDirectory.TASK + task_id,
+                    )
+                )
+
+                logger.info(f"Starting task {task_id}")
+                with db():
+                    stmt = update(TaskJob).where(TaskJob.id == task_id).values(status=TaskStatus.RUNNING.value)
+                    db.session.execute(stmt)
+                    db.session.commit()
+                logger.info(f"Task {task_id} set to RUNNING")
+
+                with db():
+                    # We must use the DB session attached to the current thread
+                    result = callback(TaskLogAndProgressRecorder(task_id, db.session, self.event_bus))
+
+                status = TaskStatus.COMPLETED if result.success else TaskStatus.FAILED
+                logger.info(f"Task {task_id} ended with status {status}")
+
+                with db():
+                    # Do not use the `timezone.utc` timezone to preserve a naive datetime.
+                    completion_date = current_time() if status.is_final() else None
+                    stmt = (
+                        update(TaskJob)
+                        .where(TaskJob.id == task_id)
+                        .values(
+                            status=status.value,
+                            result_msg=result.message,
+                            result_status=result.success,
+                            result=result.return_value,
+                            completion_date=completion_date,
                         )
                     )
+                    db.session.execute(stmt)
+                    db.session.commit()
 
-                    logger.info(f"Starting task {task_id}")
-                    with db():
-                        stmt = update(TaskJob).where(TaskJob.id == task_id).values(status=TaskStatus.RUNNING.value)
-                        db.session.execute(stmt)
-                        db.session.commit()
-                    logger.info(f"Task {task_id} set to RUNNING")
-
-                    with db():
-                        # We must use the DB session attached to the current thread
-                        result = callback(TaskLogAndProgressRecorder(task_id, db.session, self.event_bus))
-
-                    status = TaskStatus.COMPLETED if result.success else TaskStatus.FAILED
-                    logger.info(f"Task {task_id} ended with status {status}")
-
-                    with db():
-                        # Do not use the `timezone.utc` timezone to preserve a naive datetime.
-                        completion_date = current_time() if status.is_final() else None
-                        stmt = (
-                            update(TaskJob)
-                            .where(TaskJob.id == task_id)
-                            .values(
-                                status=status.value,
-                                result_msg=result.message,
-                                result_status=result.success,
-                                result=result.return_value,
-                                completion_date=completion_date,
-                            )
-                        )
-                        db.session.execute(stmt)
-                        db.session.commit()
-
-                    event_type = {True: EventType.TASK_COMPLETED, False: EventType.TASK_FAILED}[result.success]
-                    event_msg = {True: "completed", False: "failed"}[result.success]
-                    self.event_bus.push(
-                        Event(
-                            type=event_type,
-                            payload=TaskEventPayload(
-                                id=task_id,
-                                message=(
-                                    custom_event_messages.end
-                                    if custom_event_messages is not None
-                                    else f"Task {task_id} {event_msg}"
-                                ),
-                                type=task_type,
-                                study_id=study_id,
-                            ).model_dump(),
-                            permissions=PermissionInfo(public_mode=PublicMode.READ),
-                            channel=EventChannelDirectory.TASK + task_id,
-                        )
+                event_type = {True: EventType.TASK_COMPLETED, False: EventType.TASK_FAILED}[result.success]
+                event_msg = {True: "completed", False: "failed"}[result.success]
+                self.event_bus.push(
+                    Event(
+                        type=event_type,
+                        payload=TaskEventPayload(
+                            id=task_id,
+                            message=(
+                                custom_event_messages.end
+                                if custom_event_messages is not None
+                                else f"Task {task_id} {event_msg}"
+                            ),
+                            type=task_type,
+                            study_id=study_id,
+                        ).model_dump(),
+                        permissions=PermissionInfo(public_mode=PublicMode.READ),
+                        channel=EventChannelDirectory.TASK + task_id,
                     )
+                )
             except Exception as exc:
                 err_msg = f"Task {task_id} failed: Unhandled exception {exc}"
                 logger.error(err_msg, exc_info=exc)

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -460,129 +460,129 @@ class TaskJobService(ITaskService):
     ) -> None:
         # We need to catch all exceptions so that the calling thread is guaranteed
         # to not die
-        try:
-            status = TaskStatus.FAILED
-            for listener in self._listeners:
-                listener.on_task_start(task_id, task_type)
-
-            # attention: this function is executed in a thread, not in the main process
-            with task_context(task_id=task_id, user=jwt_user):
-                with db():
-                    # Important to keep this retry for now,
-                    # in case commit is not visible (read from replica ...)
-                    task = retry(lambda: self.repo.get_or_raise(task_id))
-                    study_id = task.ref_id
-
-                self.event_bus.push(
-                    Event(
-                        type=EventType.TASK_RUNNING,
-                        payload=TaskEventPayload(
-                            id=task_id,
-                            message=(
-                                custom_event_messages.running
-                                if custom_event_messages is not None
-                                else f"Task {task_id} is running"
-                            ),
-                            type=task_type,
-                            study_id=study_id,
-                        ).model_dump(),
-                        permissions=PermissionInfo(public_mode=PublicMode.READ),
-                        channel=EventChannelDirectory.TASK + task_id,
-                    )
-                )
-
-                logger.info(f"Starting task {task_id}")
-                with db():
-                    stmt = update(TaskJob).where(TaskJob.id == task_id).values(status=TaskStatus.RUNNING.value)
-                    db.session.execute(stmt)
-                    db.session.commit()
-                logger.info(f"Task {task_id} set to RUNNING")
-
-                with db():
-                    # We must use the DB session attached to the current thread
-                    result = callback(TaskLogAndProgressRecorder(task_id, db.session, self.event_bus))
-
-                status = TaskStatus.COMPLETED if result.success else TaskStatus.FAILED
-                logger.info(f"Task {task_id} ended with status {status}")
-
-                with db():
-                    # Do not use the `timezone.utc` timezone to preserve a naive datetime.
-                    completion_date = current_time() if status.is_final() else None
-                    stmt = (
-                        update(TaskJob)
-                        .where(TaskJob.id == task_id)
-                        .values(
-                            status=status.value,
-                            result_msg=result.message,
-                            result_status=result.success,
-                            result=result.return_value,
-                            completion_date=completion_date,
-                        )
-                    )
-                    db.session.execute(stmt)
-                    db.session.commit()
-
-                event_type = {True: EventType.TASK_COMPLETED, False: EventType.TASK_FAILED}[result.success]
-                event_msg = {True: "completed", False: "failed"}[result.success]
-                self.event_bus.push(
-                    Event(
-                        type=event_type,
-                        payload=TaskEventPayload(
-                            id=task_id,
-                            message=(
-                                custom_event_messages.end
-                                if custom_event_messages is not None
-                                else f"Task {task_id} {event_msg}"
-                            ),
-                            type=task_type,
-                            study_id=study_id,
-                        ).model_dump(),
-                        permissions=PermissionInfo(public_mode=PublicMode.READ),
-                        channel=EventChannelDirectory.TASK + task_id,
-                    )
-                )
-        except Exception as exc:
-            err_msg = f"Task {task_id} failed: Unhandled exception {exc}"
-            logger.error(err_msg, exc_info=exc)
-
+        with task_context(task_id=task_id, user=jwt_user):
             try:
-                with db():
-                    stmt = (
-                        update(TaskJob)
-                        .where(TaskJob.id == task_id)
-                        .values(
-                            status=TaskStatus.FAILED.value,
-                            result_msg=str(exc),
-                            result_status=False,
-                            completion_date=current_time(),
+                status = TaskStatus.FAILED
+                for listener in self._listeners:
+                    listener.on_task_start(task_id, task_type)
+
+                    # attention: this function is executed in a thread, not in the main process
+                    with db():
+                        # Important to keep this retry for now,
+                        # in case commit is not visible (read from replica ...)
+                        task = retry(lambda: self.repo.get_or_raise(task_id))
+                        study_id = task.ref_id
+
+                    self.event_bus.push(
+                        Event(
+                            type=EventType.TASK_RUNNING,
+                            payload=TaskEventPayload(
+                                id=task_id,
+                                message=(
+                                    custom_event_messages.running
+                                    if custom_event_messages is not None
+                                    else f"Task {task_id} is running"
+                                ),
+                                type=task_type,
+                                study_id=study_id,
+                            ).model_dump(),
+                            permissions=PermissionInfo(public_mode=PublicMode.READ),
+                            channel=EventChannelDirectory.TASK + task_id,
                         )
                     )
-                    db.session.execute(stmt)
-                    db.session.commit()
 
-                message = err_msg if custom_event_messages is None else custom_event_messages.end
-                self.event_bus.push(
-                    Event(
-                        type=EventType.TASK_FAILED,
-                        payload=TaskEventPayload(
-                            id=task_id, message=message, type=task_type, study_id=study_id
-                        ).model_dump(),
-                        permissions=PermissionInfo(public_mode=PublicMode.READ),
-                        channel=EventChannelDirectory.TASK + task_id,
+                    logger.info(f"Starting task {task_id}")
+                    with db():
+                        stmt = update(TaskJob).where(TaskJob.id == task_id).values(status=TaskStatus.RUNNING.value)
+                        db.session.execute(stmt)
+                        db.session.commit()
+                    logger.info(f"Task {task_id} set to RUNNING")
+
+                    with db():
+                        # We must use the DB session attached to the current thread
+                        result = callback(TaskLogAndProgressRecorder(task_id, db.session, self.event_bus))
+
+                    status = TaskStatus.COMPLETED if result.success else TaskStatus.FAILED
+                    logger.info(f"Task {task_id} ended with status {status}")
+
+                    with db():
+                        # Do not use the `timezone.utc` timezone to preserve a naive datetime.
+                        completion_date = current_time() if status.is_final() else None
+                        stmt = (
+                            update(TaskJob)
+                            .where(TaskJob.id == task_id)
+                            .values(
+                                status=status.value,
+                                result_msg=result.message,
+                                result_status=result.success,
+                                result=result.return_value,
+                                completion_date=completion_date,
+                            )
+                        )
+                        db.session.execute(stmt)
+                        db.session.commit()
+
+                    event_type = {True: EventType.TASK_COMPLETED, False: EventType.TASK_FAILED}[result.success]
+                    event_msg = {True: "completed", False: "failed"}[result.success]
+                    self.event_bus.push(
+                        Event(
+                            type=event_type,
+                            payload=TaskEventPayload(
+                                id=task_id,
+                                message=(
+                                    custom_event_messages.end
+                                    if custom_event_messages is not None
+                                    else f"Task {task_id} {event_msg}"
+                                ),
+                                type=task_type,
+                                study_id=study_id,
+                            ).model_dump(),
+                            permissions=PermissionInfo(public_mode=PublicMode.READ),
+                            channel=EventChannelDirectory.TASK + task_id,
+                        )
                     )
-                )
-            except Exception as inner_exc:
-                logger.error(
-                    f"An exception occurred while handling execution error of task {task_id}: {inner_exc}",
-                    exc_info=inner_exc,
-                )
-        finally:
-            for listener in self._listeners:
-                listener.on_task_end(task_id, task_type, status)
+            except Exception as exc:
+                err_msg = f"Task {task_id} failed: Unhandled exception {exc}"
+                logger.error(err_msg, exc_info=exc)
 
-            # Task has been updated in database, we can safely remove it from running tasks
-            if task_id in self.tasks:
-                del self.tasks[task_id]
+                try:
+                    with db():
+                        stmt = (
+                            update(TaskJob)
+                            .where(TaskJob.id == task_id)
+                            .values(
+                                status=TaskStatus.FAILED.value,
+                                result_msg=str(exc),
+                                result_status=False,
+                                completion_date=current_time(),
+                            )
+                        )
+                        db.session.execute(stmt)
+                        db.session.commit()
+
+                    message = err_msg if custom_event_messages is None else custom_event_messages.end
+                    self.event_bus.push(
+                        Event(
+                            type=EventType.TASK_FAILED,
+                            payload=TaskEventPayload(
+                                id=task_id, message=message, type=task_type, study_id=study_id
+                            ).model_dump(),
+                            permissions=PermissionInfo(public_mode=PublicMode.READ),
+                            channel=EventChannelDirectory.TASK + task_id,
+                        )
+                    )
+                except Exception as inner_exc:
+                    logger.error(
+                        f"An exception occurred while handling execution error of task {task_id}: {inner_exc}",
+                        exc_info=inner_exc,
+                    )
+            finally:
+                for listener in self._listeners:
+                    listener.on_task_end(task_id, task_type, status)
+
+                # Task has been updated in database, we can safely remove it from running tasks
+                if task_id in self.tasks:
+                    del self.tasks[task_id]
 
     def get_task_progress(self, task_id: str) -> Optional[int]:
         task = self.repo.get_or_raise(task_id)

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -180,7 +180,9 @@ def add_exception_handlers(application: FastAPI) -> None:
         Returns:
             The JSON response containing error details.
         """
-        logger.error("Unexpected Exception", exc_info=exc)
+
+        # Note: we don't log here, because the exception is supposed to be already logged by the logging
+        # middleware, with more context
         return JSONResponse(
             content={
                 "description": f"Unexpected server error: {exc}",

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -235,8 +235,6 @@ def fastapi_app(
     # So we manually instantiate it here.
     DBSessionMiddleware(None, custom_engine=engine, session_args=cast(Dict[str, bool], SESSION_ARGS))
 
-    application.add_middleware(LoggingMiddleware)
-
     # TODO move that elsewhere
     @AuthJWT.load_config  # type: ignore
     def get_config() -> JwtSettings:
@@ -290,6 +288,10 @@ def fastapi_app(
         @application.get("/", include_in_schema=False)
         def home(request: Request) -> Any:
             return ""
+
+    # It's important to add the logging middleware last, so that any log written or exception thrown
+    # by inner middlewares are correctly logged with the context of the request.
+    application.add_middleware(LoggingMiddleware)
 
     return application, services
 


### PR DESCRIPTION
Moves the logging of generic exceptions to the logging middleware.

Currently, they are logged by the exception handler, which is executed **after** the logging
middleware, this without any request context. In particular, when we look for logs of a
particular request, we don't get those error logs, which is very inconvenient.

With that PR, we will correctly get the logs from those errors with the trace_id of the request.

The PR also ensures tasks exceptions are logged in the task context, to get the proper task_id.