### PR TITLE
fix(matrix): fix unit test and revert lock around polars

### DIFF
--- a/antarest/core/utils/polars.py
+++ b/antarest/core/utils/polars.py
@@ -9,24 +9,13 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-import threading
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
-import pandas as pd
 import polars as pl
 from polars.exceptions import ComputeError, NoDataError
-
-_LOCK = threading.Lock()
-
-
-def convert_polars_dataframe_to_pandas(df: pl.DataFrame) -> pd.DataFrame:
-    with _LOCK:
-        # When multiple threads call `to_pandas()` concurrently, we can hit a deadlock scenario.
-        # So we use our own lock to avoid this issue.
-        return df.to_pandas()
 
 
 def create_polars_dataframe(data: npt.NDArray[np.float64] | list[list[Any]]) -> pl.DataFrame:

--- a/antarest/matrixstore/parsing.py
+++ b/antarest/matrixstore/parsing.py
@@ -18,7 +18,7 @@ import polars as pl
 
 from antarest.core.config import InternalMatrixFormat
 from antarest.core.serde.matrix_export import write_dataframe_in_tsv_format
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas, read_input_dataframe
+from antarest.core.utils.polars import read_input_dataframe
 
 
 def load_matrix(matrix_format: InternalMatrixFormat, path: Path, matrix_version: int) -> pl.DataFrame:
@@ -46,7 +46,7 @@ def save_matrix(matrix_format: InternalMatrixFormat, dataframe: pl.DataFrame, pa
     if matrix_format == InternalMatrixFormat.TSV:
         write_dataframe_in_tsv_format(dataframe, path, headers=True)
     elif matrix_format == InternalMatrixFormat.HDF:
-        convert_polars_dataframe_to_pandas(dataframe).to_hdf(str(path), key="data", index=False)
+        dataframe.to_pandas().to_hdf(str(path), key="data", index=False)
     elif matrix_format == InternalMatrixFormat.PARQUET:
         dataframe.write_parquet(path)
     elif matrix_format == InternalMatrixFormat.FEATHER:

--- a/antarest/matrixstore/repository.py
+++ b/antarest/matrixstore/repository.py
@@ -28,7 +28,6 @@ from sqlalchemy.orm import Session
 
 from antarest.core.config import InternalMatrixFormat
 from antarest.core.utils.fastapi_sqlalchemy import db
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas
 from antarest.matrixstore.model import Matrix, MatrixDataSet
 from antarest.matrixstore.parsing import load_matrix, save_matrix
 
@@ -211,7 +210,7 @@ def compute_hash(df: pl.DataFrame) -> str:
         return hashlib.sha256(content.data).hexdigest()
 
     # Convert polars dataframe to pandas one for backward compatibility of the hashing value.
-    pandas_df = convert_polars_dataframe_to_pandas(df)
+    pandas_df = df.to_pandas()
     pandas_df.replace({None: np.nan}, inplace=True)
     if df.columns == [str(i) for i in range(len(df.columns))]:
         pandas_df.columns = pd.RangeIndex(0, pandas_df.shape[1])  # type: ignore

--- a/antarest/study/business/matrix_management.py
+++ b/antarest/study/business/matrix_management.py
@@ -19,7 +19,6 @@ import numpy as np
 import pandas as pd
 import polars as pl
 
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas
 from antarest.matrixstore.matrix_editor import MatrixEditInstruction, MatrixSlice, Operation
 from antarest.study.business.study_interface import StudyInterface
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
@@ -251,7 +250,7 @@ class MatrixManager:
 
         try:
             logger.info(f"Loading matrix data from node '{path}'...")
-            matrix_df = convert_polars_dataframe_to_pandas(matrix_node.parse_as_dataframe())
+            matrix_df = matrix_node.parse_as_dataframe().to_pandas()
             matrix_df.columns = [int(i) for i in matrix_df.columns]  # type: ignore
         except ValueError as exc:
             raise MatrixManagerError(f"Cannot parse matrix: {exc}") from exc

--- a/antarest/study/dao/file/file_study_constraint_dao.py
+++ b/antarest/study/dao/file/file_study_constraint_dao.py
@@ -263,14 +263,14 @@ def generate_replacement_matrices(
             BindingConstraintFrequency.HOURLY: default_bc_hourly_86,
             BindingConstraintFrequency.DAILY: default_bc_weekly_daily_86,
             BindingConstraintFrequency.WEEKLY: default_bc_weekly_daily_86,
-        }[new_time_step].tolist()
+        }[new_time_step]().tolist()
         yield target, matrix
     else:
         matrix = {
             BindingConstraintFrequency.HOURLY: default_bc_hourly_87,
             BindingConstraintFrequency.DAILY: default_bc_weekly_daily_87,
             BindingConstraintFrequency.WEEKLY: default_bc_weekly_daily_87,
-        }[new_time_step].tolist()
+        }[new_time_step]().tolist()
         matrices_to_replace = OPERATOR_MATRIX_FILE_MAP[current_operator]
         for matrix_name in matrices_to_replace:
             matrix_id = matrix_name.format(bc_id=bc_id)

--- a/antarest/study/output/output_service.py
+++ b/antarest/study/output/output_service.py
@@ -40,7 +40,6 @@ from antarest.core.tasks.service import ITaskNotifier, ITaskService
 from antarest.core.utils.archives import ArchiveFormat
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.files import temp_file_path
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas
 from antarest.core.utils.utils import StopWatch, current_time
 from antarest.login.utils import get_user_id
 from antarest.matrixstore.service import ISimpleMatrixService
@@ -773,7 +772,7 @@ class OutputService:
             # Convert it to pandas and use np.NaN as null values for backward compatibility
             if not all(dtype.is_numeric() for dtype in polars_df.dtypes):
                 polars_df = polars_df.with_columns(pl.all().cast(pl.Float64))
-            df = convert_polars_dataframe_to_pandas(polars_df)
+            df = polars_df.to_pandas()
             if with_index:
                 add_time_index_to_dataframe(df, self.get_output_time_index(study_id, output_id, frequency))
             return df

--- a/antarest/study/output/utils.py
+++ b/antarest/study/output/utils.py
@@ -19,7 +19,6 @@ import pandas as pd
 import polars as pl
 from polars.exceptions import ComputeError
 
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas
 from antarest.study.model import MatrixFrequency, MatrixIndex, TimeSerie
 
 """Column name for the Monte Carlo year."""
@@ -144,7 +143,7 @@ def parse_output_file(file_path: Path, first_column: int) -> OutputDataFrame:
     output_headers = parse_headers(content, first_column)
     polars_df = _parse_output_dataframe(file_path)
 
-    df = convert_polars_dataframe_to_pandas(polars_df[polars_df.columns[first_column:]]).astype(np.float64)
+    df = polars_df[polars_df.columns[first_column:]].to_pandas().astype(np.float64)
 
     df.columns = pd.MultiIndex.from_tuples(output_headers)  # type: ignore
     return OutputDataFrame(data=df, headers=output_headers)

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -59,7 +59,6 @@ from antarest.core.tasks.model import TaskListFilter, TaskResult, TaskStatus, Ta
 from antarest.core.tasks.service import ITaskNotifier, ITaskService, NoopNotifier
 from antarest.core.utils.archives import ArchiveFormat, is_archive_format
 from antarest.core.utils.fastapi_sqlalchemy import db
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas
 from antarest.core.utils.utils import StopWatch, current_time
 from antarest.launcher.repository import JobResultRepository
 from antarest.login.model import Group
