### PR TITLE
feat(variable-view-gc): clean old materialized output variable view

### DIFF
--- a/antarest/core/config.py
+++ b/antarest/core/config.py
@@ -169,6 +169,9 @@ class StorageConfig:
     blobstore: Path = Path("./blobstore")
     blob_gc_sleeping_time: int = 86400
     blob_gc_dry_run: bool = False
+    variable_view_gc_sleeping_time: int = 3600
+    variable_view_gc_dry_run: bool = False
+    variable_view_gc_retention_days: int = 30
 
     @classmethod
     def from_dict(cls, data: JSON, desktop_mode: bool = False) -> "StorageConfig":
@@ -206,6 +209,13 @@ class StorageConfig:
             blobstore=Path(data["blobstore"]) if "blobstore" in data else defaults.blobstore,
             blob_gc_sleeping_time=data.get("blob_gc_sleeping_time", defaults.blob_gc_sleeping_time),
             blob_gc_dry_run=data.get("blob_gc_dry_run", defaults.blob_gc_dry_run),
+            variable_view_gc_sleeping_time=data.get(
+                "variable_view_gc_sleeping_time", defaults.variable_view_gc_sleeping_time
+            ),
+            variable_view_gc_dry_run=data.get("variable_view_gc_dry_run", defaults.variable_view_gc_dry_run),
+            variable_view_gc_retention_days=data.get(
+                "variable_view_gc_retention_days", defaults.variable_view_gc_retention_days
+            ),
         )
 
     @classmethod

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -275,6 +275,8 @@ def fastapi_app(
         services.auto_archiver.start()
     if services.blob_gc and Module.BLOB_GC in config.server.services:
         services.blob_gc.start()
+    if services.variable_view_gc and Module.VARIABLE_VIEW_GC in config.server.services:
+        services.variable_view_gc.start()
 
     customize_openapi(application)
 

--- a/antarest/maintenance/app.py
+++ b/antarest/maintenance/app.py
@@ -117,6 +117,7 @@ def _setup_periodic_tasks(sender: Celery, **_: object) -> None:
     from antarest.maintenance.tasks.auto_archive_task import auto_archive_task
     from antarest.maintenance.tasks.gc_blob_task import clean_blobs_task
     from antarest.maintenance.tasks.gc_matrix_task import clean_matrices_task
+    from antarest.maintenance.tasks.gc_variable_view_task import clean_variable_views_task
     from antarest.maintenance.tasks.watcher_scan_task import watcher_scan_task
 
     config: Optional[Config] = getattr(celery_app.conf, "antarest_config", None)
@@ -126,6 +127,9 @@ def _setup_periodic_tasks(sender: Celery, **_: object) -> None:
     sender.add_periodic_task(storage.blob_gc_sleeping_time, clean_blobs_task.s(), name="blobs_cleaner")
     sender.add_periodic_task(storage.auto_archive_sleeping_time, auto_archive_task.s(), name="auto_archiver")
     sender.add_periodic_task(storage.watcher_scan_sleeping_time, watcher_scan_task.s(), name="watcher_scan")
+    sender.add_periodic_task(
+        storage.variable_view_gc_sleeping_time, clean_variable_views_task.s(), name="variable_view_cleaner"
+    )
 
     # Stagger first execution to avoid hitting everything at once
     clean_matrices_task.apply_async(countdown=60)
@@ -135,7 +139,7 @@ def _setup_periodic_tasks(sender: Celery, **_: object) -> None:
     logger.info(
         f"Periodic tasks: matrix_gc={storage.matrix_gc_sleeping_time}s, "
         f"blob_gc={storage.blob_gc_sleeping_time}s, auto_archive={storage.auto_archive_sleeping_time}s, "
-        f"watcher_scan={storage.watcher_scan_sleeping_time}s"
+        f"watcher_scan={storage.watcher_scan_sleeping_time}s, variable_view_gc={storage.variable_view_gc_sleeping_time}s"
     )
 
 

--- a/antarest/maintenance/tasks/auto_archive_task.py
+++ b/antarest/maintenance/tasks/auto_archive_task.py
@@ -19,6 +19,7 @@ from antarest.login.utils import current_user_context
 from antarest.maintenance.app import celery_app
 from antarest.maintenance.context import MaintenanceContext
 from antarest.maintenance.tasks.auto_archive import AutoArchiveTaskResult, archive_old_studies
+from antarest.maintenance.tasks.common import MaintenanceContextNotFoundError
 
 
 @celery_app.task(bind=True, name="auto_archiver", pydantic=True)
@@ -26,7 +27,7 @@ def auto_archive_task(self: Task) -> AutoArchiveTaskResult:  # type: ignore[type
     """Celery wrapper that delegates to archive_old_studies() with admin context."""
     ctx: MaintenanceContext | None = self.app.conf.get("maintenance_ctx")
     if not ctx:
-        raise RuntimeError("MaintenanceContext not in app.conf - worker not initialized?")
+        raise MaintenanceContextNotFoundError()
 
     with current_user_context(DEFAULT_ADMIN_USER):
         return archive_old_studies(

--- a/antarest/maintenance/tasks/common.py
+++ b/antarest/maintenance/tasks/common.py
@@ -18,6 +18,13 @@ from typing import Optional
 from antarest.core.serde import AntaresBaseModel
 
 
+class MaintenanceContextNotFoundError(RuntimeError):
+    """Raised when MaintenanceContext is not found in app.conf."""
+
+    def __init__(self) -> None:
+        super().__init__("MaintenanceContext not in app.conf - worker not initialized?")
+
+
 class BackGroundTaskStatus(StrEnum):
     SUCCESS = "success"
     PARTIAL_SUCCESS = "partial_success"

--- a/antarest/maintenance/tasks/common.py
+++ b/antarest/maintenance/tasks/common.py
@@ -43,3 +43,4 @@ class LockId(IntEnum):
     MATRIX_GC = 1001
     BLOB_GC = 1002
     AUTO_ARCHIVE = 1003
+    VARIABLE_VIEW_GC = 1004

--- a/antarest/maintenance/tasks/common.py
+++ b/antarest/maintenance/tasks/common.py
@@ -43,8 +43,8 @@ class LockId(IntEnum):
     MATRIX_GC = 1001
     BLOB_GC = 1002
     AUTO_ARCHIVE = 1003
-    WATCHER_SCAN = 1005
-    VARIABLE_VIEW_GC = 1006
+    WATCHER_SCAN = 1004
+    VARIABLE_VIEW_GC = 1005
 
 
 class WatcherScanTaskResult(AntaresBaseModel):

--- a/antarest/maintenance/tasks/gc_blob_task.py
+++ b/antarest/maintenance/tasks/gc_blob_task.py
@@ -16,7 +16,7 @@ from celery import Task
 
 from antarest.maintenance.app import celery_app
 from antarest.maintenance.context import MaintenanceContext
-from antarest.maintenance.tasks.common import GarbageCollectorTaskResult
+from antarest.maintenance.tasks.common import GarbageCollectorTaskResult, MaintenanceContextNotFoundError
 from antarest.maintenance.tasks.gc_blob import clean_blobs
 
 
@@ -25,6 +25,6 @@ def clean_blobs_task(self: Task) -> GarbageCollectorTaskResult:  # type: ignore[
     """Celery wrapper that delegates to clean_blobs()."""
     ctx: MaintenanceContext | None = self.app.conf.get("maintenance_ctx")
     if not ctx:
-        raise RuntimeError("MaintenanceContext not in app.conf - worker not initialized?")
+        raise MaintenanceContextNotFoundError()
 
     return clean_blobs(ctx.blob_service, ctx.config.storage.blob_gc_dry_run)

--- a/antarest/maintenance/tasks/gc_matrix_task.py
+++ b/antarest/maintenance/tasks/gc_matrix_task.py
@@ -16,7 +16,7 @@ from celery import Task
 
 from antarest.maintenance.app import celery_app
 from antarest.maintenance.context import MaintenanceContext
-from antarest.maintenance.tasks.common import GarbageCollectorTaskResult
+from antarest.maintenance.tasks.common import GarbageCollectorTaskResult, MaintenanceContextNotFoundError
 from antarest.maintenance.tasks.gc_matrix import clean_matrices
 
 
@@ -25,7 +25,7 @@ def clean_matrices_task(self: Task) -> GarbageCollectorTaskResult:  # type: igno
     """Celery wrapper that delegates to clean_matrices()."""
     ctx: MaintenanceContext | None = self.app.conf.get("maintenance_ctx")
     if not ctx:
-        raise RuntimeError("MaintenanceContext not in app.conf - worker not initialized?")
+        raise MaintenanceContextNotFoundError()
 
     return clean_matrices(
         ctx.matrix_service,

--- a/antarest/maintenance/tasks/gc_variable_view.py
+++ b/antarest/maintenance/tasks/gc_variable_view.py
@@ -53,12 +53,15 @@ def clean_variable_views(
             with create_lock(db.session, lock_id=LockId.VARIABLE_VIEW_GC):
                 cutoff = current_time() - timedelta(days=retention_time)
 
-                rows = (
-                    db.session.query(OutputVariablesViewsModel)
-                    .filter(OutputVariablesViewsModel.last_read < cutoff)
-                    .all()
-                )
-                if not rows:
+                query = db.session.query(OutputVariablesViewsModel).filter(OutputVariablesViewsModel.last_read < cutoff)
+
+                if dry_run:
+                    deleted_count = query.count()
+                else:
+                    deleted_count = query.delete()
+                    db.session.commit()
+
+                if deleted_count == 0:
                     return GarbageCollectorTaskResult(
                         status=BackGroundTaskStatus.SKIPPED,
                         reason="no_unused_variable_view",
@@ -66,14 +69,7 @@ def clean_variable_views(
                         duration_seconds=time.time() - start_time,
                     )
 
-                logger.info("Variable view GC: deleting %d view rows (dry_run=%s)", len(rows), dry_run)
-
-                if not dry_run:
-                    for r in rows:
-                        db.session.delete(r)
-                    db.session.commit()
-
-                deleted_count = len(rows)
+                logger.info("Variable view GC: deleted %d view rows (dry_run=%s)", deleted_count, dry_run)
 
     except LockNotAcquired:
         logger.warning(

--- a/antarest/maintenance/tasks/gc_variable_view.py
+++ b/antarest/maintenance/tasks/gc_variable_view.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Variable view garbage collection task, agnostic from the way it is executed.
+This task deletes unused variable views from the variable view store based on retention time.
+"""
+
+import logging
+import time
+from datetime import timedelta
+
+from antarest.core.utils.fastapi_sqlalchemy import db
+from antarest.core.utils.lock import LockNotAcquired, create_lock
+from antarest.core.utils.utils import current_time
+from antarest.maintenance.tasks.common import BackGroundTaskStatus, GarbageCollectorTaskResult, LockId
+from antarest.study.output.output_model import OutputVariablesViewsModel
+
+logger = logging.getLogger(__name__)
+
+
+def clean_variable_views(
+    dry_run: bool,
+    retention_time: int,
+) -> GarbageCollectorTaskResult:
+    """
+    Delete variable views if their last_read is older than retention_time.
+    Note: matrices are not deleted here. Once rows are deleted, their matrice ids are not returned
+    anymore by the variable view usage provider, so they become eligible for matrix GC.
+    Args:
+        dry_run: If True, don't actually delete variable views rows
+        retention_time: Time in days before unused variable views can be deleted
+    Returns:
+        GarbageCollectorTaskResult with execution stats (deleted count, duration, status)
+    """
+    start_time = time.time()
+
+    logger.info("Beginning variables view GC process")
+    logger.info(f"Configuration: dry_run={dry_run}, retention_time={retention_time} days")
+
+    deleted_count = 0
+    try:
+        with db():
+            with create_lock(db.session, lock_id=LockId.VARIABLE_VIEW_GC):
+                cutoff = current_time() - timedelta(days=retention_time)
+
+                rows = (
+                    db.session.query(OutputVariablesViewsModel)
+                    .filter(OutputVariablesViewsModel.last_read < cutoff)
+                    .all()
+                )
+                if not rows:
+                    return GarbageCollectorTaskResult(
+                        status=BackGroundTaskStatus.SKIPPED,
+                        reason="no_unused_variable_view",
+                        deleted_count=0,
+                        duration_seconds=time.time() - start_time,
+                    )
+
+                logger.info("Variable view GC: deleting %d view rows (dry_run=%s)", len(rows), dry_run)
+
+                if not dry_run:
+                    for r in rows:
+                        db.session.delete(r)
+                    db.session.commit()
+
+                deleted_count = len(rows)
+
+    except LockNotAcquired:
+        logger.warning(
+            f"Could not acquire advisory lock {LockId.VARIABLE_VIEW_GC}. "
+            "Another variable GC process is probably running. Skipping this run."
+        )
+        return GarbageCollectorTaskResult(
+            status=BackGroundTaskStatus.SKIPPED,
+            reason="lock_not_acquired",
+            deleted_count=0,
+            duration_seconds=time.time() - start_time,
+        )
+    except Exception as e:
+        logger.error("Error during variable view GC", exc_info=e)
+        return GarbageCollectorTaskResult(
+            status=BackGroundTaskStatus.ERROR,
+            error=str(e),
+            deleted_count=0,
+            duration_seconds=time.time() - start_time,
+        )
+
+    duration = time.time() - start_time
+    logger.info(f"Finished variable view GC in {duration}s (deleted {deleted_count})")
+
+    return GarbageCollectorTaskResult(
+        status=BackGroundTaskStatus.SUCCESS,
+        deleted_count=deleted_count,
+        duration_seconds=duration,
+        dry_run=dry_run,
+    )

--- a/antarest/maintenance/tasks/gc_variable_view.py
+++ b/antarest/maintenance/tasks/gc_variable_view.py
@@ -34,8 +34,11 @@ def clean_variable_views(
 ) -> GarbageCollectorTaskResult:
     """
     Delete variable views if their last_read is older than retention_time.
-    Note: matrices are not deleted here. Once rows are deleted, their matrice ids are not returned
-    anymore by the variable view usage provider, so they become eligible for matrix GC.
+
+    Note: matrices are not deleted here. Once a row is deleted from OutputVariablesViewsModel,
+    its matrix id is not returned anymore by the variable view usage provider, so the matrix
+    for that view becomes eligible for matrix GC.
+
     Args:
         dry_run: If True, don't actually delete variable views rows
         retention_time: Time in days before unused variable views can be deleted

--- a/antarest/maintenance/tasks/gc_variable_view_task.py
+++ b/antarest/maintenance/tasks/gc_variable_view_task.py
@@ -19,22 +19,18 @@ from celery import Task
 
 from antarest.maintenance.app import celery_app
 from antarest.maintenance.context import MaintenanceContext
-from antarest.maintenance.tasks.common import GarbageCollectorTaskResult
+from antarest.maintenance.tasks.common import GarbageCollectorTaskResult, MaintenanceContextNotFoundError
 from antarest.maintenance.tasks.gc_variable_view import clean_variable_views
 
 
-@celery_app.task(bind=True, name="antarest.maintenance.tasks.clean_variable_views_task", pydantic=True)
+@celery_app.task(bind=True, name="variable_view_cleaner", pydantic=True)
 def clean_variable_views_task(self: Task) -> GarbageCollectorTaskResult:  # type: ignore[type-arg]
     """
     Celery task wrapper for clean_variable_views.
-    Retrieves dependencies from the Celery app configuration (injected during worker init)
-    and delegates to clean_variable_views().
-    Args:
-        self: The bound task instance, provides access to self.app
     """
-    ctx: MaintenanceContext | None = getattr(self.app.conf, "maintenance_ctx", None)
+    ctx: MaintenanceContext | None = self.app.conf.get("maintenance_ctx")
     if ctx is None:
-        raise RuntimeError("MaintenanceContext not found in app.conf. Ensure worker was properly started.")
+        raise MaintenanceContextNotFoundError()
 
     return clean_variable_views(
         dry_run=ctx.config.storage.variable_view_gc_dry_run,

--- a/antarest/maintenance/tasks/gc_variable_view_task.py
+++ b/antarest/maintenance/tasks/gc_variable_view_task.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Output variables views garbage collection task wrapper for Celery.
+This task deletes old materialized output variables views based on their last_read timestamp.
+"""
+
+from celery import Task
+
+from antarest.maintenance.app import celery_app
+from antarest.maintenance.context import MaintenanceContext
+from antarest.maintenance.tasks.common import GarbageCollectorTaskResult
+from antarest.maintenance.tasks.gc_variable_view import clean_variable_views
+
+
+@celery_app.task(bind=True, name="antarest.maintenance.tasks.clean_variable_views_task", pydantic=True)
+def clean_variable_views_task(self: Task) -> GarbageCollectorTaskResult:  # type: ignore[type-arg]
+    """
+    Celery task wrapper for clean_variable_views.
+    Retrieves dependencies from the Celery app configuration (injected during worker init)
+    and delegates to clean_variable_views().
+    Args:
+        self: The bound task instance, provides access to self.app
+    """
+    ctx: MaintenanceContext | None = getattr(self.app.conf, "maintenance_ctx", None)
+    if ctx is None:
+        raise RuntimeError("MaintenanceContext not found in app.conf. Ensure worker was properly started.")
+
+    return clean_variable_views(
+        dry_run=ctx.config.storage.variable_view_gc_dry_run,
+        retention_time=ctx.config.storage.variable_view_gc_retention_days,
+    )

--- a/antarest/maintenance/tasks/watcher_scan_task.py
+++ b/antarest/maintenance/tasks/watcher_scan_task.py
@@ -16,7 +16,7 @@ from celery import Task
 
 from antarest.maintenance.app import celery_app
 from antarest.maintenance.context import MaintenanceContext
-from antarest.maintenance.tasks.common import WatcherScanTaskResult
+from antarest.maintenance.tasks.common import MaintenanceContextNotFoundError, WatcherScanTaskResult
 from antarest.maintenance.tasks.watcher_scan import scan_workspaces
 
 
@@ -25,7 +25,7 @@ def watcher_scan_task(self: Task) -> WatcherScanTaskResult:  # type: ignore[type
     """Celery wrapper that delegates to scan_workspaces()."""
     ctx: MaintenanceContext | None = self.app.conf.get("maintenance_ctx")
     if not ctx:
-        raise RuntimeError("MaintenanceContext not in app.conf - worker not initialized?")
+        raise MaintenanceContextNotFoundError()
 
     return scan_workspaces(
         ctx.config,

--- a/antarest/service_creator.py
+++ b/antarest/service_creator.py
@@ -50,6 +50,7 @@ from antarest.study.main import build_study_service
 from antarest.study.output.adapters import study_service_as_file_outputs_provider, study_service_as_studies_repository
 from antarest.study.output.file_output_storage import FileOutputStorage
 from antarest.study.output.output_service import OutputService
+from antarest.study.output.variable_view_gc import VariableViewGarbageCollector
 from antarest.study.service import StudyService
 from antarest.study.storage.auto_archive_service import AutoArchiveService
 from antarest.study.storage.explorer_service import Explorer
@@ -83,6 +84,7 @@ class Module(StrEnum):
     ARCHIVE_WORKER = "archive_worker"
     AUTO_ARCHIVER = "auto_archiver"
     BLOB_GC = "blob_gc"
+    VARIABLE_VIEW_GC = "variable_view_gc"
 
 
 def init_db_engine(
@@ -256,6 +258,14 @@ def create_blob_gc(config: Config, blob_service: BlobService) -> BlobGarbageColl
     )
 
 
+def create_variable_view_gc(config: Config) -> VariableViewGarbageCollector:
+    return VariableViewGarbageCollector(
+        sleeping_time=config.storage.variable_view_gc_sleeping_time,
+        dry_run=config.storage.variable_view_gc_dry_run,
+        retention_time=config.storage.variable_view_gc_retention_days,
+    )
+
+
 def create_watcher(
     config: Config,
     app_ctxt: Optional[AppBuildContext],
@@ -314,6 +324,7 @@ class Services:
     matrix_gc: Optional[MatrixGarbageCollector] = None
     auto_archiver: Optional[AutoArchiveService] = None
     blob_gc: Optional[BlobGarbageCollector] = None
+    variable_view_gc: Optional[VariableViewGarbageCollector] = None
 
 
 def create_services(config: Config, app_ctxt: Optional[AppBuildContext], create_all: bool = False) -> Services:
@@ -350,6 +361,10 @@ def create_services(config: Config, app_ctxt: Optional[AppBuildContext], create_
     if config.server.services and Module.AUTO_ARCHIVER.value in config.server.services or create_all:
         auto_archiver = AutoArchiveService(core_services.study_service, core_services.output_service, config)
 
+    variable_view_gc = None
+    if config.server.services and Module.VARIABLE_VIEW_GC.value in config.server.services or create_all:
+        variable_view_gc = create_variable_view_gc(config)
+
     return Services(
         watcher=watcher,
         explorer=explorer_service,
@@ -363,4 +378,5 @@ def create_services(config: Config, app_ctxt: Optional[AppBuildContext], create_
         matrix_gc=matrix_garbage_collector,
         auto_archiver=auto_archiver,
         blob_gc=blob_garbage_collector,
+        variable_view_gc=variable_view_gc,
     )

--- a/antarest/study/output/variable_view_gc.py
+++ b/antarest/study/output/variable_view_gc.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+import logging
+import time
+
+from typing_extensions import override
+
+from antarest.core.interfaces.service import IService
+from antarest.maintenance.tasks.gc_variable_view import clean_variable_views
+
+logger = logging.getLogger(__name__)
+
+
+class VariableViewGarbageCollector(IService):
+    """
+    Background service that periodically cleans unused variable views.
+    This is used in non-Celery environments (desktop version and self-hosted) where
+    we can't rely on Celery.
+    """
+
+    def __init__(self, sleeping_time: float, dry_run: bool, retention_time: int):
+        self.sleeping_time = sleeping_time
+        self.dry_run = dry_run
+        self.retention_time = retention_time
+
+    @override
+    def _loop(self) -> None:
+        while True:
+            try:
+                clean_variable_views(self.dry_run, self.retention_time)
+            except Exception as e:
+                logger.error("Error while cleaning variable views", exc_info=e)
+            logger.info(f"Sleeping for {self.sleeping_time}s")
+            time.sleep(self.sleeping_time)

--- a/docs/developer-guide/install/1-CONFIG.md
+++ b/docs/developer-guide/install/1-CONFIG.md
@@ -720,6 +720,7 @@ server:
   services:
     - watcher
     - matrix_gc
+    - variable_view_gc
 ```
 
 # redis

--- a/tests/integration/maintenance_blueprint/test_gc_variable_view.py
+++ b/tests/integration/maintenance_blueprint/test_gc_variable_view.py
@@ -15,34 +15,25 @@
 import uuid
 from datetime import datetime, timedelta
 
+import pandas as pd
+
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import current_time
 from antarest.maintenance.tasks.common import BackGroundTaskStatus
 from antarest.maintenance.tasks.gc_variable_view import clean_variable_views
-from antarest.matrixstore.model import Matrix
+from antarest.matrixstore.service import MatrixService
 from antarest.study.model import MatrixFrequency, RawStudy
 from antarest.study.output.output_model import OutputVariablesType, OutputVariablesViewsModel
 
 
 def _create_study(study_id: str) -> RawStudy:
-    """Helper to create a minimal study for FK requirements."""
+    """Helper to create a minimal study."""
     return RawStudy(
         id=study_id,
         name="Test Study",
         version="8.6",
         path="/tmp/test",
         workspace="default",
-    )
-
-
-def _create_matrix(matrix_id: str) -> Matrix:
-    """Helper to create a minimal matrix for FK requirements."""
-    return Matrix(
-        id=matrix_id,
-        width=2,
-        height=2,
-        created_at=current_time(),
-        version=1,
     )
 
 
@@ -69,15 +60,15 @@ def _create_variable_view(
 class TestCleanVariableViewsIntegration:
     """Integration tests for clean_variable_views using real database."""
 
-    def test_deletes_old_variable_views(self):
+    def test_deletes_old_variable_views(self, matrix_service: MatrixService):
         """Test that old variable views are deleted."""
         study_id = str(uuid.uuid4())
-        matrix_id = "a" * 64
         output_id = "test-output"
+        matrix_data = pd.DataFrame([[1, 2], [3, 4]])
 
         with db():
+            matrix_id = matrix_service.create(matrix_data)
             db.session.add(_create_study(study_id))
-            db.session.add(_create_matrix(matrix_id))
             db.session.add(
                 _create_variable_view(
                     study_id=study_id,
@@ -101,15 +92,15 @@ class TestCleanVariableViewsIntegration:
             views_after = db.session.query(OutputVariablesViewsModel).all()
             assert len(views_after) == 0
 
-    def test_keeps_recent_variable_views(self):
+    def test_keeps_recent_variable_views(self, matrix_service: MatrixService):
         """Test that recent variable views are NOT deleted."""
         study_id = str(uuid.uuid4())
-        matrix_id = "b" * 64
         output_id = "test-output"
+        matrix_data = pd.DataFrame([[1, 2], [3, 4]])
 
         with db():
+            matrix_id = matrix_service.create(matrix_data)
             db.session.add(_create_study(study_id))
-            db.session.add(_create_matrix(matrix_id))
             db.session.add(
                 _create_variable_view(
                     study_id=study_id,
@@ -130,15 +121,15 @@ class TestCleanVariableViewsIntegration:
             views_after = db.session.query(OutputVariablesViewsModel).all()
             assert len(views_after) == 1
 
-    def test_dry_run_does_not_delete(self):
+    def test_dry_run_does_not_delete(self, matrix_service: MatrixService):
         """Test that dry_run mode does not delete variable views."""
         study_id = str(uuid.uuid4())
-        matrix_id = "c" * 64
         output_id = "test-output"
+        matrix_data = pd.DataFrame([[1, 2], [3, 4]])
 
         with db():
+            matrix_id = matrix_service.create(matrix_data)
             db.session.add(_create_study(study_id))
-            db.session.add(_create_matrix(matrix_id))
             db.session.add(
                 _create_variable_view(
                     study_id=study_id,
@@ -168,17 +159,16 @@ class TestCleanVariableViewsIntegration:
         assert result.deleted_count == 0
         assert result.duration_seconds >= 0
 
-    def test_deletes_only_old_views_keeps_recent(self):
+    def test_deletes_only_old_views_keeps_recent(self, matrix_service: MatrixService):
         """Test that only old views are deleted while recent ones are kept."""
         study_id = str(uuid.uuid4())
-        matrix_id_old = "d" * 64
-        matrix_id_recent = "e" * 64
         output_id = "test-output"
+        matrix_data = pd.DataFrame([[1, 2], [3, 4]])
 
         with db():
+            matrix_id_old = matrix_service.create(matrix_data)
+            matrix_id_recent = matrix_service.create(matrix_data)
             db.session.add(_create_study(study_id))
-            db.session.add(_create_matrix(matrix_id_old))
-            db.session.add(_create_matrix(matrix_id_recent))
 
             # Old view - should be deleted
             db.session.add(

--- a/tests/integration/maintenance_blueprint/test_gc_variable_view.py
+++ b/tests/integration/maintenance_blueprint/test_gc_variable_view.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""Integration tests for the variable view garbage collection task."""
+
+import uuid
+from datetime import datetime, timedelta
+
+from antarest.core.utils.fastapi_sqlalchemy import db
+from antarest.core.utils.utils import current_time
+from antarest.maintenance.tasks.common import BackGroundTaskStatus
+from antarest.maintenance.tasks.gc_variable_view import clean_variable_views
+from antarest.matrixstore.model import Matrix
+from antarest.study.model import MatrixFrequency, RawStudy
+from antarest.study.output.output_model import OutputVariablesType, OutputVariablesViewsModel
+
+
+def _create_study(study_id: str) -> RawStudy:
+    """Helper to create a minimal study for FK requirements."""
+    return RawStudy(
+        id=study_id,
+        name="Test Study",
+        version="8.6",
+        path="/tmp/test",
+        workspace="default",
+    )
+
+
+def _create_matrix(matrix_id: str) -> Matrix:
+    """Helper to create a minimal matrix for FK requirements."""
+    return Matrix(
+        id=matrix_id,
+        width=2,
+        height=2,
+        created_at=current_time(),
+        version=1,
+    )
+
+
+def _create_variable_view(
+    study_id: str,
+    output_id: str,
+    matrix_id: str,
+    last_read: datetime,
+) -> OutputVariablesViewsModel:
+    """Helper to create a variable view entry."""
+    return OutputVariablesViewsModel(
+        id=str(uuid.uuid4()),
+        study_id=study_id,
+        output_id=output_id,
+        type=OutputVariablesType.AREA,
+        frequency=MatrixFrequency.WEEKLY,
+        variable_name="TEST_VAR",
+        area_id="test_area",
+        matrix_id=matrix_id,
+        last_read=last_read,
+    )
+
+
+class TestCleanVariableViewsIntegration:
+    """Integration tests for clean_variable_views using real database."""
+
+    def test_deletes_old_variable_views(self):
+        """Test that old variable views are deleted."""
+        study_id = str(uuid.uuid4())
+        matrix_id = "a" * 64
+        output_id = "test-output"
+
+        with db():
+            db.session.add(_create_study(study_id))
+            db.session.add(_create_matrix(matrix_id))
+            db.session.add(
+                _create_variable_view(
+                    study_id=study_id,
+                    output_id=output_id,
+                    matrix_id=matrix_id,
+                    last_read=current_time() - timedelta(days=40),
+                )
+            )
+            db.session.commit()
+
+            views_before = db.session.query(OutputVariablesViewsModel).all()
+            assert len(views_before) == 1
+
+        result = clean_variable_views(dry_run=False, retention_time=7)
+
+        assert result.status == BackGroundTaskStatus.SUCCESS
+        assert result.deleted_count == 1
+        assert result.dry_run is False
+
+        with db():
+            views_after = db.session.query(OutputVariablesViewsModel).all()
+            assert len(views_after) == 0
+
+    def test_keeps_recent_variable_views(self):
+        """Test that recent variable views are NOT deleted."""
+        study_id = str(uuid.uuid4())
+        matrix_id = "b" * 64
+        output_id = "test-output"
+
+        with db():
+            db.session.add(_create_study(study_id))
+            db.session.add(_create_matrix(matrix_id))
+            db.session.add(
+                _create_variable_view(
+                    study_id=study_id,
+                    output_id=output_id,
+                    matrix_id=matrix_id,
+                    last_read=current_time() - timedelta(days=1),
+                )
+            )
+            db.session.commit()
+
+        result = clean_variable_views(dry_run=False, retention_time=7)
+
+        assert result.status == BackGroundTaskStatus.SKIPPED
+        assert result.reason == "no_unused_variable_view"
+        assert result.deleted_count == 0
+
+        with db():
+            views_after = db.session.query(OutputVariablesViewsModel).all()
+            assert len(views_after) == 1
+
+    def test_dry_run_does_not_delete(self):
+        """Test that dry_run mode does not delete variable views."""
+        study_id = str(uuid.uuid4())
+        matrix_id = "c" * 64
+        output_id = "test-output"
+
+        with db():
+            db.session.add(_create_study(study_id))
+            db.session.add(_create_matrix(matrix_id))
+            db.session.add(
+                _create_variable_view(
+                    study_id=study_id,
+                    output_id=output_id,
+                    matrix_id=matrix_id,
+                    last_read=current_time() - timedelta(days=10),
+                )
+            )
+            db.session.commit()
+
+        result = clean_variable_views(dry_run=True, retention_time=7)
+
+        assert result.status == BackGroundTaskStatus.SUCCESS
+        assert result.deleted_count == 1
+        assert result.dry_run is True
+
+        with db():
+            views_after = db.session.query(OutputVariablesViewsModel).all()
+            assert len(views_after) == 1
+
+    def test_returns_skipped_with_no_views(self):
+        """Test execution when there are no variable views."""
+        result = clean_variable_views(dry_run=False, retention_time=7)
+
+        assert result.status == BackGroundTaskStatus.SKIPPED
+        assert result.reason == "no_unused_variable_view"
+        assert result.deleted_count == 0
+        assert result.duration_seconds >= 0
+
+    def test_deletes_only_old_views_keeps_recent(self):
+        """Test that only old views are deleted while recent ones are kept."""
+        study_id = str(uuid.uuid4())
+        matrix_id_old = "d" * 64
+        matrix_id_recent = "e" * 64
+        output_id = "test-output"
+
+        with db():
+            db.session.add(_create_study(study_id))
+            db.session.add(_create_matrix(matrix_id_old))
+            db.session.add(_create_matrix(matrix_id_recent))
+
+            # Old view - should be deleted
+            db.session.add(
+                _create_variable_view(
+                    study_id=study_id,
+                    output_id=output_id,
+                    matrix_id=matrix_id_old,
+                    last_read=current_time() - timedelta(days=10),
+                )
+            )
+            # Recent view - should be kept
+            db.session.add(
+                _create_variable_view(
+                    study_id=study_id,
+                    output_id=output_id,
+                    matrix_id=matrix_id_recent,
+                    last_read=current_time() - timedelta(days=1),
+                )
+            )
+            db.session.commit()
+
+            views_before = db.session.query(OutputVariablesViewsModel).all()
+            assert len(views_before) == 2
+
+        result = clean_variable_views(dry_run=False, retention_time=7)
+
+        assert result.status == BackGroundTaskStatus.SUCCESS
+        assert result.deleted_count == 1
+
+        with db():
+            views_after = db.session.query(OutputVariablesViewsModel).all()
+            assert len(views_after) == 1
+            assert views_after[0].matrix_id == matrix_id_recent

--- a/tests/integration/maintenance_blueprint/test_gc_variable_view.py
+++ b/tests/integration/maintenance_blueprint/test_gc_variable_view.py
@@ -15,7 +15,7 @@
 import uuid
 from datetime import datetime, timedelta
 
-import pandas as pd
+import polars as pl
 
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import current_time
@@ -64,7 +64,7 @@ class TestCleanVariableViewsIntegration:
         """Test that old variable views are deleted."""
         study_id = str(uuid.uuid4())
         output_id = "test-output"
-        matrix_data = pd.DataFrame([[1, 2], [3, 4]])
+        matrix_data = pl.DataFrame([[1, 2], [3, 4]])
 
         with db():
             matrix_id = matrix_service.create(matrix_data)
@@ -96,7 +96,7 @@ class TestCleanVariableViewsIntegration:
         """Test that recent variable views are NOT deleted."""
         study_id = str(uuid.uuid4())
         output_id = "test-output"
-        matrix_data = pd.DataFrame([[1, 2], [3, 4]])
+        matrix_data = pl.DataFrame([[1, 2], [3, 4]])
 
         with db():
             matrix_id = matrix_service.create(matrix_data)
@@ -125,7 +125,7 @@ class TestCleanVariableViewsIntegration:
         """Test that dry_run mode does not delete variable views."""
         study_id = str(uuid.uuid4())
         output_id = "test-output"
-        matrix_data = pd.DataFrame([[1, 2], [3, 4]])
+        matrix_data = pl.DataFrame([[1, 2], [3, 4]])
 
         with db():
             matrix_id = matrix_service.create(matrix_data)
@@ -163,7 +163,7 @@ class TestCleanVariableViewsIntegration:
         """Test that only old views are deleted while recent ones are kept."""
         study_id = str(uuid.uuid4())
         output_id = "test-output"
-        matrix_data = pd.DataFrame([[1, 2], [3, 4]])
+        matrix_data = pl.DataFrame([[1, 2], [3, 4]])
 
         with db():
             matrix_id_old = matrix_service.create(matrix_data)

--- a/tests/maintenance/test_app.py
+++ b/tests/maintenance/test_app.py
@@ -124,12 +124,13 @@ class TestSetupPeriodicTasks:
 
         _setup_periodic_tasks(sender=sender)
 
-        assert sender.add_periodic_task.call_count == 4
+        assert sender.add_periodic_task.call_count == 5
         calls = sender.add_periodic_task.call_args_list
         assert calls[0][0][0] == 3600  # matrix GC default
         assert calls[1][0][0] == 86400  # blob GC default
         assert calls[2][0][0] == 3600  # auto-archive default
         assert calls[3][0][0] == 60  # watcher scan default
+        assert calls[4][0][0] == 3600  # variable view GC default
 
     def test_uses_config_intervals(self, celery_app_config_backup):
         sender = Mock()
@@ -155,4 +156,4 @@ class TestSetupPeriodicTasks:
         _setup_periodic_tasks(sender=sender)
 
         names = [c[1]["name"] for c in sender.add_periodic_task.call_args_list]
-        assert names == ["matrices_cleaner", "blobs_cleaner", "auto_archiver", "watcher_scan"]
+        assert names == ["matrices_cleaner", "blobs_cleaner", "auto_archiver", "watcher_scan", "variable_view_cleaner"]


### PR DESCRIPTION
  This PR implements a garbage collector for materialized output variable views. 

**How materialized_output_view are created ?**  
On user demand, by the OutputService. Also when we GET an OutputVariablesViewsModel view its last_read is updated, each time.  
 
  **How variable view gc  works ?**  
  - Deletes rows from OutputVariablesViewsModel where last_read < now - retention_days
  - Once a row is deleted,  OutputVariablesMatrixUsageProvider (who returns all ids in the table) no longer returns its matrix ID 
  - MatrixGarbage collector will see that the matrix is in the store but not returned by any provider so he'll delete it from the matrix store 
  
  **Note**  : if the matrice is for some reason referenced somewhere else, it won't be deleted as its id will be returned by another usage provider. 
  
  **Once a variable view is deleted, how long before its matrix is deleted ?** 
It depends, Matrix gc rely on creation date while variable view gc relies on last read date. With current default conf : 30 days retention for variable gc, one hour for matrix gc, the matrice will be deleted the next matrix gc run. If the matrix gc retention time was one year (this will never happen), then the matrix will be deleted only when it reaches both gc conditions : created one year ago, hasn't been read for a month.   
  
  **Additional changes:** 
  - Added MaintenanceContextNotFoundError exception in common.py to reduce code duplication
  
  
 #### How garbage collection works diagram
 The new component to review is VariableViewGC, bottow left of this diagram : 

<img width="1061" height="754" alt="image" src="https://github.com/user-attachments/assets/cf197065-7668-4350-a22c-b140e896a60a" />
