### PR TITLE
fix(matrix-gc): don't clean variant used matrices in a limit case

### DIFF
--- a/antarest/study/storage/rawstudy/raw_study_matrix_usage_provider.py
+++ b/antarest/study/storage/rawstudy/raw_study_matrix_usage_provider.py
@@ -32,14 +32,18 @@ class RawStudyMatrixUsageProvider(IMatrixUsageProvider):
     def get_matrix_usage(self) -> Iterable[MatrixReference]:
         logger.info("Getting all matrices used in raw studies")
 
-        study_filter = StudyFilter(managed=True, variant=False, access_permissions=AccessPermissions(is_admin=True))
+        study_filter = StudyFilter(
+            managed=True, variant=False, archived=False, access_permissions=AccessPermissions(is_admin=True)
+        )
 
         for study in self.study_metadata_repo.get_all(study_filter):
             study_id = study.id
             study_path = Path(study.path)
-            for f in study_path.rglob("*.link"):
-                matrix_id = extract_matrix_id(f.read_text())
-                matrix_reference = MatrixReference(
-                    matrix_id=f"{matrix_id}", use_description=f"Used by raw study {study_id}"
-                )
-                yield matrix_reference
+            # Only check `input` and `user/expansion` path as they are the only folders capable of having `.link` files.
+            for path in [study_path / "input", study_path / "user" / "expansion"]:
+                for f in path.rglob("*.link"):
+                    matrix_id = extract_matrix_id(f.read_text())
+                    matrix_reference = MatrixReference(
+                        matrix_id=f"{matrix_id}", use_description=f"Used by raw study {study_id}"
+                    )
+                    yield matrix_reference

--- a/antarest/study/storage/variantstudy/command_matrix_usage_provider.py
+++ b/antarest/study/storage/variantstudy/command_matrix_usage_provider.py
@@ -10,12 +10,15 @@
 #
 # This file is part of the Antares project.
 import logging
+from pathlib import Path
 from typing import Iterable, List
 
 from typing_extensions import override
 
+from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.matrixstore.matrix_usage_provider import IMatrixUsageProvider
 from antarest.matrixstore.model import MatrixReference
+from antarest.study.repository import AccessPermissions, StudyFilter
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.dbmodel import CommandBlock
@@ -39,6 +42,7 @@ class CommandMatrixUsageProvider(IMatrixUsageProvider):
     @override
     def get_matrix_usage(self) -> Iterable[MatrixReference]:
         logger.info("Getting all matrices used in variant studies")
+        # First gets all matrices used in commands
         command_blocks: List[CommandBlock] = self.variant_study_repo.get_all_command_blocks()
 
         def transform_to_command(command_dto: CommandDTO, study_ref: str) -> List[ICommand]:
@@ -54,11 +58,29 @@ class CommandMatrixUsageProvider(IMatrixUsageProvider):
         variant_study_commands = [
             (cmd, c.study_id) for c in command_blocks for cmd in transform_to_command(c.to_dto(), c.study_id)
         ]
+        snapshots_to_check = set()
         for command, study_id in variant_study_commands:
-            for matrix in command.get_inner_matrices():
-                command_id = str(matrix)
+            inner_matrices = command.get_inner_matrices()
+            if inner_matrices.generates_matrices_at_run_time:
+                snapshots_to_check.add(study_id)
+            for matrix_id in inner_matrices.matrices:
                 mat_reference = MatrixReference(
-                    matrix_id=command_id,
-                    use_description=f"Used by command {command_id} from variant study {study_id}",
+                    matrix_id=matrix_id,
+                    use_description=f"Used by command {command.command_id} from variant study {study_id}",
                 )
                 yield mat_reference
+
+        # For variants with a command that generated matrices at the runtime, yield all matrices in the snapshot.
+        study_filter = StudyFilter(
+            study_ids=list(snapshots_to_check), access_permissions=AccessPermissions(is_admin=True)
+        )
+        for study in self.variant_study_repo.get_all(study_filter):
+            study_id = study.id
+            snapshot_path = Path(study.path) / "snapshot"
+            if snapshot_path.exists():
+                for f in snapshot_path.rglob("*.link"):
+                    matrix_id = extract_matrix_id(f.read_text())
+                    matrix_reference = MatrixReference(
+                        matrix_id=f"{matrix_id}", use_description=f"Used by variant study {study_id} snapshot"
+                    )
+                    yield matrix_reference

--- a/antarest/study/storage/variantstudy/model/command/common.py
+++ b/antarest/study/storage/variantstudy/model/command/common.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 
@@ -99,3 +99,10 @@ class CommandName(Enum):
     UPDATE_TIMESERIES_CONFIG = "update_time"
     REPLACE_HYDRO_ALLOCATION = "replace_hydro_allocation"
     REPLACE_HYDRO_CORRELATION = "replace_hydro_correlation"
+
+
+@dataclass(frozen=True)
+class InnerMatrices:
+    matrices: list[str] = field(default_factory=list)
+    # If the command generates matrices at the runtime, it cannot return them in the `matrices` attribute. If so, we should check the variant snapshot.
+    generates_matrices_at_run_time: bool = False

--- a/antarest/study/storage/variantstudy/model/command/create_area.py
+++ b/antarest/study/storage/variantstudy/model/command/create_area.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, Final, List, Optional
+from typing import Any, Dict, Final, Optional
 
 from pydantic import model_validator
 from pydantic_core.core_schema import ValidationInfo
@@ -107,7 +107,3 @@ class CreateArea(ICommand):
             study_version=self.study_version,
             version=self._SERIALIZATION_VERSION,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
@@ -40,7 +40,12 @@ from antarest.study.model import STUDY_VERSION_8_7
 from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint import parse_binding_constraint
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
 from antarest.study.storage.variantstudy.business.utils import strip_matrix_protocol, validate_matrix
-from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput, command_succeeded
+from antarest.study.storage.variantstudy.model.command.common import (
+    CommandName,
+    CommandOutput,
+    InnerMatrices,
+    command_succeeded,
+)
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.command_listener.command_listener import ICommandListener
 from antarest.study.storage.variantstudy.model.model import CommandDTO
@@ -172,18 +177,20 @@ class AbstractBindingConstraintCommand(ICommand, metaclass=ABCMeta):
                 raise NotImplementedError(f"Invalid link or thermal ID: {link_or_cluster}")
         return terms
 
-    def command_get_inner_matrices(self, matrices: BindingConstraintMatrices) -> list[str]:
+    def command_get_inner_matrices(self, matrices: BindingConstraintMatrices) -> InnerMatrices:
         matrix_service = self.command_context.matrix_service
-        return [
-            matrix_service.get_matrix_id(matrix)
-            for matrix in [
-                matrices.values,
-                matrices.less_term_matrix,
-                matrices.greater_term_matrix,
-                matrices.equal_term_matrix,
+        return InnerMatrices(
+            matrices=[
+                matrix_service.get_matrix_id(matrix)
+                for matrix in [
+                    matrices.values,
+                    matrices.less_term_matrix,
+                    matrices.greater_term_matrix,
+                    matrices.equal_term_matrix,
+                ]
+                if matrix is not None
             ]
-            if matrix is not None
-        ]
+        )
 
     def command_to_dto(
         self, parameters: BindingConstraintCreation | BindingConstraintUpdate, matrices: BindingConstraintMatrices
@@ -326,7 +333,7 @@ class CreateBindingConstraint(AbstractBindingConstraintCommand):
         return super().command_to_dto(self.parameters, self.matrices)
 
     @override
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> InnerMatrices:
         return super().command_get_inner_matrices(self.matrices)
 
     def _create_default_matrix(self, time_step: BindingConstraintFrequency) -> str:

--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -34,6 +34,7 @@ from antarest.study.storage.variantstudy.business.utils import strip_matrix_prot
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
+    InnerMatrices,
     command_failed,
     command_succeeded,
 )
@@ -137,7 +138,7 @@ class CreateCluster(ICommand):
         )
 
     @override
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> InnerMatrices:
         matrices: List[str] = []
         if self.prepro:
             assert_this(isinstance(self.prepro, str))
