### PR TITLE
perf(aggregation): use /variables endpoint to avoid having columns mismatch

### DIFF
--- a/antarest/study/business/output/variables_management.py
+++ b/antarest/study/business/output/variables_management.py
@@ -30,7 +30,14 @@ from antarest.study.business.output.utils import (
     normalize_df_column_names,
     parse_headers,
 )
-from antarest.study.storage.output_model import OutputVariablesList, OutputVariablesType, OutputVariablesViewsModel
+from antarest.study.storage.output_model import (
+    AreaVariables,
+    LinkVariables,
+    OutputVariablesList,
+    OutputVariablesType,
+    OutputVariablesViewsModel,
+    Variables,
+)
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
 
 
@@ -457,3 +464,53 @@ def create_output_view_db_model(
             raise NotImplementedError(f"output identifier `{output_identifier.__class__}` is not implemented")
 
     return model
+
+
+def _filter_link_variables(ids_to_consider: set[str], link_variables: list[LinkVariables]) -> set[str]:
+    final_variables: set[str] = set()
+    for var in link_variables:
+        if ids_to_consider and f"{var.area_1_name} - {var.area_2_name}" not in ids_to_consider:
+            continue
+        final_variables.update(var.variables)
+    return final_variables
+
+
+def _filter_area_variables(
+    ids_to_consider: set[str],
+    area_variables: list[AreaVariables],
+    query_file: MCIndAreasQueryFile | MCAllAreasQueryFile,
+) -> set[str]:
+    intermediate_dict: dict[str, dict[str, list[list[str]]]] = {}
+    for variable in area_variables:
+        intermediate_dict[variable.name] = {
+            MCIndAreasQueryFile.DETAILS.value: [v.variables for v in variable.thermal_clusters],
+            MCIndAreasQueryFile.DETAILS_RES.value: [v.variables for v in variable.renewable_clusters],
+            MCIndAreasQueryFile.DETAILS_ST_STORAGE.value: [v.variables for v in variable.short_term_storages],
+            MCIndAreasQueryFile.VALUES.value: [variable.variables],
+            MCAllAreasQueryFile.ID.value: [variable.variables],
+        }
+
+    area_ids = ids_to_consider if ids_to_consider else intermediate_dict.keys()
+    final_variables: set[str] = set()
+    for area_id in area_ids:
+        for var in intermediate_dict[area_id][query_file.value]:
+            final_variables.update(var)
+    return final_variables
+
+
+def get_available_variables(
+    variables_list: OutputVariablesList, query_file: QueryFileType, ids_to_consider: set[str]
+) -> Variables:
+    if isinstance(query_file, MCAllAreasQueryFile):
+        return list(_filter_area_variables(ids_to_consider, variables_list.mc_all.areas, query_file))
+
+    elif isinstance(query_file, MCAllLinksQueryFile):
+        return list(_filter_link_variables(ids_to_consider, variables_list.mc_all.links))
+
+    elif isinstance(query_file, MCIndAreasQueryFile):
+        return list(_filter_area_variables(ids_to_consider, variables_list.mc_ind.areas, query_file))
+
+    elif isinstance(query_file, MCIndLinksQueryFile):
+        return list(_filter_link_variables(ids_to_consider, variables_list.mc_ind.links))
+
+    raise NotImplementedError(f"QueryFile `{query_file.__class__}` is not implemented")

--- a/antarest/study/storage/output_service.py
+++ b/antarest/study/storage/output_service.py
@@ -19,6 +19,7 @@ from starlette.responses import FileResponse, Response
 
 from antarest.core.config import DEFAULT_WORKSPACE_NAME
 from antarest.core.exceptions import (
+    OutputAggregationError,
     OutputAlreadyArchived,
     OutputAlreadyUnarchived,
     OutputNotFound,
@@ -50,6 +51,7 @@ from antarest.study.business.output.variables_management import (
     check_output_variable_exists,
     create_output_view_db_model,
     extract_variables_list,
+    get_available_variables,
     get_output_view_inside_db,
 )
 from antarest.study.business.output.variables_matrix_usage_provider import OutputVariablesMatrixUsageProvider
@@ -663,12 +665,22 @@ class OutputService:
         study = self._study_service.get_study(uuid)
         assert_permission(study, StudyPermissionType.READ)
         output_path = self._storage.get_output_path(study, output_id)
+        # Fetch available variables for the given inputs
+        variables_list = self.get_output_variables_list(uuid, output_id)
+        available_variables = get_available_variables(variables_list, query_file, set(ids_to_consider))
+        # If any of the asked column names isn't available, raise immediately
+        for column in columns_names:
+            if column not in available_variables:
+                raise OutputAggregationError(output_id, f"The variable {column} does not exist for the given output.")
+        # Give the column names to the aggregator in advance.
+        # This way the aggregation won't generate dataframes with column mismatch.
+        final_columns = columns_names if columns_names else available_variables
         aggregator_manager = AggregatorManager(
             output_path,
             query_file,
             frequency,
             ids_to_consider,
-            columns_names,
+            final_columns,
             mc_years,
         )
 


### PR DESCRIPTION
We could use this `pl.scan_csv("data.csv").select(pl.col("^A.*$")).collect()` to fasten the reading performances when the user asks for specific columns (i.e. for the variables view endpoint) But it will not be very useful as we only perform the aggregation once, after this it's stored in DB.


TODO:
- Remove the columns mismatch related code
- Benchmark the performances
- Fix potential failing tests
- Add test for new behavior for wrong columns