@@ -2306,7 +2305,7 @@ class StudyService:
         # Checks that the provided path refers to a matrix
         node = self.get_file_study(study).tree.get_node(list(url))
         if isinstance(node, MatrixNode):
-            pandas_df = convert_polars_dataframe_to_pandas(node.parse_as_dataframe())
+            pandas_df = node.parse_as_dataframe().to_pandas()
         elif isinstance(node, OutputSeriesMatrix):
             pandas_df = node.parse_dataframe()
             pandas_df.columns = pd.Index(pandas_df.columns)

--- a/antarest/study/storage/rawstudy/model/filesystem/common/prepro.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/common/prepro.py
@@ -30,15 +30,18 @@ class PreproAreaSettings(IniFileNode):
         IniFileNode.__init__(self, config)
 
 
-default_k = np.zeros((24, 12), dtype=np.float64)
-default_k.flags.writeable = False
+def default_k() -> np.ndarray:
+    return np.zeros((24, 12), dtype=np.float64)
 
-default_conversion = np.array([[-9999999980506447872, 0, -9999999980506447872], [0, 0, 0]], dtype=np.float64)
-default_conversion.flags.writeable = False
 
-default_data = np.ones((12, 6), dtype=np.float64)
-default_data[:, 2] = 0
-default_data.flags.writeable = False
+def default_conversion() -> np.ndarray:
+    return np.array([[-9999999980506447872, 0, -9999999980506447872], [0, 0, 0]], dtype=np.float64)
+
+
+def default_data() -> np.ndarray:
+    res = np.ones((12, 6), dtype=np.float64)
+    res[:, 2] = 0
+    return res
 
 
 class PreproArea(FolderNode):

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/constants.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/constants.py
@@ -12,26 +12,34 @@
 
 import numpy as np
 
-default_scenario_hourly = np.zeros((8760, 1), dtype=np.float64)
-default_scenario_hourly.flags.writeable = False
 
-default_scenario_hourly_ones = np.ones((8760, 1), dtype=np.float64)
-default_scenario_hourly_ones.flags.writeable = False
+def default_scenario_hourly() -> np.ndarray:
+    return np.zeros((8760, 1), dtype=np.float64)
 
-default_scenario_daily = np.zeros((365, 1), dtype=np.float64)
-default_scenario_daily.flags.writeable = False
 
-default_scenario_daily_ones = np.ones((365, 1), dtype=np.float64)
-default_scenario_daily_ones.flags.writeable = False
+def default_scenario_hourly_ones() -> np.ndarray:
+    return np.ones((8760, 1), dtype=np.float64)
 
-default_scenario_monthly = np.zeros((12, 1), dtype=np.float64)
-default_scenario_monthly.flags.writeable = False
 
-default_4_fixed_hourly = np.zeros((8760, 4), dtype=np.float64)
-default_4_fixed_hourly.flags.writeable = False
+def default_scenario_daily() -> np.ndarray:
+    return np.zeros((365, 1), dtype=np.float64)
 
-default_6_fixed_hourly = np.zeros((8760, 6), dtype=np.float64)
-default_6_fixed_hourly.flags.writeable = False
 
-default_8_fixed_hourly = np.zeros((8760, 8), dtype=np.float64)
-default_8_fixed_hourly.flags.writeable = False
+def default_scenario_daily_ones() -> np.ndarray:
+    return np.ones((365, 1), dtype=np.float64)
+
+
+def default_scenario_monthly() -> np.ndarray:
+    return np.zeros((12, 1), dtype=np.float64)
+
+
+def default_4_fixed_hourly() -> np.ndarray:
+    return np.zeros((8760, 4), dtype=np.float64)
+
+
+def default_6_fixed_hourly() -> np.ndarray:
+    return np.zeros((8760, 6), dtype=np.float64)
+
+
+def default_8_fixed_hourly() -> np.ndarray:
+    return np.zeros((8760, 8), dtype=np.float64)

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -16,12 +16,12 @@ from pathlib import Path
 from typing import Callable, Optional, TypeAlias
 
 import numpy as np
+import numpy.typing as npt
 import polars as pl
 from typing_extensions import override
 
 from antarest.core.exceptions import ChildNotFoundError
 from antarest.core.serde.matrix_export import write_dataframe_in_tsv_format
-from antarest.core.serde.np_array import NpArray
 from antarest.core.utils.archives import read_original_file_in_archive
 from antarest.core.utils.polars import create_polars_dataframe, read_input_dataframe
 from antarest.core.utils.utils import StopWatch
@@ -34,7 +34,7 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import Matri
 logger = logging.getLogger(__name__)
 
 
-MatrixSupplier: TypeAlias = Callable[[], NpArray]
+MatrixSupplier: TypeAlias = Callable[[], npt.NDArray[np.float64]]
 
 
 class InputSeriesMatrix(MatrixNode):

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -137,7 +137,7 @@ class InputSeriesMatrix(MatrixNode):
         if content == b"" and self.default_empty is not None:
             # The file is empty, we should return the `default_empty` value
             buffer = io.BytesIO()
-            dump_dataframe(pl.DataFrame(self.default_empty), buffer)
+            dump_dataframe(pl.DataFrame(self.default_empty()), buffer)
             content = buffer.getvalue()
 
         return OriginalFile(content=content, suffix=suffix, filename=filename)

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -13,7 +13,7 @@ import io
 import logging
 import shutil
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional, TypeAlias
 
 import numpy as np
 import polars as pl
@@ -34,6 +34,9 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import Matri
 logger = logging.getLogger(__name__)
 
 
