### PR TITLE
chore(stopwatch): simplify stopwatch API

### DIFF
--- a/antarest/core/utils/utils.py
+++ b/antarest/core/utils/utils.py
@@ -105,16 +105,63 @@ def get_local_path() -> Path:
 
 
 class StopWatch:
+    """A simple stopwatch for measuring elapsed time, with support for laps.
+
+    The stopwatch starts automatically on creation. It tracks two timers:
+    a start timer (never reset) and a lap timer (reset on each call to ``lap()``).
+
+    Properties:
+        since_start: Total time since creation (never resets).
+        elapsed: Time since the last ``lap()`` call (or creation if ``lap()`` was never called).
+
+    Methods:
+        lap(): Returns the time since the last lap and resets the lap timer.
+
+    The stopwatch can also be used directly in f-strings via ``__format__``,
+    which formats the time since the last lap.
+
+    Examples::
+
+        stopwatch = StopWatch()
+
+        do_first_step()
+        logger.info(f"First step done in {stopwatch.lap()}s")
+
+        do_second_step()
+        logger.info(f"Second step done in {stopwatch.lap()}s")
+
+        logger.info(f"Total time: {stopwatch.since_start}s")
+
+        # Using __format__ for the current lap duration without resetting:
+        do_third_step()
+        logger.info(f"Third step running for {stopwatch:.2f}s")
+    """
+
     def __init__(self) -> None:
-        self.current_time: float = time.time()
-        self.start_time = self.current_time
+        self._start: float = time.time()
+        self._lap: float = self._start
 
-    def reset_current(self) -> None:
-        self.current_time = time.time()
+    def lap(self) -> float:
+        """Return the time elapsed since the last lap (or creation), then reset the lap timer."""
+        now = time.time()
+        elapsed = now - self._lap
+        self._lap = now
+        return elapsed
 
-    def log_elapsed(self, logger_: Callable[[float], None], since_start: bool = False) -> None:
-        logger_(time.time() - (self.start_time if since_start else self.current_time))
-        self.current_time = time.time()
+    @property
+    def since_start(self) -> float:
+        """Return the time elapsed since creation. No side effects."""
+        return time.time() - self._start
+
+    @property
+    def elapsed(self) -> float:
+        """Return the time elapsed since the last lap (or creation). No side effects."""
+        return time.time() - self._lap
+
+    @override
+    def __format__(self, format_spec: str) -> str:
+        """Format the time elapsed since the last lap. No side effects (does not reset the lap timer)."""
+        return format(self.elapsed, format_spec)
 
 
 T = TypeVar("T")

--- a/antarest/launcher/service.py
+++ b/antarest/launcher/service.py
@@ -549,7 +549,7 @@ class LauncherService:
                 logger.info("Re zipping output for transfer")
                 zip_path = output_true_path.parent / f"{output_true_path.name}.zip"
                 archive_dir(output_true_path, target_archive_path=zip_path, archive_format=ArchiveFormat.ZIP)
-                stopwatch.log_elapsed(lambda x: logger.info(f"Zipped output for job {job_id} in {x}s"))
+                logger.info(f"Zipped output for job {job_id} in {stopwatch}s")
 
             final_output_path = zip_path or output_true_path
             with db():

--- a/antarest/matrixstore/service.py
+++ b/antarest/matrixstore/service.py
@@ -593,7 +593,7 @@ class MatrixService(ISimpleMatrixService):
                     # noinspection PyTypeChecker
                     np.savetxt(filepath, array, delimiter="\t", fmt="%.18f")
             archive_dir(Path(tmpdir), export_path, archive_format=ArchiveFormat.ZIP)
-            stopwatch.log_elapsed(lambda x: logger.info(f"Matrix dataset exported (zipped mode) in {x}s"))
+            logger.info(f"Matrix dataset exported (zipped mode) in {stopwatch}s")
         return str(export_path)
 
     def download_dataset(self, dataset_id: str) -> FileDownloadTaskDTO:

--- a/antarest/study/output/file_output_storage.py
+++ b/antarest/study/output/file_output_storage.py
@@ -122,7 +122,7 @@ class FileOutputStorage(IOutputStorage):
             else:
                 extract_archive_from_stream(output, path_output, tmp_dir=self._tmp_dir)
 
-            stopwatch.log_elapsed(lambda elapsed_time: logger.info(f"Copied output for {study_id} in {elapsed_time}s"))
+            logger.info(f"Copied output for {study_id} in {stopwatch}s")
             fix_study_root(path_output)
             output_full_name = extract_output_name(path_output, output_name)
             extension = f"{ArchiveFormat.ZIP}" if is_zipped else ""
