### PR TITLE
fix(tests): fix random test failures where study is not yet scanned

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,7 +21,6 @@ import jinja2
 import pytest
 from _pytest.tmpdir import TempPathFactory
 from fastapi import FastAPI
-from integration.utils import wait_for
 from sqlalchemy import create_engine
 from starlette.testclient import TestClient
 
@@ -33,6 +32,7 @@ from antarest.service_creator import Services
 from antarest.study.repository import AccessPermissions, StudyFilter
 from antarest.study.service import StudyService
 from tests.integration.assets import ASSETS_DIR
+from tests.integration.utils import wait_for
 
 HERE = Path(__file__).parent.resolve()
 PROJECT_DIR = next(iter(p for p in HERE.parents if p.joinpath("antarest").exists()))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -113,14 +113,14 @@ def app_and_services(tmp_path: Path, db_path: Path) -> Iterable[tuple[FastAPI, S
 
     app, services = fastapi_app(config_path, RESOURCES_DIR, mount_front=False)
 
-    def is_study_ready():
+    def is_study_scanned():
         with db():
             studies = services.study.get_studies_information(
                 StudyFilter(access_permissions=AccessPermissions.for_user(DEFAULT_ADMIN_USER))
             )
             return len(studies) == 1
 
-    wait_for(is_study_ready, timeout=10, sleep_time=0.01)
+    wait_for(is_study_scanned, timeout=10, sleep_time=0.01)
 
     yield app, services
     services.watcher.stop()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,12 +21,16 @@ import jinja2
 import pytest
 from _pytest.tmpdir import TempPathFactory
 from fastapi import FastAPI
+from integration.utils import wait_for
 from sqlalchemy import create_engine
 from starlette.testclient import TestClient
 
+from antarest.core.jwt import DEFAULT_ADMIN_USER
+from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.dbmodel import Base
 from antarest.main import fastapi_app
 from antarest.service_creator import Services
+from antarest.study.repository import AccessPermissions, StudyFilter
 from antarest.study.service import StudyService
 from tests.integration.assets import ASSETS_DIR
 
@@ -108,6 +112,16 @@ def app_and_services(tmp_path: Path, db_path: Path) -> Iterable[tuple[FastAPI, S
         )
 
     app, services = fastapi_app(config_path, RESOURCES_DIR, mount_front=False)
+
+    def is_study_ready():
+        with db():
+            studies = services.study.get_studies_information(
+                StudyFilter(access_permissions=AccessPermissions.for_user(DEFAULT_ADMIN_USER))
+            )
+            return len(studies) == 1
+
+    wait_for(is_study_ready, timeout=10, sleep_time=0.01)
+
     yield app, services
     services.watcher.stop()
 


### PR DESCRIPTION

Many integration tests rely on the scan of the STA-mini study, but we don't
ensure that it is actually scanned before starting the tests.
This causes random failures of integration tests, in particular in windows CI,
particularly since they have been made a little faster by avoiding constant
matrix writing.