### PR TITLE
fix(metrics): avoid arbitrary metrics creation

### DIFF
--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -222,19 +222,16 @@ def _add_metrics_middleware(registry: CollectorRegistry, application: FastAPI) -
     current_requests_gauge = Gauge(
         "http_requests_current",
         "Requests currently executing",
-        ["worker_id", "method", "endpoint"],
+        ["worker_id", "method"],
         multiprocess_mode="liveall",
         registry=registry,
     )
 
     @application.middleware("http")
     async def add_metrics(request: Request, call_next: Any) -> Any:
-        if "route" in request.scope:
-            request_path = request.scope["root_path"] + request.scope["route"].path
-        else:
-            request_path = request.url.path
-
-        current_requests_gauge.labels(WORKER_ID, request.method, request_path).inc()
+        # Unfortunately we cannot get the route here because it has not yet been determined by fastapi,
+        # so we only have a global gauge for all endpoints.
+        current_requests_gauge.labels(WORKER_ID, request.method).inc()
 
         start_time = time.time()
         status_code = None
@@ -247,12 +244,18 @@ def _add_metrics_middleware(registry: CollectorRegistry, application: FastAPI) -
             # except for "unhandled" exceptions, which are handled at the outermost level and translated to 500
             status_code = status_code or HTTPStatus.INTERNAL_SERVER_ERROR.value
 
+            if "route" in request.scope:
+                endpoint = request.scope["root_path"] + request.scope["route"].path
+            else:
+                # We avoid to create an arbitrary number of metrics, by using for example the request path
+                endpoint = "others"
+
             process_time = time.time() - start_time
 
-            current_requests_gauge.labels(WORKER_ID, request.method, request_path).dec()
+            current_requests_gauge.labels(WORKER_ID, request.method).dec()
 
-            request_counter.labels(WORKER_ID, request.method, request_path, status_code).inc()
-            request_duration_histo.labels(WORKER_ID, request.method, request_path, status_code).observe(process_time)
+            request_counter.labels(WORKER_ID, request.method, endpoint, status_code).inc()
+            request_duration_histo.labels(WORKER_ID, request.method, endpoint, status_code).observe(process_time)
         return response
 
 

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -383,8 +383,8 @@ def test_http_request_metrics() -> None:
 
     app = FastAPI()
 
-    @app.get("/ok")
-    def ok() -> None:
+    @app.get("/ok/{value}")
+    def ok(value: str) -> None:
         pass
 
     @app.get("/notfound")
@@ -404,10 +404,15 @@ def test_http_request_metrics() -> None:
     _add_metrics_middleware(registry=registry, application=app)
 
     client = TestClient(app, raise_server_exceptions=False)
-    res = client.get("/ok")
+    res = client.get("/ok/test")
     assert res.status_code == 200
 
-    assert _get_histo_count(registry, "http_requests_duration_seconds", labels={"http_status": "200"}) == 1
+    assert (
+        _get_histo_count(
+            registry, "http_requests_duration_seconds", labels={"http_status": "200", "endpoint": "/ok/{value}"}
+        )
+        == 1
+    )
 
     res = client.get("/error")
     assert res.status_code == 500
@@ -421,3 +426,14 @@ def test_http_request_metrics() -> None:
     res = client.post("/validation", json={"value": "invalid"})
     assert res.status_code == 422
     assert _get_histo_count(registry, "http_requests_duration_seconds", labels={"http_status": "422"}) == 1
+
+    res = client.get("/doesnotexist")
+    assert res.status_code == 404
+    assert (
+        _get_histo_count(
+            registry,
+            "http_requests_duration_seconds",
+            labels={"method": "GET", "endpoint": "others", "http_status": "404"},
+        )
+        == 1
+    )


### PR DESCRIPTION

The actual route is only resolved by fastapi after the first part of the middleware,
which makes it impossible to use for the http gauge metric, in particular.

Also, all requests that don't get a proper route will now be labelled with the 
"others" endpoint.

This will avoid to have an explosion of the cardinality of timeseries in prometheus.