@@ -145,4 +146,4 @@ class CreateCluster(ICommand):
         if self.modulation:
             assert_this(isinstance(self.modulation, str))
             matrices.append(strip_matrix_protocol(self.modulation))
-        return matrices
+        return InnerMatrices(matrices=matrices)

--- a/antarest/study/storage/variantstudy/model/command/create_district.py
+++ b/antarest/study/storage/variantstudy/model/command/create_district.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, Final, List, Optional
+from typing import Any, Dict, Final, Optional
 
 from pydantic import ValidationInfo, field_validator, model_validator
 from typing_extensions import override
@@ -101,7 +101,3 @@ class CreateDistrict(ICommand):
             version=self._SERIALIZATION_VERSION,
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/create_layer.py
+++ b/antarest/study/storage/variantstudy/model/command/create_layer.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List
 
 from typing_extensions import override
 
@@ -52,7 +51,3 @@ class CreateLayer(ICommand):
             args={"parameters": self.parameters.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/create_link.py
+++ b/antarest/study/storage/variantstudy/model/command/create_link.py
@@ -26,6 +26,7 @@ from antarest.study.storage.variantstudy.business.utils import strip_matrix_prot
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
+    InnerMatrices,
     command_failed,
     command_succeeded,
 )
@@ -85,13 +86,13 @@ class AbstractLinkCommand(AntaresBaseModel, extra="forbid"):
             study_version=self.study_version,
         )
 
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> InnerMatrices:
         list_matrices = []
         for attr in MATRIX_ATTRIBUTES:
             if value := getattr(self, attr, None):
                 assert_this(isinstance(value, str))
                 list_matrices.append(strip_matrix_protocol(value))
-        return list_matrices
+        return InnerMatrices(matrices=list_matrices)
 
 
 class CreateLink(AbstractLinkCommand, ICommand):

--- a/antarest/study/storage/variantstudy/model/command/create_renewables_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_renewables_cluster.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, Final, List, Optional, Self
+from typing import Any, Dict, Final, Optional, Self
 
 from antares.study.version import StudyVersion
 from pydantic import ValidationInfo, model_validator
@@ -103,7 +103,3 @@ class CreateRenewablesCluster(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/create_st_storage.py
+++ b/antarest/study/storage/variantstudy/model/command/create_st_storage.py
@@ -31,6 +31,7 @@ from antarest.study.storage.variantstudy.business.utils import strip_matrix_prot
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
+    InnerMatrices,
     command_failed,
     command_succeeded,
 )
@@ -242,7 +243,7 @@ class CreateSTStorage(ICommand):
         )
 
     @override
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> InnerMatrices:
         """
         Retrieves the list of matrix IDs.
         """
@@ -250,7 +251,7 @@ class CreateSTStorage(ICommand):
         for matrix_name, matrix_data in self._get_matrices().items():
             if matrix_data is not None:
                 matrices.append(strip_matrix_protocol(matrix_data))
-        return matrices
+        return InnerMatrices(matrices=matrices)
 
     def _fill_none_matrices(self) -> dict[str, str]:
         constants: GeneratorMatrixConstants = self.command_context.generator_matrix_constants

--- a/antarest/study/storage/variantstudy/model/command/create_st_storage_constraints.py
+++ b/antarest/study/storage/variantstudy/model/command/create_st_storage_constraints.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 
-from typing import List, Optional, Self
+from typing import Optional, Self
 
 from pydantic import model_validator
 from typing_extensions import override
@@ -97,7 +97,3 @@ class CreateSTStorageAdditionalConstraints(ICommand):
         constraints = [c.model_dump(mode="json", by_alias=True, exclude_none=True) for c in self.constraints]
         args = {"area_id": self.area_id, "storage_id": self.storage_id, "constraints": constraints}
         return CommandDTO(action=self.command_name.value, args=args, study_version=self.study_version)
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/create_xpansion_candidate.py
+++ b/antarest/study/storage/variantstudy/model/command/create_xpansion_candidate.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -65,7 +65,3 @@ class CreateXpansionCandidate(ICommand):
             args={"candidate": self.candidate.model_dump(mode="json", by_alias=True, exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/create_xpansion_configuration.py
+++ b/antarest/study/storage/variantstudy/model/command/create_xpansion_configuration.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -38,7 +38,3 @@ class CreateXpansionConfiguration(ICommand):
     @override
     def to_dto(self) -> CommandDTO:
         return CommandDTO(action=self.command_name.value, args={}, study_version=self.study_version)
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/create_xpansion_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/create_xpansion_constraint.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -49,7 +49,3 @@ class CreateXpansionConstraint(ICommand):
             args={"filename": self.filename, "data": self.data},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/create_xpansion_matrix.py
+++ b/antarest/study/storage/variantstudy/model/command/create_xpansion_matrix.py
@@ -19,7 +19,12 @@ from antarest.core.utils.utils import assert_this
 from antarest.matrixstore.model import MatrixData
 from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.storage.variantstudy.business.utils import strip_matrix_protocol, validate_matrix
-from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput, command_succeeded
+from antarest.study.storage.variantstudy.model.command.common import (
+    CommandName,
+    CommandOutput,
+    InnerMatrices,
+    command_succeeded,
+)
 from antarest.study.storage.variantstudy.model.command.icommand import ICommand
 from antarest.study.storage.variantstudy.model.command_listener.command_listener import ICommandListener
 from antarest.study.storage.variantstudy.model.model import CommandDTO
@@ -45,9 +50,9 @@ class AbstractCreateXpansionMatrix(ICommand):
         )
 
     @override
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> InnerMatrices:
         assert_this(isinstance(self.matrix, str))
-        return [strip_matrix_protocol(self.matrix)]
+        return InnerMatrices(matrices=[strip_matrix_protocol(self.matrix)])
 
 
 class CreateXpansionWeight(AbstractCreateXpansionMatrix):

--- a/antarest/study/storage/variantstudy/model/command/generate_thermal_cluster_timeseries.py
+++ b/antarest/study/storage/variantstudy/model/command/generate_thermal_cluster_timeseries.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -25,6 +25,7 @@ from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
+    InnerMatrices,
     command_failed,
     command_succeeded,
 )
@@ -129,6 +130,5 @@ class GenerateThermalClusterTimeSeries(ICommand):
         return CommandDTO(action=self.command_name.value, args={}, study_version=self.study_version)
 
     @override
-    def get_inner_matrices(self) -> List[str]:
-        # This is used to get used matrices and not remove them inside the garbage collector loop.
-        return []
+    def get_inner_matrices(self) -> InnerMatrices:
+        return InnerMatrices(generates_matrices_at_run_time=True)

--- a/antarest/study/storage/variantstudy/model/command/icommand.py
+++ b/antarest/study/storage/variantstudy/model/command/icommand.py
@@ -20,7 +20,12 @@ from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.dao.file.file_study_dao import FileStudyTreeDao
 from antarest.study.model import StudyVersionStr
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput, command_failed
+from antarest.study.storage.variantstudy.model.command.common import (
+    CommandName,
+    CommandOutput,
+    InnerMatrices,
+    command_failed,
+)
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.model.command_listener.command_listener import ICommandListener
 from antarest.study.storage.variantstudy.model.model import CommandDTO
