### PR TITLE
fix(db): remove nested sessions

### DIFF
--- a/antarest/study/business/output/variables_management.py
+++ b/antarest/study/business/output/variables_management.py
@@ -395,43 +395,42 @@ def get_output_view_inside_db(
     frequency: MatrixFrequency,
     output_identifier: OutputIdentifier,
 ) -> OutputVariablesViewsModel | None:
-    with db():
-        q = db.session.query(OutputVariablesViewsModel)
-        q = q.filter(OutputVariablesViewsModel.study_id == study_id)
-        q = q.filter(OutputVariablesViewsModel.output_id == output_id)
-        q = q.filter(OutputVariablesViewsModel.type == variable_type)
-        q = q.filter(OutputVariablesViewsModel.frequency == frequency)
-        q = q.filter(OutputVariablesViewsModel.variable_name == variable_name)
+    q = db.session.query(OutputVariablesViewsModel)
+    q = q.filter(OutputVariablesViewsModel.study_id == study_id)
+    q = q.filter(OutputVariablesViewsModel.output_id == output_id)
+    q = q.filter(OutputVariablesViewsModel.type == variable_type)
+    q = q.filter(OutputVariablesViewsModel.frequency == frequency)
+    q = q.filter(OutputVariablesViewsModel.variable_name == variable_name)
 
-        match output_identifier:
-            case AreaOutputIdentifier():
-                filters = [(OutputVariablesViewsModel.area_id, output_identifier.get_id_for_aggregation())]
-            case ThermalClusterOutputIdentifier():
-                filters = [(OutputVariablesViewsModel.area_id, output_identifier.get_id_for_aggregation())]
-                sub_id = output_identifier.get_sub_id_for_aggregation()
-                assert sub_id is not None
-                filters.append((OutputVariablesViewsModel.thermal_id, sub_id))
-            case RenewableClusterOutputIdentifier():
-                filters = [(OutputVariablesViewsModel.area_id, output_identifier.get_id_for_aggregation())]
-                sub_id = output_identifier.get_sub_id_for_aggregation()
-                assert sub_id is not None
-                filters.append((OutputVariablesViewsModel.renewable_id, sub_id))
-            case ShortTermStorageOutputIdentifier():
-                filters = [(OutputVariablesViewsModel.area_id, output_identifier.get_id_for_aggregation())]
-                sub_id = output_identifier.get_sub_id_for_aggregation()
-                assert sub_id is not None
-                filters.append((OutputVariablesViewsModel.st_storage_id, sub_id))
-            case LinkOutputIdentifier():
-                area_from_id, area_to_id = output_identifier.get_id_for_aggregation().split(" - ")
-                filters = [(OutputVariablesViewsModel.area_from_id, area_from_id)]
-                filters.append((OutputVariablesViewsModel.area_to_id, area_to_id))
-            case _:
-                raise NotImplementedError(f"output identifier `{output_identifier.__class__}` is not implemented")
+    match output_identifier:
+        case AreaOutputIdentifier():
+            filters = [(OutputVariablesViewsModel.area_id, output_identifier.get_id_for_aggregation())]
+        case ThermalClusterOutputIdentifier():
+            filters = [(OutputVariablesViewsModel.area_id, output_identifier.get_id_for_aggregation())]
+            sub_id = output_identifier.get_sub_id_for_aggregation()
+            assert sub_id is not None
+            filters.append((OutputVariablesViewsModel.thermal_id, sub_id))
+        case RenewableClusterOutputIdentifier():
+            filters = [(OutputVariablesViewsModel.area_id, output_identifier.get_id_for_aggregation())]
+            sub_id = output_identifier.get_sub_id_for_aggregation()
+            assert sub_id is not None
+            filters.append((OutputVariablesViewsModel.renewable_id, sub_id))
+        case ShortTermStorageOutputIdentifier():
+            filters = [(OutputVariablesViewsModel.area_id, output_identifier.get_id_for_aggregation())]
+            sub_id = output_identifier.get_sub_id_for_aggregation()
+            assert sub_id is not None
+            filters.append((OutputVariablesViewsModel.st_storage_id, sub_id))
+        case LinkOutputIdentifier():
+            area_from_id, area_to_id = output_identifier.get_id_for_aggregation().split(" - ")
+            filters = [(OutputVariablesViewsModel.area_from_id, area_from_id)]
+            filters.append((OutputVariablesViewsModel.area_to_id, area_to_id))
+        case _:
+            raise NotImplementedError(f"output identifier `{output_identifier.__class__}` is not implemented")
 
-        for column, value in filters:
-            q = q.filter(column == value)
+    for column, value in filters:
+        q = q.filter(column == value)
 
