### PR TITLE
chore(deps): upgrade fastapi from 0.124.2 to 0.130.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ antares-timeseries-generation==0.1.9
 
 # We prefer to add only the specific libraries we need for our project
 # and **manage their versions** for better control and to avoid unnecessary dependencies.
-fastapi==0.124.2
+fastapi==0.130.0
 uvicorn[standard]~=0.37.0
 pydantic~=2.12.5
 httpx~=0.27.0


### PR DESCRIPTION
Include performance improvements when there's a Pydantic return type

See: https://github.com/fastapi/fastapi/releases/tag/0.130.0