@@ -99,12 +104,14 @@ class ICommand(ABC, AntaresBaseModel, extra="forbid", arbitrary_types_allowed=Tr
         """
         raise NotImplementedError()
 
-    @abstractmethod
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> InnerMatrices:
         """
-        Retrieves the list of matrix IDs.
+        Method used by the CommandMatrixUsageProvider.
+        It retrieves the list of matrix IDs used by the command.
+        It also returns a flag indicating if the command generates matrices at the run time.
+        If so, the provider will also have to check the variant snapshot to check all used matrices.
         """
-        raise NotImplementedError()
+        return InnerMatrices()
 
     def get_inner_blobs(self) -> List[str]:
         """

--- a/antarest/study/storage/variantstudy/model/command/remove_area.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_area.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -49,7 +49,3 @@ class RemoveArea(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_cluster.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -74,7 +74,3 @@ class RemoveCluster(ICommand):
             args={"area_id": self.area_id, "cluster_id": self.cluster_id},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_district.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_district.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -62,7 +62,3 @@ class RemoveDistrict(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_layer.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_layer.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List
 
 from typing_extensions import override
 
@@ -48,7 +47,3 @@ class RemoveLayer(ICommand):
             args={"layer_id": self.layer_id},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_link.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_link.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import field_validator, model_validator
 from typing_extensions import override
@@ -84,7 +84,3 @@ class RemoveLink(ICommand):
             args={"area1": self.area1, "area2": self.area2},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_multiple_binding_constraints.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_multiple_binding_constraints.py
@@ -64,7 +64,3 @@ class RemoveMultipleBindingConstraints(ICommand):
             args={"ids": self.ids},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_multiple_storage_constraints.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_multiple_storage_constraints.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import Field
 from typing_extensions import override
@@ -63,7 +63,3 @@ class RemoveMultipleSTStorageConstraints(ICommand):
             args={"area_id": self.area_id, "storage_id": self.storage_id, "ids": self.ids},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_renewables_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_renewables_cluster.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -59,7 +59,3 @@ class RemoveRenewablesCluster(ICommand):
             args={"area_id": self.area_id, "cluster_id": self.cluster_id},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_st_storage.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_st_storage.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import Field
 from typing_extensions import override
@@ -71,7 +71,3 @@ class RemoveSTStorage(ICommand):
             args={"area_id": self.area_id, "storage_id": self.storage_id},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_user_resource.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_user_resource.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 from pathlib import PurePosixPath
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -54,7 +54,3 @@ class RemoveUserResource(ICommand):
             args={"data": self.data.model_dump(mode="json")},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_xpansion_candidate.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_xpansion_candidate.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -53,7 +53,3 @@ class RemoveXpansionCandidate(ICommand):
             args={"candidate_name": self.candidate_name},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_xpansion_configuration.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_xpansion_configuration.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -42,7 +42,3 @@ class RemoveXpansionConfiguration(ICommand):
     @override
     def to_dto(self) -> CommandDTO:
         return CommandDTO(action=self.command_name.value, args={}, study_version=self.study_version)
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/remove_xpansion_resource.py
+++ b/antarest/study/storage/variantstudy/model/command/remove_xpansion_resource.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -52,7 +52,3 @@ class RemoveXpansionResource(ICommand):
             args={"resource_type": self.resource_type.value, "filename": self.filename},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/replace_comments.py
+++ b/antarest/study/storage/variantstudy/model/command/replace_comments.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -50,7 +50,3 @@ class ReplaceComments(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/replace_hydro_allocation.py
+++ b/antarest/study/storage/variantstudy/model/command/replace_hydro_allocation.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -51,7 +51,3 @@ class ReplaceHydroAllocation(ICommand):
             args={"area_id": self.area_id, "allocation": self.allocation.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/replace_hydro_correlation.py
+++ b/antarest/study/storage/variantstudy/model/command/replace_hydro_correlation.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -50,7 +50,3 @@ class ReplaceHydroCorrelation(ICommand):
             args={"area_id": self.area_id, "correlation": self.correlation.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/replace_layer_areas.py
+++ b/antarest/study/storage/variantstudy/model/command/replace_layer_areas.py
@@ -50,7 +50,3 @@ class ReplaceLayerAreas(ICommand):
             args={"layer_id": self.layer_id, "area_ids": self.area_ids},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/replace_matrix.py
+++ b/antarest/study/storage/variantstudy/model/command/replace_matrix.py
@@ -25,6 +25,7 @@ from antarest.study.storage.variantstudy.business.utils import AliasDecoder, str
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
+    InnerMatrices,
     command_failed,
     command_succeeded,
 )
@@ -90,6 +91,6 @@ class ReplaceMatrix(ICommand):
         )
 
     @override
-    def get_inner_matrices(self) -> List[str]:
+    def get_inner_matrices(self) -> InnerMatrices:
         assert_this(isinstance(self.matrix, str))
-        return [strip_matrix_protocol(self.matrix)]
+        return InnerMatrices(matrices=[strip_matrix_protocol(self.matrix)])

--- a/antarest/study/storage/variantstudy/model/command/replace_user_resource.py
+++ b/antarest/study/storage/variantstudy/model/command/replace_user_resource.py
@@ -79,10 +79,6 @@ class ReplaceUserResource(ICommand):
         )
 
     @override
-    def get_inner_matrices(self) -> List[str]:
-        return []
-
-    @override
     def get_inner_blobs(self) -> List[str]:
         if self.data.blob_id:
             return [self.data.blob_id]

--- a/antarest/study/storage/variantstudy/model/command/replace_xpansion_adequacy_criterion.py
+++ b/antarest/study/storage/variantstudy/model/command/replace_xpansion_adequacy_criterion.py
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -61,7 +61,3 @@ class ReplaceXpansionAdequacyCriterion(ICommand):
             args={"criterion": self.criterion.model_dump(mode="json", exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/replace_xpansion_candidate.py
+++ b/antarest/study/storage/variantstudy/model/command/replace_xpansion_candidate.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -77,7 +77,3 @@ class ReplaceXpansionCandidate(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_adequacy_patch_parameters.py
+++ b/antarest/study/storage/variantstudy/model/command/update_adequacy_patch_parameters.py
@@ -59,7 +59,3 @@ class UpdateAdequacyPatchParameters(ICommand):
             args={"parameters": self.parameters.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> list[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_advanced_parameters.py
+++ b/antarest/study/storage/variantstudy/model/command/update_advanced_parameters.py
@@ -59,7 +59,3 @@ class UpdateAdvancedParameters(ICommand):
             args={"parameters": self.parameters.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> list[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_area_ui.py
+++ b/antarest/study/storage/variantstudy/model/command/update_area_ui.py
@@ -111,7 +111,3 @@ class UpdateAreaUI(ICommand):
             study_version=self.study_version,
             version=2,
         )
-
-    @override
-    def get_inner_matrices(self) -> t.List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_areas_properties.py
+++ b/antarest/study/storage/variantstudy/model/command/update_areas_properties.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from typing_extensions import override
 
@@ -59,7 +59,3 @@ class UpdateAreasProperties(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/update_binding_constraint.py
@@ -31,7 +31,12 @@ from antarest.study.model import STUDY_VERSION_8_7
 from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint import (
     parse_binding_constraint_for_update,
 )
-from antarest.study.storage.variantstudy.model.command.common import CommandName, CommandOutput, command_succeeded
+from antarest.study.storage.variantstudy.model.command.common import (
+    CommandName,
+    CommandOutput,
+    InnerMatrices,
+    command_succeeded,
+)
 from antarest.study.storage.variantstudy.model.command.create_binding_constraint import (
     AbstractBindingConstraintCommand,
     TermMatrices,
@@ -160,5 +165,5 @@ class UpdateBindingConstraint(AbstractBindingConstraintCommand):
         return dto
 
     @override
-    def get_inner_matrices(self) -> list[str]:
+    def get_inner_matrices(self) -> InnerMatrices:
         return super().command_get_inner_matrices(self.matrices)

--- a/antarest/study/storage/variantstudy/model/command/update_binding_constraints.py
+++ b/antarest/study/storage/variantstudy/model/command/update_binding_constraints.py
@@ -105,7 +105,3 @@ class UpdateBindingConstraints(ICommand):
             version=self._SERIALIZATION_VERSION,
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> t.List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_config.py
+++ b/antarest/study/storage/variantstudy/model/command/update_config.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Generator, List, Optional, Tuple
+from typing import Any, Generator, Optional, Tuple
 
 import typing_extensions as te
 from typing_extensions import override
@@ -89,7 +89,3 @@ class UpdateConfig(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_district.py
+++ b/antarest/study/storage/variantstudy/model/command/update_district.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, Final, List, Optional
+from typing import Any, Dict, Final, Optional
 
 from pydantic import ValidationInfo, model_validator
 from typing_extensions import override
@@ -96,7 +96,3 @@ class UpdateDistrict(ICommand):
             version=self._SERIALIZATION_VERSION,
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_general_config.py
+++ b/antarest/study/storage/variantstudy/model/command/update_general_config.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -49,7 +49,3 @@ class UpdateGeneralConfig(ICommand):
             args={"parameters": self.parameters.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_hydro_management.py
+++ b/antarest/study/storage/variantstudy/model/command/update_hydro_management.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import model_validator
 from typing_extensions import override
@@ -64,7 +64,3 @@ class UpdateHydroManagement(ICommand):
             args={"area_id": self.area_id, "properties": self.properties.model_dump(mode="json", exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_inflow_structure.py
+++ b/antarest/study/storage/variantstudy/model/command/update_inflow_structure.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -57,7 +57,3 @@ class UpdateInflowStructure(ICommand):
             args={"area_id": self.area_id, "properties": self.properties.model_dump(mode="json")},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_layer.py
+++ b/antarest/study/storage/variantstudy/model/command/update_layer.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List
 
 from typing_extensions import override
 
@@ -49,7 +48,3 @@ class UpdateLayer(ICommand):
             args={"parameters": self.parameters.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_optimization_preferences.py
+++ b/antarest/study/storage/variantstudy/model/command/update_optimization_preferences.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -53,7 +53,3 @@ class UpdateOptimizationPreferences(ICommand):
             args={"parameters": self.parameters.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_playlist.py
+++ b/antarest/study/storage/variantstudy/model/command/update_playlist.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, Final, List, Optional
+from typing import Any, Dict, Final, Optional
 
 from pydantic import model_validator
 from pydantic_core.core_schema import ValidationInfo
@@ -79,7 +79,3 @@ class UpdatePlaylist(ICommand):
             args={"playlist": self.playlist.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_raw_file.py
+++ b/antarest/study/storage/variantstudy/model/command/update_raw_file.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 import base64
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -71,7 +71,3 @@ class UpdateRawFile(ICommand):
             args={"target": self.target, "b64Data": self.b64Data},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_renewables_clusters.py
+++ b/antarest/study/storage/variantstudy/model/command/update_renewables_clusters.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from typing_extensions import override
 
@@ -85,7 +85,3 @@ class UpdateRenewablesClusters(ICommand):
         return CommandDTO(
             action=self.command_name.value, args={"cluster_properties": args}, study_version=self.study_version
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_scenario_builder.py
+++ b/antarest/study/storage/variantstudy/model/command/update_scenario_builder.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 
-from typing import Any, Dict, Final, List, Optional, Self
+from typing import Any, Dict, Final, Optional, Self
 
 from pydantic import TypeAdapter, model_validator
 from pydantic_core.core_schema import ValidationInfo
@@ -104,7 +104,3 @@ class UpdateScenarioBuilder(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_st_storage_additional_constraints.py
+++ b/antarest/study/storage/variantstudy/model/command/update_st_storage_additional_constraints.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional, Self
+from typing import Optional, Self
 
 from pydantic import TypeAdapter, model_validator
 from typing_extensions import override
@@ -89,7 +89,3 @@ class UpdateSTStorageAdditionalConstraints(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_st_storages.py
+++ b/antarest/study/storage/variantstudy/model/command/update_st_storages.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import Any, List, Optional, Self
+from typing import Any, Optional, Self
 
 from pydantic import model_validator
 from typing_extensions import override
@@ -99,7 +99,3 @@ class UpdateSTStorages(ICommand):
         return CommandDTO(
             action=self.command_name.value, args={"storage_properties": args}, study_version=self.study_version
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_thematic_trimming.py
+++ b/antarest/study/storage/variantstudy/model/command/update_thematic_trimming.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import model_validator
 from typing_extensions import override
@@ -60,7 +60,3 @@ class UpdateThematicTrimming(ICommand):
             args={"parameters": self.parameters.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_thermal_clusters.py
+++ b/antarest/study/storage/variantstudy/model/command/update_thermal_clusters.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import Any, List, Optional, Self
+from typing import Any, Optional, Self
 
 from pydantic import model_validator
 from typing_extensions import override
@@ -97,7 +97,3 @@ class UpdateThermalClusters(ICommand):
         return CommandDTO(
             action=self.command_name.value, args={"cluster_properties": args}, study_version=self.study_version
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_timeseries_config.py
+++ b/antarest/study/storage/variantstudy/model/command/update_timeseries_config.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -52,7 +52,3 @@ class UpdateTimeSeriesConfig(ICommand):
             args={"parameters": self.parameters.model_dump(exclude_none=True)},
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/model/command/update_xpansion_settings.py
+++ b/antarest/study/storage/variantstudy/model/command/update_xpansion_settings.py
@@ -20,7 +20,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import List, Optional
+from typing import Optional
 
 from typing_extensions import override
 
@@ -66,7 +66,3 @@ class UpdateXpansionSettings(ICommand):
             },
             study_version=self.study_version,
         )
-
-    @override
-    def get_inner_matrices(self) -> List[str]:
-        return []

--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -348,7 +348,7 @@ class VariantStudyService(AbstractStorageService):
             for command in study.commands
             for matrix in suppress_exception(
                 lambda: reduce(
-                    lambda m, c: m + c.get_inner_matrices(),
+                    lambda m, c: m + c.get_inner_matrices().matrices,
                     self.command_factory.to_command(command.to_dto()),
                     cast(List[str], []),
                 ),

--- a/tests/matrixstore/test_matrix_garbage_collector.py
+++ b/tests/matrixstore/test_matrix_garbage_collector.py
@@ -9,8 +9,9 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+import shutil
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -31,6 +32,7 @@ from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
 from antarest.study.storage.variantstudy.command_matrix_usage_provider import CommandMatrixUsageProvider
+from antarest.study.storage.variantstudy.model.command.common import InnerMatrices
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command.create_cluster import CreateCluster
 from antarest.study.storage.variantstudy.model.command.generate_thermal_cluster_timeseries import (
@@ -152,6 +154,7 @@ def test_clean_matrices_variant_snapshot(
     create_area_cmd = CreateArea(area_name="fr", command_context=command_context, study_version=version)
     output = create_area_cmd.apply(study)
     assert output.status
+    assert create_area_cmd.get_inner_matrices() == InnerMatrices(generates_matrices_at_run_time=False)
     cmd = CreateCluster(
         area_id="fr",
         parameters=ThermalClusterCreation(name="thermal_cluster", nominal_capacity=1000),
@@ -171,24 +174,22 @@ def test_clean_matrices_variant_snapshot(
     variant_study = variant_study_service.create_variant_study(parent_id, "variant_study")
 
     # Add a GenerateThermalTimeSeries command
-    command = GenerateThermalClusterTimeSeries(command_context=command_context, study_version=version).to_dto()
-    variant_study_service.append_command(variant_study.id, command)
+    command = GenerateThermalClusterTimeSeries(command_context=command_context, study_version=version)
+    assert command.get_inner_matrices() == InnerMatrices(generates_matrices_at_run_time=True)
+    variant_study_service.append_command(variant_study.id, command.to_dto())
 
     # Generate the snapshot
     variant_study_service.get_raw(variant_study)
 
-    # Ensures the matrix created by the `GenerateThermalClusterTimeSeries` command is seen as used.
-    # Because it's present in the variant snapshot
+    # Ensures the provider sees matrices in the snapshot as the variant contains the command `GenerateThermalClusterTimeSeries`.
     # This way it won't be cleaned by the garbage collector.
     provider = CommandMatrixUsageProvider(variant_study_service.repository, variant_study_service.command_factory)
-    a = provider.get_matrix_usage()
-    print(list(a))
-    used_matrices = list(matrix_service.get_used_matrices())
-    assert len(used_matrices) == 1
+    used_matrices = list(provider.get_matrix_usage())
+    assert len(used_matrices) > 0
 
-    # Clean the snapshot
-    variant_study_service.clear_all_snapshots(retention_time=timedelta())
+    # Clean the snapshot manually
+    shutil.rmtree(Path(variant_study.path) / "snapshot")
 
     # Ensures no matrix is used now that the snapshot is cleaned
-    used_matrices = list(matrix_service.get_used_matrices())
+    used_matrices = list(provider.get_matrix_usage())
     assert len(used_matrices) == 0

--- a/tests/matrixstore/test_matrix_garbage_collector.py
+++ b/tests/matrixstore/test_matrix_garbage_collector.py
@@ -9,38 +9,21 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-import shutil
-import uuid
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock
 
 import pandas as pd
 import pytest
-from helpers import with_admin_user, with_db_context
 
 from antarest.blobstore.service import BlobService
-from antarest.core.config import InternalMatrixFormat
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.matrixstore.matrix_garbage_collector import MatrixGarbageCollector
 from antarest.matrixstore.model import MatrixMetadataDTO, MatrixReference
-from antarest.matrixstore.repository import MatrixContentRepository, MatrixDataSetRepository, MatrixRepository
 from antarest.matrixstore.service import MatrixService
-from antarest.study.business.model.thermal_cluster_model import ThermalClusterCreation
-from antarest.study.model import RawStudy
-from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
-from antarest.study.storage.variantstudy.command_matrix_usage_provider import CommandMatrixUsageProvider
-from antarest.study.storage.variantstudy.model.command.common import InnerMatrices
-from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
-from antarest.study.storage.variantstudy.model.command.create_cluster import CreateCluster
-from antarest.study.storage.variantstudy.model.command.generate_thermal_cluster_timeseries import (
-    GenerateThermalClusterTimeSeries,
-)
-from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.repository import VariantStudyRepository
-from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 
 
 @pytest.fixture
@@ -126,70 +109,3 @@ def test_clean_matrices_actual_service(
         else:
             # Ensures the matrix wasn't deleted as it was created recently
             assert len(matrices_after_clean) == 1
-
-
-@with_db_context
-@with_admin_user
-def test_clean_matrices_variant_snapshot(
-    empty_study_930: FileStudy, variant_study_service: VariantStudyService, command_context: CommandContext
-) -> None:
-    # Create a real matrix_service
-    bucket_dir = (
-        variant_study_service.command_factory.command_context.matrix_service.matrix_content_repository.bucket_dir
-    )
-    matrix_service = MatrixService(
-        repo=MatrixRepository(db.session),
-        repo_dataset=MatrixDataSetRepository(db.session),
-        matrix_content_repository=MatrixContentRepository(bucket_dir, InternalMatrixFormat.TSV),
-        file_transfer_manager=Mock(),
-        task_service=Mock(),
-        config=Mock(),
-        user_service=Mock(),
-    )
-    variant_study_service.command_factory.command_context.matrix_service = matrix_service
-
-    # Create a RawStudy with 1 area and 1 thermal
-    study = empty_study_930
-    version = study.config.version
-    create_area_cmd = CreateArea(area_name="fr", command_context=command_context, study_version=version)
-    output = create_area_cmd.apply(study)
-    assert output.status
-    assert create_area_cmd.get_inner_matrices() == InnerMatrices(generates_matrices_at_run_time=False)
-    cmd = CreateCluster(
-        area_id="fr",
-        parameters=ThermalClusterCreation(name="thermal_cluster", nominal_capacity=1000),
-        command_context=command_context,
-        study_version=version,
-    )
-    output = cmd.apply(study)
-    assert output.status
-
-    # Add the study in DB
-    parent_id = str(uuid.uuid4())
-    parent = RawStudy(id=parent_id, name="Parent", path=str(study.config.study_path), version=str(version))
-    db.session.add(parent)
-    db.session.commit()
-
-    # Create a variant
-    variant_study = variant_study_service.create_variant_study(parent_id, "variant_study")
-
-    # Add a GenerateThermalTimeSeries command
-    command = GenerateThermalClusterTimeSeries(command_context=command_context, study_version=version)
-    assert command.get_inner_matrices() == InnerMatrices(generates_matrices_at_run_time=True)
-    variant_study_service.append_command(variant_study.id, command.to_dto())
-
-    # Generate the snapshot
-    variant_study_service.get_raw(variant_study)
-
-    # Ensures the provider sees matrices in the snapshot as the variant contains the command `GenerateThermalClusterTimeSeries`.
-    # This way it won't be cleaned by the garbage collector.
-    provider = CommandMatrixUsageProvider(variant_study_service.repository, variant_study_service.command_factory)
-    used_matrices = list(provider.get_matrix_usage())
-    assert len(used_matrices) > 0
-
-    # Clean the snapshot manually
-    shutil.rmtree(Path(variant_study.path) / "snapshot")
-
-    # Ensures no matrix is used now that the snapshot is cleaned
-    used_matrices = list(provider.get_matrix_usage())
-    assert len(used_matrices) == 0

--- a/tests/matrixstore/test_matrix_garbage_collector.py
+++ b/tests/matrixstore/test_matrix_garbage_collector.py
@@ -30,11 +30,13 @@ from antarest.study.model import RawStudy
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
+from antarest.study.storage.variantstudy.command_matrix_usage_provider import CommandMatrixUsageProvider
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command.create_cluster import CreateCluster
 from antarest.study.storage.variantstudy.model.command.generate_thermal_cluster_timeseries import (
     GenerateThermalClusterTimeSeries,
 )
+from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.repository import VariantStudyRepository
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 
@@ -127,7 +129,7 @@ def test_clean_matrices_actual_service(
 @with_db_context
 @with_admin_user
 def test_clean_matrices_variant_snapshot(
-    empty_study_930: FileStudy, variant_study_service: VariantStudyService
+    empty_study_930: FileStudy, variant_study_service: VariantStudyService, command_context: CommandContext
 ) -> None:
     # Create a real matrix_service
     bucket_dir = (
@@ -143,7 +145,6 @@ def test_clean_matrices_variant_snapshot(
         user_service=Mock(),
     )
     variant_study_service.command_factory.command_context.matrix_service = matrix_service
-    command_context = variant_study_service.command_factory.command_context
 
     # Create a RawStudy with 1 area and 1 thermal
     study = empty_study_930
@@ -179,6 +180,9 @@ def test_clean_matrices_variant_snapshot(
     # Ensures the matrix created by the `GenerateThermalClusterTimeSeries` command is seen as used.
     # Because it's present in the variant snapshot
     # This way it won't be cleaned by the garbage collector.
+    provider = CommandMatrixUsageProvider(variant_study_service.repository, variant_study_service.command_factory)
+    a = provider.get_matrix_usage()
+    print(list(a))
     used_matrices = list(matrix_service.get_used_matrices())
     assert len(used_matrices) == 1
 

--- a/tests/matrixstore/test_matrix_garbage_collector.py
+++ b/tests/matrixstore/test_matrix_garbage_collector.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -28,7 +28,6 @@ from antarest.matrixstore.service import MatrixService
 from antarest.study.business.model.thermal_cluster_model import ThermalClusterCreation
 from antarest.study.model import RawStudy
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
@@ -36,7 +35,6 @@ from antarest.study.storage.variantstudy.model.command.create_cluster import Cre
 from antarest.study.storage.variantstudy.model.command.generate_thermal_cluster_timeseries import (
     GenerateThermalClusterTimeSeries,
 )
-from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.repository import VariantStudyRepository
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 
@@ -129,13 +127,13 @@ def test_clean_matrices_actual_service(
 @with_db_context
 @with_admin_user
 def test_clean_matrices_variant_snapshot(
-    command_context: CommandContext, empty_study_930: FileStudy, variant_study_service: VariantStudyService
+    empty_study_930: FileStudy, variant_study_service: VariantStudyService
 ) -> None:
     # Create a real matrix_service
     bucket_dir = (
         variant_study_service.command_factory.command_context.matrix_service.matrix_content_repository.bucket_dir
     )
-    service = MatrixService(
+    matrix_service = MatrixService(
         repo=MatrixRepository(db.session),
         repo_dataset=MatrixDataSetRepository(db.session),
         matrix_content_repository=MatrixContentRepository(bucket_dir, InternalMatrixFormat.TSV),
@@ -144,13 +142,14 @@ def test_clean_matrices_variant_snapshot(
         config=Mock(),
         user_service=Mock(),
     )
-    variant_study_service.command_factory.command_context.matrix_service = service
+    variant_study_service.command_factory.command_context.matrix_service = matrix_service
+    command_context = variant_study_service.command_factory.command_context
 
     # Create a RawStudy with 1 area and 1 thermal
     study = empty_study_930
     version = study.config.version
-    cmd = CreateArea(area_name="fr", command_context=command_context, study_version=version)
-    output = cmd.apply(study)
+    create_area_cmd = CreateArea(area_name="fr", command_context=command_context, study_version=version)
+    output = create_area_cmd.apply(study)
     assert output.status
     cmd = CreateCluster(
         area_id="fr",
@@ -169,27 +168,23 @@ def test_clean_matrices_variant_snapshot(
 
     # Create a variant
     variant_study = variant_study_service.create_variant_study(parent_id, "variant_study")
-    variant_id = variant_study.id
 
     # Add a GenerateThermalTimeSeries command
-    cmd = GenerateThermalClusterTimeSeries(command_context=command_context, study_version=version).to_dto()
-    variant_study_service.append_command(variant_id, cmd)
+    command = GenerateThermalClusterTimeSeries(command_context=command_context, study_version=version).to_dto()
+    variant_study_service.append_command(variant_study.id, command)
 
     # Generate the snapshot
-    file_study_variant = variant_study_service.get_raw(variant_study)
+    variant_study_service.get_raw(variant_study)
 
-    # Ensure we can fetch the matrix content
-    node = file_study_variant.tree.get_node(["input", "thermal", "series", "fr", "thermal_cluster", "series"])
-    assert isinstance(node, InputSeriesMatrix)
-    df = node.parse_as_dataframe()
-    pd.testing.assert_frame_equal(df, pd.DataFrame(8760 * [[1000]]), check_dtype=False)
+    # Ensures the matrix created by the `GenerateThermalClusterTimeSeries` command is seen as used.
+    # Because it's present in the variant snapshot
+    # This way it won't be cleaned by the garbage collector.
+    used_matrices = list(matrix_service.get_used_matrices())
+    assert len(used_matrices) == 1
 
-    # Build a MatrixGarbageCollector that runs instantly
-    gc = MatrixGarbageCollector(matrix_service=service, sleeping_time=0, dry_run=False, retention_time=0)
-    gc.clean_matrices()
+    # Clean the snapshot
+    variant_study_service.clear_all_snapshots(retention_time=timedelta())
 
-    # Ensures we can still fetch the matrix
-    node = file_study_variant.tree.get_node(["input", "thermal", "series", "fr", "thermal_cluster", "series"])
-    assert isinstance(node, InputSeriesMatrix)
-    df = node.parse_as_dataframe()
-    pd.testing.assert_frame_equal(df, pd.DataFrame(8760 * [[1000]]), check_dtype=False)
+    # Ensures no matrix is used now that the snapshot is cleaned
+    used_matrices = list(matrix_service.get_used_matrices())
+    assert len(used_matrices) == 0

--- a/tests/matrixstore/test_matrix_garbage_collector.py
+++ b/tests/matrixstore/test_matrix_garbage_collector.py
@@ -9,21 +9,36 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+import uuid
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock
 
 import pandas as pd
 import pytest
+from helpers import with_admin_user, with_db_context
 
 from antarest.blobstore.service import BlobService
+from antarest.core.config import InternalMatrixFormat
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.matrixstore.matrix_garbage_collector import MatrixGarbageCollector
 from antarest.matrixstore.model import MatrixMetadataDTO, MatrixReference
+from antarest.matrixstore.repository import MatrixContentRepository, MatrixDataSetRepository, MatrixRepository
 from antarest.matrixstore.service import MatrixService
+from antarest.study.business.model.thermal_cluster_model import ThermalClusterCreation
+from antarest.study.model import RawStudy
+from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
+from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
+from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
+from antarest.study.storage.variantstudy.model.command.create_cluster import CreateCluster
+from antarest.study.storage.variantstudy.model.command.generate_thermal_cluster_timeseries import (
+    GenerateThermalClusterTimeSeries,
+)
+from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.repository import VariantStudyRepository
+from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 
 
 @pytest.fixture
@@ -109,3 +124,72 @@ def test_clean_matrices_actual_service(
         else:
             # Ensures the matrix wasn't deleted as it was created recently
             assert len(matrices_after_clean) == 1
+
+
+@with_db_context
+@with_admin_user
+def test_clean_matrices_variant_snapshot(
+    command_context: CommandContext, empty_study_930: FileStudy, variant_study_service: VariantStudyService
+) -> None:
+    # Create a real matrix_service
+    bucket_dir = (
+        variant_study_service.command_factory.command_context.matrix_service.matrix_content_repository.bucket_dir
+    )
+    service = MatrixService(
+        repo=MatrixRepository(db.session),
+        repo_dataset=MatrixDataSetRepository(db.session),
+        matrix_content_repository=MatrixContentRepository(bucket_dir, InternalMatrixFormat.TSV),
+        file_transfer_manager=Mock(),
+        task_service=Mock(),
+        config=Mock(),
+        user_service=Mock(),
+    )
+    variant_study_service.command_factory.command_context.matrix_service = service
+
+    # Create a RawStudy with 1 area and 1 thermal
+    study = empty_study_930
+    version = study.config.version
+    cmd = CreateArea(area_name="fr", command_context=command_context, study_version=version)
+    output = cmd.apply(study)
+    assert output.status
+    cmd = CreateCluster(
+        area_id="fr",
+        parameters=ThermalClusterCreation(name="thermal_cluster", nominal_capacity=1000),
+        command_context=command_context,
+        study_version=version,
+    )
+    output = cmd.apply(study)
+    assert output.status
+
+    # Add the study in DB
+    parent_id = str(uuid.uuid4())
+    parent = RawStudy(id=parent_id, name="Parent", path=str(study.config.study_path), version=str(version))
+    db.session.add(parent)
+    db.session.commit()
+
+    # Create a variant
+    variant_study = variant_study_service.create_variant_study(parent_id, "variant_study")
+    variant_id = variant_study.id
+
+    # Add a GenerateThermalTimeSeries command
+    cmd = GenerateThermalClusterTimeSeries(command_context=command_context, study_version=version).to_dto()
+    variant_study_service.append_command(variant_id, cmd)
+
+    # Generate the snapshot
+    file_study_variant = variant_study_service.get_raw(variant_study)
+
+    # Ensure we can fetch the matrix content
+    node = file_study_variant.tree.get_node(["input", "thermal", "series", "fr", "thermal_cluster", "series"])
+    assert isinstance(node, InputSeriesMatrix)
+    df = node.parse_as_dataframe()
+    pd.testing.assert_frame_equal(df, pd.DataFrame(8760 * [[1000]]), check_dtype=False)
+
+    # Build a MatrixGarbageCollector that runs instantly
+    gc = MatrixGarbageCollector(matrix_service=service, sleeping_time=0, dry_run=False, retention_time=0)
+    gc.clean_matrices()
+
+    # Ensures we can still fetch the matrix
+    node = file_study_variant.tree.get_node(["input", "thermal", "series", "fr", "thermal_cluster", "series"])
+    assert isinstance(node, InputSeriesMatrix)
+    df = node.parse_as_dataframe()
+    pd.testing.assert_frame_equal(df, pd.DataFrame(8760 * [[1000]]), check_dtype=False)

--- a/tests/matrixstore/test_matrix_usage_providers.py
+++ b/tests/matrixstore/test_matrix_usage_providers.py
@@ -156,7 +156,6 @@ def test_command_matrix_usage_provider(
         study_version = "880"
         variant_study_repository.save(VariantStudy(id=study_id, version=study_version, path=tmp_path.as_posix()))
         matrices_id = "a68de4b5e96a60c8ceb3c7b7ef93461725bdbbff3516b136585a743b5c0ec664"
-        use_description = f"Used by command {matrices_id} from variant study {study_id}"
 
         # TODO: add series to the command blocks
         command_block1 = CommandBlock(
@@ -171,7 +170,7 @@ def test_command_matrix_usage_provider(
             study_id=study_id,
             command=CommandName.CREATE_LINK.value,
             args='{"area1": "area2", "area2": "area3","series": [[1,2,3]]}',
-            index=0,
+            index=1,
             version=7,
             study_version=study_version,
         )
@@ -180,14 +179,28 @@ def test_command_matrix_usage_provider(
         db.session.add(command_block2)
         db.session.commit()
 
+        # DB request to fetch the command ids
+        cmd1_id, cmd2_id = "", ""
+        for cmd in db.session.query(CommandBlock).all():
+            if cmd.index == 0:
+                cmd1_id = cmd.id
+            else:
+                cmd2_id = cmd.id
+        description1 = f"Used by command {cmd1_id} from variant study {study_id}"
+        description2 = f"Used by command {cmd2_id} from variant study {study_id}"
+
+        # Check the response
         matrices_references = list(command_matrix_usage_provider.get_matrix_usage())
 
-        assert matrices_references == [MatrixReference(matrix_id=matrices_id, use_description=use_description)] * 2
+        assert matrices_references == [
+            MatrixReference(matrix_id=matrices_id, use_description=description1),
+            MatrixReference(matrix_id=matrices_id, use_description=description2),
+        ]
 
 
 @with_db_context
 @with_admin_user
-def test_clean_matrices_variant_snapshot(
+def test_command_matrix_usage_provider_with_snapshot(
     empty_study_930: FileStudy, variant_study_service: VariantStudyService, command_context: CommandContext
 ) -> None:
     # Create a real matrix_service

--- a/tests/matrixstore/test_matrix_usage_providers.py
+++ b/tests/matrixstore/test_matrix_usage_providers.py
@@ -264,6 +264,17 @@ def test_command_matrix_usage_provider_with_snapshot(
     used_matrices = list(provider.get_matrix_usage())
     assert len(used_matrices) == 0
 
+    # Create another variant with a command that is not a `GenerateThermalTimeSeries`
+    variant_study = variant_study_service.create_variant_study(parent_id, "variant_study2")
+    command = CreateArea(area_name="be", command_context=command_context, study_version=version)
+    assert command.get_inner_matrices() == InnerMatrices(generates_matrices_at_run_time=False)
+    variant_study_service.append_command(variant_study.id, command.to_dto())
+    # Generate its snapshot
+    variant_study_service.get_raw(variant_study)
+    # Ensures no matrix is used even if the snapshot exists
+    used_matrices = list(provider.get_matrix_usage())
+    assert len(used_matrices) == 0
+
 
 def test_constants_matrix_usage_provider(constants_matrix_usage_provider: ConstantsMatrixUsageProvider) -> None:
     constant1 = {"c1": "constant_name1"}

--- a/tests/matrixstore/test_matrix_usage_providers.py
+++ b/tests/matrixstore/test_matrix_usage_providers.py
@@ -130,11 +130,19 @@ def test_raw_studies_matrix_usage_provider(
 
     with db():
         raw_study = raw_study_service.create(metadata_raw_study)
+        study_path = Path(raw_study.path)
+        input_path = study_path / "input"
+        expansion_path = study_path / "user" / "expansion"
+        expansion_path.mkdir(parents=True, exist_ok=True)
 
-        (Path(raw_study.path) / f"{matrix_name1}.link").write_text(f"matrix://{matrix_name1}")
-        (Path(raw_study.path) / f"{matrix_name2}.link").write_text(f"matrix://{matrix_name2}")
-        (Path(raw_study.path) / f"{matrix_name3}.link").write_text(f"matrix://{matrix_name3}")
-        (Path(raw_study.path) / f"{matrix_name4}.txt").write_text(f"matrix://{matrix_name4}")
+        (input_path / f"{matrix_name1}.link").write_text(f"matrix://{matrix_name1}")
+        (input_path / f"{matrix_name2}.link").write_text(f"matrix://{matrix_name2}")
+        (expansion_path / f"{matrix_name3}.link").write_text(f"matrix://{matrix_name3}")
+
+        # Not a .link file -> Should not appear
+        (input_path / f"{matrix_name4}.txt").write_text(f"matrix://{matrix_name4}")
+        # Not in `input` or `expansion` folder -> Should not appear
+        (study_path / f"{matrix_name4}.link").write_text(f"matrix://{matrix_name4}")
 
         raw_studies_matrix_usage_provider.study_metadata_repo.save(metadata_raw_study)
 

--- a/tests/matrixstore/test_matrix_usage_providers.py
+++ b/tests/matrixstore/test_matrix_usage_providers.py
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+import shutil
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -19,7 +20,7 @@ import pandas as pd
 import pytest
 from typing_extensions import override
 
-from antarest.core.config import DEFAULT_WORKSPACE_NAME
+from antarest.core.config import DEFAULT_WORKSPACE_NAME, InternalMatrixFormat
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import current_time
 from antarest.login.model import Group
@@ -28,11 +29,14 @@ from antarest.login.service import LoginService
 from antarest.login.utils import current_user_context
 from antarest.matrixstore.matrix_usage_provider import IMatrixUsageProvider
 from antarest.matrixstore.model import MatrixDataSetUpdateDTO, MatrixInfoDTO, MatrixReference
-from antarest.matrixstore.repository import MatrixDataSetRepository
+from antarest.matrixstore.repository import MatrixContentRepository, MatrixDataSetRepository, MatrixRepository
 from antarest.matrixstore.service import ISimpleMatrixService, MatrixService
+from antarest.study.business.model.thermal_cluster_model import ThermalClusterCreation
 from antarest.study.business.output.variables_matrix_usage_provider import OutputVariablesMatrixUsageProvider
+from antarest.study.model import RawStudy
 from antarest.study.repository import StudyMetadataRepository
 from antarest.study.storage.output_model import OutputVariablesType, OutputVariablesViewsModel
+from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
 from antarest.study.storage.rawstudy.raw_study_matrix_usage_provider import RawStudyMatrixUsageProvider
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
@@ -42,10 +46,17 @@ from antarest.study.storage.variantstudy.business.matrix_constants.matrix_consta
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
 from antarest.study.storage.variantstudy.command_matrix_usage_provider import CommandMatrixUsageProvider
-from antarest.study.storage.variantstudy.model.command.common import CommandName
+from antarest.study.storage.variantstudy.model.command.common import CommandName, InnerMatrices
+from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
+from antarest.study.storage.variantstudy.model.command.create_cluster import CreateCluster
+from antarest.study.storage.variantstudy.model.command.generate_thermal_cluster_timeseries import (
+    GenerateThermalClusterTimeSeries,
+)
+from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.model.dbmodel import CommandBlock, VariantStudy
 from antarest.study.storage.variantstudy.repository import VariantStudyRepository
-from tests.helpers import create_raw_study, with_db_context
+from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
+from tests.helpers import create_raw_study, with_admin_user, with_db_context
 
 
 @pytest.fixture
@@ -172,6 +183,73 @@ def test_command_matrix_usage_provider(
         matrices_references = list(command_matrix_usage_provider.get_matrix_usage())
 
         assert matrices_references == [MatrixReference(matrix_id=matrices_id, use_description=use_description)] * 2
+
+
+@with_db_context
+@with_admin_user
+def test_clean_matrices_variant_snapshot(
+    empty_study_930: FileStudy, variant_study_service: VariantStudyService, command_context: CommandContext
+) -> None:
+    # Create a real matrix_service
+    bucket_dir = (
+        variant_study_service.command_factory.command_context.matrix_service.matrix_content_repository.bucket_dir
+    )
+    matrix_service = MatrixService(
+        repo=MatrixRepository(db.session),
+        repo_dataset=MatrixDataSetRepository(db.session),
+        matrix_content_repository=MatrixContentRepository(bucket_dir, InternalMatrixFormat.TSV),
+        file_transfer_manager=Mock(),
+        task_service=Mock(),
+        config=Mock(),
+        user_service=Mock(),
+    )
+    variant_study_service.command_factory.command_context.matrix_service = matrix_service
+
+    # Create a RawStudy with 1 area and 1 thermal
+    study = empty_study_930
+    version = study.config.version
+    create_area_cmd = CreateArea(area_name="fr", command_context=command_context, study_version=version)
+    output = create_area_cmd.apply(study)
+    assert output.status
+    assert create_area_cmd.get_inner_matrices() == InnerMatrices(generates_matrices_at_run_time=False)
+    cmd = CreateCluster(
+        area_id="fr",
+        parameters=ThermalClusterCreation(name="thermal_cluster", nominal_capacity=1000),
+        command_context=command_context,
+        study_version=version,
+    )
+    output = cmd.apply(study)
+    assert output.status
+
+    # Add the study in DB
+    parent_id = str(uuid.uuid4())
+    parent = RawStudy(id=parent_id, name="Parent", path=str(study.config.study_path), version=str(version))
+    db.session.add(parent)
+    db.session.commit()
+
+    # Create a variant
+    variant_study = variant_study_service.create_variant_study(parent_id, "variant_study")
+
+    # Add a GenerateThermalTimeSeries command
+    command = GenerateThermalClusterTimeSeries(command_context=command_context, study_version=version)
+    assert command.get_inner_matrices() == InnerMatrices(generates_matrices_at_run_time=True)
+    variant_study_service.append_command(variant_study.id, command.to_dto())
+
+    # Generate the snapshot
+    variant_study_service.get_raw(variant_study)
+
+    # Ensures the provider sees matrices in the snapshot as the variant contains the command `GenerateThermalClusterTimeSeries`.
+    # This way it won't be cleaned by the garbage collector.
+    provider = CommandMatrixUsageProvider(variant_study_service.repository, variant_study_service.command_factory)
+    used_matrices = list(provider.get_matrix_usage())
+    assert len(used_matrices) > 0
+
+    # Clean the snapshot manually
+    shutil.rmtree(Path(variant_study.path) / "snapshot")
+
+    # Ensures no matrix is used now that the snapshot is cleaned
+    used_matrices = list(provider.get_matrix_usage())
+    assert len(used_matrices) == 0
 
 
 def test_constants_matrix_usage_provider(constants_matrix_usage_provider: ConstantsMatrixUsageProvider) -> None:

--- a/tests/variantstudy/model/command/test_create_st_storage.py
+++ b/tests/variantstudy/model/command/test_create_st_storage.py
@@ -22,7 +22,7 @@ from antarest.study.business.model.sts_model import STStorageCreation, STStorage
 from antarest.study.model import STUDY_VERSION_8_6, STUDY_VERSION_8_8, STUDY_VERSION_9_2
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-from antarest.study.storage.variantstudy.model.command.common import CommandName
+from antarest.study.storage.variantstudy.model.command.common import CommandName, InnerMatrices
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command.create_st_storage import CreateSTStorage
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
@@ -406,7 +406,7 @@ class TestCreateSTStorage:
                 study_version=study_version,
             )
             # Ensures we don't fill default matrices inside the command parameters
-            assert cmd.get_inner_matrices() == []
+            assert cmd.get_inner_matrices() == InnerMatrices()
 
     def test_version_9_2(self, command_context: CommandContext, empty_study_920: FileStudy) -> None:
         study = empty_study_920

--- a/tests/variantstudy/model/command/test_remove_st_storage.py
+++ b/tests/variantstudy/model/command/test_remove_st_storage.py
@@ -19,7 +19,7 @@ from antarest.study.dao.file.file_study_dao import FileStudyTreeDao
 from antarest.study.model import STUDY_VERSION_8_8
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.study_upgrader import StudyUpgrader
-from antarest.study.storage.variantstudy.model.command.common import CommandName
+from antarest.study.storage.variantstudy.model.command.common import CommandName, InnerMatrices
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command.create_st_storage import CreateSTStorage
 from antarest.study.storage.variantstudy.model.command.create_st_storage_constraints import (
@@ -116,7 +116,7 @@ class TestRemoveSTStorage:
             command_context=command_context, area_id="area_fr", storage_id="storage_1", study_version=STUDY_VERSION_8_8
         )
         actual = cmd.get_inner_matrices()
-        assert actual == []
+        assert actual == InnerMatrices()
 
     def test_error_cases(self, empty_study_920: FileStudy, command_context: CommandContext) -> None:
         # Create an area and a short-term storage inside it

--- a/tests/variantstudy/model/command/test_update_rawfile.py
+++ b/tests/variantstudy/model/command/test_update_rawfile.py
@@ -34,7 +34,7 @@ def test_update_rawfile(empty_study_880: FileStudy, command_context: CommandCont
         study_version=empty_study.config.version,
     )
 
-    assert len(command.get_inner_matrices()) == 0
+    assert len(command.get_inner_matrices().matrices) == 0
 
     res = command.apply(empty_study)
     assert res.status


### PR DESCRIPTION
Bug that existed and is fixed inside this PR (never happened but could):
1) Create a study with 1 area and 1 thermal at least
2) Create a variant and launch a time series generation
3) The matrix garbage collector does not see the generated matrix as used ones and remove them from the matrix-store.
4) If the snapshot is not cleaned, fetching this matrix will raise an error

Now, if a variant contains a `GenerateThermalTimeSeries` command, we'll scan its snapshot. This way we avoid the problem.

Also improves a bit the speed of the `RawStudyMatrixProvider` by:
- Don't scan archived studies
- Only scan `input` and `expansion` folder