+MatrixSupplier: TypeAlias = Callable[[], NpArray]
+
+
 class InputSeriesMatrix(MatrixNode):
     """
     Generic node to handle input matrix behavior
@@ -45,17 +48,12 @@ class InputSeriesMatrix(MatrixNode):
         config: FileStudyTreeConfig,
         freq: MatrixFrequency = MatrixFrequency.HOURLY,
         nb_columns: Optional[int] = None,
-        default_empty: Optional[NpArray] = None,  # optional only for the capacity matrix in Xpansion
+        default_empty: Optional[MatrixSupplier] = None,  # optional only for the capacity matrix in Xpansion
         should_exist: bool = True,
     ):
         super().__init__(matrix_mapper=matrix_mapper, config=config, freq=freq)
         self.nb_columns = nb_columns
-        if default_empty is None:
-            self.default_empty = None
-        else:
-            # Clone the template value and make it writable
-            self.default_empty = np.copy(default_empty)
-            self.default_empty.flags.writeable = True
+        self.default_empty = default_empty
         # Removes the .link suffix if the matrix is normalized
         self.config.path = self.config.path.parent / self.config.path.name.removesuffix(".link")
         self.should_exist = should_exist
@@ -76,7 +74,7 @@ class InputSeriesMatrix(MatrixNode):
                 # If so, we shouldn't raise but just return the `default_empty` value
                 if not self.should_exist:
                     if self.default_empty is not None:
-                        return create_polars_dataframe(self.default_empty)
+                        return create_polars_dataframe(self.default_empty())
                     return pl.DataFrame()
                 # Otherwise, we raise a 404 'Not Found' exception.
                 logger.warning(f"Matrix file'{file_path}' not found")
@@ -85,7 +83,7 @@ class InputSeriesMatrix(MatrixNode):
                 raise ChildNotFoundError(f"File '{relpath}' not found in the study '{study_id}'") from e
 
         if matrix.is_empty() and self.default_empty is not None:
-            matrix = create_polars_dataframe(self.default_empty)
+            matrix = create_polars_dataframe(self.default_empty())
         stopwatch.log_elapsed(lambda x: logger.debug(f"Matrix parsed in {x}s"))
         return matrix
 
@@ -93,7 +91,7 @@ class InputSeriesMatrix(MatrixNode):
     def write_dataframe(self, df: pl.DataFrame) -> None:
         # If the DataFrame content corresponds to the `default_empty` attribute, we should just create an empty file.
         # This way, we can write the content quicker, and the file takes less place on the fs.
-        if df.is_empty() or self.default_empty is not None and np.array_equal(df.to_numpy(), self.default_empty):
+        if df.is_empty() or self.default_empty is not None and np.array_equal(df.to_numpy(), self.default_empty()):
             self.config.path.write_text("")
         else:
             write_dataframe_in_tsv_format(df, self.config.path)

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/matrix.py
@@ -23,7 +23,6 @@ from typing_extensions import override
 
 from antarest.core.model import JSON
 from antarest.core.serde.np_array import NpArray
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas
 from antarest.core.utils.utils import StopWatch
 from antarest.matrixstore.matrix_uri_mapper import MatrixUriMapper
 from antarest.study.model import MatrixFrequency
@@ -111,7 +110,7 @@ class MatrixNode(LazyNode[bytes | JSON, MatrixId | MatrixContent, JSON], ABC):
         df = self.parse_as_dataframe()
 
         stopwatch = StopWatch()
-        data = cast(JSON, convert_polars_dataframe_to_pandas(df).to_dict(orient="split"))
+        data = cast(JSON, df.to_pandas().to_dict(orient="split"))
         stopwatch.log_elapsed(lambda x: logger.info(f"Matrix to dict in {x}s"))
         return data
 

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
@@ -42,7 +42,6 @@ def default_reservoir() -> NpArray:
     reservoir = np.zeros((365, 3), dtype=np.float64)
     reservoir[:, 1] = 0.5
     reservoir[:, 2] = 1
-    reservoir.flags.writeable = False
     return reservoir
 
 

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-
+from collections.abc import Callable
 from typing import List, TypedDict
 
 import numpy as np
@@ -28,24 +28,31 @@ class MatrixInfo(TypedDict, total=False):
     name: str
     freq: MatrixFrequency
     start_version: StudyVersion
-    default_empty: NpArray
+    default_empty: Callable[[], NpArray]
 
 
-default_maxpower = np.zeros((365, 4), dtype=np.float64)
-default_maxpower[:, 1] = 24
-default_maxpower[:, 3] = 24
-default_maxpower.flags.writeable = False
+def default_maxpower() -> NpArray:
+    maxpower = np.zeros((365, 4), dtype=np.float64)
+    maxpower[:, 1] = 24
+    maxpower[:, 3] = 24
+    return maxpower
 
-default_reservoir = np.zeros((365, 3), dtype=np.float64)
-default_reservoir[:, 1] = 0.5
-default_reservoir[:, 2] = 1
-default_reservoir.flags.writeable = False
 
-default_credit_modulation = np.ones((2, 100), dtype=np.float64)
-default_credit_modulation.flags.writeable = False
+def default_reservoir() -> NpArray:
+    reservoir = np.zeros((365, 3), dtype=np.float64)
+    reservoir[:, 1] = 0.5
+    reservoir[:, 2] = 1
+    reservoir.flags.writeable = False
+    return reservoir
 
-default_water_values = np.zeros((365, 101), dtype=np.float64)
-default_water_values.flags.writeable = False
+
+def default_credit_modulation() -> NpArray:
+    return np.ones((2, 100), dtype=np.float64)
+
+
+def default_water_values() -> NpArray:
+    return np.zeros((365, 101), dtype=np.float64)
+
 
 INITIAL_VERSION = StudyVersion.parse(0)
 # noinspection SpellCheckingInspection

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
@@ -13,10 +13,10 @@ from collections.abc import Callable
 from typing import List, TypedDict
 
 import numpy as np
+import numpy.typing as npt
 from antares.study.version import StudyVersion
 from typing_extensions import override
 
-from antarest.core.serde.np_array import NpArray
 from antarest.study.model import STUDY_VERSION_6_5, MatrixFrequency
 from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
 from antarest.study.storage.rawstudy.model.filesystem.inode import TREE
@@ -28,28 +28,28 @@ class MatrixInfo(TypedDict, total=False):
     name: str
     freq: MatrixFrequency
     start_version: StudyVersion
-    default_empty: Callable[[], NpArray]
+    default_empty: Callable[[], npt.NDArray[np.float64]]
 
 
-def default_maxpower() -> NpArray:
+def default_maxpower() -> npt.NDArray[np.float64]:
     maxpower = np.zeros((365, 4), dtype=np.float64)
     maxpower[:, 1] = 24
     maxpower[:, 3] = 24
     return maxpower
 
 
-def default_reservoir() -> NpArray:
+def default_reservoir() -> npt.NDArray[np.float64]:
     reservoir = np.zeros((365, 3), dtype=np.float64)
     reservoir[:, 1] = 0.5
     reservoir[:, 2] = 1
     return reservoir
 
 
-def default_credit_modulation() -> NpArray:
+def default_credit_modulation() -> npt.NDArray[np.float64]:
     return np.ones((2, 100), dtype=np.float64)
 
 
-def default_water_values() -> NpArray:
+def default_water_values() -> npt.NDArray[np.float64]:
     return np.zeros((365, 101), dtype=np.float64)
 
 

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/prepro/area/area.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/prepro/area/area.py
@@ -19,8 +19,9 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.hydro.prepro.ar
     InputHydroPreproAreaPrepro,
 )
 
-default_energy = np.zeros((12, 5), dtype=np.float64)
-default_energy.flags.writeable = False
+
+def default_energy() -> np.ndarray:
+    return np.zeros((12, 5), dtype=np.float64)
 
 
 class InputHydroPreproArea(FolderNode):

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/link/area/area.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/link/area/area.py
@@ -24,9 +24,11 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.link.area.capac
 )
 from antarest.study.storage.rawstudy.model.filesystem.root.input.link.area.properties import InputLinkAreaProperties
 
-default_link_legacy_matrix = np.zeros((8760, 8), dtype=np.float64)
-default_link_legacy_matrix[:, :2] = 1
-default_link_legacy_matrix.flags.writeable = False
+
+def default_link_legacy_matrix() -> np.ndarray:
+    link_legacy_matrix = np.zeros((8760, 8), dtype=np.float64)
+    link_legacy_matrix[:, :2] = 1
+    return link_legacy_matrix
 
 
 class InputLinkArea(FolderNode):

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/thermal/prepro/area/thermal/thermal.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/thermal/prepro/area/thermal/thermal.py
@@ -17,11 +17,13 @@ from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderN
 from antarest.study.storage.rawstudy.model.filesystem.inode import TREE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
 
-default_data_matrix = np.zeros((365, 6), dtype=np.float64)
-default_data_matrix.flags.writeable = False
 
-default_modulation_matrix = np.zeros((8760, 4), dtype=np.float64)
-default_modulation_matrix.flags.writeable = False
+def default_data_matrix() -> np.ndarray:
+    return np.zeros((365, 6), dtype=np.float64)
+
+
+def default_modulation_matrix() -> np.ndarray:
+    return np.zeros((8760, 4), dtype=np.float64)
 
 
 class InputThermalPreproAreaThermal(FolderNode):

--- a/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/mode/mcall/digest.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/output/simulation/mode/mcall/digest.py
@@ -18,7 +18,7 @@ from typing_extensions import override
 
 from antarest.core.model import JSON
 from antarest.core.serde import AntaresBaseModel
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas, create_polars_dataframe
+from antarest.core.utils.polars import create_polars_dataframe
 from antarest.study.storage.rawstudy.model.filesystem.root.output.simulation.mode.mcall.synthesis import OutputSynthesis
 
 
@@ -89,7 +89,7 @@ class DigestSynthesis(OutputSynthesis):
     ) -> JSON:
         df = self._parse_digest_file()
 
-        output = convert_polars_dataframe_to_pandas(df).to_dict(orient="split")
+        output = df.to_pandas().to_dict(orient="split")
         del output["index"]
         return cast(JSON, output)
 

--- a/antarest/study/storage/variantstudy/business/matrix_constants/binding_constraint/series_after_v87.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/binding_constraint/series_after_v87.py
@@ -12,8 +12,10 @@
 
 import numpy as np
 
-default_bc_hourly = np.zeros((8784, 1), dtype=np.float64)
-default_bc_hourly.flags.writeable = False
 
-default_bc_weekly_daily = np.zeros((366, 1), dtype=np.float64)
-default_bc_weekly_daily.flags.writeable = False
+def default_bc_hourly() -> np.ndarray:
+    return np.zeros((8784, 1), dtype=np.float64)
+
+
+def default_bc_weekly_daily() -> np.ndarray:
+    return np.zeros((366, 1), dtype=np.float64)

--- a/antarest/study/storage/variantstudy/business/matrix_constants/binding_constraint/series_before_v87.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/binding_constraint/series_before_v87.py
@@ -18,8 +18,10 @@ import numpy as np
 # because the solver calculates the weekly matrix from the daily matrix.
 # See https://github.com/AntaresSimulatorTeam/AntaREST/issues/1843
 
-default_bc_hourly = np.zeros((8784, 3), dtype=np.float64)
-default_bc_hourly.flags.writeable = False
 
-default_bc_weekly_daily = np.zeros((366, 3), dtype=np.float64)
-default_bc_weekly_daily.flags.writeable = False
+def default_bc_hourly() -> np.ndarray:
+    return np.zeros((8784, 3), dtype=np.float64)
+
+
+def default_bc_weekly_daily() -> np.ndarray:
+    return np.zeros((366, 3), dtype=np.float64)

--- a/antarest/study/storage/variantstudy/business/matrix_constants/common.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/common.py
@@ -14,17 +14,17 @@ import polars as pl
 from antarest.core.utils.polars import create_polars_dataframe
 
 
-def NULL_MATRIX() -> pl.DataFrame:
+def null_matrix() -> pl.DataFrame:
     return pl.DataFrame()
 
 
-def NULL_SCENARIO_MATRIX() -> pl.DataFrame:
+def null_scenario_matrix() -> pl.DataFrame:
     return create_polars_dataframe([[0.0]] * 8760)
 
 
-def FIXED_4_COLUMNS() -> pl.DataFrame:
+def fixed_4_columns() -> pl.DataFrame:
     return create_polars_dataframe([[0.0, 0.0, 0.0, 0.0]] * 8760)
 
 
-def FIXED_8_COLUMNS() -> pl.DataFrame:
+def fixed_8_columns() -> pl.DataFrame:
     return create_polars_dataframe([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]] * 8760)

--- a/antarest/study/storage/variantstudy/business/matrix_constants/common.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/common.py
@@ -13,7 +13,18 @@ import polars as pl
 
 from antarest.core.utils.polars import create_polars_dataframe
 
-NULL_MATRIX = pl.DataFrame()
-NULL_SCENARIO_MATRIX = create_polars_dataframe([[0.0]] * 8760)
-FIXED_4_COLUMNS = create_polars_dataframe([[0.0, 0.0, 0.0, 0.0]] * 8760)
-FIXED_8_COLUMNS = create_polars_dataframe([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]] * 8760)
+
+def NULL_MATRIX() -> pl.DataFrame:
+    return pl.DataFrame()
+
+
+def NULL_SCENARIO_MATRIX() -> pl.DataFrame:
+    return create_polars_dataframe([[0.0]] * 8760)
+
+
+def FIXED_4_COLUMNS() -> pl.DataFrame:
+    return create_polars_dataframe([[0.0, 0.0, 0.0, 0.0]] * 8760)
+
+
+def FIXED_8_COLUMNS() -> pl.DataFrame:
+    return create_polars_dataframe([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]] * 8760)

--- a/antarest/study/storage/variantstudy/business/matrix_constants/hydro/v6.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/hydro/v6.py
@@ -13,4 +13,6 @@
 
 import polars as pl
 
-reservoir = pl.DataFrame([[0.0, 0.5, 1.0]] * 12, schema=["0", "1", "2"])
+
+def reservoir() -> pl.DataFrame:
+    return pl.DataFrame([[0.0, 0.5, 1.0]] * 12, schema=["0", "1", "2"])

--- a/antarest/study/storage/variantstudy/business/matrix_constants/hydro/v7.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/hydro/v7.py
@@ -10,9 +10,22 @@
 #
 # This file is part of the Antares project.
 
+import polars as pl
+
 from antarest.core.utils.polars import create_polars_dataframe
 
-credit_modulations = create_polars_dataframe([[1.0] * 101] * 2)
-inflow_pattern = create_polars_dataframe([[1.0]] * 365)
-max_power = create_polars_dataframe([[0.0, 24.0, 0.0, 24.0]] * 365)
-reservoir = create_polars_dataframe([[0.0, 0.5, 1.0]] * 365)
+
+def credit_modulations() -> pl.DataFrame:
+    return create_polars_dataframe([[1.0] * 101] * 2)
+
+
+def inflow_pattern() -> pl.DataFrame:
+    return create_polars_dataframe([[1.0]] * 365)
+
+
+def max_power() -> pl.DataFrame:
+    return create_polars_dataframe([[0.0, 24.0, 0.0, 24.0]] * 365)
+
+
+def reservoir() -> pl.DataFrame:
+    return create_polars_dataframe([[0.0, 0.5, 1.0]] * 365)

--- a/antarest/study/storage/variantstudy/business/matrix_constants/link/v7.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/link/v7.py
@@ -10,6 +10,10 @@
 #
 # This file is part of the Antares project.
 
+import polars as pl
+
 from antarest.core.utils.polars import create_polars_dataframe
 
-link = create_polars_dataframe([[1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]] * 8760)
+
+def link() -> pl.DataFrame:
+    return create_polars_dataframe([[1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]] * 8760)

--- a/antarest/study/storage/variantstudy/business/matrix_constants/link/v8.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/link/v8.py
@@ -10,8 +10,18 @@
 #
 # This file is part of the Antares project.
 
+import polars as pl
+
 from antarest.core.utils.polars import create_polars_dataframe
 
-link = create_polars_dataframe([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]] * 8760)
-direct = create_polars_dataframe([[1.0]] * 8760)
-indirect = create_polars_dataframe([[1.0]] * 8760)
+
+def link() -> pl.DataFrame:
+    return create_polars_dataframe([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]] * 8760)
+
+
+def direct() -> pl.DataFrame:
+    return create_polars_dataframe([[1.0]] * 8760)
+
+
+def indirect() -> pl.DataFrame:
+    return create_polars_dataframe([[1.0]] * 8760)

--- a/antarest/study/storage/variantstudy/business/matrix_constants/prepro.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/prepro.py
@@ -10,7 +10,14 @@
 #
 # This file is part of the Antares project.
 
+import polars as pl
+
 from antarest.core.utils.polars import create_polars_dataframe
 
-conversion = create_polars_dataframe([[-9999999980506447872.0, 0.0, 9999999980506447872.0], [0.0, 0.0, 0.0]])
-data = create_polars_dataframe([[1.0, 1.0, 0.0, 1.0, 1.0, 1.0]] * 12)
+
+def conversion() -> pl.DataFrame:
+    return create_polars_dataframe([[-9999999980506447872.0, 0.0, 9999999980506447872.0], [0.0, 0.0, 0.0]])
+
+
+def data() -> pl.DataFrame:
+    return create_polars_dataframe([[1.0, 1.0, 0.0, 1.0, 1.0, 1.0]] * 12)

--- a/antarest/study/storage/variantstudy/business/matrix_constants/st_storage/series.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/st_storage/series.py
@@ -12,23 +12,30 @@
 
 import numpy as np
 
-pmax_injection = np.ones((8760, 1), dtype=np.float64)
-pmax_injection.flags.writeable = False
 
-pmax_withdrawal = np.ones((8760, 1), dtype=np.float64)
-pmax_withdrawal.flags.writeable = False
+def pmax_injection() -> np.ndarray:
+    return np.ones((8760, 1), dtype=np.float64)
 
-inflows = np.zeros((8760, 1), dtype=np.float64)
-inflows.flags.writeable = False
 
-lower_rule_curve = np.zeros((8760, 1), dtype=np.float64)
-lower_rule_curve.flags.writeable = False
+def pmax_withdrawal() -> np.ndarray:
+    return np.ones((8760, 1), dtype=np.float64)
 
-upper_rule_curve = np.ones((8760, 1), dtype=np.float64)
-upper_rule_curve.flags.writeable = False
 
-costs = np.zeros((8760, 1), dtype=np.float64)
-costs.flags.writeable = False
+def inflows() -> np.ndarray:
+    return np.zeros((8760, 1), dtype=np.float64)
 
-additional_constraints = np.zeros((8760, 1), dtype=np.float64)
-additional_constraints.flags.writeable = False
+
+def lower_rule_curve() -> np.ndarray:
+    return np.zeros((8760, 1), dtype=np.float64)
+
+
+def upper_rule_curve() -> np.ndarray:
+    return np.ones((8760, 1), dtype=np.float64)
+
+
+def costs() -> np.ndarray:
+    return np.zeros((8760, 1), dtype=np.float64)
+
+
+def additional_constraints() -> np.ndarray:
+    return np.zeros((8760, 1), dtype=np.float64)

--- a/antarest/study/storage/variantstudy/business/matrix_constants/thermals/prepro.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/thermals/prepro.py
@@ -10,7 +10,14 @@
 #
 # This file is part of the Antares project.
 
+import polars as pl
+
 from antarest.core.utils.polars import create_polars_dataframe
 
-data = create_polars_dataframe([[1.0, 1.0, 0.0, 0.0, 0.0, 0.0]] * 365)
-modulation = create_polars_dataframe([[1.0, 1.0, 1.0, 0.0]] * 8760)
+
+def data() -> pl.DataFrame:
+    return create_polars_dataframe([[1.0, 1.0, 0.0, 0.0, 0.0, 0.0]] * 365)
+
+
+def modulation() -> pl.DataFrame:
+    return create_polars_dataframe([[1.0, 1.0, 1.0, 0.0]] * 8760)

--- a/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
@@ -19,10 +19,10 @@ from antarest.matrixstore.service import MATRIX_PROTOCOL_PREFIX, ISimpleMatrixSe
 from antarest.study.model import STUDY_VERSION_6_5, STUDY_VERSION_8_2
 from antarest.study.storage.variantstudy.business import matrix_constants
 from antarest.study.storage.variantstudy.business.matrix_constants.common import (
-    FIXED_4_COLUMNS,
-    FIXED_8_COLUMNS,
-    NULL_MATRIX,
-    NULL_SCENARIO_MATRIX,
+    fixed_4_columns,
+    fixed_8_columns,
+    null_matrix,
+    null_scenario_matrix,
 )
 from antarest.study.storage.variantstudy.business.matrix_constants.matrix_constants_usage_provider import (
     ConstantsMatrixUsageProvider,
@@ -103,10 +103,10 @@ class GeneratorMatrixConstants:
         self.hashes[LINK_DIRECT] = self.matrix_service.add_predefined_matrix(matrix_constants.link.v8.direct)
         self.hashes[LINK_INDIRECT] = self.matrix_service.add_predefined_matrix(matrix_constants.link.v8.indirect)
 
-        self.hashes[NULL_MATRIX_NAME] = self.matrix_service.add_predefined_matrix(NULL_MATRIX)
-        self.hashes[EMPTY_SCENARIO_MATRIX] = self.matrix_service.add_predefined_matrix(NULL_SCENARIO_MATRIX)
-        self.hashes[RESERVES_TS] = self.matrix_service.add_predefined_matrix(FIXED_4_COLUMNS)
-        self.hashes[MISCGEN_TS] = self.matrix_service.add_predefined_matrix(FIXED_8_COLUMNS)
+        self.hashes[NULL_MATRIX_NAME] = self.matrix_service.add_predefined_matrix(null_matrix)
+        self.hashes[EMPTY_SCENARIO_MATRIX] = self.matrix_service.add_predefined_matrix(null_scenario_matrix)
+        self.hashes[RESERVES_TS] = self.matrix_service.add_predefined_matrix(fixed_4_columns)
+        self.hashes[MISCGEN_TS] = self.matrix_service.add_predefined_matrix(fixed_8_columns)
 
         # Binding constraint matrices
         series_before_87 = matrix_constants.binding_constraint.series_before_v87

--- a/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
@@ -75,63 +75,59 @@ class GeneratorMatrixConstants:
         self,
     ) -> None:
         self.hashes[HYDRO_COMMON_CAPACITY_MAX_POWER_V7] = self.matrix_service.add_predefined_matrix(
-            lambda: matrix_constants.hydro.v7.max_power
+            matrix_constants.hydro.v7.max_power
         )
         self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V7] = self.matrix_service.add_predefined_matrix(
-            lambda: matrix_constants.hydro.v7.reservoir
+            matrix_constants.hydro.v7.reservoir
         )
         self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V6] = self.matrix_service.add_predefined_matrix(
-            lambda: matrix_constants.hydro.v6.reservoir
+            matrix_constants.hydro.v6.reservoir
         )
         self.hashes[HYDRO_COMMON_CAPACITY_INFLOW_PATTERN] = self.matrix_service.add_predefined_matrix(
-            lambda: matrix_constants.hydro.v7.inflow_pattern
+            matrix_constants.hydro.v7.inflow_pattern
         )
         self.hashes[HYDRO_COMMON_CAPACITY_CREDIT_MODULATION] = self.matrix_service.add_predefined_matrix(
-            lambda: matrix_constants.hydro.v7.credit_modulations
+            matrix_constants.hydro.v7.credit_modulations
         )
-        self.hashes[PREPRO_CONVERSION] = self.matrix_service.add_predefined_matrix(
-            lambda: matrix_constants.prepro.conversion
-        )
-        self.hashes[PREPRO_DATA] = self.matrix_service.add_predefined_matrix(lambda: matrix_constants.prepro.data)
+        self.hashes[PREPRO_CONVERSION] = self.matrix_service.add_predefined_matrix(matrix_constants.prepro.conversion)
+        self.hashes[PREPRO_DATA] = self.matrix_service.add_predefined_matrix(matrix_constants.prepro.data)
         self.hashes[THERMAL_PREPRO_DATA] = self.matrix_service.add_predefined_matrix(
-            lambda: matrix_constants.thermals.prepro.data
+            matrix_constants.thermals.prepro.data
         )
 
         self.hashes[THERMAL_PREPRO_MODULATION] = self.matrix_service.add_predefined_matrix(
-            lambda: matrix_constants.thermals.prepro.modulation
+            matrix_constants.thermals.prepro.modulation
         )
-        self.hashes[LINK_V7] = self.matrix_service.add_predefined_matrix(lambda: matrix_constants.link.v7.link)
-        self.hashes[LINK_V8] = self.matrix_service.add_predefined_matrix(lambda: matrix_constants.link.v8.link)
-        self.hashes[LINK_DIRECT] = self.matrix_service.add_predefined_matrix(lambda: matrix_constants.link.v8.direct)
-        self.hashes[LINK_INDIRECT] = self.matrix_service.add_predefined_matrix(
-            lambda: matrix_constants.link.v8.indirect
-        )
+        self.hashes[LINK_V7] = self.matrix_service.add_predefined_matrix(matrix_constants.link.v7.link)
+        self.hashes[LINK_V8] = self.matrix_service.add_predefined_matrix(matrix_constants.link.v8.link)
+        self.hashes[LINK_DIRECT] = self.matrix_service.add_predefined_matrix(matrix_constants.link.v8.direct)
+        self.hashes[LINK_INDIRECT] = self.matrix_service.add_predefined_matrix(matrix_constants.link.v8.indirect)
 
-        self.hashes[NULL_MATRIX_NAME] = self.matrix_service.add_predefined_matrix(lambda: NULL_MATRIX)
-        self.hashes[EMPTY_SCENARIO_MATRIX] = self.matrix_service.add_predefined_matrix(lambda: NULL_SCENARIO_MATRIX)
-        self.hashes[RESERVES_TS] = self.matrix_service.add_predefined_matrix(lambda: FIXED_4_COLUMNS)
-        self.hashes[MISCGEN_TS] = self.matrix_service.add_predefined_matrix(lambda: FIXED_8_COLUMNS)
+        self.hashes[NULL_MATRIX_NAME] = self.matrix_service.add_predefined_matrix(NULL_MATRIX)
+        self.hashes[EMPTY_SCENARIO_MATRIX] = self.matrix_service.add_predefined_matrix(NULL_SCENARIO_MATRIX)
+        self.hashes[RESERVES_TS] = self.matrix_service.add_predefined_matrix(FIXED_4_COLUMNS)
+        self.hashes[MISCGEN_TS] = self.matrix_service.add_predefined_matrix(FIXED_8_COLUMNS)
 
         # Binding constraint matrices
         series_before_87 = matrix_constants.binding_constraint.series_before_v87
         self.hashes[BINDING_CONSTRAINT_HOURLY_v86] = self.matrix_service.add_predefined_matrix(
-            lambda: pl.DataFrame(series_before_87.default_bc_hourly)
+            lambda: pl.DataFrame(series_before_87.default_bc_hourly())
         )
         self.hashes[BINDING_CONSTRAINT_DAILY_WEEKLY_v86] = self.matrix_service.add_predefined_matrix(
-            lambda: pl.DataFrame(series_before_87.default_bc_weekly_daily)
+            lambda: pl.DataFrame(series_before_87.default_bc_weekly_daily())
         )
 
         series_after_87 = matrix_constants.binding_constraint.series_after_v87
         self.hashes[BINDING_CONSTRAINT_HOURLY_v87] = self.matrix_service.add_predefined_matrix(
-            lambda: pl.DataFrame(series_after_87.default_bc_hourly)
+            lambda: pl.DataFrame(series_after_87.default_bc_hourly())
         )
         self.hashes[BINDING_CONSTRAINT_DAILY_WEEKLY_v87] = self.matrix_service.add_predefined_matrix(
-            lambda: pl.DataFrame(series_after_87.default_bc_weekly_daily)
+            lambda: pl.DataFrame(series_after_87.default_bc_weekly_daily())
         )
 
         # Some short-term storage matrices use np.ones((8760, 1))
         self.hashes[ONES_SCENARIO_MATRIX] = self.matrix_service.add_predefined_matrix(
-            lambda: pl.DataFrame(matrix_constants.st_storage.series.pmax_injection)
+            lambda: pl.DataFrame(matrix_constants.st_storage.series.pmax_injection())
         )
 
     def get_hydro_max_power(self, version: StudyVersion) -> str:

--- a/antarest/study/web/raw_studies_blueprint.py
+++ b/antarest/study/web/raw_studies_blueprint.py
@@ -27,7 +27,6 @@ from antarest.core.model import SUB_JSON
 from antarest.core.serde.json import from_json, to_json
 from antarest.core.serde.matrix_export import TableExportFormat, simplify_dataframe
 from antarest.core.swagger import get_path_examples
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas
 from antarest.core.utils.utils import sanitize_string, sanitize_uuid
 from antarest.core.utils.web import APITag
 from antarest.login.auth import Auth
@@ -97,7 +96,7 @@ class MatrixFormat(EnumIgnoreCase):
 
         buffer = io.BytesIO()
         if self == MatrixFormat.JSON:
-            convert_polars_dataframe_to_pandas(dataframe).to_json(buffer, orient="split")
+            dataframe.to_pandas().to_json(buffer, orient="split")
             return Response(content=buffer.getvalue(), media_type="application/json")
 
         else:

--- a/antarest/study/web/xpansion_studies_blueprint.py
+++ b/antarest/study/web/xpansion_studies_blueprint.py
@@ -20,7 +20,6 @@ from starlette.responses import Response
 from antarest.core.config import Config
 from antarest.core.model import StudyPermissionType
 from antarest.core.serde.json import to_json
-from antarest.core.utils.polars import convert_polars_dataframe_to_pandas
 from antarest.core.utils.web import APITag
 from antarest.login.auth import Auth
 from antarest.study.business.model.xpansion_model import (
@@ -162,7 +161,7 @@ def create_xpansion_routes(study_service: StudyService, config: Config) -> APIRo
 
         if isinstance(output, pl.DataFrame):
             buffer = io.BytesIO()
-            convert_polars_dataframe_to_pandas(output).to_json(buffer, orient="split")
+            output.to_pandas().to_json(buffer, orient="split")
             return Response(content=buffer.getvalue(), media_type="application/json")
 
         return Response(content=to_json(output.decode("utf-8")), media_type="application/json")

--- a/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
@@ -277,7 +277,7 @@ class TestFetchRawData:
         assert res.status_code == 200, res.json()
         assert res.json()["index"] == list(range(365))
         assert res.json()["columns"] == ["0", "1", "2", "3", "4", "5"]
-        assert res.json()["data"] == default_data_matrix.tolist()
+        assert res.json()["data"] == default_data_matrix().tolist()
 
         # =============================
         #  ERRORS

--- a/tests/matrixstore/test_repository.py
+++ b/tests/matrixstore/test_repository.py
@@ -252,13 +252,16 @@ class TestMatrixContentRepository:
         for more chances to generate problems.
         """
         trial_count = 10
