### PR TITLE
chore(archives): remove caching of zip file lists

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/lazy_node.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/lazy_node.py
@@ -10,24 +10,15 @@
 #
 # This file is part of the Antares project.
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, Generic, List, Optional, Tuple
+from typing import Any, Generic, List, Optional, Tuple
 from zipfile import ZipFile
 
 from typing_extensions import override
 
-from antarest.core.utils.utils import current_time
 from antarest.matrixstore.matrix_uri_mapper import MatrixUriMapper
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.inode import G, INode, S, V
-
-
-@dataclass
-class SimpleCache:
-    value: Any
-    expiration_date: datetime
 
 
 class LazyNode(INode, ABC, Generic[G, S, V]):  # type: ignore
@@ -35,8 +26,6 @@ class LazyNode(INode, ABC, Generic[G, S, V]):  # type: ignore
     A "lazy" node does not return its full content but a summarized, short representation
     when in the context of a tree expansion (typically getting children of a folder node).
     """
-
-    ZIP_FILELIST_CACHE: Dict[str, SimpleCache] = {}
 
     def __init__(
         self,
@@ -61,13 +50,9 @@ class LazyNode(INode, ABC, Generic[G, S, V]):  # type: ignore
             str_zipped_path = str(self.config.archive_path)
             inside_zip_path = str(self.config.path)[len(str_zipped_path[:-4]) + 1 :]
             str_inside_zip_path = str(inside_zip_path).replace("\\", "/")
-            if str_zipped_path not in LazyNode.ZIP_FILELIST_CACHE:
-                with ZipFile(file=self.config.archive_path) as zip_file:
-                    LazyNode.ZIP_FILELIST_CACHE[str_zipped_path] = SimpleCache(
-                        value=zip_file.namelist(),
-                        expiration_date=current_time() + timedelta(hours=2),
-                    )
-            return str_inside_zip_path in LazyNode.ZIP_FILELIST_CACHE[str_zipped_path].value
+            with ZipFile(file=self.config.archive_path) as zip_file:
+                file_names = zip_file.namelist()
+            return str_inside_zip_path in file_names
         else:
             return self.config.path.exists()
 

--- a/antarest/study/storage/rawstudy/raw_study_service.py
+++ b/antarest/study/storage/rawstudy/raw_study_service.py
@@ -12,10 +12,8 @@
 
 import logging
 import shutil
-import time
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
-from threading import Thread
 from typing import BinaryIO, List, Optional, Sequence
 from uuid import uuid4
 
@@ -35,7 +33,6 @@ from antarest.study.repository import StudyMetadataRepository
 from antarest.study.storage.abstract_storage_service import AbstractStorageService
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig, FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy, StudyFactory
-from antarest.study.storage.rawstudy.model.filesystem.lazy_node import LazyNode
 from antarest.study.storage.rawstudy.raw_study_matrix_usage_provider import RawStudyMatrixUsageProvider
 from antarest.study.storage.utils import (
     create_new_empty_study,
@@ -94,12 +91,6 @@ class RawStudyService(AbstractStorageService):
             study_factory=study_factory,
             cache=cache,
         )
-        self.cleanup_thread = Thread(
-            target=RawStudyService.cleanup_lazynode_zipfilelist_cache,
-            name=f"{self.__class__.__name__}-Cleaner",
-            daemon=True,
-        )
-        self.cleanup_thread.start()
 
         RawStudyMatrixUsageProvider(
             StudyMetadataRepository(cache_service=cache),
@@ -494,18 +485,6 @@ class RawStudyService(AbstractStorageService):
                 study.id,
                 exc_info=e,
             )
-
-    @staticmethod
-    def cleanup_lazynode_zipfilelist_cache() -> None:
-        while True:
-            logger.info(f"Cleaning lazy node zipfilelist cache ({len(LazyNode.ZIP_FILELIST_CACHE)} items)")
-            LazyNode.ZIP_FILELIST_CACHE = {
-                key: LazyNode.ZIP_FILELIST_CACHE[key]
-                for key in LazyNode.ZIP_FILELIST_CACHE
-                if LazyNode.ZIP_FILELIST_CACHE[key].expiration_date < current_time()
-            }
-            logger.info(f"Cleaned lazy node zipfilelist cache ({len(LazyNode.ZIP_FILELIST_CACHE)} items)")
-            time.sleep(600)
 
     @override
     def get_output_path(self, study: Study, output_id: str) -> Path:


### PR DESCRIPTION

This is actually never used, it uses threads for nothing, and spams logs.
Logs in production showed that it was not used in 2 months.