@@ -225,7 +225,7 @@ class FileOutputStorage(IOutputStorage):
         stopwatch = StopWatch()
         if not path_output_zip.exists():
             archive_dir(path_output, target, archive_format=ArchiveFormat.ZIP)
-        stopwatch.log_elapsed(lambda x: logger.info(f"Output {output_id} from study {study_id} exported in {x}s"))
+        logger.info(f"Output {output_id} from study {study_id} exported in {stopwatch}s")
 
     @override
     def output_exists(self, study_id: str, output_id: str) -> bool:

--- a/antarest/study/output/output_service.py
+++ b/antarest/study/output/output_service.py
@@ -274,9 +274,7 @@ class OutputService:
             try:
                 stopwatch = StopWatch()
                 self._storage.unarchive_study_output(study_id, output_id)
-                stopwatch.log_elapsed(
-                    lambda x: logger.info(f"Output {output_id} of study {study_id} unarchived in {x}s")
-                )
+                logger.info(f"Output {output_id} of study {study_id} unarchived in {stopwatch}s")
                 return TaskResult(
                     success=True,
                     message=f"Study output {study_id}/{output_id} successfully unarchived",
@@ -560,7 +558,7 @@ class OutputService:
             try:
                 stopwatch = StopWatch()
                 self._storage.archive_study_output(study_id, output_id)
-                stopwatch.log_elapsed(lambda x: logger.info(f"Output {output_id} of study {study_id} archived in {x}s"))
+                logger.info(f"Output {output_id} of study {study_id} archived in {stopwatch}s")
                 return TaskResult(
                     success=True,
                     message=f"Study output {study_id}/{output_id} successfully archived",
@@ -684,7 +682,7 @@ class OutputService:
                 )
                 export_df_chunks(self._tmp_dir, file_path, results, export_format)
 
-                stopwatch.log_elapsed(lambda x: logger.info(f"Created aggregated outputs file '{file_path}' in {x}s."))
+                logger.info(f"Created aggregated outputs file '{file_path}' in {stopwatch}s.")
 
                 if on_success:
                     on_success()

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -690,7 +690,7 @@ class StudyService:
                 f"{job_id}-{log_suffix}",
             ],
         )
-        stopwatch.log_elapsed(lambda d: logger.info(f"Saved logs for job {job_id} in {d}s"))
+        logger.info(f"Saved logs for job {job_id} in {stopwatch}s")
 
     def get_comments(self, study_id: str) -> str:
         """

--- a/antarest/study/storage/abstract_storage_service.py
+++ b/antarest/study/storage/abstract_storage_service.py
@@ -200,7 +200,5 @@ class AbstractStorageService(IStudyStorage, ABC):
             self.export_study_flat(metadata, tmp_study_path, outputs)
             stopwatch = StopWatch()
             archive_dir(tmp_study_path, target, archive_format=archive_format)
-            stopwatch.log_elapsed(
-                lambda x: logger.info(f"Study {path_study} exported ({target.suffix} format) in {x}s")
-            )
+            logger.info(f"Study {path_study} exported ({target.suffix} format) in {stopwatch}s")
         return target

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -90,7 +90,7 @@ class InputSeriesMatrix(MatrixNode):
 
         if matrix.is_empty() and use_default_empty and self.default_empty is not None:
             matrix = create_polars_dataframe(self.default_empty())
-        stopwatch.log_elapsed(lambda x: logger.debug(f"Matrix parsed in {x}s"))
+        logger.debug(f"Matrix parsed in {stopwatch}s")
         return matrix
 
     @override

--- a/antarest/study/storage/rawstudy/watcher.py
+++ b/antarest/study/storage/rawstudy/watcher.py
@@ -46,16 +46,6 @@ from antarest.study.storage.utils import (
 logger = logging.getLogger(__name__)
 
 
-class _LogScanDuration:
-    """Functional object use to log the scanning duration of a workspace."""
-
-    def __init__(self, workspace_name: str) -> None:
-        self.workspace_name = workspace_name
-
-    def __call__(self, duration: float) -> None:
-        logger.info(f"Workspace {self.workspace_name} scanned in {duration}s")
-
-
 class Watcher(IService):
     """
     Background service that periodically scans workspaces for studies.
@@ -204,7 +194,7 @@ class Watcher(IService):
                     studies = studies + rec_scan_for_studies(
                         path, name, groups, workspace.filter_in, workspace.filter_out, max_depth=max_depth
                     )