-        matrix = pl.DataFrame(data=np.zeros(shape=(8760, 1)))
+        # note: important to have different instances, which will be the cas in real usage
+        #       when using the same instance, polars can deadlock
+        matrix1 = pl.DataFrame(data=np.zeros(shape=(8760, 1)))
+        matrix2 = pl.DataFrame(data=np.zeros(shape=(8760, 1)))
 
         matrix_content_repo: MatrixContentRepository
         with matrix_repository(tmp_path, matrix_format=InternalMatrixFormat.TSV) as matrix_content_repo:
             with multiprocessing.pool.ThreadPool(2) as tp:
                 for i in range(0, trial_count):
-                    results = tp.map(matrix_content_repo.save, [matrix, matrix])
+                    results = tp.map(matrix_content_repo.save, [matrix1, matrix2])
 
                     assert results[0].new or results[1].new
                     assert not (results[0].new and results[1].new)

--- a/tests/matrixstore/test_repository.py
+++ b/tests/matrixstore/test_repository.py
@@ -253,7 +253,7 @@ class TestMatrixContentRepository:
         """
         trial_count = 10
         # note: important to have different instances, which will be the cas in real usage
-        #       when using the same instance, polars can deadlock
+        #       when using the same instance, polars may deadlock
         matrix1 = pl.DataFrame(data=np.zeros(shape=(8760, 1)))
         matrix2 = pl.DataFrame(data=np.zeros(shape=(8760, 1)))
 

--- a/tests/matrixstore/test_repository.py
+++ b/tests/matrixstore/test_repository.py
@@ -252,8 +252,8 @@ class TestMatrixContentRepository:
         for more chances to generate problems.
         """
         trial_count = 10