-        return q.scalar()  # type: ignore
+    return q.scalar()  # type: ignore
 
 
 def create_output_view_db_model(

--- a/antarest/study/storage/output_service.py
+++ b/antarest/study/storage/output_service.py
@@ -140,18 +140,17 @@ class OutputVariablesViewMaterializationTask:
 
         dataframe.index = pd.RangeIndex(len(dataframe))  # matrix-store does not support dataframes with specific index
         matrix_id = self._output_service._matrix_service.create(dataframe)
-        with db():
-            db_model = create_output_view_db_model(
-                self._study_id,
-                self._output_id,
-                self._variable_type,
-                self._variable_name,
-                self._frequency,
-                self._output_identifier,
-                matrix_id,
-            )
-            db.session.add(db_model)
-            db.session.commit()
+        db_model = create_output_view_db_model(
+            self._study_id,
+            self._output_id,
+            self._variable_type,
+            self._variable_name,
+            self._frequency,
+            self._output_identifier,
+            matrix_id,
+        )
+        db.session.add(db_model)
+        db.session.commit()
 
     def run_task(self, notifier: ITaskNotifier) -> TaskResult:
         msg = f"Materializing output variables view for study '{self._study_id}' and output '{self._output_id}'"
@@ -721,20 +720,18 @@ class OutputService:
         study = self._study_service.get_study(study_id)
         assert_permission(study, StudyPermissionType.READ)
 
-        with db():
-            output_variables: OutputVariables | None = db.session.get(OutputVariables, (study_id, output_id))
-            if output_variables:
-                return output_variables.to_model()
+        output_variables: OutputVariables | None = db.session.get(OutputVariables, (study_id, output_id))
+        if output_variables:
+            return output_variables.to_model()
 
         # Fetches the data inside the FS
         output_path = self._storage.get_output_path(study, output_id)
         model = extract_variables_list(output_path)
 
         # Save the model inside DB for next calls
-        with db():
-            db_model = OutputVariables.from_model(study_id, output_id, model)
-            db.session.add(db_model)
-            db.session.commit()
+        db_model = OutputVariables.from_model(study_id, output_id, model)
+        db.session.add(db_model)
+        db.session.commit()
 
         # Returns it
         return model
@@ -781,9 +778,10 @@ class OutputService:
         if db_model is not None:
             # Update `last_read` value inside DB
             db_model.last_read = current_time()
-            with db():
-                db.session.merge(db_model)
-                db.session.commit()
+            db.session.merge(db_model)
+            db.session.commit()
+            db.session.refresh(db_model)
+
             # Return the view
             dataframe = self._matrix_service.get(db_model.matrix_id)
             output_view = get_view_from_dataframe(dataframe, variable_name)

--- a/antarest/study/storage/output_service.py
+++ b/antarest/study/storage/output_service.py
@@ -780,7 +780,6 @@ class OutputService:
             db_model.last_read = current_time()
             db.session.merge(db_model)
             db.session.commit()
-            db.session.refresh(db_model)
 
             # Return the view
             dataframe = self._matrix_service.get(db_model.matrix_id)

--- a/tests/storage/integration/test_STA_mini.py
+++ b/tests/storage/integration/test_STA_mini.py
@@ -22,7 +22,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from fastapi import FastAPI
-from helpers import with_db_context
 from sqlalchemy import Engine
 from starlette.testclient import TestClient
 
@@ -39,7 +38,7 @@ from antarest.study.storage.output_model import OutputVariablesInformation
 from antarest.study.storage.output_service import OutputService
 from antarest.study.storage.rawstudy.model.filesystem.config.files import build
 from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
-from tests.helpers import assert_study, with_admin_user
+from tests.helpers import assert_study, with_admin_user, with_db_context
 from tests.storage.integration.conftest import UUID
 from tests.storage.integration.data.de_details_hourly import de_details_hourly
 from tests.storage.integration.data.de_fr_values_hourly import de_fr_values_hourly

--- a/tests/storage/integration/test_STA_mini.py
+++ b/tests/storage/integration/test_STA_mini.py
@@ -22,6 +22,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from fastapi import FastAPI
+from helpers import with_db_context
 from sqlalchemy import Engine
 from starlette.testclient import TestClient
 
@@ -648,6 +649,7 @@ def _add_study_in_db(output_service: OutputService) -> None:
 
 
 @with_admin_user
+@with_db_context
 def test_sta_mini_output_variables_nominal_case(output_service: OutputService) -> None:
     _add_study_in_db(output_service)
     variables = output_service.get_output_variables_information(UUID, "20201014-1422eco-hello")
@@ -705,6 +707,7 @@ def test_sta_mini_output_variables_nominal_case(output_service: OutputService) -
 
 
 @with_admin_user
+@with_db_context
 def test_sta_mini_output_variables_no_mc_ind(output_service: OutputService) -> None:
     _add_study_in_db(output_service)
     res = output_service.get_output_variables_information(UUID, "20201014-1427eco")
@@ -712,6 +715,7 @@ def test_sta_mini_output_variables_no_mc_ind(output_service: OutputService) -> N
 
 
 @with_admin_user
+@with_db_context
 def test_sta_mini_output_variables_no_links(output_service: OutputService) -> None:
     _add_study_in_db(output_service)
     study_path = Path(output_service._study_service.get_study(UUID).path)
@@ -723,6 +727,7 @@ def test_sta_mini_output_variables_no_links(output_service: OutputService) -> No
 
 
 @with_admin_user
+@with_db_context
 def test_sta_mini_output_variables_no_areas(output_service: OutputService) -> None:
     _add_study_in_db(output_service)
     study_path = Path(output_service._study_service.get_study(UUID).path)


### PR DESCRIPTION

Fixes CI on dev, which was broken by the change in sessions closing, which
now always rollbacks the connection.

It has revealed an issue in recent evolutions about output variables, which were
using nested sessions, and re-used objects from session to session.