### PR TITLE
fix(alembic): merge alembic heads

### DIFF
--- a/alembic/versions/9770c0960334_merge_heads.py
+++ b/alembic/versions/9770c0960334_merge_heads.py
@@ -1,0 +1,21 @@
+"""merge study additional data removal and variables views creation
+
+Revision ID: 9770c0960334
+Revises: 9du891hc3051, fb5ad6c72ad4
+Create Date: 2025-11-27 15:35:02.892214
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "9770c0960334"
+down_revision = ("9du891hc3051", "fb5ad6c72ad4")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION

The removal of study_additional_data and the addition of output_variables_views
have created 2 separate alembic branches, this merges back the 2 branches.