-        # note: important to have different instances, which will be the cas in real usage
-        #       when using the same instance, polars may deadlock
+        # note: important to have different instances, which will be the case in real usage.
+        #       When using the same instance, polars may deadlock.
         matrix1 = pl.DataFrame(data=np.zeros(shape=(8760, 1)))
         matrix2 = pl.DataFrame(data=np.zeros(shape=(8760, 1)))
 

--- a/tests/storage/repository/filesystem/matrix/test_input_series_matrix.py
+++ b/tests/storage/repository/filesystem/matrix/test_input_series_matrix.py
@@ -70,7 +70,10 @@ class TestInputSeriesMatrix:
     @pytest.mark.parametrize("link", [True, False])
     def test_load_empty_file(self, my_study_config: FileStudyTreeConfig, link: bool) -> None:
         file_path = my_study_config.path
-        default_matrix = np.array([[1, 2], [3, 4]])
+
+        def default_matrix():
+            return np.array([[1, 2], [3, 4]])
+
         if not link:
             file_path.touch()
             node = InputSeriesMatrix(matrix_mapper=Mock(), config=my_study_config, default_empty=default_matrix)

--- a/tests/storage/repository/filesystem/matrix/test_input_series_matrix.py
+++ b/tests/storage/repository/filesystem/matrix/test_input_series_matrix.py
@@ -89,7 +89,7 @@ class TestInputSeriesMatrix:
 
         # checks formatted response
         actual = node.load(formatted=True)
