### PR TITLE
chore(tests): add tests dir to pythonpath for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ no_implicit_reexport = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = "tests"
 
 [tool.coverage.run]
 omit = ["antarest/tools/admin.py", "antarest/fastapi_jwt_auth/*.py"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,11 @@ from typing import Callable
 import pytest
 from antares.study.version import StudyVersion
 from antares.study.version.create_app import CreateApp
+from conftest_db import db_engine_fixture, db_middleware_fixture, db_session_fixture  # noqa: F401
+from conftest_instances import admin_user  # noqa: F401
+
+# noinspection PyUnresolvedReferences
+from conftest_services import *  # noqa: F403
 
 from antarest.blobstore.in_memory import InMemoryBlobService
 from antarest.favorite.repository import FavoriteDirectoryRepository, FavoriteStudyRepository
@@ -36,11 +41,6 @@ from antarest.study.model import (
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
-from tests.conftest_db import db_engine_fixture, db_middleware_fixture, db_session_fixture  # noqa: F401
-from tests.conftest_instances import admin_user  # noqa: F401
-
-# noinspection PyUnresolvedReferences
-from tests.conftest_services import *  # noqa: F403
 
 HERE = Path(__file__).parent.resolve()
 PROJECT_DIR = next(iter(p for p in HERE.parents if p.joinpath("antarest").exists()))

--- a/tests/core/tasks/test_tasks_db_model.py
+++ b/tests/core/tasks/test_tasks_db_model.py
@@ -13,6 +13,7 @@ import datetime
 import uuid
 
 import pytest
+from helpers import create_raw_study
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -20,7 +21,6 @@ from antarest.core.tasks.model import TaskJob, TaskJobLog
 from antarest.core.utils.utils import current_time
 from antarest.login.model import Password, User
 from antarest.study.model import RawStudy
-from tests.helpers import create_raw_study
 
 
 def test_database_constraints(db_session: Session) -> None:

--- a/tests/core/tasks/test_tasks_service.py
+++ b/tests/core/tasks/test_tasks_service.py
@@ -20,8 +20,10 @@ import numpy as np
 import pandas as pd
 import pytest
 from fastapi import HTTPException
+from helpers import create_raw_study, with_admin_user, with_db_context
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine.base import Engine
+from storage.test_service import build_study_service
 
 from antarest.core.config import Config
 from antarest.core.interfaces.eventbus import DummyEventBusService, EventType, IEventBus
@@ -53,8 +55,6 @@ from antarest.study.storage.rawstudy.model.filesystem.factory import StudyFactor
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.helpers import create_raw_study, with_admin_user, with_db_context
-from tests.storage.test_service import build_study_service
 
 
 @pytest.fixture(name="db_engine", autouse=True)

--- a/tests/core/test_file_transfer.py
+++ b/tests/core/test_file_transfer.py
@@ -16,6 +16,7 @@ from unittest.mock import Mock
 
 import pytest
 from fastapi import Depends, FastAPI
+from helpers import with_admin_user
 from starlette.testclient import TestClient
 
 from antarest.core.config import Config, StorageConfig
@@ -26,7 +27,6 @@ from antarest.core.model import PermissionInfo, PublicMode
 from antarest.core.requests import MustBeAuthenticatedError
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.login.utils import current_user_context
-from tests.helpers import with_admin_user
 
 
 def test_file_request() -> None:

--- a/tests/db_statement_recorder.py
+++ b/tests/db_statement_recorder.py
@@ -29,7 +29,7 @@ class DBStatementRecorder(contextlib.AbstractContextManager):  # type: ignore
 
     Usage::
 
-        from tests.db_statement_logger import DBStatementRecorder
+        from db_statement_logger import DBStatementRecorder
 
         db_session = ...
         with DBStatementRecorder(db_session.bind) as db_recorder:

--- a/tests/eventbus/test_service.py
+++ b/tests/eventbus/test_service.py
@@ -13,11 +13,12 @@
 from typing import Awaitable, Callable, List
 from unittest.mock import MagicMock, Mock
 
+from helpers import auto_retry_assert
+
 from antarest.core.config import Config, EventBusConfig, RedisConfig
 from antarest.core.interfaces.eventbus import Event, EventType
 from antarest.core.model import PermissionInfo, PublicMode
 from antarest.eventbus.main import build_eventbus
-from tests.helpers import auto_retry_assert
 
 
 def test_service_factory() -> None:

--- a/tests/favorite_study/test_favorite_directory.py
+++ b/tests/favorite_study/test_favorite_directory.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock
 
 import pytest
 from fastapi import HTTPException
+from helpers import with_db_context
 
 from antarest.core.jwt import JWTUser
 from antarest.core.utils.fastapi_sqlalchemy import db
@@ -22,7 +23,6 @@ from antarest.login.utils import current_user_context
 from antarest.study.directory_service import DirectoryService
 from antarest.study.model import Directory
 from antarest.study.repository import DirectoryRepository
-from tests.helpers import with_db_context
 
 
 @pytest.fixture

--- a/tests/favorite_study/test_favorite_study.py
+++ b/tests/favorite_study/test_favorite_study.py
@@ -12,13 +12,13 @@
 
 import pytest
 from fastapi import HTTPException
+from helpers import create_study, with_db_context
 
 from antarest.core.jwt import JWTUser
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.favorite.model import FavoriteStudyDTO
 from antarest.favorite.service import FavoriteStudyService
 from antarest.login.utils import current_user_context
-from tests.helpers import create_study, with_db_context
 
 
 @with_db_context

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,6 +23,7 @@ from unittest.mock import Mock
 
 import numpy as np
 import polars as pl
+from conftest_instances import create_admin_user
 from numpy import typing as npt
 from polars.testing import assert_frame_equal
 from typing_extensions import override
@@ -34,7 +35,6 @@ from antarest.study.business.study_interface import FileStudyInterface
 from antarest.study.model import RawStudy, Study
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
-from tests.conftest_instances import create_admin_user
 
 
 def dirhash(dirname: Union[str, Path], hashfunc: str = "md5") -> str:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,6 +21,8 @@ import jinja2
 import pytest
 from _pytest.tmpdir import TempPathFactory
 from fastapi import FastAPI
+from integration.assets import ASSETS_DIR
+from integration.utils import wait_for
 from sqlalchemy import create_engine
 from starlette.testclient import TestClient
 
@@ -31,8 +33,6 @@ from antarest.main import fastapi_app
 from antarest.service_creator import Services
 from antarest.study.repository import AccessPermissions, StudyFilter
 from antarest.study.service import StudyService
-from tests.integration.assets import ASSETS_DIR
-from tests.integration.utils import wait_for
 
 HERE = Path(__file__).parent.resolve()
 PROJECT_DIR = next(iter(p for p in HERE.parents if p.joinpath("antarest").exists()))

--- a/tests/integration/filesystem_blueprint/test_filesystem_endpoints.py
+++ b/tests/integration/filesystem_blueprint/test_filesystem_endpoints.py
@@ -16,11 +16,10 @@ import re
 import typing as t
 from pathlib import Path
 
+from integration.conftest import RESOURCES_DIR
 from pytest_mock import MockerFixture
 from starlette.testclient import TestClient
 from typing_extensions import override
-
-from tests.integration.conftest import RESOURCES_DIR
 
 
 class AnyDiskUsagePercent:

--- a/tests/integration/maintenance_blueprint/conftest.py
+++ b/tests/integration/maintenance_blueprint/conftest.py
@@ -15,6 +15,13 @@
 from pathlib import Path
 
 import pytest
+from conftest_db import db_engine_fixture, db_middleware_fixture
+from matrixstore.conftest import (
+    content_repo_fixture,
+    dataset_repo_fixture,
+    matrix_repo_fixture,
+    matrix_service_fixture,
+)
 
 from antarest.blobstore.repository import BlobContentRepository
 from antarest.blobstore.service import BlobService
@@ -24,13 +31,6 @@ from antarest.core.tasks.repository import TaskJobRepository
 from antarest.core.tasks.service import ITaskService, TaskJobService
 from antarest.eventbus.business.local_eventbus import LocalEventBus
 from antarest.eventbus.service import EventBusService
-from tests.conftest_db import db_engine_fixture, db_middleware_fixture
-from tests.matrixstore.conftest import (
-    content_repo_fixture,
-    dataset_repo_fixture,
-    matrix_repo_fixture,
-    matrix_service_fixture,
-)
 
 db_engine = db_engine_fixture
 db_middleware = db_middleware_fixture

--- a/tests/integration/maintenance_blueprint/test_auto_archive.py
+++ b/tests/integration/maintenance_blueprint/test_auto_archive.py
@@ -15,6 +15,8 @@
 import datetime
 from unittest.mock import Mock
 
+from helpers import create_raw_study, create_variant_study
+
 from antarest.core.interfaces.cache import ICache
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import current_time
@@ -24,7 +26,6 @@ from antarest.study.model import DEFAULT_WORKSPACE_NAME
 from antarest.study.output.output_service import OutputService
 from antarest.study.repository import StudyMetadataRepository
 from antarest.study.service import StudyService
-from tests.helpers import create_raw_study, create_variant_study
 
 
 class TestArchiveOldStudiesIntegration:

--- a/tests/integration/maintenance_blueprint/test_gc_blob.py
+++ b/tests/integration/maintenance_blueprint/test_gc_blob.py
@@ -14,6 +14,8 @@
 
 import uuid
 
+from helpers import create_study
+
 from antarest.blobstore.service import BlobService
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.lock import create_lock
@@ -22,7 +24,6 @@ from antarest.maintenance.tasks.gc_blob import clean_blobs
 from antarest.study.business.model.user_model import ResourceType
 from antarest.study.dao.database.database_blob_usage_provider import DatabaseBlobUsageProvider
 from antarest.study.dao.database.models.user_resources import USER_RESOURCES_TABLE
-from tests.helpers import create_study
 
 
 class TestCleanBlobsIntegration:

--- a/tests/integration/maintenance_blueprint/test_gc_tasks.py
+++ b/tests/integration/maintenance_blueprint/test_gc_tasks.py
@@ -15,6 +15,8 @@
 from datetime import datetime
 from unittest.mock import patch
 
+from helpers import with_admin_user
+
 from antarest.core.tasks.model import TaskDTO, TaskJob, TaskListFilter, TaskStatus
 from antarest.core.tasks.repository import TaskJobRepository
 from antarest.core.tasks.service import ITaskService
@@ -22,7 +24,6 @@ from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.lock import create_lock
 from antarest.maintenance.tasks.common import BackGroundTaskStatus, LockId
 from antarest.maintenance.tasks.gc_tasks import clean_tasks
-from tests.helpers import with_admin_user
 
 
 class TestTasksGCIntegration:

--- a/tests/integration/output_blueprint/test_aggregate_raw_data.py
+++ b/tests/integration/output_blueprint/test_aggregate_raw_data.py
@@ -18,12 +18,12 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from integration.assets import ASSETS_DIR as INTEGRATION_ASSETS_DIR
+from integration.raw_studies_blueprint.assets import ASSETS_DIR
 from starlette.testclient import TestClient
 
 from antarest.core.serde.matrix_export import TableExportFormat
 from antarest.core.utils.utils import current_time
-from tests.integration.assets import ASSETS_DIR as INTEGRATION_ASSETS_DIR
-from tests.integration.raw_studies_blueprint.assets import ASSETS_DIR
 
 # define the requests parameters for the `economy/mc-ind` outputs aggregation
 AREAS_REQUESTS__IND = [

--- a/tests/integration/output_blueprint/test_output_variables.py
+++ b/tests/integration/output_blueprint/test_output_variables.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from integration.raw_studies_blueprint.assets import ASSETS_DIR as assets_dir
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.serde.json import from_json
@@ -20,8 +22,6 @@ from antarest.core.tasks.model import TaskStatus
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.study.model import MatrixFrequency
 from antarest.study.output.output_model import OutputVariables, OutputVariablesViewsModel
-from tests.integration.raw_studies_blueprint.assets import ASSETS_DIR as assets_dir
-from tests.integration.utils import wait_task_completion
 
 ASSETS_DIR = assets_dir / "output_variables_list"
 

--- a/tests/integration/prepare_proxy.py
+++ b/tests/integration/prepare_proxy.py
@@ -14,10 +14,10 @@ import io
 import typing as t
 
 import pandas as pd
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
-from tests.integration.utils import wait_task_completion
 
 
 class PreparerProxy:

--- a/tests/integration/raw_studies_blueprint/test_download_matrices.py
+++ b/tests/integration/raw_studies_blueprint/test_download_matrices.py
@@ -16,11 +16,11 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+from integration.utils import wait_task_completion
 from pandas._testing import assert_frame_equal
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
-from tests.integration.utils import wait_task_completion
 
 
 class Proxy:

--- a/tests/integration/raw_studies_blueprint/test_download_outputs.py
+++ b/tests/integration/raw_studies_blueprint/test_download_outputs.py
@@ -11,11 +11,11 @@
 # This file is part of the Antares project.
 import json
 
+from integration.raw_studies_blueprint.assets import ASSETS_DIR as assets_dir
 from py7zr import py7zr
 from starlette.testclient import TestClient
 
 from antarest.core.serde.json import from_json
-from tests.integration.raw_studies_blueprint.assets import ASSETS_DIR as assets_dir
 
 ASSETS_DIR = assets_dir / "output_downloads_list"
 

--- a/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
+++ b/tests/integration/raw_studies_blueprint/test_fetch_raw_data.py
@@ -21,6 +21,8 @@ from unittest.mock import ANY
 import numpy as np
 import pandas as pd
 import pytest
+from integration.raw_studies_blueprint.assets import ASSETS_DIR
+from integration.utils import wait_for
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
@@ -29,8 +31,6 @@ from antarest.study.model import RawStudy, Study
 from antarest.study.storage.rawstudy.model.filesystem.root.input.thermal.prepro.area.thermal.thermal import (
     default_data_matrix,
 )
-from tests.integration.raw_studies_blueprint.assets import ASSETS_DIR
-from tests.integration.utils import wait_for
 
 
 class TestFetchRawData:

--- a/tests/integration/studies_blueprint/test_comments.py
+++ b/tests/integration/studies_blueprint/test_comments.py
@@ -15,11 +15,10 @@ import time
 from xml.etree import ElementTree
 
 import pytest
+from integration.studies_blueprint.assets import ASSETS_DIR
+from integration.utils import duration_threshold
 from starlette.testclient import TestClient
-
-from tests.integration.studies_blueprint.assets import ASSETS_DIR
-from tests.integration.utils import duration_threshold
-from tests.xml_compare import compare_elements
+from xml_compare import compare_elements
 
 
 class TestStudyComments:

--- a/tests/integration/studies_blueprint/test_get_studies.py
+++ b/tests/integration/studies_blueprint/test_get_studies.py
@@ -20,13 +20,13 @@ from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
+from integration.assets import ASSETS_DIR
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.model import PublicMode
 from antarest.core.roles import RoleType
 from antarest.core.tasks.model import TaskStatus
-from tests.integration.assets import ASSETS_DIR
-from tests.integration.utils import wait_task_completion
 
 # URL used to create or list studies
 STUDIES_URL = "/v1/studies"

--- a/tests/integration/studies_blueprint/test_normalization.py
+++ b/tests/integration/studies_blueprint/test_normalization.py
@@ -14,10 +14,10 @@ import shutil
 import zipfile
 from pathlib import Path
 
+from integration.assets import ASSETS_DIR as INTEGRATION_ASSETS_DIR
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
-from tests.integration.assets import ASSETS_DIR as INTEGRATION_ASSETS_DIR
 
 
 class TestNormalization:

--- a/tests/integration/studies_blueprint/test_study_version.py
+++ b/tests/integration/studies_blueprint/test_study_version.py
@@ -16,11 +16,11 @@ import zipfile
 from pathlib import Path
 
 from antares.study.version.upgrade_app import UpgradeApp
+from integration.assets import ASSETS_DIR
 from starlette.testclient import TestClient
 
 from antarest.core.serde.ini_reader import read_ini
 from antarest.study.model import STUDY_VERSION_9_2
-from tests.integration.assets import ASSETS_DIR
 
 
 class TestStudyVersions:

--- a/tests/integration/studies_blueprint/test_synthesis.py
+++ b/tests/integration/studies_blueprint/test_synthesis.py
@@ -17,10 +17,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from integration.studies_blueprint.assets import ASSETS_DIR
+from integration.utils import duration_threshold
 from starlette.testclient import TestClient
-
-from tests.integration.studies_blueprint.assets import ASSETS_DIR
-from tests.integration.utils import duration_threshold
 
 
 def _compare_resource_file(actual: dict[str, Any], res_path: Path) -> None:

--- a/tests/integration/study_data_blueprint/test_advanced_parameters.py
+++ b/tests/integration/study_data_blueprint/test_advanced_parameters.py
@@ -13,10 +13,10 @@
 from http import HTTPStatus
 
 import pytest
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
-from tests.integration.utils import wait_task_completion
 
 
 class TestAdvancedParametersForm:

--- a/tests/integration/study_data_blueprint/test_area.py
+++ b/tests/integration/study_data_blueprint/test_area.py
@@ -11,9 +11,8 @@
 # This file is part of the Antares project.
 
 import pytest
+from integration.prepare_proxy import PreparerProxy
 from starlette.testclient import TestClient
-
-from tests.integration.prepare_proxy import PreparerProxy
 
 
 class TestArea:

--- a/tests/integration/study_data_blueprint/test_area_database_mode.py
+++ b/tests/integration/study_data_blueprint/test_area_database_mode.py
@@ -24,9 +24,8 @@ DAO methods are implemented.
 """
 
 import pytest
+from integration.prepare_proxy import PreparerProxy
 from starlette.testclient import TestClient
-
-from tests.integration.prepare_proxy import PreparerProxy
 
 # Reason for xfail - CREATE_AREA command requires methods not yet implemented in DatabaseStudyDao
 DATABASE_MODE_INCOMPLETE = (

--- a/tests/integration/study_data_blueprint/test_binding_constraints.py
+++ b/tests/integration/study_data_blueprint/test_binding_constraints.py
@@ -18,11 +18,11 @@ import numpy as np
 import pandas as pd
 import pytest
 from httpx._exceptions import HTTPError
+from integration.prepare_proxy import PreparerProxy
+from integration.utils import duration_threshold
 from starlette.testclient import TestClient
 
 from antarest.study.business.model.binding_constraint_model import ClusterTerm, ConstraintTerm, LinkTerm
-from tests.integration.prepare_proxy import PreparerProxy
-from tests.integration.utils import duration_threshold
 
 MATRIX_SIZES = {"hourly": 8784, "daily": 366, "weekly": 366}
 

--- a/tests/integration/study_data_blueprint/test_generate_thermal_cluster_timeseries.py
+++ b/tests/integration/study_data_blueprint/test_generate_thermal_cluster_timeseries.py
@@ -14,12 +14,12 @@ import io
 
 import numpy as np
 import pytest
+from integration.assets import ASSETS_DIR
+from integration.prepare_proxy import PreparerProxy
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskDTO, TaskStatus
-from tests.integration.assets import ASSETS_DIR
-from tests.integration.prepare_proxy import PreparerProxy
-from tests.integration.utils import wait_task_completion
 
 TIMESERIES_ASSETS_DIR = ASSETS_DIR.joinpath("timeseries_generation")
 

--- a/tests/integration/study_data_blueprint/test_layer.py
+++ b/tests/integration/study_data_blueprint/test_layer.py
@@ -11,9 +11,8 @@
 # This file is part of the Antares project.
 
 import pytest
+from integration.prepare_proxy import PreparerProxy
 from starlette.testclient import TestClient
-
-from tests.integration.prepare_proxy import PreparerProxy
 
 
 class TestLayer:

--- a/tests/integration/study_data_blueprint/test_link.py
+++ b/tests/integration/study_data_blueprint/test_link.py
@@ -11,10 +11,10 @@
 # This file is part of the Antares project.
 
 import pytest
+from integration.prepare_proxy import PreparerProxy
 from starlette.testclient import TestClient
 
 from antarest.study.business.model.link_model import TransmissionCapacity
-from tests.integration.prepare_proxy import PreparerProxy
 
 
 class TestLink:

--- a/tests/integration/study_data_blueprint/test_renewable.py
+++ b/tests/integration/study_data_blueprint/test_renewable.py
@@ -43,11 +43,11 @@ import uuid
 
 import numpy as np
 import pytest
+from integration.utils import duration_threshold, wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
-from tests.integration.utils import duration_threshold, wait_task_completion
 
 # noinspection SpellCheckingInspection
 EXISTING_CLUSTERS: list[str] = []

--- a/tests/integration/study_data_blueprint/test_st_storage.py
+++ b/tests/integration/study_data_blueprint/test_st_storage.py
@@ -18,13 +18,13 @@ from unittest.mock import ANY
 import numpy as np
 import pytest
 from antares.study.version import StudyVersion
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
 from antarest.study.model import STUDY_VERSION_8_6, STUDY_VERSION_8_8
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
 from antarest.study.storage.rawstudy.model.filesystem.config.st_storage import STStorageFileData, parse_st_storage
-from tests.integration.utils import wait_task_completion
 
 _ST_STORAGE_860 = parse_st_storage(STUDY_VERSION_8_6, data={"name": "dummy"})
 _ST_STORAGE_880 = parse_st_storage(STUDY_VERSION_8_8, data={"name": "dummy"})

--- a/tests/integration/study_data_blueprint/test_study_data.py
+++ b/tests/integration/study_data_blueprint/test_study_data.py
@@ -11,12 +11,12 @@
 # This file is part of the Antares project.
 
 
+from integration.study_data_blueprint import ASSETS_DIR
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.serde.json import from_json
 from antarest.core.tasks.model import TaskStatus
-from tests.integration.study_data_blueprint import ASSETS_DIR
-from tests.integration.utils import wait_task_completion
 
 
 def test_study_data(client: TestClient, user_access_token: str, internal_study_id: str) -> None:

--- a/tests/integration/study_data_blueprint/test_table_mode.py
+++ b/tests/integration/study_data_blueprint/test_table_mode.py
@@ -14,10 +14,10 @@ import copy
 import typing as t
 
 import pytest
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
-from tests.integration.utils import wait_task_completion
 
 # noinspection SpellCheckingInspection
 POLLUTANTS_860 = ("nh3", "nmvoc", "nox", "op1", "op2", "op3", "op4", "op5", "pm10", "pm25", "pm5", "so2")

--- a/tests/integration/study_data_blueprint/test_thermal.py
+++ b/tests/integration/study_data_blueprint/test_thermal.py
@@ -49,11 +49,11 @@ import uuid
 import numpy as np
 import pandas as pd
 import pytest
+from integration.utils import duration_threshold, wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.study.model import STUDY_VERSION_8_6, STUDY_VERSION_8_7
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
-from tests.integration.utils import duration_threshold, wait_task_completion
 
 # noinspection SpellCheckingInspection
 EXISTING_CLUSTERS = [

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -19,15 +19,15 @@ from unittest.mock import ANY
 
 from antares.study.version import StudyVersion
 from antares.study.version.create_app import CreateApp
+from integration.assets import ASSETS_DIR
+from integration.prepare_proxy import PreparerProxy
+from integration.utils import wait_for
 from starlette.testclient import TestClient
 
 from antarest.core.serde.ini_reader import read_ini
 from antarest.core.serde.ini_writer import write_ini_file
 from antarest.study.business.model.layer_model import Layer
 from antarest.study.storage.variantstudy.model.command.common import CommandName
-from tests.integration.assets import ASSETS_DIR
-from tests.integration.prepare_proxy import PreparerProxy
-from tests.integration.utils import wait_for
 
 
 def test_main(client: TestClient, admin_access_token: str) -> None:

--- a/tests/integration/test_integration_token_end_to_end.py
+++ b/tests/integration/test_integration_token_end_to_end.py
@@ -15,12 +15,12 @@ import typing as t
 from unittest.mock import ANY
 
 import numpy as np
+from integration.assets import ASSETS_DIR
+from integration.utils import wait_for
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskDTO, TaskStatus
 from antarest.launcher.model import JobResultDTO, JobStatus
-from tests.integration.assets import ASSETS_DIR
-from tests.integration.utils import wait_for
 
 
 def test_nominal_case_of_an_api_user(client: TestClient, admin_access_token: str) -> None:

--- a/tests/integration/test_studies_upgrade.py
+++ b/tests/integration/test_studies_upgrade.py
@@ -13,10 +13,10 @@
 import sys
 
 import pytest
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
-from tests.integration.utils import wait_task_completion
 
 RUN_ON_WINDOWS = sys.platform == "win32"
 

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -9,10 +9,10 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskDTO, TaskStatus
-from tests.integration.utils import wait_task_completion
 
 
 def test_list_tasks(client: TestClient, user_access_token: str, internal_study_id: str):

--- a/tests/integration/variant_blueprint/test_renewable_cluster.py
+++ b/tests/integration/variant_blueprint/test_renewable_cluster.py
@@ -13,11 +13,11 @@
 import http
 
 import numpy as np
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
-from tests.integration.utils import wait_task_completion
 
 
 # noinspection SpellCheckingInspection

--- a/tests/integration/variant_blueprint/test_st_storage.py
+++ b/tests/integration/variant_blueprint/test_st_storage.py
@@ -14,11 +14,11 @@ import http
 from unittest.mock import ANY
 
 import numpy as np
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
-from tests.integration.utils import wait_task_completion
 
 
 class TestSTStorage:

--- a/tests/integration/variant_blueprint/test_variant_manager.py
+++ b/tests/integration/variant_blueprint/test_variant_manager.py
@@ -18,14 +18,14 @@ import typing as t
 from pathlib import Path
 
 import pytest
+from integration.assets import ASSETS_DIR
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskDTO, TaskStatus
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import current_time
 from antarest.study.model import Study
-from tests.integration.assets import ASSETS_DIR
-from tests.integration.utils import wait_task_completion
 
 
 @pytest.fixture(name="base_study_id")

--- a/tests/integration/xpansion_studies_blueprint/test_integration_xpansion.py
+++ b/tests/integration/xpansion_studies_blueprint/test_integration_xpansion.py
@@ -18,11 +18,11 @@ from unittest.mock import ANY
 from urllib.parse import urljoin
 
 import pytest
+from integration.utils import wait_task_completion
 from starlette.testclient import TestClient
 
 from antarest.core.tasks.model import TaskStatus
 from antarest.study.business.model.xpansion_model import XpansionCandidate
-from tests.integration.utils import wait_task_completion
 
 
 def _create_area(

--- a/tests/launcher/test_extension_adequacy_patch.py
+++ b/tests/launcher/test_extension_adequacy_patch.py
@@ -14,10 +14,10 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from helpers import with_db_context
 
 from antarest.core.config import Config, StorageConfig
 from antarest.launcher.extensions.adequacy_patch.extension import AdequacyPatchExtension
-from tests.helpers import with_db_context
 
 
 @with_db_context

--- a/tests/launcher/test_log_parser.py
+++ b/tests/launcher/test_log_parser.py
@@ -15,10 +15,10 @@ import sys
 from typing import List, Union
 
 import pytest
+from launcher.assets import ASSETS_DIR
 from typing_extensions import override
 
 from antarest.launcher.adapters.log_parser import LaunchProgressDTO
-from tests.launcher.assets import ASSETS_DIR
 
 
 @pytest.mark.parametrize(

--- a/tests/launcher/test_repository.py
+++ b/tests/launcher/test_repository.py
@@ -14,12 +14,13 @@ import datetime
 from unittest.mock import Mock
 from uuid import uuid4
 
+from helpers import create_raw_study, with_db_context
+
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.launcher.model import JobLog, JobLogType, JobResult, JobStatus
 from antarest.launcher.repository import JobResultRepository
 from antarest.login.model import Identity
 from antarest.study.repository import StudyMetadataRepository
-from tests.helpers import create_raw_study, with_db_context
 
 
 @with_db_context

--- a/tests/launcher/test_service.py
+++ b/tests/launcher/test_service.py
@@ -22,6 +22,7 @@ from uuid import uuid4
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import pytest
+from helpers import with_admin_user
 from sqlalchemy import create_engine
 
 from antarest.core.config import (
@@ -71,7 +72,6 @@ from antarest.study.service import StudyService
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.helpers import with_admin_user
 
 
 class TestLauncherService:

--- a/tests/login/test_login_service.py
+++ b/tests/login/test_login_service.py
@@ -14,6 +14,8 @@ import typing as t
 from unittest.mock import patch
 
 import pytest
+from db_statement_recorder import DBStatementRecorder
+from helpers import with_db_context
 from sqlalchemy.orm import Session
 
 from antarest.core.jwt import JWTGroup, JWTUser
@@ -35,8 +37,6 @@ from antarest.login.model import (
 )
 from antarest.login.service import GroupNotFoundError, LoginService
 from antarest.login.utils import current_user_context
-from tests.db_statement_recorder import DBStatementRecorder
-from tests.helpers import with_db_context
 
 # For the unit tests, we will define several fictitious users, groups and roles.
 

--- a/tests/matrixstore/test_matrix_usage_providers.py
+++ b/tests/matrixstore/test_matrix_usage_providers.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 
 import polars as pl
 import pytest
+from helpers import create_raw_study, with_admin_user, with_db_context
 from typing_extensions import override
 
 from antarest.core.config import DEFAULT_WORKSPACE_NAME, InternalMatrixFormat
@@ -56,7 +57,6 @@ from antarest.study.storage.variantstudy.model.command_context import CommandCon
 from antarest.study.storage.variantstudy.model.dbmodel import CommandBlock, VariantStudy
 from antarest.study.storage.variantstudy.repository import VariantStudyRepository
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.helpers import create_raw_study, with_admin_user, with_db_context
 
 
 @pytest.fixture

--- a/tests/matrixstore/test_service.py
+++ b/tests/matrixstore/test_service.py
@@ -23,7 +23,9 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
+from conftest import PROJECT_DIR
 from fastapi import UploadFile
+from helpers import with_db_context
 from sqlalchemy import select
 from starlette.datastructures import Headers
 
@@ -52,8 +54,6 @@ from antarest.matrixstore.model import (
 from antarest.matrixstore.parsing import load_matrix
 from antarest.matrixstore.repository import compute_hash
 from antarest.matrixstore.service import MatrixService, check_dataframe_compliance
-from tests.conftest import PROJECT_DIR
-from tests.helpers import with_db_context
 
 MatrixType = list[list[float]]
 TEST_MATRIX = [[1, 2, 3], [4, 5, 6]]

--- a/tests/matrixstore/test_web.py
+++ b/tests/matrixstore/test_web.py
@@ -17,6 +17,8 @@ from unittest.mock import Mock
 import numpy as np
 import polars as pl
 from fastapi import FastAPI
+from helpers import with_admin_user
+from login.test_web import create_auth_token
 from starlette.testclient import TestClient
 
 from antarest.core.application import create_app_ctxt
@@ -27,8 +29,6 @@ from antarest.login.auth import JwtSettings
 from antarest.matrixstore.main import build_matrix_service
 from antarest.matrixstore.model import MatrixDescriptionDTO, MatrixInfoDTO, MatrixReference, MatrixReferencesDTO
 from antarest.matrixstore.web import MatrixDTO
-from tests.helpers import with_admin_user
-from tests.login.test_web import create_auth_token
 
 
 def create_app(service: Mock, auth_disabled: bool = False) -> FastAPI:

--- a/tests/storage/business/conftest.py
+++ b/tests/storage/business/conftest.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 from antares.study.version.create_app import CreateApp
+from helpers import file_study_interface
 
 from antarest.blobstore.service import IBlobService
 from antarest.matrixstore.matrix_uri_mapper import MatrixUriMapperFactory, NormalizedMatrixUriMapper
@@ -27,7 +28,6 @@ from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 @pytest.fixture

--- a/tests/storage/business/test_arealink_manager.py
+++ b/tests/storage/business/test_arealink_manager.py
@@ -13,6 +13,8 @@
 from pathlib import Path
 from unittest.mock import Mock
 
+from helpers import file_study_interface
+
 from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.area_management import AreaManager
 from antarest.study.business.link_management import LinkManager
@@ -30,7 +32,6 @@ from antarest.study.storage.rawstudy.model.filesystem.config.model import (
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
 from antarest.study.storage.variantstudy.model.command.common import FilteringOptions
-from tests.helpers import file_study_interface
 
 
 def test_area_crud(

--- a/tests/storage/business/test_autoarchive_service.py
+++ b/tests/storage/business/test_autoarchive_service.py
@@ -13,6 +13,8 @@
 import datetime
 from unittest.mock import Mock
 
+from helpers import create_raw_study, create_variant_study, with_db_context
+
 from antarest.core.exceptions import TaskAlreadyRunning
 from antarest.core.interfaces.cache import ICache
 from antarest.core.utils.utils import current_time
@@ -22,7 +24,6 @@ from antarest.study.model import DEFAULT_WORKSPACE_NAME
 from antarest.study.output.output_service import OutputService
 from antarest.study.repository import StudyMetadataRepository
 from antarest.study.service import StudyService
-from tests.helpers import create_raw_study, create_variant_study, with_db_context
 
 
 @with_db_context

--- a/tests/storage/business/test_config_manager.py
+++ b/tests/storage/business/test_config_manager.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 from antares.study.version import StudyVersion
+from helpers import file_study_interface
 
 from antarest.study.business.model.thematic_trimming_model import (
     ThematicTrimming,
@@ -33,7 +34,6 @@ from antarest.study.model import (
 )
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 @pytest.mark.parametrize(

--- a/tests/storage/business/test_export.py
+++ b/tests/storage/business/test_export.py
@@ -15,6 +15,9 @@ from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
+from conftest import empty_study_fixture
+from db_statement_recorder import DBStatementRecorder
+from helpers import create_raw_study, dirhash, with_db_context
 from py7zr import SevenZipFile, py7zr
 
 from antarest.blobstore.service import BlobService
@@ -33,9 +36,6 @@ from antarest.study.storage.variantstudy.business.matrix_constants_generator imp
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command.create_cluster import CreateCluster
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.conftest import empty_study_fixture
-from tests.db_statement_recorder import DBStatementRecorder
-from tests.helpers import create_raw_study, dirhash, with_db_context
 
 
 def test_export(

--- a/tests/storage/business/test_import.py
+++ b/tests/storage/business/test_import.py
@@ -18,13 +18,13 @@ from unittest.mock import Mock
 
 import py7zr
 import pytest
+from helpers import create_raw_study
 
 from antarest.core.exceptions import BadArchiveContent, StudyValidationError
 from antarest.study.model import DEFAULT_WORKSPACE_NAME
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
 from antarest.study.storage.utils import fix_study_root
-from tests.helpers import create_raw_study
 
 
 def test_import_study(tmp_path: Path) -> None:

--- a/tests/storage/business/test_raw_study_service.py
+++ b/tests/storage/business/test_raw_study_service.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import pytest
+from helpers import create_raw_study, with_admin_user, with_db_context
 
 from antarest.core.config import Config, StorageConfig, WorkspaceConfig
 from antarest.core.exceptions import StudyDeletionNotAllowed, StudyNotFoundError
@@ -30,7 +31,6 @@ from antarest.study.model import DEFAULT_WORKSPACE_NAME, RawStudy
 from antarest.study.output.file_output_storage import FileOutputStorage, FileStudyOutputs, IFileOutputsProvider
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
-from tests.helpers import create_raw_study, with_admin_user, with_db_context
 
 
 def build_config(

--- a/tests/storage/business/test_repository.py
+++ b/tests/storage/business/test_repository.py
@@ -13,11 +13,11 @@
 import datetime
 from unittest.mock import Mock
 
+from helpers import create_raw_study, create_variant_study
 from sqlalchemy.orm import Session
 
 from antarest.core.interfaces.cache import ICache
 from antarest.study.storage.variantstudy.repository import VariantStudyRepository
-from tests.helpers import create_raw_study, create_variant_study
 
 
 class TestVariantStudyRepository:

--- a/tests/storage/business/test_study_version_upgrader.py
+++ b/tests/storage/business/test_study_version_upgrader.py
@@ -21,6 +21,7 @@ from typing import Any, AnyStr, List, Optional
 import pandas
 import pytest
 from pandas.errors import EmptyDataError
+from storage.business.assets import ASSETS_DIR
 
 from antarest.core.exceptions import UnsupportedStudyVersion
 from antarest.core.serde.ini_reader import IniReader
@@ -32,7 +33,6 @@ from antarest.study.storage.study_upgrader import (
     check_versions_coherence,
     find_next_version,
 )
-from tests.storage.business.assets import ASSETS_DIR
 
 MAPPING_TRANSMISSION_CAPACITIES = {
     True: "local-values",

--- a/tests/storage/business/test_timeseries_config_manager.py
+++ b/tests/storage/business/test_timeseries_config_manager.py
@@ -17,6 +17,7 @@ from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
+from helpers import file_study_interface
 
 from antarest.core.serde.ini_reader import read_ini
 from antarest.core.serde.ini_writer import write_ini_file
@@ -32,7 +33,6 @@ from antarest.study.storage.rawstudy.model.filesystem.config.files import build
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 @pytest.fixture

--- a/tests/storage/business/test_variant_study_service.py
+++ b/tests/storage/business/test_variant_study_service.py
@@ -15,6 +15,7 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from helpers import create_variant_study
 
 from antarest.core.config import Config, StorageConfig, WorkspaceConfig
 from antarest.core.exceptions import StudyNotFoundError, VariantGenerationError
@@ -30,7 +31,6 @@ from antarest.study.model import DEFAULT_WORKSPACE_NAME
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.repository import VariantStudyRepository
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.helpers import create_variant_study
 
 
 def build_config(study_path: Path) -> Config:

--- a/tests/storage/business/test_watcher.py
+++ b/tests/storage/business/test_watcher.py
@@ -19,8 +19,10 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
+from helpers import create_study
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
+from storage.conftest import SimpleSyncTaskService
 
 from antarest.core.config import Config, StorageConfig, WorkspaceConfig
 from antarest.core.exceptions import CannotAccessInternalWorkspace, ScanDisabled
@@ -39,8 +41,6 @@ from antarest.study.service import StudyService
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
 from antarest.study.storage.rawstudy.watcher import Watcher
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.helpers import create_study
-from tests.storage.conftest import SimpleSyncTaskService
 
 
 def build_config(root: Path, desktop_mode: bool = False) -> Config:

--- a/tests/storage/business/test_xpansion_manager.py
+++ b/tests/storage/business/test_xpansion_manager.py
@@ -17,6 +17,7 @@ import pandas as pd
 import polars as pl
 import pytest
 from fastapi import UploadFile
+from helpers import file_study_interface
 from polars.testing import assert_frame_equal
 
 from antarest.core.exceptions import (
@@ -48,7 +49,6 @@ from antarest.study.business.xpansion_management import (
 )
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix import MatrixNode
-from tests.helpers import file_study_interface
 
 
 def make_areas(area_manager: AreaManager, study: StudyInterface) -> None:

--- a/tests/storage/integration/conftest.py
+++ b/tests/storage/integration/conftest.py
@@ -19,6 +19,7 @@ from zipfile import ZipFile
 
 import py7zr
 import pytest
+from helpers import create_raw_study
 
 from antarest.blobstore.repository import BlobContentRepository
 from antarest.blobstore.service import BlobService
@@ -40,7 +41,6 @@ from antarest.study.main import build_study_service
 from antarest.study.model import DEFAULT_WORKSPACE_NAME
 from antarest.study.output.output_service import OutputService
 from antarest.study.service import StudyService
-from tests.helpers import create_raw_study
 
 UUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 

--- a/tests/storage/integration/study_converter/test_study_converter.py
+++ b/tests/storage/integration/study_converter/test_study_converter.py
@@ -14,6 +14,8 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import polars as pl
+from helpers import with_admin_user
+from storage.integration.conftest import UUID
 
 from antarest.core.utils.polars import create_polars_dataframe
 from antarest.study.business.model.area_model import AreaUIData
@@ -55,8 +57,6 @@ from antarest.study.model import STUDY_VERSION_7_0, STUDY_VERSION_9_2
 from antarest.study.service import StudyService
 from antarest.study.storage.rawstudy.model.filesystem.config.model import Mode
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import with_admin_user
-from tests.storage.integration.conftest import UUID
 
 
 @with_admin_user

--- a/tests/storage/integration/study_converter/test_study_converter_hydro.py
+++ b/tests/storage/integration/study_converter/test_study_converter_hydro.py
@@ -13,6 +13,7 @@
 import polars as pl
 import pytest
 from sqlalchemy.orm import Session
+from study.dao.conftest import build_dao
 
 from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.config.compatibility_parameters_model import CompatibilityParameters, HydroPmax
@@ -22,7 +23,6 @@ from antarest.study.business.model.hydro_model import HydroManagement, InflowStr
 from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
 from antarest.study.dao.study_conversion.study_converter import StudyConverter
 from antarest.study.model import STUDY_VERSION_8_8, STUDY_VERSION_9_2
-from tests.study.dao.conftest import build_dao
 
 
 def _setup_area_with_hydro(dao: DatabaseStudyDao, area_name: str) -> str:

--- a/tests/storage/integration/test_STA_mini.py
+++ b/tests/storage/integration/test_STA_mini.py
@@ -23,8 +23,15 @@ import pandas as pd
 import polars as pl
 import pytest
 from fastapi import FastAPI
+from helpers import assert_study, with_admin_user, with_db_context
 from sqlalchemy import Engine
 from starlette.testclient import TestClient
+from storage.integration.conftest import UUID
+from storage.integration.data.de_details_hourly import de_details_hourly
+from storage.integration.data.de_fr_values_hourly import de_fr_values_hourly
+from storage.integration.data.digest_file import digest_file
+from storage.integration.data.set_id_annual import set_id_annual
+from storage.integration.data.set_values_monthly import set_values_monthly
 
 from antarest.core.application import create_app_ctxt
 from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware, db
@@ -40,13 +47,6 @@ from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import 
 from antarest.study.storage.rawstudy.model.filesystem.root.input.hydro.prepro.area.area import default_energy
 from antarest.study.storage.variantstudy.business.matrix_constants.common import fixed_4_columns
 from antarest.study.web.output_blueprint import create_output_routes
-from tests.helpers import assert_study, with_admin_user, with_db_context
-from tests.storage.integration.conftest import UUID
-from tests.storage.integration.data.de_details_hourly import de_details_hourly
-from tests.storage.integration.data.de_fr_values_hourly import de_fr_values_hourly
-from tests.storage.integration.data.digest_file import digest_file
-from tests.storage.integration.data.set_id_annual import set_id_annual
-from tests.storage.integration.data.set_values_monthly import set_values_monthly
 
 
 @pytest.fixture

--- a/tests/storage/integration/test_exporter.py
+++ b/tests/storage/integration/test_exporter.py
@@ -20,7 +20,10 @@ from unittest.mock import Mock
 import py7zr
 import pytest
 from fastapi import FastAPI
+from helpers import create_raw_study, with_admin_user
 from starlette.testclient import TestClient
+from storage.conftest import SimpleFileTransferManager, SimpleSyncTaskService
+from storage.integration.conftest import UUID
 
 from antarest.blobstore.service import BlobService
 from antarest.core.application import create_app_ctxt
@@ -31,9 +34,6 @@ from antarest.study.main import build_study_service
 from antarest.study.model import DEFAULT_WORKSPACE_NAME
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
-from tests.helpers import create_raw_study, with_admin_user
-from tests.storage.conftest import SimpleFileTransferManager, SimpleSyncTaskService
-from tests.storage.integration.conftest import UUID
 
 
 def assert_url_content(url: str, tmp_dir: Path, sta_mini_archive_path: Path) -> bytes:

--- a/tests/storage/integration/test_write_STA_mini.py
+++ b/tests/storage/integration/test_write_STA_mini.py
@@ -15,13 +15,13 @@ from typing import Optional
 import numpy as np
 import polars as pl
 import pytest
+from helpers import with_admin_user
 from polars.testing import assert_frame_equal
+from storage.integration.conftest import UUID
 
 from antarest.core.model import SUB_JSON
 from antarest.core.utils.polars import create_polars_dataframe
 from antarest.study.service import StudyService
-from tests.helpers import with_admin_user
-from tests.storage.integration.conftest import UUID
 
 
 def assert_with_errors(

--- a/tests/storage/rawstudies/test_factory.py
+++ b/tests/storage/rawstudies/test_factory.py
@@ -12,13 +12,14 @@
 
 from unittest.mock import Mock
 
+from storage.rawstudies.samples import ASSETS_DIR
+
 from antarest.core.interfaces.cache import study_config_cache_key
 from antarest.matrixstore.matrix_uri_mapper import MatrixUriMapper
 from antarest.study.storage.rawstudy.model.filesystem.config.files import build
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfigDTO
 from antarest.study.storage.rawstudy.model.filesystem.factory import StudyFactory
 from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
-from tests.storage.rawstudies.samples import ASSETS_DIR
 
 
 def test_renewable_subtree() -> None:

--- a/tests/storage/repository/filesystem/config/test_config_files.py
+++ b/tests/storage/repository/filesystem/config/test_config_files.py
@@ -18,6 +18,7 @@ from typing import Any, Iterable, Mapping
 from zipfile import ZipFile
 
 import pytest
+from storage.business.assets import ASSETS_DIR
 
 from antarest.core.serde.ini_writer import write_ini_file
 from antarest.study.business.model.binding_constraint_model import (
@@ -60,7 +61,6 @@ from antarest.study.storage.rawstudy.model.filesystem.config.model import (
     Simulation,
 )
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
-from tests.storage.business.assets import ASSETS_DIR
 
 
 @pytest.fixture(name="study_path")

--- a/tests/storage/repository/filesystem/test_folder_node.py
+++ b/tests/storage/repository/filesystem/test_folder_node.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from storage.repository.filesystem.utils import CheckSubNode, MiddleNode
 
 from antarest.core.exceptions import ChildNotFoundError
 from antarest.study.model import STUDY_VERSION_8
@@ -27,7 +28,6 @@ from antarest.study.storage.rawstudy.model.filesystem.ini_file_node import IniFi
 from antarest.study.storage.rawstudy.model.filesystem.inode import INode
 from antarest.study.storage.rawstudy.model.filesystem.raw_file_node import RawFileNode
 from antarest.study.storage.rawstudy.model.filesystem.root.input.areas.list import InputAreasList
-from tests.storage.repository.filesystem.utils import CheckSubNode, MiddleNode
 
 
 def build_tree() -> INode[t.Any, t.Any, t.Any]:

--- a/tests/storage/repository/filesystem/test_lazy_node.py
+++ b/tests/storage/repository/filesystem/test_lazy_node.py
@@ -14,12 +14,12 @@ from pathlib import Path
 from typing import List, Optional
 from unittest.mock import Mock
 
+from storage.repository.filesystem.matrix.test_matrix_node import MockMatrixNode
 from typing_extensions import override
 
 from antarest.matrixstore.matrix_uri_mapper import MatrixUriMapperManaged
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.lazy_node import LazyNode
-from tests.storage.repository.filesystem.matrix.test_matrix_node import MockMatrixNode
 
 
 class MockLazyNode(LazyNode[str, str, str]):

--- a/tests/storage/repository/test_study.py
+++ b/tests/storage/repository/test_study.py
@@ -11,6 +11,7 @@
 # This file is part of the Antares project.
 
 
+from helpers import create_raw_study, create_study, create_variant_study
 from sqlalchemy.orm import Session
 
 from antarest.core.cache.business.local_chache import LocalCache
@@ -19,7 +20,6 @@ from antarest.core.utils.utils import current_time
 from antarest.login.model import Group, User
 from antarest.study.model import DEFAULT_WORKSPACE_NAME, RawStudy, StudyContentStatus
 from antarest.study.repository import AccessPermissions, StudyFilter, StudyMetadataRepository
-from tests.helpers import create_raw_study, create_study, create_variant_study
 
 
 def test_lifecycle(db_session: Session) -> None:

--- a/tests/storage/test_service.py
+++ b/tests/storage/test_service.py
@@ -25,7 +25,9 @@ from unittest.mock import ANY, Mock, patch, seal
 import pytest
 from _pytest.logging import LogCaptureFixture
 from antares.study.version import StudyVersion
+from db_statement_recorder import DBStatementRecorder
 from fastapi import HTTPException
+from helpers import create_raw_study, create_study, create_variant_study, with_admin_user, with_db_context
 from sqlalchemy.orm import Session
 
 from antarest.blobstore.service import BlobService
@@ -83,8 +85,6 @@ from antarest.study.storage.variantstudy.command_factory import CommandFactory
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.db_statement_recorder import DBStatementRecorder
-from tests.helpers import create_raw_study, create_study, create_variant_study, with_admin_user, with_db_context
 
 JWT_USER = JWTUser(id=0, impersonator=0, type="users")
 

--- a/tests/storage/web/test_output_bp.py
+++ b/tests/storage/web/test_output_bp.py
@@ -14,6 +14,10 @@ from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import Mock
 
+from storage.conftest import SimpleFileTransferManager
+from storage.integration.conftest import UUID
+from storage.web.test_studies_bp import create_test_client
+
 from antarest.core.config import Config, StorageConfig
 from antarest.core.filetransfer.model import FileDownloadDTO, FileDownloadTaskDTO
 from antarest.core.filetransfer.service import FileTransferManager
@@ -22,9 +26,6 @@ from antarest.study.model import (
     StudySimSettingsDTO,
 )
 from antarest.study.output.output_service import OutputService
-from tests.storage.conftest import SimpleFileTransferManager
-from tests.storage.integration.conftest import UUID
-from tests.storage.web.test_studies_bp import create_test_client
 
 
 def test_output_whole_download(tmp_path: Path) -> None:

--- a/tests/storage/web/test_studies_bp.py
+++ b/tests/storage/web/test_studies_bp.py
@@ -20,8 +20,10 @@ from pathlib import Path, PurePosixPath
 from unittest.mock import Mock, call
 
 from fastapi import FastAPI
+from helpers import with_admin_user
 from markupsafe import Markup
 from starlette.testclient import TestClient
+from storage.integration.conftest import UUID
 
 from antarest.blobstore.service import BlobService
 from antarest.core.application import create_app_ctxt
@@ -47,8 +49,6 @@ from antarest.study.model import (
 from antarest.study.output.output_service import OutputService
 from antarest.study.service import StudyService
 from antarest.study.web.output_blueprint import create_output_routes
-from tests.helpers import with_admin_user
-from tests.storage.integration.conftest import UUID
 
 ADMIN = JWTUser(
     id=1,

--- a/tests/study/business/areas/test_hydro_management.py
+++ b/tests/study/business/areas/test_hydro_management.py
@@ -12,6 +12,7 @@
 import copy
 
 import pytest
+from helpers import file_study_interface
 from pydantic import ValidationError
 
 from antarest.study.business.areas.hydro_management import HydroManager
@@ -26,7 +27,6 @@ from antarest.study.model import STUDY_VERSION_9_2
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 hydro_ini_content = {
     "input": {

--- a/tests/study/business/areas/test_st_storage_management.py
+++ b/tests/study/business/areas/test_st_storage_management.py
@@ -12,6 +12,7 @@
 
 
 import pytest
+from helpers import file_study_interface
 
 from antarest.core.exceptions import ChildNotFoundError, STStorageNotFound
 from antarest.matrixstore.service import ISimpleMatrixService
@@ -28,7 +29,6 @@ from antarest.study.storage.variantstudy.model.command.create_area import Create
 from antarest.study.storage.variantstudy.model.command.create_st_storage import CreateSTStorage
 from antarest.study.storage.variantstudy.model.command.remove_area import RemoveArea
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 EXPECTED_STORAGES = {
     "de": [

--- a/tests/study/business/areas/test_thermal_management.py
+++ b/tests/study/business/areas/test_thermal_management.py
@@ -14,6 +14,8 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from helpers import file_study_interface
+from study.business.areas.assets import ASSETS_DIR
 
 import antarest.study.storage.rawstudy.model.filesystem.config.files
 from antarest.blobstore.in_memory import InMemoryBlobService
@@ -33,8 +35,6 @@ from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
-from tests.study.business.areas.assets import ASSETS_DIR
 
 
 class TestThermalClusterGroup:

--- a/tests/study/business/test_adequacy_patch_manager.py
+++ b/tests/study/business/test_adequacy_patch_manager.py
@@ -11,11 +11,12 @@
 # This file is part of the Antares project.
 import copy
 
+from helpers import file_study_interface
+
 from antarest.study.business.adequacy_patch_management import AdequacyPatchManager
 from antarest.study.business.model.config.adequacy_patch_model import AdequacyPatchParameters, PriceTakingOrder
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 EXPECTED_PARAMS = AdequacyPatchParameters(
     enable_adequacy_patch=False,

--- a/tests/study/business/test_allocation_manager.py
+++ b/tests/study/business/test_allocation_manager.py
@@ -12,6 +12,7 @@
 
 import numpy as np
 import pytest
+from helpers import file_study_interface
 
 from antarest.study.business.allocation_management import AllocationManager
 from antarest.study.business.model.hydro_allocation_model import (
@@ -23,7 +24,6 @@ from antarest.study.storage.rawstudy.model.filesystem.config.identifier import t
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 def _set_up(command_context: CommandContext, study: FileStudy) -> None:

--- a/tests/study/business/test_correlation_manager.py
+++ b/tests/study/business/test_correlation_manager.py
@@ -13,6 +13,7 @@ import re
 
 import numpy as np
 import pytest
+from helpers import file_study_interface
 
 from antarest.study.business.correlation_management import CorrelationManager
 from antarest.study.business.model.hydro_correlation_model import (
@@ -23,7 +24,6 @@ from antarest.study.business.model.hydro_correlation_model import (
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 def _set_up(command_context: CommandContext, study: FileStudy) -> None:

--- a/tests/study/business/test_district_manager.py
+++ b/tests/study/business/test_district_manager.py
@@ -13,6 +13,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from helpers import file_study_interface
 
 from antarest.core.exceptions import AreaNotFound, DistrictAlreadyExist, DistrictNotFound
 from antarest.study.business.district_manager import DistrictManager
@@ -24,7 +25,6 @@ from antarest.study.storage.variantstudy.model.command.create_district import Cr
 from antarest.study.storage.variantstudy.model.command.remove_district import RemoveDistrict
 from antarest.study.storage.variantstudy.model.command.update_district import UpdateDistrict
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 def _check_add_commands(patched_func: Any, expected_cls: Any) -> None:

--- a/tests/study/business/test_optimization_parameters_manager.py
+++ b/tests/study/business/test_optimization_parameters_manager.py
@@ -11,6 +11,8 @@
 # This file is part of the Antares project.
 
 
+from helpers import file_study_interface
+
 from antarest.study.business.model.config.optimization_config_model import (
     OptimizationPreferences,
     TransmissionCapacities,
@@ -18,7 +20,6 @@ from antarest.study.business.model.config.optimization_config_model import (
 from antarest.study.business.optimization_management import OptimizationManager
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 def test_missing_section(empty_study_880: FileStudy, command_context: CommandContext) -> None:

--- a/tests/study/business/test_playlist_manager.py
+++ b/tests/study/business/test_playlist_manager.py
@@ -12,12 +12,12 @@
 from typing import Any
 
 import pytest
+from helpers import file_study_interface
 
 from antarest.study.business.model.config.playlist_model import Playlist, PlaylistValues
 from antarest.study.business.playlist_management import PlaylistManager
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 @pytest.mark.parametrize(

--- a/tests/study/dao/conftest.py
+++ b/tests/study/dao/conftest.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 import polars as pl
 import pytest
 from antares.study.version import StudyVersion
+from helpers import create_study
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -30,7 +31,6 @@ from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
 from antarest.study.dao.database.database_study_factory_dao import DatabaseStudyDaoFactory
 from antarest.study.model import STUDY_VERSION_8_8, STUDY_VERSION_9_2, STUDY_VERSION_9_3, StorageMode
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
-from tests.helpers import create_study
 
 
 def build_dao(db_session: Session, matrix_service: ISimpleMatrixService, version: StudyVersion) -> DatabaseStudyDao:

--- a/tests/study/dao/matrix_raw_mapper/test_raw_path_to_matrix_mapper.py
+++ b/tests/study/dao/matrix_raw_mapper/test_raw_path_to_matrix_mapper.py
@@ -14,12 +14,12 @@ from pathlib import Path
 import numpy as np
 import polars as pl
 import pytest
+from study.dao.conftest import build_dao, build_real_case_db_study
 
 from antarest.core.exceptions import IncorrectPathError
 from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
 from antarest.study.model import STUDY_VERSION_8_1
 from antarest.study.storage.rawstudy.raw_path_to_matrix_mapper import RawPathToMatrixMapper
-from tests.study.dao.conftest import build_dao, build_real_case_db_study
 
 
 def test_get_matrix_from_path(dao_930: DatabaseStudyDao) -> None:

--- a/tests/study/dao/test_database_area_properties_dao.py
+++ b/tests/study/dao/test_database_area_properties_dao.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 import pytest
+from db_statement_recorder import DBStatementRecorder
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -17,7 +18,6 @@ from antarest.core.exceptions import AreaNotFound
 from antarest.study.business.model.area_properties_model import AreaProperties
 from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
 from antarest.study.dao.database.models.area import AREA_TABLE
-from tests.db_statement_recorder import DBStatementRecorder
 
 
 def test_save_area_creates_area_with_default_properties(db_session: Session, dao: DatabaseStudyDao) -> None:

--- a/tests/study/dao/test_database_initialize_study.py
+++ b/tests/study/dao/test_database_initialize_study.py
@@ -12,6 +12,7 @@
 import pytest
 from antares.study.version import StudyVersion
 from sqlalchemy.orm import Session
+from study.dao.conftest import build_dao
 
 from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.config.adequacy_patch_model import (
@@ -33,7 +34,6 @@ from antarest.study.business.model.thematic_trimming_model import (
     initialize_thematic_trimming_against_version,
 )
 from antarest.study.model import STUDY_REFERENCE_TEMPLATES, STUDY_VERSION_8_3, STUDY_VERSION_9_2
-from tests.study.dao.conftest import build_dao
 
 
 @pytest.mark.parametrize("version", STUDY_REFERENCE_TEMPLATES)

--- a/tests/study/dao/test_database_link_dao.py
+++ b/tests/study/dao/test_database_link_dao.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 import pytest
+from db_statement_recorder import DBStatementRecorder
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -18,7 +19,6 @@ from antarest.study.business.model.common import FilterOption
 from antarest.study.business.model.link_model import DEFAULT_COLOR, AssetType, Link, LinkStyle, TransmissionCapacity
 from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
 from antarest.study.dao.database.models.link import LINK_TABLE
-from tests.db_statement_recorder import DBStatementRecorder
 
 
 def _create_default_link(dao: DatabaseStudyDao) -> None:

--- a/tests/study/dao/test_database_settings_dao.py
+++ b/tests/study/dao/test_database_settings_dao.py
@@ -11,6 +11,7 @@
 # This file is part of the Antares project.
 
 from sqlalchemy.orm import Session
+from study.dao.conftest import build_dao
 
 from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.config.adequacy_patch_model import AdequacyPatchParameters, PriceTakingOrder
@@ -37,7 +38,6 @@ from antarest.study.business.model.config.playlist_model import Playlist, Playli
 from antarest.study.business.model.config.timeseries_config_model import TimeSeriesConfiguration, TimeSeriesType
 from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
 from antarest.study.model import STUDY_VERSION_9_3
-from tests.study.dao.conftest import build_dao
 
 
 def test_nominal_case(dao: DatabaseStudyDao) -> None:

--- a/tests/study/dao/test_garbage_collector.py
+++ b/tests/study/dao/test_garbage_collector.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock
 
 import polars as pl
 from sqlalchemy.orm import Session
+from study.dao.conftest import build_real_case_db_study
 
 from antarest.core.config import InternalMatrixFormat
 from antarest.maintenance.tasks.common import BackGroundTaskStatus
@@ -22,7 +23,6 @@ from antarest.matrixstore.repository import MatrixContentRepository, MatrixDataS
 from antarest.matrixstore.service import MatrixService
 from antarest.study.dao.database.database_matrices_provider import StudyDatabaseMatrixUsageProvider
 from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
-from tests.study.dao.conftest import build_real_case_db_study
 
 
 def test_garbage_collection(dao: DatabaseStudyDao, db_session: Session, tmp_path: Path) -> None:

--- a/tests/study/dao/test_sql_utils.py
+++ b/tests/study/dao/test_sql_utils.py
@@ -13,12 +13,12 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
+from db_statement_recorder import DBStatementRecorder
 from sqlalchemy import Column, Engine, Integer, MetaData, String, Table, create_engine, select
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session, sessionmaker
 
 from antarest.study.dao.database.sql_utils import generic_upsert_multiple, upsert_multiple, upsert_one
-from tests.db_statement_recorder import DBStatementRecorder
 
 METADATA = MetaData()
 

--- a/tests/study/output/test_output_service.py
+++ b/tests/study/output/test_output_service.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from unittest.mock import ANY, Mock
 
 import pytest
+from helpers import with_admin_user
+from storage.conftest import SimpleSyncTaskService
 
 from antarest.core.exceptions import TaskAlreadyRunning
 from antarest.core.model import PublicMode, StudyPermissionType
@@ -30,8 +32,6 @@ from antarest.study.output.output_service import IStudyMetadataProvider, OutputS
 from antarest.study.storage.utils import is_output_archived
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.worker.archive_worker import ArchiveTaskArgs
-from tests.helpers import with_admin_user
-from tests.storage.conftest import SimpleSyncTaskService
 
 
 def test_is_output_archived(tmp_path: Path) -> None:

--- a/tests/study/storage/rawstudy/test_raw_study_service.py
+++ b/tests/study/storage/rawstudy/test_raw_study_service.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from helpers import create_raw_study, with_admin_user, with_db_context
 
 from antarest.core.model import PublicMode
 from antarest.core.utils.fastapi_sqlalchemy import db
@@ -29,7 +30,6 @@ from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
 from antarest.study.storage.variantstudy.command_factory import CommandFactory
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command.create_st_storage import CreateSTStorage
-from tests.helpers import create_raw_study, with_admin_user, with_db_context
 
 
 class TestRawStudyService:

--- a/tests/study/storage/test_abstract_storage_service.py
+++ b/tests/study/storage/test_abstract_storage_service.py
@@ -13,6 +13,7 @@
 import datetime
 from pathlib import Path
 
+from helpers import create_study, with_db_context
 from py7zr import SevenZipFile
 
 from antarest.core.model import PublicMode
@@ -21,7 +22,6 @@ from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import current_time
 from antarest.login.model import Group, User
 from antarest.study.storage.rawstudy.raw_study_service import RawStudyService
-from tests.helpers import create_study, with_db_context
 
 
 class TestAbstractStorageService:

--- a/tests/study/storage/test_utils.py
+++ b/tests/study/storage/test_utils.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from helpers import create_study
 
 from antarest.core.config import WorkspaceConfig
 from antarest.core.serde.ini_reader import read_ini
@@ -22,7 +23,6 @@ from antarest.study.model import STUDY_VERSION_8_8
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.root.filestudytree import FileStudyTree
 from antarest.study.storage.utils import is_folder_safe, update_antares_info
-from tests.helpers import create_study
 
 
 @pytest.fixture

--- a/tests/study/storage/variantstudy/model/test_dbmodel.py
+++ b/tests/study/storage/variantstudy/model/test_dbmodel.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 from antares.study.version import StudyVersion
+from helpers import create_raw_study, create_variant_study
 from sqlalchemy.orm import Session
 
 from antarest.core.model import PublicMode
@@ -25,7 +26,6 @@ from antarest.core.roles import RoleType
 from antarest.core.utils.utils import current_time
 from antarest.login.model import Group, Role, User
 from antarest.study.storage.variantstudy.model.dbmodel import CommandBlock, VariantStudy, VariantStudySnapshot
-from tests.helpers import create_raw_study, create_variant_study
 
 
 @pytest.fixture(name="user_id")

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -22,6 +22,15 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 from antares.study.version import StudyVersion
+from db_statement_recorder import DBStatementRecorder
+from helpers import (
+    AnyUUID,
+    create_raw_study,
+    create_study,
+    create_variant_study,
+    with_admin_user,
+    with_db_context,
+)
 from typing_extensions import override
 
 from antarest.core.cache.business.local_chache import LocalCache
@@ -42,15 +51,6 @@ from antarest.study.storage.variantstudy.model.dbmodel import CommandBlock, Vari
 from antarest.study.storage.variantstudy.model.model import CommandDTO
 from antarest.study.storage.variantstudy.snapshot_generator import SnapshotGenerator, search_ref_study
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.db_statement_recorder import DBStatementRecorder
-from tests.helpers import (
-    AnyUUID,
-    create_raw_study,
-    create_study,
-    create_variant_study,
-    with_admin_user,
-    with_db_context,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/study/storage/variantstudy/test_variant_study_service.py
+++ b/tests/study/storage/variantstudy/test_variant_study_service.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 from antares.study.version import StudyVersion
+from helpers import create_raw_study, with_db_context
 
 from antarest.blobstore.service import IBlobService
 from antarest.core.jwt import DEFAULT_ADMIN_USER, JWTUser
@@ -38,7 +39,6 @@ from antarest.study.storage.variantstudy.model.command.create_area import Create
 from antarest.study.storage.variantstudy.model.command.create_st_storage import CreateSTStorage
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.helpers import create_raw_study, with_db_context
 
 # noinspection SpellCheckingInspection
 EXPECTED_DENORMALIZED = {

--- a/tests/study/test_directory_repository.py
+++ b/tests/study/test_directory_repository.py
@@ -13,12 +13,12 @@
 import uuid
 
 import pytest
+from helpers import create_raw_study
 from sqlalchemy.orm import Session
 
 from antarest.login.model import Identity
 from antarest.study.model import Directory
 from antarest.study.repository import DirectoryRepository
-from tests.helpers import create_raw_study
 
 
 @pytest.fixture

--- a/tests/study/test_model.py
+++ b/tests/study/test_model.py
@@ -16,12 +16,12 @@ Test the database model.
 
 import uuid
 
+from helpers import create_study
 from sqlalchemy import inspect
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, joinedload
 
 from antarest.study.model import Study, StudyTag, Tag
-from tests.helpers import create_study
 
 
 class TestStudy:

--- a/tests/study/test_repository.py
+++ b/tests/study/test_repository.py
@@ -14,6 +14,8 @@ import typing as t
 from unittest.mock import Mock
 
 import pytest
+from db_statement_recorder import DBStatementRecorder
+from helpers import create_raw_study, create_variant_study
 from sqlalchemy.orm import Session
 
 from antarest.core.interfaces.cache import ICache
@@ -28,8 +30,6 @@ from antarest.study.repository import (
     StudyPagination,
     StudySortBy,
 )
-from tests.db_statement_recorder import DBStatementRecorder
-from tests.helpers import create_raw_study, create_variant_study
 
 
 @pytest.mark.parametrize(

--- a/tests/variantstudy/model/command/test_remove_area.py
+++ b/tests/variantstudy/model/command/test_remove_area.py
@@ -12,6 +12,9 @@
 
 import configparser
 
+from helpers import dirhash
+from variantstudy.model.command.helpers import reset_line_separator
+
 from antarest.core.serde.ini_reader import IniReader
 from antarest.study.business.model.binding_constraint_model import (
     BindingConstraintFrequency,
@@ -46,8 +49,6 @@ from antarest.study.storage.variantstudy.model.command.remove_multiple_binding_c
 from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 from antarest.study.storage.variantstudy.model.command.update_scenario_builder import UpdateScenarioBuilder
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import dirhash
-from tests.variantstudy.model.command.helpers import reset_line_separator
 
 
 class TestRemoveArea:

--- a/tests/variantstudy/model/command/test_remove_cluster.py
+++ b/tests/variantstudy/model/command/test_remove_cluster.py
@@ -11,6 +11,8 @@
 # This file is part of the Antares project.
 
 import numpy as np
+from helpers import dirhash
+from variantstudy.model.command.helpers import reset_line_separator
 
 from antarest.study.business.model.binding_constraint_model import (
     BindingConstraintFrequency,
@@ -31,8 +33,6 @@ from antarest.study.storage.variantstudy.model.command.remove_multiple_binding_c
 )
 from antarest.study.storage.variantstudy.model.command.update_scenario_builder import UpdateScenarioBuilder
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import dirhash
-from tests.variantstudy.model.command.helpers import reset_line_separator
 
 
 class TestRemoveCluster:

--- a/tests/variantstudy/model/command/test_remove_link.py
+++ b/tests/variantstudy/model/command/test_remove_link.py
@@ -18,7 +18,9 @@ from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
+from helpers import dirhash
 from pydantic import ValidationError
+from variantstudy.model.command.helpers import reset_line_separator
 
 from antarest.study.business.model.scenario_builder_model import RulesetUpdate
 from antarest.study.model import STUDY_VERSION_8_8
@@ -31,8 +33,6 @@ from antarest.study.storage.variantstudy.model.command.create_link import Create
 from antarest.study.storage.variantstudy.model.command.remove_link import RemoveLink
 from antarest.study.storage.variantstudy.model.command.update_scenario_builder import UpdateScenarioBuilder
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import dirhash
-from tests.variantstudy.model.command.helpers import reset_line_separator
 
 
 class TestRemoveLink:

--- a/tests/variantstudy/model/command/test_remove_renewables_cluster.py
+++ b/tests/variantstudy/model/command/test_remove_renewables_cluster.py
@@ -10,6 +10,8 @@
 #
 # This file is part of the Antares project.
 from antares.study.version import StudyVersion
+from helpers import dirhash
+from variantstudy.model.command.helpers import reset_line_separator
 
 from antarest.study.business.model.renewable_cluster_model import RenewableClusterCreation, TimeSeriesInterpretation
 from antarest.study.business.model.scenario_builder_model import RulesetUpdate
@@ -21,8 +23,6 @@ from antarest.study.storage.variantstudy.model.command.create_renewables_cluster
 from antarest.study.storage.variantstudy.model.command.remove_renewables_cluster import RemoveRenewablesCluster
 from antarest.study.storage.variantstudy.model.command.update_scenario_builder import UpdateScenarioBuilder
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import dirhash
-from tests.variantstudy.model.command.helpers import reset_line_separator
 
 
 class TestRemoveRenewablesCluster:

--- a/tests/variantstudy/model/command/test_update_renewable_cluster.py
+++ b/tests/variantstudy/model/command/test_update_renewable_cluster.py
@@ -9,6 +9,8 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+from helpers import dirhash
+
 from antarest.core.serde.ini_reader import IniReader
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
@@ -16,7 +18,6 @@ from antarest.study.storage.variantstudy.model.command.create_renewables_cluster
 from antarest.study.storage.variantstudy.model.command.update_config import UpdateConfig
 from antarest.study.storage.variantstudy.model.command.update_renewables_clusters import UpdateRenewablesClusters
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import dirhash
 
 
 class TestUpdateRenewableCluster:

--- a/tests/variantstudy/model/command/test_update_short_term_storage.py
+++ b/tests/variantstudy/model/command/test_update_short_term_storage.py
@@ -11,6 +11,7 @@
 # This file is part of the Antares project.
 
 import pytest
+from helpers import dirhash
 from pydantic import ValidationError
 
 from antarest.core.serde.ini_reader import read_ini
@@ -22,7 +23,6 @@ from antarest.study.storage.variantstudy.model.command.create_area import Create
 from antarest.study.storage.variantstudy.model.command.create_st_storage import CreateSTStorage
 from antarest.study.storage.variantstudy.model.command.update_st_storages import UpdateSTStorages
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import dirhash
 
 
 class TestUpdateShortTermSorage:

--- a/tests/variantstudy/model/command/test_update_st_storage_additional_constraints.py
+++ b/tests/variantstudy/model/command/test_update_st_storage_additional_constraints.py
@@ -9,6 +9,8 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+from helpers import file_study_interface
+
 from antarest.core.serde.ini_reader import read_ini
 from antarest.study.business.areas.st_storage_management import STStorageManager
 from antarest.study.business.model.sts_model import (
@@ -29,7 +31,6 @@ from antarest.study.storage.variantstudy.model.command.update_st_storage_additio
     UpdateSTStorageAdditionalConstraints,
 )
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 class TestUpdateSTStorageAdditionalConstraint:

--- a/tests/variantstudy/model/command/test_update_thematic_trimming.py
+++ b/tests/variantstudy/model/command/test_update_thematic_trimming.py
@@ -11,6 +11,7 @@
 # This file is part of the Antares project.
 
 import pytest
+from helpers import file_study_interface
 from pydantic import ValidationError
 
 from antarest.study.business.model.thematic_trimming_model import ThematicTrimmingUpdate
@@ -24,7 +25,6 @@ from antarest.study.model import (
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.update_thematic_trimming import UpdateThematicTrimming
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import file_study_interface
 
 
 class TestUpdateThematicTrimming:

--- a/tests/variantstudy/model/command/test_update_thermal_cluster.py
+++ b/tests/variantstudy/model/command/test_update_thermal_cluster.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 import pytest
+from helpers import dirhash
 from pydantic import ValidationError
 
 from antarest.study.business.model.thermal_cluster_model import (
@@ -28,7 +29,6 @@ from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
 from antarest.study.storage.variantstudy.model.command.create_area import CreateArea
 from antarest.study.storage.variantstudy.model.command.update_thermal_clusters import UpdateThermalClusters
 from antarest.study.storage.variantstudy.model.command_context import CommandContext
-from tests.helpers import dirhash
 
 
 class TestUpdateThermalCluster:

--- a/tests/variantstudy/model/test_variant_model.py
+++ b/tests/variantstudy/model/test_variant_model.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 from antares.study.version import StudyVersion
+from helpers import AnyUUID, create_raw_study, with_admin_user, with_db_context
 from sqlalchemy import event
 
 from antarest.core.jwt import JWTGroup, JWTUser
@@ -31,7 +32,6 @@ from antarest.study.storage.variantstudy.model.dbmodel import VariantStudy
 from antarest.study.storage.variantstudy.model.model import CommandDTO, CommandDTOAPI
 from antarest.study.storage.variantstudy.snapshot_generator import SnapshotGenerator
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
-from tests.helpers import AnyUUID, create_raw_study, with_admin_user, with_db_context
 
 
 class TestVariantStudyService:

--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import List
 from unittest.mock import MagicMock
 
+from helpers import auto_retry_assert
 from typing_extensions import override
 
 from antarest.core.config import Config
@@ -23,7 +24,6 @@ from antarest.core.model import PermissionInfo, PublicMode
 from antarest.core.tasks.model import TaskResult
 from antarest.eventbus.main import build_eventbus
 from antarest.worker.worker import AbstractWorker, WorkerTaskCommand
-from tests.helpers import auto_retry_assert
 
 
 class DummyWorker(AbstractWorker):


### PR DESCRIPTION

Explanation: in most dev environment, the tests directory will be identified as a source dir, and import automatically added relative to it. This causes many CI failures since in CI, we have not configured pytest to consider tests as a source dir.

This PR fixes that consistency issue.