### PR TITLE
fix(output): aggregation failed on columns mismatch

### DIFF
--- a/antarest/core/serde/parquet_writer.py
+++ b/antarest/core/serde/parquet_writer.py
@@ -60,8 +60,7 @@ def write_dataframes_in_parquet_format_by_column_sets(
 
         first_df = _adapt_polars_schema(first_df)
         table = first_df.to_arrow()
-        current_schema = table.schema
-        current_writer = _parquet_writer(file_path, current_schema)
+        current_writer = _parquet_writer(file_path, table.schema)
         current_writer.write_table(table)
 
         while True:
@@ -88,10 +87,7 @@ def write_dataframes_in_parquet_format_by_column_sets(
                     file_paths.append(file_path)
                     file_counter += 1
 
-                    # merge the current schema and the new one, to get both sets of columns:
-                    # if previous schema was A and B, and new schema is B and C, we need to have a new one with A, B, C
-                    current_schema = pa.unify_schemas([current_schema, table.schema], promote_options="permissive")
-                    current_writer = _parquet_writer(file_path, current_schema)
+                    current_writer = _parquet_writer(file_path, table.schema)
 
                 current_writer.write_table(table)
 

--- a/antarest/core/serde/parquet_writer.py
+++ b/antarest/core/serde/parquet_writer.py
@@ -74,7 +74,13 @@ def write_dataframes_in_parquet_format_by_column_sets(
                         existing_columns.add(col)
                         new_index.append(col)
 
+                if df.columns != new_index:
+                    expr = pl.lit(None, dtype=pl.Float64)
+                    df = df.select([pl.col(c) if c in df.columns else expr.alias(c) for c in new_index])
+
                 df = _adapt_polars_schema(df)
+                table = df.to_arrow()
+
                 if should_write_new_file:
                     current_writer.close()
 
@@ -82,14 +88,10 @@ def write_dataframes_in_parquet_format_by_column_sets(
                     file_paths.append(file_path)
                     file_counter += 1
 
-                    table = df.to_arrow()
-                    current_schema = table.schema
+                    # merge the current schema and the new one, to get both sets of columns:
+                    # if previous schema was A and B, and new schema is B and C, we need to have a new one with A, B, C
+                    current_schema = pa.unify_schemas([current_schema, table.schema], promote_options="permissive")
                     current_writer = _parquet_writer(file_path, current_schema)
-                else:
-                    if df.columns != new_index:
-                        expr = pl.lit(None, dtype=pl.Float64)
-                        df = df.select([pl.col(c) if c in df.columns else expr.alias(c) for c in new_index])
-                    table = df.to_arrow()
 
                 current_writer.write_table(table)
 

--- a/tests/core/serde/test_parquet_writer.py
+++ b/tests/core/serde/test_parquet_writer.py
@@ -26,9 +26,12 @@ def test_different_columns(tmp_path: Path) -> None:
     dataframes = iter(
         [
             pl.DataFrame(data=[(1, 2), (3, 4)], schema=["A", "B"], orient="row"),
+            # will cause a new file creation with schema A,B,C
             pl.DataFrame(data=[(5, 6, 7), (8, 9, 10)], schema=["A", "B", "C"], orient="row"),
             pl.DataFrame(data=[(11, 12), (13, 14)], schema=["A", "B"], orient="row"),
+            # will cause a new file creation with schema A,B,C,D
             pl.DataFrame(data=[(15, 16, 17), (18, 19, 20)], schema=["B", "A", "D"], orient="row"),
+            pl.DataFrame(data=[(21, 22), (23, 24)], schema=["C", "D"], orient="row"),
         ]
     )
 
@@ -60,6 +63,12 @@ def test_different_columns(tmp_path: Path) -> None:
     # values of A and B are correctly "inverted"
     expected_fourth_df = pd.DataFrame(data=[(16, 15, np.nan, 17), (19, 18, np.nan, 20)], columns=["A", "B", "C", "D"])
     pd.testing.assert_frame_equal(next(dfs), expected_fourth_df, check_dtype=False)
+
+    # values of C and D are correctly
+    expected_fifth_df = pd.DataFrame(
+        data=[(np.nan, np.nan, 21, 22), (np.nan, np.nan, 23, 24)], columns=["A", "B", "C", "D"]
+    )
+    pd.testing.assert_frame_equal(next(dfs), expected_fifth_df, check_dtype=False)
 
 
 def test_same_columns(tmp_path: Path) -> None:


### PR DESCRIPTION

In more details, the aggregation failed when a file was created with some columns missing compared to previous schema:

- 1st file with A and B
- 2nd file with B and C --> creates a new writer for schema B and C, instead of A, B, C
- 3rd file with A and B --> failure, because A is missing
- 