### PR TITLE
feat(metrics,db): add select event type

### DIFF
--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -28,7 +28,7 @@ from prometheus_client import (
 )
 from sqlalchemy import Engine, Pool, PoolProxiedConnection
 from sqlalchemy.event import listens_for
-from sqlalchemy.orm import Session, SessionTransaction, sessionmaker
+from sqlalchemy.orm import ORMExecuteState, Session, SessionTransaction, sessionmaker
 from sqlalchemy.pool import ConnectionPoolEntry
 from starlette.requests import Request
 from typing_extensions import override
@@ -195,6 +195,11 @@ def _add_db_session_metrics(registry: CollectorRegistry, session_factory: sessio
         if "start_time" in session.info:
             transaction_duration_histo.labels(WORKER_ID).observe(time.time() - session.info["start_time"])
             del session.info["start_time"]
+
+    @listens_for(target, "do_orm_execute")
+    def on_select(orm_execute_state: ORMExecuteState) -> None:
+        if orm_execute_state.is_select:
+            events_counter.labels(WORKER_ID, "select").inc()
 
 
 def _add_metrics_middleware(registry: CollectorRegistry, application: FastAPI) -> None:

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -16,7 +16,7 @@ import pytest
 from fastapi import FastAPI
 from prometheus_client import CollectorRegistry, Metric
 from pydantic import BaseModel
-from sqlalchemy import QueuePool, create_engine, text
+from sqlalchemy import Column, Integer, MetaData, QueuePool, Table, create_engine, text
 from sqlalchemy.orm import sessionmaker
 from starlette.exceptions import HTTPException
 from starlette.testclient import TestClient
@@ -315,6 +315,8 @@ def test_db_transaction_is_closed_on_server_disconnect():
 
 
 def test_db_session_metrics():
+    metadata = MetaData()
+
     prometheus_client.disable_created_metrics()
     engine = create_engine("sqlite:///:memory:")
     session_factory = sessionmaker(bind=engine)
@@ -335,13 +337,19 @@ def test_db_session_metrics():
     assert _get_value(registry, "db_session_events", labels={"event_type": "rollback"}) is None
     assert _get_value(registry, "db_session_events", labels={"event_type": "commit"}) is None
 
+    table = Table("test", metadata, Column("id", Integer, primary_key=True))
+
     with session_factory() as session:
         session.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
         assert _get_value(registry, "db_session_events", labels={"event_type": "begin"}) == 1
         assert _get_value(registry, "db_session_events", labels={"event_type": "rollback"}) is None
         assert _get_value(registry, "db_session_events", labels={"event_type": "commit"}) is None
+        assert _get_value(registry, "db_session_events", labels={"event_type": "select"}) is None
         assert _get_value(registry, "db_transactions_current") == 1
         assert _get_histo_count(registry, "db_transactions_duration_seconds") is None
+
+        session.execute(table.select())
+        assert _get_value(registry, "db_session_events", labels={"event_type": "select"}) == 1
 
         session.rollback()
         assert _get_value(registry, "db_session_events", labels={"event_type": "begin"}) == 1


### PR DESCRIPTION

Just adds a counter for select queries.
Should allow to identify N+1 query issues in production, if we get some.