-        expected = {"index": [0, 1], "columns": ["0", "1"], "data": node.default_empty.tolist()}
+        expected = {"index": [0, 1], "columns": ["0", "1"], "data": node.default_empty().tolist()}
         assert actual == expected
 
     def test_load__file_not_found(self, my_study_config: FileStudyTreeConfig) -> None:
@@ -141,7 +141,10 @@ class TestInputSeriesMatrix:
 
     def test_reset_to_default(self, my_study_config: FileStudyTreeConfig) -> None:
         """Test reseting the matrix to default values."""
-        default_matrix = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+        def default_matrix():
+            return np.array([[1.0, 2.0], [3.0, 4.0]])
+
         node = InputSeriesMatrix(matrix_mapper=Mock(), config=my_study_config, default_empty=default_matrix)
 
         # Save different data than default

--- a/tests/storage/repository/filesystem/root/input/hydro/series/area/test_area.py
+++ b/tests/storage/repository/filesystem/root/input/hydro/series/area/test_area.py
@@ -56,17 +56,17 @@ AFTER_650 = {
 
 AFTER_860 = {
     "mod": {
-        "default_empty": default_scenario_daily.tolist(),
+        "default_empty": default_scenario_daily().tolist(),
         "freq": MatrixFrequency.DAILY,
         "nb_columns": None,
     },
     "ror": {
-        "default_empty": default_scenario_hourly.tolist(),
+        "default_empty": default_scenario_hourly().tolist(),
         "freq": MatrixFrequency.HOURLY,
         "nb_columns": None,
     },
     "mingen": {
-        "default_empty": default_scenario_hourly.tolist(),
+        "default_empty": default_scenario_hourly().tolist(),
         "freq": MatrixFrequency.HOURLY,
         "nb_columns": None,
     },
@@ -110,7 +110,7 @@ class TestInputHydroSeriesArea:
         for key, value in actual.items():
             assert isinstance(value, InputSeriesMatrix)
             actual_obj[key] = {
-                "default_empty": value.default_empty.tolist(),
+                "default_empty": value.default_empty().tolist(),
                 "freq": value.freq,
                 "nb_columns": value.nb_columns,
             }

--- a/tests/storage/repository/filesystem/root/input/hydro/series/area/test_area.py
+++ b/tests/storage/repository/filesystem/root/input/hydro/series/area/test_area.py
@@ -30,12 +30,12 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.hydro.series.ar
 
 BEFORE_650 = {
     "mod": {
-        "default_empty": default_scenario_monthly.tolist(),
+        "default_empty": default_scenario_monthly().tolist(),
         "freq": MatrixFrequency.MONTHLY,
         "nb_columns": None,
     },
     "ror": {
-        "default_empty": default_scenario_hourly.tolist(),
+        "default_empty": default_scenario_hourly().tolist(),
         "freq": MatrixFrequency.HOURLY,
         "nb_columns": None,
     },
@@ -43,12 +43,12 @@ BEFORE_650 = {
 
 AFTER_650 = {
     "mod": {
-        "default_empty": default_scenario_daily.tolist(),
+        "default_empty": default_scenario_daily().tolist(),
         "freq": MatrixFrequency.DAILY,
         "nb_columns": None,
     },
     "ror": {
-        "default_empty": default_scenario_hourly.tolist(),
+        "default_empty": default_scenario_hourly().tolist(),
         "freq": MatrixFrequency.HOURLY,
         "nb_columns": None,
     },

--- a/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
+++ b/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
@@ -11,6 +11,8 @@
 # This file is part of the Antares project.
 from pathlib import Path
 
+import numpy as np
+
 from antarest.core.config import InternalMatrixFormat
 from antarest.matrixstore.repository import MatrixContentRepository
 from antarest.matrixstore.service import MATRIX_PROTOCOL_PREFIX, SimpleMatrixService
@@ -34,28 +36,27 @@ class TestGeneratorMatrixConstants:
         matrix_id1 = ref1.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto1 = generator.matrix_service.get(matrix_id1)
 
-        # TODO SL: those assertions are wrong ?
-        assert matrix_dto1.to_numpy().all() == matrix_constants.st_storage.series.pmax_injection().all()
+        assert np.array_equal(matrix_dto1.to_numpy(), matrix_constants.st_storage.series.pmax_injection())
 
         ref2 = generator.get_st_storage_pmax_withdrawal()
         matrix_id2 = ref2.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto2 = generator.matrix_service.get(matrix_id2)
-        assert matrix_dto2.to_numpy().all() == matrix_constants.st_storage.series.pmax_withdrawal().all()
+        assert np.array_equal(matrix_dto2.to_numpy(), matrix_constants.st_storage.series.pmax_withdrawal())
 
         ref3 = generator.get_st_storage_lower_rule_curve()
         matrix_id3 = ref3.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto3 = generator.matrix_service.get(matrix_id3)
-        assert matrix_dto3.to_numpy().all() == matrix_constants.st_storage.series.lower_rule_curve().all()
+        assert np.array_equal(matrix_dto3.to_numpy(), matrix_constants.st_storage.series.lower_rule_curve())
 
         ref4 = generator.get_st_storage_upper_rule_curve()
         matrix_id4 = ref4.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto4 = generator.matrix_service.get(matrix_id4)
-        assert matrix_dto4.to_numpy().all() == matrix_constants.st_storage.series.upper_rule_curve().all()
+        assert np.array_equal(matrix_dto4.to_numpy(), matrix_constants.st_storage.series.upper_rule_curve())
 
         ref5 = generator.get_st_storage_inflows()
         matrix_id5 = ref5.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto5 = generator.matrix_service.get(matrix_id5)
-        assert matrix_dto5.to_numpy().all() == matrix_constants.st_storage.series.inflows().all()
+        assert np.array_equal(matrix_dto5.to_numpy(), matrix_constants.st_storage.series.inflows())
 
     def test_get_binding_constraint_before_v87(self, tmp_path: Path) -> None:
         matrix_content_repository = MatrixContentRepository(bucket_dir=tmp_path, format=DEFAULT_INTERNAL_FORMAT)

--- a/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
+++ b/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
@@ -33,27 +33,29 @@ class TestGeneratorMatrixConstants:
         ref1 = generator.get_st_storage_pmax_injection()
         matrix_id1 = ref1.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto1 = generator.matrix_service.get(matrix_id1)
-        assert matrix_dto1.to_numpy().all() == matrix_constants.st_storage.series.pmax_injection.all()
+
+        # TODO SL: those assertions are wrong ?
+        assert matrix_dto1.to_numpy().all() == matrix_constants.st_storage.series.pmax_injection().all()
 
         ref2 = generator.get_st_storage_pmax_withdrawal()
         matrix_id2 = ref2.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto2 = generator.matrix_service.get(matrix_id2)
-        assert matrix_dto2.to_numpy().all() == matrix_constants.st_storage.series.pmax_withdrawal.all()
+        assert matrix_dto2.to_numpy().all() == matrix_constants.st_storage.series.pmax_withdrawal().all()
 
         ref3 = generator.get_st_storage_lower_rule_curve()
         matrix_id3 = ref3.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto3 = generator.matrix_service.get(matrix_id3)
-        assert matrix_dto3.to_numpy().all() == matrix_constants.st_storage.series.lower_rule_curve.all()
+        assert matrix_dto3.to_numpy().all() == matrix_constants.st_storage.series.lower_rule_curve().all()
 
         ref4 = generator.get_st_storage_upper_rule_curve()
         matrix_id4 = ref4.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto4 = generator.matrix_service.get(matrix_id4)
-        assert matrix_dto4.to_numpy().all() == matrix_constants.st_storage.series.upper_rule_curve.all()
+        assert matrix_dto4.to_numpy().all() == matrix_constants.st_storage.series.upper_rule_curve().all()
 
         ref5 = generator.get_st_storage_inflows()
         matrix_id5 = ref5.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto5 = generator.matrix_service.get(matrix_id5)
-        assert matrix_dto5.to_numpy().all() == matrix_constants.st_storage.series.inflows.all()
+        assert matrix_dto5.to_numpy().all() == matrix_constants.st_storage.series.inflows().all()
 
     def test_get_binding_constraint_before_v87(self, tmp_path: Path) -> None:
         matrix_content_repository = MatrixContentRepository(bucket_dir=tmp_path, format=DEFAULT_INTERNAL_FORMAT)
@@ -68,9 +70,9 @@ class TestGeneratorMatrixConstants:
         hourly = generator.get_binding_constraint_hourly_86()
         hourly_matrix_id = hourly.split(MATRIX_PROTOCOL_PREFIX)[1]
         hourly_matrix_dto = generator.matrix_service.get(hourly_matrix_id)
-        assert hourly_matrix_dto.to_numpy().all() == series.default_bc_hourly.all()
+        assert hourly_matrix_dto.to_numpy().all() == series.default_bc_hourly().all()
 
         daily_weekly = generator.get_binding_constraint_daily_weekly_86()
         matrix_id = daily_weekly.split(MATRIX_PROTOCOL_PREFIX)[1]
         matrix_dto = generator.matrix_service.get(matrix_id)
-        assert matrix_dto.to_numpy().all() == series.default_bc_weekly_daily.all()
+        assert matrix_dto.to_numpy().all() == series.default_bc_weekly_daily().all()

--- a/tests/variantstudy/model/command/test_manage_binding_constraints.py
+++ b/tests/variantstudy/model/command/test_manage_binding_constraints.py
@@ -148,12 +148,12 @@ def test_manage_binding_constraint(
         assert bd_config.get("1") == expected_bd_2
 
         if study_version < 870:
-            weekly_values = default_bc_weekly_daily.tolist()
+            weekly_values = default_bc_weekly_daily().tolist()
             values = weekly_values
             less_term_matrix = None
             greater_term_matrix = None
         else:
-            weekly_values = default_bc_weekly_daily_870.tolist()
+            weekly_values = default_bc_weekly_daily_870().tolist()
             values = None
             less_term_matrix = weekly_values
             greater_term_matrix = weekly_values

--- a/tests/variantstudy/model/command/test_update_binding_constraints.py
+++ b/tests/variantstudy/model/command/test_update_binding_constraints.py
@@ -230,7 +230,7 @@ def test_generate_replacement_matrices() -> None:
     )
     assert len(matrices) == 1
     assert matrices[0][0] == f"input/bindingconstraints/{bc_id}"
-    assert matrices[0][1] == default_bc_hourly_86.tolist()
+    assert matrices[0][1] == default_bc_hourly_86().tolist()
 
     # 8,7,0 DAILY BOTH
     bc_id = "bc_1"
@@ -243,9 +243,9 @@ def test_generate_replacement_matrices() -> None:
     )
     assert len(matrices) == 2
     assert matrices[0][0] == f"input/bindingconstraints/{bc_id}_lt"
-    assert matrices[0][1] == default_bc_weekly_daily_87.tolist()
+    assert matrices[0][1] == default_bc_weekly_daily_87().tolist()
     assert matrices[1][0] == f"input/bindingconstraints/{bc_id}_gt"
-    assert matrices[1][1] == default_bc_weekly_daily_87.tolist()
+    assert matrices[1][1] == default_bc_weekly_daily_87().tolist()
 
     # 8,7,0 WEEKLY LESS
 
@@ -257,4 +257,4 @@ def test_generate_replacement_matrices() -> None:
     assert len(matrices) == 1
     target = f"input/bindingconstraints/{bc_id}_lt"
     assert matrices[0][0] == target
-    assert matrices[0][1] == default_bc_weekly_daily_87.tolist()
+    assert matrices[0][1] == default_bc_weekly_daily_87().tolist()


### PR DESCRIPTION
The reason for the deadlock was the concurrent use of the same dataframe **object**,
which will not happen in real use cases.

I converted global variables to factory methods to ensure that we indeed use different
instances every time.

It simplifies logic where we had read-only instances that we had to copy and make
writeable for later use.