### PR TITLE
fix(config): sync enr_modelling on advanced params save

### DIFF
--- a/antarest/study/dao/file/file_study_advanced_parameters.py
+++ b/antarest/study/dao/file/file_study_advanced_parameters.py
@@ -62,6 +62,4 @@ class FileStudyAdvancedParametersDao(AdvancedParametersDao, ABC):
                 general_data[key][field] = value
 
         file_study.tree.save(general_data, GENERAL_DATA_PATH)
-
-        # Sync the in-memory config so that the study synthesis stays up-to-date
         file_study.config.enr_modelling = parameters.renewable_generation_modelling.value

--- a/antarest/study/dao/file/file_study_advanced_parameters.py
+++ b/antarest/study/dao/file/file_study_advanced_parameters.py
@@ -62,3 +62,6 @@ class FileStudyAdvancedParametersDao(AdvancedParametersDao, ABC):
                 general_data[key][field] = value
 
         file_study.tree.save(general_data, GENERAL_DATA_PATH)
+
+        # Sync the in-memory config so that the study synthesis stays up-to-date
+        file_study.config.enr_modelling = parameters.renewable_generation_modelling.value

--- a/tests/variantstudy/model/command/test_update_advanced_parameters.py
+++ b/tests/variantstudy/model/command/test_update_advanced_parameters.py
@@ -39,6 +39,18 @@ class TestUpdateAdvancedParameters:
 
         assert general_data_content == study.tree.get(["settings", "generaldata"])
 
+    def test_enr_modelling_synced_in_memory(self, empty_study_880: FileStudy, command_context: CommandContext) -> None:
+        study = empty_study_880
+        assert study.config.enr_modelling == "aggregated"
+
+        parameters = AdvancedParametersUpdate(renewable_generation_modelling="clusters")
+        command = UpdateAdvancedParameters(
+            parameters=parameters, command_context=command_context, study_version=study.config.version
+        )
+        command.apply(study_data=study)
+
+        assert study.config.enr_modelling == "clusters"
+
     def test_error_cases(self, command_context: CommandContext) -> None:
         # Give fields that do not match the version
         parameters = AdvancedParametersUpdate(**{"unit_commitment_mode": "milp"})


### PR DESCRIPTION
[ANT-4615]
`save_advanced_parameters` updated the file but not the in-memory config, so the synthesis kept returning a stale `enr_modelling`. This sync fixes that   