### PR TITLE
refactor(output): change some logic inside the /variables-views endpoints

### DIFF
--- a/antarest/core/exceptions.py
+++ b/antarest/core/exceptions.py
@@ -783,4 +783,4 @@ class NotAMatrixError(ValueError):
 class OutputVariablesViewError(HTTPException):
     def __init__(self, output_id: str, message: str) -> None:
         msg = f"Could not retrieve variables view for output '{output_id}' : {message}."
-        super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, msg)
+        super().__init__(HTTPStatus.NOT_FOUND, msg)

--- a/antarest/study/storage/output_model.py
+++ b/antarest/study/storage/output_model.py
@@ -145,3 +145,8 @@ class OutputVariablesViewsModel(Base):
 class OutputVariablesViewStatus(StrEnum):
     NOT_FOUND = "NOT_FOUND"
     IN_PROGRESS = "IN_PROGRESS"
+
+
+class OutputVariablesViewResponse(AntaresBaseModel, extra="forbid", alias_generator=to_camel, populate_by_name=True):
+    status: OutputVariablesViewStatus
+    task_id: str | None

--- a/antarest/study/storage/output_model.py
+++ b/antarest/study/storage/output_model.py
@@ -140,3 +140,8 @@ class OutputVariablesViewsModel(Base):
     st_storage_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     matrix_id: Mapped[str] = mapped_column(String, ForeignKey("matrix.id"), nullable=False)
     last_read: Mapped[datetime] = mapped_column(DateTime)
+
+
+class OutputVariablesViewStatus(StrEnum):
+    NOT_FOUND = "NOT_FOUND"
+    IN_PROGRESS = "IN_PROGRESS"

--- a/antarest/study/storage/output_service.py
+++ b/antarest/study/storage/output_service.py
@@ -107,12 +107,6 @@ class OutputVariablesViewMaterializationTask:
 
     def _materialize_view(self) -> None:
         """Run the task"""
-        # Checks the asked couple `variable name` / `object_id` exists for the output
-        available_variables = self._output_service.get_output_variables_list(self._study_id, self._output_id)
-        check_output_variable_exists(
-            self._output_id, self._variable_type, self._variable_name, available_variables, self._output_identifier
-        )
-
         with temp_file_path(dir=self._output_service._study_service.config.storage.tmp_dir) as tmp_path:
             # Calls the aggregation with the right arguments
             task_id = self._output_service.start_aggregate_output_data(
@@ -788,6 +782,10 @@ class OutputService:
             dataframe.columns = pd.RangeIndex(len(dataframe.columns))  # type: ignore
             return dataframe
 
+        # Checks if the asked couple `variable name` / `output_identifier` exists for the output
+        available_variables = self.get_output_variables_list(study_id, output_id)
+        check_output_variable_exists(output_id, variable_type, variable_name, available_variables, output_identifier)
+
         raise HTTPException(status_code=404, detail="The output variables view is not materialized in DB yet")
 
     def materialize_output_variables_view(
@@ -837,6 +835,10 @@ class OutputService:
         )
         if len(study_tasks) > 0:
             return study_tasks[0].id
+
+        # Checks the asked couple `variable name` / `object_id` exists for the output
+        available_variables = self.get_output_variables_list(study_id, output_id)
+        check_output_variable_exists(output_id, variable_type, variable_name, available_variables, output_identifier)
 
         # Materialize the view
         task = OutputVariablesViewMaterializationTask(

--- a/antarest/study/storage/output_service.py
+++ b/antarest/study/storage/output_service.py
@@ -28,6 +28,7 @@ from antarest.core.filetransfer.model import FileDownloadTaskDTO
 from antarest.core.filetransfer.service import FileTransferManager
 from antarest.core.interfaces.eventbus import Event, EventType, IEventBus
 from antarest.core.model import PermissionInfo, StudyPermissionType
+from antarest.core.serde.json import to_json
 from antarest.core.serde.matrix_export import TableExportFormat
 from antarest.core.tasks.model import TaskListFilter, TaskResult, TaskStatus, TaskType
 from antarest.core.tasks.service import ITaskNotifier, ITaskService
@@ -68,6 +69,7 @@ from antarest.study.storage.output_model import (
     OutputVariablesInformation,
     OutputVariablesList,
     OutputVariablesType,
+    OutputVariablesViewStatus,
 )
 from antarest.study.storage.output_storage import IOutputStorage
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
@@ -186,6 +188,25 @@ class OutputService:
         digest_node = file_study.tree.get_node(url=["output", output_id, "economy", "mc-all", "grid", "digest"])
         assert isinstance(digest_node, DigestSynthesis)
         return digest_node.get_ui()
+
+    def _get_ongoing_variables_view_materialization_task(
+        self, output_identifier: OutputIdentifier, study_id: str, output_id: str, frequency: MatrixFrequency
+    ) -> tuple[str | None, str]:
+        task_name = f"Materializing output view for study `{study_id}`, output `{output_id}`, frequency `{frequency}`, id `{output_identifier.get_id_for_aggregation()}`"
+        if sub_id := output_identifier.get_sub_id_for_aggregation():
+            task_name += f" sub_id `{sub_id}`"
+
+        study_tasks = self._task_service.list_tasks(
+            TaskListFilter(
+                ref_id=study_id,
+                type=[TaskType.OUTPUT_VARIABLES_VIEW_MATERIALIZATION],
+                status=[TaskStatus.RUNNING, TaskStatus.PENDING],
+                name=task_name,
+            )
+        )
+        if len(study_tasks) > 0:
+            return study_tasks[0].id, task_name
+        return None, task_name
 
     @staticmethod
     def _get_output_archive_task_names(study: Study, output_id: str) -> tuple[str, str]:
@@ -755,10 +776,11 @@ class OutputService:
         thermal_id: str | None = None,
         renewable_id: str | None = None,
         st_storage_id: str | None = None,
-    ) -> pd.DataFrame:
+    ) -> pd.DataFrame | Response:
         """
         If the view is already registered in DB, updates its `last_read` value and returns it.
-        Else, raise an HTTP 404 error.
+        Else, returns a Response with a 404 status code.
+        The response body specifies if the view materialization is in progress or not.
         """
         study = self._study_service.get_study(study_id)
         assert_permission(study, StudyPermissionType.READ)
