### PR TITLE
feat(ci): use uv to install dependencies

### DIFF
--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -14,10 +14,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          activate-environment: true
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install click
+          uv pip install click
       - name: Check licenses header
         run: |
           python license_checker_and_adder.py --path=../antarest/ --action=check-strict

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,6 @@ jobs:
           python-version: 3.11
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
       - name: Install dependencies
         run: |
           uv pip install -r requirements-dev.txt
@@ -46,8 +44,6 @@ jobs:
           python-version: 3.11
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
       - name: Install dependencies
         run: |
           uv pip install -r requirements-dev.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: 3.11
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           activate-environment: true
       - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
         with:
           python-version: 3.11
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           activate-environment: true
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
           python-version: 3.11
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          activate-environment: true
       - name: Install dependencies
         run: |
           uv pip install -r requirements-dev.txt
@@ -44,6 +46,8 @@ jobs:
           python-version: 3.11
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          activate-environment: true
       - name: Install dependencies
         run: |
           uv pip install -r requirements-dev.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          uv pip install -r requirements-dev.txt
       - name: Check format (ruff)
         run: |
           ruff check antarest/ tests/
@@ -41,10 +44,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          uv pip install -r requirements-dev.txt
       - name: Test with pytest
         run: |
           pytest --cov antarest --cov-report xml -n 4 --dist=worksteal


### PR DESCRIPTION
Poor version of https://github.com/AntaresSimulatorTeam/AntaREST/pull/2796  to benefit from CI speedup without actually changing the current workflows.

In particular dependencies install step on windows CI drops by more than 1 minute.
