### PR TITLE
fix(import): make default matrix values consistent with antares-solver

### DIFF
--- a/antarest/study/storage/rawstudy/model/filesystem/common/prepro.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/common/prepro.py
@@ -33,11 +33,10 @@ class PreproAreaSettings(IniFileNode):
 default_k = np.zeros((24, 12), dtype=np.float64)
 default_k.flags.writeable = False
 
-default_conversion = np.array([[-9999999980506447872, 0, -9999999980506447872], [0, 0, 0]], dtype=np.float64)
+default_conversion = np.zeros((2, 3), dtype=np.float64)
 default_conversion.flags.writeable = False
 
-default_data = np.ones((12, 6), dtype=np.float64)
-default_data[:, 2] = 0
+default_data = np.zeros((12, 6), dtype=np.float64)
 default_data.flags.writeable = False
 
 

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
@@ -33,16 +33,12 @@ class MatrixInfo(TypedDict, total=False):
 
 
 default_maxpower = np.zeros((365, 4), dtype=np.float64)
-default_maxpower[:, 1] = 24
-default_maxpower[:, 3] = 24
 default_maxpower.flags.writeable = False
 
 default_reservoir = np.zeros((365, 3), dtype=np.float64)
-default_reservoir[:, 1] = 0.5
-default_reservoir[:, 2] = 1
 default_reservoir.flags.writeable = False
 
-default_credit_modulation = np.ones((2, 100), dtype=np.float64)
+default_credit_modulation = np.zeros((2, 101), dtype=np.float64)
 default_credit_modulation.flags.writeable = False
 
 default_water_values = np.zeros((365, 101), dtype=np.float64)

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/link/area/area.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/link/area/area.py
@@ -25,7 +25,6 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.link.area.capac
 from antarest.study.storage.rawstudy.model.filesystem.root.input.link.area.properties import InputLinkAreaProperties
 
 default_link_legacy_matrix = np.zeros((8760, 8), dtype=np.float64)
-default_link_legacy_matrix[:, :2] = 1
 default_link_legacy_matrix.flags.writeable = False
 
 

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/link/area/capacities/capacities.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/link/area/capacities/capacities.py
@@ -15,7 +15,9 @@ from antarest.matrixstore.matrix_uri_mapper import MatrixUriMapper
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
 from antarest.study.storage.rawstudy.model.filesystem.inode import TREE
-from antarest.study.storage.rawstudy.model.filesystem.matrix.constants import default_scenario_hourly_ones
+from antarest.study.storage.rawstudy.model.filesystem.matrix.constants import (
+    default_scenario_hourly,
+)
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
 
 
@@ -36,12 +38,12 @@ class InputLinkAreaCapacities(FolderNode):
             children[f"{area_to}_direct"] = InputSeriesMatrix(
                 self.matrix_mapper,
                 self.config.next_file(f"{area_to}_direct.txt"),
-                default_empty=default_scenario_hourly_ones,
+                default_empty=default_scenario_hourly,
             )
             children[f"{area_to}_indirect"] = InputSeriesMatrix(
                 self.matrix_mapper,
                 self.config.next_file(f"{area_to}_indirect.txt"),
-                default_empty=default_scenario_hourly_ones,
+                default_empty=default_scenario_hourly,
             )
 
         return children

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/st_storage/series/area/st_storage/st_storage.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/st_storage/series/area/st_storage/st_storage.py
@@ -65,7 +65,7 @@ class InputSTStorageAreaStorage(FolderNode):
             children["cost_level"] = InputSeriesMatrix(
                 self.matrix_mapper,
                 self.config.next_file("cost-level.txt"),
-                default_empty=series.costs,
+                default_empty=series.costs_level,
                 should_exist=False,
             )
             children["cost_variation_injection"] = InputSeriesMatrix(

--- a/antarest/study/storage/variantstudy/business/matrix_constants/st_storage/series.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants/st_storage/series.py
@@ -30,5 +30,8 @@ upper_rule_curve.flags.writeable = False
 costs = np.zeros((8760, 1), dtype=np.float64)
 costs.flags.writeable = False
 
+costs_level = -1e-6 * np.ones((8760, 1), dtype=np.float64)
+costs.flags.writeable = False
+
 additional_constraints = np.zeros((8760, 1), dtype=np.float64)
 additional_constraints.flags.writeable = False

--- a/tests/storage/business/test_optional_matrices.py
+++ b/tests/storage/business/test_optional_matrices.py
@@ -53,16 +53,22 @@ def test_optional_matrices(empty_study_920: FileStudy, command_context: CommandC
         ["input", "thermal", "series", "fr", "thermal_cluster", "CO2Cost"],
         ["input", "st-storage", "series", "fr", "sts", "cost_injection"],
         ["input", "st-storage", "series", "fr", "sts", "cost_withdrawal"],
-        ["input", "st-storage", "series", "fr", "sts", "cost_level"],
         ["input", "st-storage", "series", "fr", "sts", "cost_variation_injection"],
         ["input", "st-storage", "series", "fr", "sts", "cost_variation_withdrawal"],
     ]:
         # Removes the file from the fs
         study.tree.get_node(url).delete()
 
-        # Ensures we can still fetch its content without raising an issue as these files are optional for the Simulator.
-        content = study.tree.get(url)
-        assert content["data"] == expected_content
+    # Ensures we can still fetch its content without raising an issue as these files are optional for the Simulator.
+    content = study.tree.get(url)
+    assert content["data"] == expected_content
+
+    # Cost level has specific default values
+    study.tree.get_node(["input", "st-storage", "series", "fr", "sts", "cost_level"]).delete()
+    assert (
+        study.tree.get(["input", "st-storage", "series", "fr", "sts", "cost_level"])["data"]
+        == (-1e-6 * np.ones((8760, 1))).tolist()
+    )
 
     # Ensures the normalization succeeds even if the files are missing
     study.tree.normalize()


### PR DESCRIPTION

This is a hotfix for release v2.27.0.

It changes default values of several matrices so that they correspond to the actual default values
of antares-solver.
Currently, there are some mismatches, which cause incorrect data to be taken into account by
the solver. For example, if a reservoir matrix has columns of 0, 0.5, and 1, they will be turned
into an empty file at export time, and considered as zeros by antares-solver.