@@ -786,7 +808,13 @@ class OutputService:
         available_variables = self.get_output_variables_list(study_id, output_id)
         check_output_variable_exists(output_id, variable_type, variable_name, available_variables, output_identifier)
 
-        raise HTTPException(status_code=404, detail="The output variables view is not materialized in DB yet")
+        # Return a 404 Response with a body specifying if the materialization is in progress or not.
+        task_id, _ = self._get_ongoing_variables_view_materialization_task(
+            output_identifier, study_id, output_id, frequency
+        )
+        status = OutputVariablesViewStatus.IN_PROGRESS if task_id else OutputVariablesViewStatus.NOT_FOUND
+        content = {"status": status, "task_id": task_id}
+        return Response(status_code=404, content=to_json(content), media_type="application/json")
 
     def materialize_output_variables_view(
         self,
@@ -821,20 +849,11 @@ class OutputService:
             raise HTTPException(status_code=417, detail="The output variables view is already materialized in DB")
 
         # If a task materializing the same view is already running, returns its id
-        task_name = f"Materializing output view for study `{study_id}`, output `{output_id}`, frequency `{frequency}`, id `{output_identifier.get_id_for_aggregation()}`"
-        if sub_id := output_identifier.get_sub_id_for_aggregation():
-            task_name += f" sub_id `{sub_id}`"
-
-        study_tasks = self._task_service.list_tasks(
-            TaskListFilter(
-                ref_id=study_id,
-                type=[TaskType.OUTPUT_VARIABLES_VIEW_MATERIALIZATION],
-                status=[TaskStatus.RUNNING, TaskStatus.PENDING],
-                name=task_name,
-            )
+        task_id, task_name = self._get_ongoing_variables_view_materialization_task(
+            output_identifier, study_id, output_id, frequency
         )
-        if len(study_tasks) > 0:
-            return study_tasks[0].id
+        if task_id:
+            return task_id
 
         # Checks the asked couple `variable name` / `object_id` exists for the output
         available_variables = self.get_output_variables_list(study_id, output_id)

--- a/antarest/study/storage/output_service.py
+++ b/antarest/study/storage/output_service.py
@@ -28,7 +28,6 @@ from antarest.core.filetransfer.model import FileDownloadTaskDTO
 from antarest.core.filetransfer.service import FileTransferManager
 from antarest.core.interfaces.eventbus import Event, EventType, IEventBus
 from antarest.core.model import PermissionInfo, StudyPermissionType
-from antarest.core.serde.json import to_json
 from antarest.core.serde.matrix_export import TableExportFormat
 from antarest.core.tasks.model import TaskListFilter, TaskResult, TaskStatus, TaskType
 from antarest.core.tasks.service import ITaskNotifier, ITaskService
@@ -69,6 +68,7 @@ from antarest.study.storage.output_model import (
     OutputVariablesInformation,
     OutputVariablesList,
     OutputVariablesType,
+    OutputVariablesViewResponse,
     OutputVariablesViewStatus,
 )
 from antarest.study.storage.output_storage import IOutputStorage
@@ -776,11 +776,10 @@ class OutputService:
         thermal_id: str | None = None,
         renewable_id: str | None = None,
         st_storage_id: str | None = None,
-    ) -> pd.DataFrame | Response:
+    ) -> pd.DataFrame | OutputVariablesViewResponse:
         """
         If the view is already registered in DB, updates its `last_read` value and returns it.
-        Else, returns a Response with a 404 status code.
-        The response body specifies if the view materialization is in progress or not.
+        Else, returns a pydantic model specifying if the view materialization is in progress or not.
         """
         study = self._study_service.get_study(study_id)
         assert_permission(study, StudyPermissionType.READ)
