### PR TITLE
fix(ci): fix broken deps

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
-checksumdir~=1.2.0
 pytest~=8.3.0
 pytest-xdist~=3.6.0
 pytest-cov~=4.0.0

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,13 +10,15 @@
 #
 # This file is part of the Antares project.
 
+import hashlib
 import math
+import os
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 from unittest.mock import Mock
 
 import numpy as np
@@ -33,6 +35,26 @@ from antarest.study.model import RawStudy, Study
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
 from tests.conftest_instances import create_admin_user
+
+
+def dirhash(dirname: Union[str, Path], hashfunc: str = "md5") -> str:
+    """Compute a single hash for all files in a directory tree (replacement for checksumdir.dirhash)."""
+    hash_constructor = getattr(hashlib, hashfunc)
+    hashvalues = []
+    for root, dirs, files in os.walk(str(dirname)):
+        dirs.sort()
+        files.sort()
+        for fname in files:
+            hasher = hash_constructor()
+            filepath = os.path.join(root, fname)
+            with open(filepath, "rb") as fp:
+                for chunk in iter(lambda: fp.read(65536), b""):
+                    hasher.update(chunk)
+            hashvalues.append(hasher.hexdigest())
+    hasher = hash_constructor()
+    for h in sorted(hashvalues):
+        hasher.update(h.encode("utf-8"))
+    return hasher.hexdigest()
 
 
 def with_db_context(f: Callable[..., Any]) -> Callable[..., Any]:

--- a/tests/storage/business/test_export.py
+++ b/tests/storage/business/test_export.py
@@ -15,7 +15,6 @@ from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
-from tests.helpers import dirhash
 from py7zr import SevenZipFile, py7zr
 
 from antarest.blobstore.service import BlobService
@@ -36,7 +35,7 @@ from antarest.study.storage.variantstudy.model.command.create_cluster import Cre
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from tests.conftest import empty_study_fixture
 from tests.db_statement_recorder import DBStatementRecorder