-                    stopwatch.log_elapsed(_LogScanDuration(name))
+                    logger.info(f"Workspace {name} scanned in {stopwatch.lap()}s")
         else:
             raise ValueError("Both workspace_name and directory_path must be specified")
         with db():
@@ -212,10 +202,7 @@ class Watcher(IService):
             with FileLock(Watcher.SCAN_LOCK):
                 logger.info(f"FileLock acquired to synchronize for {directory_path or 'all studies'}")
                 self.study_service.sync_studies_on_disk(studies, directory_path, recursive)
-                stopwatch.log_elapsed(
-                    lambda x: logger.info(f"{directory_path or 'All studies'} synchronized in {x}s"),
-                    since_start=True,
-                )
+                logger.info(f"{directory_path or 'All studies'} synchronized in {stopwatch.since_start}s")
 
     def clean_desktop_studies(
         self,
@@ -243,7 +230,4 @@ class Watcher(IService):
             with FileLock(Watcher.SCAN_LOCK):
                 logger.info("FileLock acquired to delete missing studies")
                 self.study_service.delete_missing_studies()
-                stopwatch.log_elapsed(
-                    lambda x: logger.info(f"deleted missing studies in {x}s"),
-                    since_start=True,
-                )
+                logger.info(f"deleted missing studies in {stopwatch.since_start}s")

--- a/antarest/study/storage/utils.py
+++ b/antarest/study/storage/utils.py
@@ -173,7 +173,7 @@ def extract_output_name(path_output: Path, new_suffix_name: Optional[str] = None
         with ZipFile(path_output, "r") as zip_obj:
             zip_obj.extract("info.antares-output", temp_dir.name)
             info_antares_output = ini_reader.read(Path(temp_dir.name) / "info.antares-output")
-        s.log_elapsed(lambda x: logger.info(f"info.antares_output has been read in {x}s"))
+        logger.info(f"info.antares_output has been read in {s}s")
         temp_dir.cleanup()
 
     else:

--- a/antarest/study/storage/variantstudy/variant_command_generator.py
+++ b/antarest/study/storage/variantstudy/variant_command_generator.py
@@ -36,8 +36,8 @@ class CmdNotifier:
         self.study_id = study_id
         self.total_count = total_count
 
-    def __call__(self, x: float) -> None:
-        logger.info(f"Command {self.index}/{self.total_count} [{self.study_id}] applied in {x}s")
+    def log(self, elapsed: float) -> None:
+        logger.info(f"Command {self.index}/{self.total_count} [{self.study_id}] applied in {elapsed}s")
 
 
 def _generate(
@@ -58,8 +58,6 @@ def _generate(
 
     # Prepare the stopwatch
     cmd_notifier = CmdNotifier(metadata.id, len(all_commands))
-    stopwatch.reset_current()
-
     # Store all the outputs
     for index, cmd in enumerate(all_commands, 1):
         try:
@@ -79,7 +77,7 @@ def _generate(
         results.details.append(detail)
 
         cmd_notifier.index = index
-        stopwatch.log_elapsed(cmd_notifier)
+        cmd_notifier.log(stopwatch.lap())
 
         # stop variant generation as soon as a command fails
         if not output.status:
@@ -92,13 +90,8 @@ def _generate(
 
     results.success = all(detail["status"] for detail in results.details)  # type: ignore
 
-    data_type = isinstance(data, FileStudy)
-    stopwatch.log_elapsed(
-        lambda x: logger.info(
-            f"Variant generation done in {x}s" if data_type else f"Variant light generation done in {x}s"
-        ),
-        since_start=True,
-    )
+    generation_type = "Variant generation" if isinstance(data, FileStudy) else "Variant light generation"
+    logger.info(f"{generation_type} done in {stopwatch.since_start}s")
     return results
 
 

--- a/antarest/worker/archive_worker.py
+++ b/antarest/worker/archive_worker.py
@@ -69,7 +69,7 @@ class ArchiveWorker(AbstractWorker):
             stopwatch = StopWatch()
             logger.info(f"Extracting {src} into {dest}")
             unzip(dest, src)
-            stopwatch.log_elapsed(lambda t: logger.info(f"Successfully extracted {src} into {dest} in {t}s"))
+            logger.info(f"Successfully extracted {src} into {dest} in {stopwatch}s")
             return TaskResult(success=True, message="")
         except Exception as e:
             logger.warning(


### PR DESCRIPTION

Minor improvements to our timer class:
 - removes the need for lambda, which shortens syntax
 - replace calls to `log_elapsed` by plain logging calls