@@ -813,8 +812,7 @@ class OutputService:
             output_identifier, study_id, output_id, frequency
         )
         status = OutputVariablesViewStatus.IN_PROGRESS if task_id else OutputVariablesViewStatus.NOT_FOUND
-        content = {"status": status, "task_id": task_id}
-        return Response(status_code=404, content=to_json(content), media_type="application/json")
+        return OutputVariablesViewResponse(status=status, task_id=task_id)
 
     def materialize_output_variables_view(
         self,

--- a/antarest/study/web/output_blueprint.py
+++ b/antarest/study/web/output_blueprint.py
@@ -37,6 +37,7 @@ from antarest.study.storage.output_model import (
     OutputVariablesInformation,
     OutputVariablesList,
     OutputVariablesType,
+    OutputVariablesViewResponse,
 )
 from antarest.study.storage.output_service import OutputService
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixFrequency
@@ -539,6 +540,10 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
     @bp.get(
         "/studies/{uuid}/output/{output_id}/variables-views/data",
         summary="Fetches the variables view for a given output and a given configuration",
+        responses={
+            404: {"model": OutputVariablesViewResponse},
+            200: {"data": [[4], [5]], "columns": [0, 1]},
+        },
     )
     def get_output_variables_view(
         uuid: str,

--- a/antarest/study/web/output_blueprint.py
+++ b/antarest/study/web/output_blueprint.py
@@ -15,6 +15,7 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Annotated, Any, Sequence
 
+import pandas as pd
 from fastapi import APIRouter, Depends, Query, Request, UploadFile
 from starlette.responses import FileResponse, Response
 
@@ -554,12 +555,12 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
     ) -> Response:
         """
         Fetches the variables view for a given output and a given configuration.
-        If the view does not exist in DB yet, raises an HTTP 404 error.
+        If the view does not exist in DB yet, returns an HTTP 404 response.
         The user will have to use the endpoint `POST /variables-views/materialize` with the same configuration first.
         """
         uuid = sanitize_uuid(uuid)
         output_id = sanitize_string(output_id)
-        dataframe = output_service.get_output_variables_view(
+        view = output_service.get_output_variables_view(
             uuid,
             output_id,
             type,
@@ -572,8 +573,10 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
             renewable_id,
             st_storage_id,
         )
-        content = dataframe.to_dict(orient="split", index=False)
-        return Response(content=to_json(content), media_type="application/json")
+        if isinstance(view, pd.DataFrame):
+            content = view.to_dict(orient="split", index=False)
+            return Response(content=to_json(content), media_type="application/json")
+        return view
 
     @bp.post(
         "/studies/{uuid}/output/{output_id}/variables-views/materialize",

--- a/antarest/study/web/output_blueprint.py
+++ b/antarest/study/web/output_blueprint.py
@@ -576,7 +576,7 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
         if isinstance(view, pd.DataFrame):
             content = view.to_dict(orient="split", index=False)
             return Response(content=to_json(content), media_type="application/json")
-        return view
+        return Response(status_code=404, content=to_json(view), media_type="application/json")
 
     @bp.post(
         "/studies/{uuid}/output/{output_id}/variables-views/materialize",

--- a/antarest/study/web/output_blueprint.py
+++ b/antarest/study/web/output_blueprint.py
@@ -20,6 +20,7 @@ from starlette.responses import FileResponse, Response
 
 from antarest.core.config import Config
 from antarest.core.filetransfer.model import FileDownloadTaskDTO
+from antarest.core.serde.json import to_json
 from antarest.core.serde.matrix_export import TableExportFormat
 from antarest.core.utils.utils import sanitize_string, sanitize_uuid
 from antarest.core.utils.web import APITag
@@ -571,8 +572,8 @@ def create_output_routes(output_service: OutputService, config: Config) -> APIRo
             renewable_id,
             st_storage_id,
         )
-        content = dataframe.to_json(orient="split", index=False)
-        return Response(content=content, media_type="application/json")
+        content = dataframe.to_dict(orient="split", index=False)
+        return Response(content=to_json(content), media_type="application/json")
 
     @bp.post(
         "/studies/{uuid}/output/{output_id}/variables-views/materialize",

--- a/tests/integration/raw_studies_blueprint/test_output_variables.py
+++ b/tests/integration/raw_studies_blueprint/test_output_variables.py
@@ -248,3 +248,11 @@ def test_get_output_variables_view(client: TestClient, user_access_token: str, i
     assert task.status == TaskStatus.COMPLETED
     res = client.get(f"{url}/data", params=query_params)
     assert np.isnan(np.array(res.json()["data"])).all()
+
+    # Ensures we raise before running the task when asking for materializing wrong data.
+    query_params = {"type": "area", "variable_name": "H. LEV", "frequency": "weekly", "area_id": "FAKE_AREA"}
+    res = client.post(f"{url}/materialize", params=query_params).json()
+    assert res == {
+        "description": "Could not retrieve variables view for output '20201014-1425eco-goodbye' : The variable 'H. LEV' does not exist for area 'FAKE_AREA' and type 'area'.",
+        "exception": "OutputVariablesViewError",
+    }

--- a/tests/integration/raw_studies_blueprint/test_output_variables.py
+++ b/tests/integration/raw_studies_blueprint/test_output_variables.py
@@ -163,15 +163,16 @@ def test_get_output_variables_view(client: TestClient, user_access_token: str, i
 
     # Areas
     query_params = {"type": "area", "variable_name": "OP. COST", "frequency": "weekly", "area_id": "de"}
-    # Ensures asking for the data before it was materialized raises an exception
+    # Ensures asking for the data before it was materialized returns a HTTP 404 with a status `NOT_FOUND`
     res = client.get(f"{url}/data", params=query_params)
-    assert res.json() == {
-        "description": "The output variables view is not materialized in DB yet",
-        "exception": "HTTPException",
-    }
+    assert res.json() == {"status": "NOT_FOUND", "task_id": None}
     assert res.status_code == 404
     # Materialize the data
     task_id = client.post(f"{url}/materialize", params=query_params).json()
+    # Ask for data with materializing in process -> Should return a 404 with a status `IN_PROGRESS`
+    res = client.get(f"{url}/data", params=query_params)
+    assert res.json() == {"status": "IN_PROGRESS", "task_id": task_id}
+    # Wait for materializing to end
     task = wait_task_completion(client, user_access_token, task_id)
     assert task.status == TaskStatus.COMPLETED
     # Asks for the data. This time, it should succeed.

--- a/tests/integration/raw_studies_blueprint/test_output_variables.py
+++ b/tests/integration/raw_studies_blueprint/test_output_variables.py
@@ -11,6 +11,7 @@
 # This file is part of the Antares project.
 from pathlib import Path
 
+import numpy as np
 from starlette.testclient import TestClient
 
 from antarest.core.serde.json import from_json
@@ -239,3 +240,11 @@ def test_get_output_variables_view(client: TestClient, user_access_token: str, i
         assert third_view.area_to_id == "fr"
         assert third_view.frequency == MatrixFrequency.HOURLY
         assert third_view.variable_name == "FLOW LIN."
+
+    # Ensures we return `NaN` and not `null` inside the endpoint
+    query_params = {"type": "area", "variable_name": "H. LEV", "frequency": "weekly", "area_id": "de"}
+    task_id = client.post(f"{url}/materialize", params=query_params).json()
+    task = wait_task_completion(client, user_access_token, task_id)
+    assert task.status == TaskStatus.COMPLETED
+    res = client.get(f"{url}/data", params=query_params)
+    assert np.isnan(np.array(res.json()["data"])).all()


### PR DESCRIPTION
- Use `NaN` instead of `null` inside the GET `/variables-views/data` endpoint
- Raise an 404 exception when asking for unexisting data inside the GET and POST `/variables-views` endpoints
- The GET endpoint now returns a 404 response with the following body {"status": xxx, "task_id": xxx} when the data is not in DB yet. status is NOT_FOUND and task_id is None when the materializing hasn't been done. status is `IN_PROGRESS` and task_id is the running task when the materializing is in progress