-from tests.helpers import create_raw_study, with_db_context
+from tests.helpers import create_raw_study, dirhash, with_db_context
 
 
 def test_export(

--- a/tests/storage/business/test_export.py
+++ b/tests/storage/business/test_export.py
@@ -15,7 +15,7 @@ from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
-from checksumdir import dirhash
+from tests.helpers import dirhash
 from py7zr import SevenZipFile, py7zr
 
 from antarest.blobstore.service import BlobService

--- a/tests/variantstudy/model/command/helpers.py
+++ b/tests/variantstudy/model/command/helpers.py
@@ -20,7 +20,7 @@ def reset_line_separator(*paths: Path) -> None:
     This utility function is used to avoid false negative in directory checksum comparison.
     The idea is to normalize text files before calculating the checksum to avoid differences in newline.
 
-    Directory checksum is done with `checksumdir.dirhash` which performs binary file reading.
+    Directory checksum is done with `tests.helpers.dirhash` which performs binary file reading.
     """
     for path in paths:
         path.write_text(path.read_text())

--- a/tests/variantstudy/model/command/test_remove_area.py
+++ b/tests/variantstudy/model/command/test_remove_area.py
@@ -12,7 +12,7 @@
 
 import configparser
 
-from checksumdir import dirhash
+from tests.helpers import dirhash
 
 from antarest.core.serde.ini_reader import IniReader
 from antarest.study.business.model.binding_constraint_model import (

--- a/tests/variantstudy/model/command/test_remove_area.py
+++ b/tests/variantstudy/model/command/test_remove_area.py
@@ -12,8 +12,6 @@
 
 import configparser
 
-from tests.helpers import dirhash
-
 from antarest.core.serde.ini_reader import IniReader
 from antarest.study.business.model.binding_constraint_model import (
     BindingConstraintFrequency,
@@ -48,6 +46,7 @@ from antarest.study.storage.variantstudy.model.command.remove_multiple_binding_c
 from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 from antarest.study.storage.variantstudy.model.command.update_scenario_builder import UpdateScenarioBuilder
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
+from tests.helpers import dirhash
 from tests.variantstudy.model.command.helpers import reset_line_separator
 
 

--- a/tests/variantstudy/model/command/test_remove_cluster.py
+++ b/tests/variantstudy/model/command/test_remove_cluster.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 import numpy as np
-from checksumdir import dirhash
+from tests.helpers import dirhash
 
 from antarest.study.business.model.binding_constraint_model import (
     BindingConstraintFrequency,

--- a/tests/variantstudy/model/command/test_remove_cluster.py
+++ b/tests/variantstudy/model/command/test_remove_cluster.py
@@ -11,7 +11,6 @@
 # This file is part of the Antares project.
 
 import numpy as np
-from tests.helpers import dirhash
 
 from antarest.study.business.model.binding_constraint_model import (
     BindingConstraintFrequency,
@@ -32,6 +31,7 @@ from antarest.study.storage.variantstudy.model.command.remove_multiple_binding_c
 )
 from antarest.study.storage.variantstudy.model.command.update_scenario_builder import UpdateScenarioBuilder
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
+from tests.helpers import dirhash
 from tests.variantstudy.model.command.helpers import reset_line_separator
 
 

--- a/tests/variantstudy/model/command/test_remove_link.py
+++ b/tests/variantstudy/model/command/test_remove_link.py
@@ -18,7 +18,6 @@ from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
-from tests.helpers import dirhash
 from pydantic import ValidationError
 
 from antarest.study.business.model.scenario_builder_model import RulesetUpdate
@@ -32,6 +31,7 @@ from antarest.study.storage.variantstudy.model.command.create_link import Create
 from antarest.study.storage.variantstudy.model.command.remove_link import RemoveLink
 from antarest.study.storage.variantstudy.model.command.update_scenario_builder import UpdateScenarioBuilder
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
+from tests.helpers import dirhash
 from tests.variantstudy.model.command.helpers import reset_line_separator
 
 

--- a/tests/variantstudy/model/command/test_remove_link.py
+++ b/tests/variantstudy/model/command/test_remove_link.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
-from checksumdir import dirhash
+from tests.helpers import dirhash
 from pydantic import ValidationError
 
 from antarest.study.business.model.scenario_builder_model import RulesetUpdate

--- a/tests/variantstudy/model/command/test_remove_renewables_cluster.py
+++ b/tests/variantstudy/model/command/test_remove_renewables_cluster.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 from antares.study.version import StudyVersion
-from checksumdir import dirhash
+from tests.helpers import dirhash
 
 from antarest.study.business.model.renewable_cluster_model import RenewableClusterCreation, TimeSeriesInterpretation
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id

--- a/tests/variantstudy/model/command/test_remove_renewables_cluster.py
+++ b/tests/variantstudy/model/command/test_remove_renewables_cluster.py
@@ -10,7 +10,6 @@
 #
 # This file is part of the Antares project.
 from antares.study.version import StudyVersion
-from tests.helpers import dirhash
 
 from antarest.study.business.model.renewable_cluster_model import RenewableClusterCreation, TimeSeriesInterpretation
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
@@ -24,6 +23,7 @@ from antarest.study.storage.variantstudy.model.command.create_renewables_cluster
 from antarest.study.storage.variantstudy.model.command.remove_renewables_cluster import RemoveRenewablesCluster
 from antarest.study.storage.variantstudy.model.command.update_scenario_builder import UpdateScenarioBuilder
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
+from tests.helpers import dirhash
 from tests.variantstudy.model.command.helpers import reset_line_separator
 
 

--- a/tests/variantstudy/model/command/test_update_renewable_cluster.py
+++ b/tests/variantstudy/model/command/test_update_renewable_cluster.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from checksumdir import dirhash
+from tests.helpers import dirhash
 
 from antarest.core.serde.ini_reader import IniReader
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy

--- a/tests/variantstudy/model/command/test_update_renewable_cluster.py
+++ b/tests/variantstudy/model/command/test_update_renewable_cluster.py
@@ -9,8 +9,6 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from tests.helpers import dirhash
-
 from antarest.core.serde.ini_reader import IniReader
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
@@ -18,6 +16,7 @@ from antarest.study.storage.variantstudy.model.command.create_renewables_cluster
 from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 from antarest.study.storage.variantstudy.model.command.update_renewables_clusters import UpdateRenewablesClusters
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
+from tests.helpers import dirhash
 
 
 class TestUpdateRenewableCluster:

--- a/tests/variantstudy/model/command/test_update_short_term_storage.py
+++ b/tests/variantstudy/model/command/test_update_short_term_storage.py
@@ -11,7 +11,6 @@
 # This file is part of the Antares project.
 
 import pytest
-from tests.helpers import dirhash
 from pydantic import ValidationError
 
 from antarest.core.serde.ini_reader import read_ini
@@ -23,6 +22,7 @@ from antarest.study.storage.variantstudy.model.command.create_area import Create
 from antarest.study.storage.variantstudy.model.command.create_st_storage import CreateSTStorage
 from antarest.study.storage.variantstudy.model.command.update_st_storages import UpdateSTStorages
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
+from tests.helpers import dirhash
 
 
 class TestUpdateShortTermSorage:

--- a/tests/variantstudy/model/command/test_update_short_term_storage.py
+++ b/tests/variantstudy/model/command/test_update_short_term_storage.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 import pytest
-from checksumdir import dirhash
+from tests.helpers import dirhash
 from pydantic import ValidationError
 
 from antarest.core.serde.ini_reader import read_ini

--- a/tests/variantstudy/model/command/test_update_thermal_cluster.py
+++ b/tests/variantstudy/model/command/test_update_thermal_cluster.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 import pytest
-from checksumdir import dirhash
+from tests.helpers import dirhash
 from pydantic import ValidationError
 
 from antarest.study.business.model.thermal_cluster_model import (

--- a/tests/variantstudy/model/command/test_update_thermal_cluster.py
+++ b/tests/variantstudy/model/command/test_update_thermal_cluster.py
@@ -10,7 +10,6 @@
 #
 # This file is part of the Antares project.
 import pytest
-from tests.helpers import dirhash
 from pydantic import ValidationError
 
 from antarest.study.business.model.thermal_cluster_model import (
@@ -29,6 +28,7 @@ from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command.update_thermal_clusters import UpdateThermalClusters
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
+from tests.helpers import dirhash
 
 
 class TestUpdateThermalCluster:


### PR DESCRIPTION
## Why it broke

- `checksumdir` depends on `pkg_resources`
- `pkg_resources` was removed from `setuptools >= 78`
- CI installs `setuptools 82` → `ModuleNotFoundError`

## Fix

- Removed `checksumdir`
- Replaced with a small `dirhash` helper using only stdlib (`hashlib`, `os`)