### PR TITLE
fix(init): remove pre-start actions from startup script

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -47,10 +47,8 @@ if [[ -v PROMETHEUS_MULTIPROC_DIR ]]; then
 fi
 
 if [ -z "$1" ] ; then
-  sh $CUR_DIR/pre-start.sh
   gunicorn --config $BASE_DIR/conf/gunicorn.py --worker-class=uvicorn.workers.UvicornWorker antarest.wsgi:app
 elif [ "$use_uvicorn" = true ]; then
-  sh $CUR_DIR/pre-start.sh
   pids=() # Initialize empty array to store background process IDs
   for ((i=0; i<workers; i++))
   do


### PR DESCRIPTION

In our multi-container environment, the initialization actions must not be executed by one of the containers, but before they are all started. Therefore the pre-start script call cannot be part of the application startup, but be executed before, typically by a dedicated container.

For example with docker compose:
```yml
services:
  antarest-init:
      image: antarest
      container_name : antarest-init
      entrypoint: ["./scripts/pre-start.sh"]

  antarest:
      image: antarest
    container_name : antarest
    depends_on:
      antarest-init:
        condition: service_completed_successfully
```