### PR TITLE
chore(app): bump some backend dependencies

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/date_serializer.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/date_serializer.py
@@ -74,13 +74,13 @@ class HourlyMatrixSerializer(IDateMatrixSerializer):
         df_date = df.iloc[:, 2:5]
         df_date.columns = pd.Index(data=["day", "month", "hour"])
         df_date["month"] = df_date["month"].map(IDateMatrixSerializer._MONTHS)
-        date = df_date["month"].astype(str) + "/" + df_date["day"].astype(str).str.zfill(2) + " " + df_date["hour"]
+        date = df_date["month"].astype(str) + "/" + df_date["day"].astype(str).str.zfill(2) + " " + df_date["hour"]  # type: ignore
 
         # Extract right part with data
         to_remove = cast(Sequence[Hashable], df.columns[0:5])
         body = df.drop(to_remove, axis=1)
 
-        return pd.Index(date), body  # type: ignore
+        return pd.Index(date), body
 
 
 class DailyMatrixSerializer(IDateMatrixSerializer):
@@ -94,7 +94,7 @@ class DailyMatrixSerializer(IDateMatrixSerializer):
         df_date = df.iloc[:, 2:4]
         df_date.columns = pd.Index(["day", "month"])
         df_date["month"] = df_date["month"].map(IDateMatrixSerializer._MONTHS)
-        date: pd.Series[str] = df_date["month"].astype(str) + "/" + df_date["day"].astype(str).str.zfill(2)
+        date: pd.Series[str] = df_date["month"].astype(str) + "/" + df_date["day"].astype(str).str.zfill(2)  # type: ignore
 
         # Extract right part with data
         to_remove = cast(Sequence[Hashable], df.columns[0:4])

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
@@ -14,7 +14,6 @@ import logging
 from pathlib import Path
 from typing import Any, List, Optional, Union, cast
 
-import numpy as np
 import pandas as pd
 from pandas import DataFrame
 from typing_extensions import override

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
@@ -96,7 +96,7 @@ class OutputSeriesMatrix(LazyNode[Union[bytes, JSON], Union[bytes, JSON], JSON])
 
         rename_unnamed(body)
         matrix = body.astype(float)
-        matrix = matrix.where(pd.notna(matrix), None)
+        matrix = matrix.fillna(value=None)
         matrix.index = date
         matrix.columns = body.columns
         return matrix

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/output_series_matrix.py
@@ -14,6 +14,7 @@ import logging
 from pathlib import Path
 from typing import Any, List, Optional, Union, cast
 
+import numpy as np
 import pandas as pd
 from pandas import DataFrame
 from typing_extensions import override
@@ -96,7 +97,6 @@ class OutputSeriesMatrix(LazyNode[Union[bytes, JSON], Union[bytes, JSON], JSON])
 
         rename_unnamed(body)
         matrix = body.astype(float)
-        matrix = matrix.fillna(value=None)
         matrix.index = date
         matrix.columns = body.columns
         return matrix

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ pyinstaller-hooks-contrib==2024.8
 # IMPORTANT: Make sure the versions of these typing libraries match the versions
 # of the corresponding implementation libraries used in production (in `requirements.txt`).
 
-pandas-stubs~=2.2.3
+pandas-stubs~=2.3.3
 pyarrow-stubs~=20.0.0
 types-openpyxl~=3.1.5
 types-paramiko~=3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Antares-Launcher==1.4.6
 antares-study-version==1.0.20
-antares-timeseries-generation==0.1.8
+antares-timeseries-generation==0.1.9
 
 # When you install `fastapi[all]`, you get FastAPI along with additional dependencies:
 # - `uvicorn`: A fast ASGI server commonly used to run FastAPI applications.

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,10 +31,10 @@ humanize~=4.11.0
 jsonref~=0.2
 PyJWT~=2.9.0
 MarkupSafe~=2.0.1
-numpy~=1.26.4
+numpy~=2.3.5
 numexpr==2.13.1
 openpyxl~=3.1.5
-pandas~=2.2.3
+pandas~=2.3.3
 paramiko~=3.4.1
 plyer~=2.0.0
 polars~=1.35.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,6 @@ python-json-logger~=2.0.7
 PyYAML~=6.0.3
 redis~=6.4.0
 SQLAlchemy~=2.0.41
-tables==3.9.2
+tables==3.10.2
 typing_extensions~=4.15.0
 xlsxwriter~=3.2.0

--- a/tests/core/serde/test_parquet_writer.py
+++ b/tests/core/serde/test_parquet_writer.py
@@ -44,20 +44,20 @@ def test_different_columns(tmp_path: Path) -> None:
 
     # Ensures we kept the order we had in the iterator
     expected_first_df = pd.DataFrame(
-        data=[(1, 2, np.NaN, np.NaN), (3, 4, np.NaN, np.NaN)], columns=["A", "B", "C", "D"]
+        data=[(1, 2, np.nan, np.nan), (3, 4, np.nan, np.nan)], columns=["A", "B", "C", "D"]
     )
     pd.testing.assert_frame_equal(next(dfs), expected_first_df, check_dtype=False)
 
-    expected_second_df = pd.DataFrame(data=[(5, 6, 7, np.NaN), (8, 9, 10, np.NaN)], columns=["A", "B", "C", "D"])
+    expected_second_df = pd.DataFrame(data=[(5, 6, 7, np.nan), (8, 9, 10, np.nan)], columns=["A", "B", "C", "D"])
     pd.testing.assert_frame_equal(next(dfs), expected_second_df, check_dtype=False)
 
     expected_third_df = pd.DataFrame(
-        data=[(11, 12, np.NaN, np.NaN), (13, 14, np.NaN, np.NaN)], columns=["A", "B", "C", "D"]
+        data=[(11, 12, np.nan, np.nan), (13, 14, np.nan, np.nan)], columns=["A", "B", "C", "D"]
     )
     pd.testing.assert_frame_equal(next(dfs), expected_third_df, check_dtype=False)
 
     # values of A and B are correctly "inverted"
-    expected_fourth_df = pd.DataFrame(data=[(16, 15, np.NaN, 17), (19, 18, np.NaN, 20)], columns=["A", "B", "C", "D"])
+    expected_fourth_df = pd.DataFrame(data=[(16, 15, np.nan, 17), (19, 18, np.nan, 20)], columns=["A", "B", "C", "D"])
     pd.testing.assert_frame_equal(next(dfs), expected_fourth_df, check_dtype=False)
 
 

--- a/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_aggregate_raw_data.py
@@ -1046,6 +1046,6 @@ def test_columns_mismatch(tmp_path: Path, client: TestClient, user_access_token:
     actual_df = pd.read_parquet(content)
     expected_df = pd.DataFrame(
         columns=["area", "mcYear", "timeId", "CO2 EMIS."],
-        data=[["de", 1, 1, np.NaN], ["es", 1, 1, 0.0], ["fr", 1, 1, np.NaN]],
+        data=[["de", 1, 1, np.nan], ["es", 1, 1, 0.0], ["fr", 1, 1, np.nan]],
     )
     pd.testing.assert_frame_equal(actual_df, expected_df)


### PR DESCRIPTION
- **pandas**: 2.2.3 -> 2.3.3
- **numpy**: 1.26.4 -> 2.3.5 (numpy stopped releasing v1.x since almost 2 years)
- **tables**: 3.9.2 -> 3.10.2 (to support numpy v2)
- **antares-timeseries-generation:** 0.1.8 -> 0.1.9 (to support numpy v2)