### PR TITLE
fix(ui-studies): cap explorer sections height to keep external tree visible

### DIFF
--- a/webapp/src/components/CustomScrollbar/index.tsx
+++ b/webapp/src/components/CustomScrollbar/index.tsx
@@ -24,6 +24,7 @@ export interface CustomScrollbarProps<T extends React.ElementType = "div"> {
   events?: EventListeners;
   defer?: boolean | IdleRequestOptions;
   children?: React.ReactNode;
+  style?: React.CSSProperties;
 }
 
 function CustomScrollbar<T extends React.ElementType>({

--- a/webapp/src/redux/ducks/studies.ts
+++ b/webapp/src/redux/ducks/studies.ts
@@ -48,10 +48,12 @@ export interface StudyFilters {
     // All directory IDs in scope (selected dir + descendants). null = root (all managed studies).
     directoryIds: string[] | null;
     showDescendants: boolean;
+    collapsed: boolean;
   };
   external: {
     path: string;
     showDescendants: boolean;
+    collapsed: boolean;
   };
   type: "all" | "references" | "variants";
   management: "all" | "managed" | "unmanaged";
@@ -100,8 +102,14 @@ function buildInitialFilters(): StudyFilters {
     groups: [],
     tags: [],
     ...saved,
-    managed: { directoryId: null, directoryIds: null, showDescendants: false, ...saved.managed },
-    external: { path: "", showDescendants: false, ...saved.external },
+    managed: {
+      directoryId: null,
+      directoryIds: null,
+      showDescendants: false,
+      collapsed: false,
+      ...saved.managed,
+    },
+    external: { path: "", showDescendants: false, collapsed: false, ...saved.external },
   };
 }
 

--- a/webapp/src/routes/_authenticated/studies/-components/StudyTree/TreeSection.tsx
+++ b/webapp/src/routes/_authenticated/studies/-components/StudyTree/TreeSection.tsx
@@ -47,6 +47,7 @@ const variantStyles: Record<
     icon: SxProps<Theme>;
     title: SxProps<Theme>;
     subtitle?: SxProps<Theme>;
+    content: SxProps<Theme>;
   }
 > = {
   managed: {
@@ -55,6 +56,10 @@ const variantStyles: Record<
       borderLeft: `3px solid ${theme.vars.palette.info.main}`,
       p: 0.5,
     }),
+    content: {
+      maxHeight: "50vh",
+      overflow: "auto",
+    },
     icon: {
       display: "flex",
       alignItems: "center",
@@ -74,6 +79,10 @@ const variantStyles: Record<
       borderLeft: `3px solid ${theme.vars.palette.action.disabled}`,
       p: 0.5,
     }),
+    content: {
+      maxHeight: "50vh",
+      overflow: "auto",
+    },
     icon: {
       display: "flex",
       alignItems: "center",
@@ -140,7 +149,9 @@ function TreeSection({
           )}
         </Stack>
       </Stack>
-      <Collapse in={!isCollapsed}>{children}</Collapse>
+      <Collapse in={!isCollapsed}>
+        <Box sx={styles.content}>{children}</Box>
+      </Collapse>
     </Box>
   );
 }

--- a/webapp/src/routes/_authenticated/studies/-components/StudyTree/TreeSection.tsx
+++ b/webapp/src/routes/_authenticated/studies/-components/StudyTree/TreeSection.tsx
@@ -13,135 +13,100 @@
  */
 
 import CustomScrollbar from "@/components/CustomScrollbar";
-import { withOpacity } from "@/utils/muiUtils";
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
 import HomeIcon from "@mui/icons-material/Home";
-import { Box, IconButton, Stack, type SxProps, type Theme, Tooltip, Typography } from "@mui/material";
-import { useState } from "react";
+import { Box, IconButton, Stack, Tooltip, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
+import {
+  contentSxOverride,
+  ICON_BUTTON_PADDING,
+  ICON_SIZE,
+  innerContentSx,
+  scrollbarStyle,
+  titleStyles,
+  variantStyles,
+} from "./styles";
 
-type TreeSectionVariant = "managed" | "external";
+export type TreeSectionVariant = "managed" | "external";
 
-interface TreeSectionProps {
+interface Props {
   variant: TreeSectionVariant;
   title: string;
   icon: React.ReactNode;
-  children: React.ReactNode;
+  onToggleCollapse: () => void;
   onAddDirectory?: () => void;
   onRootClick?: () => void;
+  children: React.ReactNode;
 }
-
-const variantStyles: Record<
-  TreeSectionVariant,
-  {
-    container: SxProps<Theme>;
-    icon: SxProps<Theme>;
-    title: SxProps<Theme>;
-    subtitle?: SxProps<Theme>;
-  }
-> = {
-  managed: {
-    container: (theme) => ({
-      backgroundColor: withOpacity(theme.vars.palette.info.main, 0.05),
-      borderLeft: `3px solid ${theme.vars.palette.info.main}`,
-      p: 0.5,
-    }),
-    icon: {
-      display: "flex",
-      alignItems: "center",
-      color: "info.main",
-      fontSize: 18,
-    },
-    title: {
-      color: "info.main",
-      fontWeight: 600,
-      textTransform: "uppercase",
-      letterSpacing: 0.5,
-    },
-  },
-  external: {
-    container: (theme) => ({
-      backgroundColor: withOpacity(theme.vars.palette.action.disabled, 0.2),
-      borderLeft: `3px solid ${theme.vars.palette.action.disabled}`,
-      p: 0.5,
-    }),
-    icon: {
-      display: "flex",
-      alignItems: "center",
-      color: "text.secondary",
-      fontSize: 18,
-    },
-    title: {
-      color: "text.secondary",
-      fontWeight: 600,
-      textTransform: "uppercase",
-      letterSpacing: 0.5,
-    },
-  },
-};
 
 function TreeSection({
   variant,
   title,
   icon,
-  children,
+  onToggleCollapse,
   onAddDirectory,
   onRootClick,
-}: TreeSectionProps) {
-  const styles = variantStyles[variant];
+  children,
+}: Props) {
+  const { container, iconColor, titleColor } = variantStyles[variant];
   const { t } = useTranslation();
-  const [isCollapsed, setIsCollapsed] = useState(false);
 
   ////////////////////////////////////////////////////////////////
   // JSX
   ////////////////////////////////////////////////////////////////
 
   return (
-    <Box
-      sx={[
-        styles.container,
-        { flex: isCollapsed ? "0 0 auto" : 1, minHeight: 0, display: "flex", flexDirection: "column" },
-      ]}
-    >
-      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
-        <Stack
-          direction="row"
-          spacing={1}
-          alignItems="center"
-          onClick={() => setIsCollapsed((prev) => !prev)}
-          sx={{ cursor: "pointer" }}
-        >
-          <Box sx={styles.icon}>{icon}</Box>
-          <Typography variant="subtitle2" sx={styles.title}>
-            {title}
-          </Typography>
-        </Stack>
-        <Stack direction="row">
-          {onAddDirectory && (
-            <Tooltip title={t("studies.tree.addRootDirectory")} placement="top" arrow>
+    <>
+      {/* Header row */}
+      <Box sx={container}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Stack
+            direction="row"
+            spacing={1}
+            alignItems="center"
+            onClick={onToggleCollapse}
+            sx={{ cursor: "pointer" }}
+          >
+            <Box sx={{ color: iconColor, fontSize: ICON_SIZE, lineHeight: 0 }}>{icon}</Box>
+            <Typography variant="subtitle2" sx={[titleStyles, { color: titleColor }]}>
+              {title}
+            </Typography>
+          </Stack>
+
+          <Stack direction="row">
+            {onAddDirectory && (
+              <Tooltip title={t("studies.tree.addRootDirectory")} placement="top" arrow>
+                <IconButton
+                  size="small"
+                  onClick={onAddDirectory}
+                  sx={{ p: ICON_BUTTON_PADDING }}
+                  aria-label="Create new folder"
+                >
+                  <CreateNewFolderIcon sx={{ fontSize: ICON_SIZE }} />
+                </IconButton>
+              </Tooltip>
+            )}
+            {onRootClick && (
               <IconButton
                 size="small"
-                onClick={onAddDirectory}
-                sx={{ p: 0.5 }}
-                aria-label="Create new folder"
+                onClick={onRootClick}
+                sx={{ p: ICON_BUTTON_PADDING }}
+                aria-label="Home"
               >
-                <CreateNewFolderIcon sx={{ fontSize: 18 }} />
+                <HomeIcon sx={{ fontSize: ICON_SIZE }} />
               </IconButton>
-            </Tooltip>
-          )}
-          {onRootClick && (
-            <IconButton size="small" onClick={onRootClick} sx={{ p: 0.5 }} aria-label="Home">
-              <HomeIcon sx={{ fontSize: 18 }} />
-            </IconButton>
-          )}
+            )}
+          </Stack>
         </Stack>
-      </Stack>
-      {!isCollapsed && (
-        <Box sx={{ flex: 1, minHeight: 0 }}>
-          <CustomScrollbar style={{ height: "100%" }}>{children}</CustomScrollbar>
+      </Box>
+
+      {/* Content row — collapses via 0fr grid row in parent */}
+      <Box sx={[container, contentSxOverride]}>
+        <Box sx={innerContentSx}>
+          <CustomScrollbar style={scrollbarStyle}>{children}</CustomScrollbar>
         </Box>
-      )}
-    </Box>
+      </Box>
+    </>
   );
 }
 

--- a/webapp/src/routes/_authenticated/studies/-components/StudyTree/TreeSection.tsx
+++ b/webapp/src/routes/_authenticated/studies/-components/StudyTree/TreeSection.tsx
@@ -12,19 +12,11 @@
  * This file is part of the Antares project.
  */
 
+import CustomScrollbar from "@/components/CustomScrollbar";
 import { withOpacity } from "@/utils/muiUtils";
 import CreateNewFolderIcon from "@mui/icons-material/CreateNewFolder";
 import HomeIcon from "@mui/icons-material/Home";
-import {
-  Box,
-  Collapse,
-  IconButton,
-  Stack,
-  type SxProps,
-  type Theme,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { Box, IconButton, Stack, type SxProps, type Theme, Tooltip, Typography } from "@mui/material";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -33,7 +25,6 @@ type TreeSectionVariant = "managed" | "external";
 interface TreeSectionProps {
   variant: TreeSectionVariant;
   title: string;
-  subtitle?: string;
   icon: React.ReactNode;
   children: React.ReactNode;
   onAddDirectory?: () => void;
@@ -47,7 +38,6 @@ const variantStyles: Record<
     icon: SxProps<Theme>;
     title: SxProps<Theme>;
     subtitle?: SxProps<Theme>;
-    content: SxProps<Theme>;
   }
 > = {
   managed: {
@@ -56,10 +46,6 @@ const variantStyles: Record<
       borderLeft: `3px solid ${theme.vars.palette.info.main}`,
       p: 0.5,
     }),
-    content: {
-      maxHeight: "50vh",
-      overflow: "auto",
-    },
     icon: {
       display: "flex",
       alignItems: "center",
@@ -79,10 +65,6 @@ const variantStyles: Record<
       borderLeft: `3px solid ${theme.vars.palette.action.disabled}`,
       p: 0.5,
     }),
-    content: {
-      maxHeight: "50vh",
-      overflow: "auto",
-    },
     icon: {
       display: "flex",
       alignItems: "center",
@@ -115,7 +97,12 @@ function TreeSection({
   ////////////////////////////////////////////////////////////////
 
   return (
-    <Box sx={styles.container}>
+    <Box
+      sx={[
+        styles.container,
+        { flex: isCollapsed ? "0 0 auto" : 1, minHeight: 0, display: "flex", flexDirection: "column" },
+      ]}
+    >
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
         <Stack
           direction="row"
@@ -149,9 +136,11 @@ function TreeSection({
           )}
         </Stack>
       </Stack>
-      <Collapse in={!isCollapsed}>
-        <Box sx={styles.content}>{children}</Box>
-      </Collapse>
+      {!isCollapsed && (
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <CustomScrollbar style={{ height: "100%" }}>{children}</CustomScrollbar>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/webapp/src/routes/_authenticated/studies/-components/StudyTree/index.tsx
+++ b/webapp/src/routes/_authenticated/studies/-components/StudyTree/index.tsx
@@ -70,7 +70,7 @@ function StudyTree() {
   ////////////////////////////////////////////////////////////////
 
   return (
-    <Box>
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column", overflow: "hidden" }}>
       <TreeSection
         variant="managed"
         title={t("studies.tree.managed")}

--- a/webapp/src/routes/_authenticated/studies/-components/StudyTree/index.tsx
+++ b/webapp/src/routes/_authenticated/studies/-components/StudyTree/index.tsx
@@ -20,20 +20,23 @@ import { useTranslation } from "react-i18next";
 import { updateStudyFilters } from "@/redux/ducks/studies";
 import useAppDispatch from "@/redux/hooks/useAppDispatch";
 import useAppSelector from "@/redux/hooks/useAppSelector";
-import { getStudies } from "@/redux/selectors";
+import { getStudies, getStudyFilters } from "@/redux/selectors";
 import ExternalTree from "./ExternalTree";
 import ManagedTree from "./ManagedTree";
-import TreeSection from "./TreeSection";
+import TreeSection, { type TreeSectionVariant } from "./TreeSection";
+import { studyTreeGridSx } from "./styles";
 
 function StudyTree() {
-  const studies = useAppSelector(getStudies);
-  const dispatch = useAppDispatch();
   const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  const studies = useAppSelector(getStudies);
+  const managedCollapsed = useAppSelector((s) => getStudyFilters(s).managed.collapsed);
+  const externalCollapsed = useAppSelector((s) => getStudyFilters(s).external.collapsed);
+  const externalStudies = useMemo(() => studies.filter((s) => !s.managed), [studies]);
 
   const [isCreatingDirectory, setIsCreatingDirectory] = useState(false);
 
-  //const managedStudies = useMemo(() => studies.filter((s) => s.managed), [studies]);
-  const externalStudies = useMemo(() => studies.filter((s) => !s.managed), [studies]);
+  const gridTemplateRows = `auto ${managedCollapsed ? "0fr" : "1fr"} auto auto ${externalCollapsed ? "0fr" : "1fr"}`;
 
   ////////////////////////////////////////////////////////////////
   // Event Handlers
@@ -65,21 +68,26 @@ function StudyTree() {
     setIsCreatingDirectory(false);
   };
 
+  const handleToggleCollapse = (section: TreeSectionVariant) => {
+    const current = section === "managed" ? managedCollapsed : externalCollapsed;
+    dispatch(updateStudyFilters({ [section]: { collapsed: !current } }));
+  };
+
   ////////////////////////////////////////////////////////////////
   // JSX
   ////////////////////////////////////////////////////////////////
 
   return (
-    <Box sx={{ height: "100%", display: "flex", flexDirection: "column", overflow: "hidden" }}>
+    <Box sx={studyTreeGridSx(gridTemplateRows)}>
       <TreeSection
         variant="managed"
         title={t("studies.tree.managed")}
         icon={<AccountTreeIcon />}
+        onToggleCollapse={() => handleToggleCollapse("managed")}
         onRootClick={handleManagedRootClick}
         onAddDirectory={handleAddDirectoryClick}
       >
         <ManagedTree
-          // studies={managedStudies}
           isCreatingDirectory={isCreatingDirectory}
           onDirectoryCreated={handleDirectoryCreated}
           onRootClick={handleManagedRootClick}
@@ -92,6 +100,7 @@ function StudyTree() {
         variant="external"
         title={t("studies.tree.external")}
         icon={<StorageIcon />}
+        onToggleCollapse={() => handleToggleCollapse("external")}
         onRootClick={handleExternalRootClick}
       >
         <ExternalTree studies={externalStudies} onRootClick={handleExternalRootClick} />

--- a/webapp/src/routes/_authenticated/studies/-components/StudyTree/styles.ts
+++ b/webapp/src/routes/_authenticated/studies/-components/StudyTree/styles.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2026, RTE (https://www.rte-france.com)
+ *
+ * See AUTHORS.txt
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This file is part of the Antares project.
+ */
+
+import { withOpacity } from "@/utils/muiUtils";
+import type { SxProps, Theme } from "@mui/material";
+import type { TreeSectionVariant } from "./TreeSection";
+
+export const ICON_SIZE = 18;
+export const ICON_BUTTON_PADDING = 0.5;
+
+////////////////////////////////////////////////////////////////
+// Shared styles
+////////////////////////////////////////////////////////////////
+
+export const titleStyles = {
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: 0.5,
+} satisfies SxProps<Theme>;
+
+const containerBaseStyles = {
+  borderLeftWidth: 3,
+  borderLeftStyle: "solid",
+  p: 0.5,
+  display: "flex",
+  flexDirection: "column",
+  minHeight: 0,
+} satisfies SxProps<Theme>;
+
+////////////////////////////////////////////////////////////////
+// Variant styles
+////////////////////////////////////////////////////////////////
+
+export const variantStyles = {
+  managed: {
+    container: (theme: Theme) => ({
+      ...containerBaseStyles,
+      backgroundColor: withOpacity(theme.vars.palette.info.main, 0.05),
+      borderLeftColor: theme.vars.palette.info.main,
+    }),
+    iconColor: "info.main" as const,
+    titleColor: "info.main" as const,
+  },
+  external: {
+    container: (theme: Theme) => ({
+      ...containerBaseStyles,
+      backgroundColor: withOpacity(theme.vars.palette.action.disabled, 0.2),
+      borderLeftColor: theme.vars.palette.action.disabled,
+    }),
+    iconColor: "text.secondary" as const,
+    titleColor: "text.secondary" as const,
+  },
+} satisfies Record<
+  TreeSectionVariant,
+  {
+    container: (theme: Theme) => SxProps<Theme>;
+    iconColor: string;
+    titleColor: string;
+  }
+>;
+
+////////////////////////////////////////////////////////////////
+// Component styles
+////////////////////////////////////////////////////////////////
+
+// Content row: no padding (inner wrapper handles it), clips during collapse animation
+export const contentSxOverride = { p: 0, overflow: "hidden" } satisfies SxProps<Theme>;
+
+export const innerContentSx = {
+  flex: 1,
+  minHeight: 0,
+} satisfies SxProps<Theme>;
+
+export const scrollbarStyle = { height: "100%" };
+
+export const studyTreeGridSx = (gridTemplateRows: string): SxProps<Theme> => ({
+  height: 1,
+  display: "grid",
+  gridTemplateRows,
+  alignContent: "start",
+  transition: "grid-template-rows 250ms ease",
+  overflow: "hidden",
+});

--- a/webapp/src/routes/_authenticated/studies/index.tsx
+++ b/webapp/src/routes/_authenticated/studies/index.tsx
@@ -17,7 +17,6 @@ import { Box } from "@mui/material";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import CustomScrollbar from "@/components/CustomScrollbar";
 import SimpleLoader from "@/components/loaders/SimpleLoader";
 import RootPage from "@/components/page/RootPage";
 import SplitView from "@/components/page/SplitView";
@@ -57,11 +56,7 @@ function Studies() {
     >
       <SplitView splitId="studies" minSize={[300, 800]}>
         {/* Left - Studies tree explorer */}
-        <CustomScrollbar>
-          <Box sx={{ overflow: "auto" }}>
-            <StudyTree />
-          </Box>
-        </CustomScrollbar>
+        <StudyTree />
 
         {/* Right - Studies list */}
         <ViewWrapper flex disablePadding>


### PR DESCRIPTION
ANT-4654

- Cap section heights so both Managed and External tree sections are always visible in the study explorer pane, regardless of content size
- Collapsible sections : clicking a section header toggles it open/closed 
- Persist collapse state in Redux (backed by localStorage) : the managed.collapsed and external.collapsed flags survive page reloads
- Scrollbar moved inside each section : each TreeSection now owns its own CustomScrollbar instead of a single outer scrollbar wrappingboth trees
- Styles extracted : all variant styles, constants, and grid helpers moved to a new styles.ts file

>note: scroll restoration will come in a separate PR