### PR TITLE
fix(output): configured output archive dir was not taken into account

### DIFF
--- a/antarest/service_creator.py
+++ b/antarest/service_creator.py
@@ -179,7 +179,7 @@ def build_output_storage_list(config: Config, file_output_storage: InStudyFileOu
     if not config.storage.output.enable:
         return [file_output_storage]
     tmp_dir = config.storage.tmp_dir / "outputs"
-    lfs = DirLargeFileStorage(config.storage.archive_dir)
+    lfs = DirLargeFileStorage(config.storage.output.archive_dir)
     v2_storage = V2OutputStorage(tmp_dir=tmp_dir, archive_storage=lfs, repository=OutputV2Repository())
 
     if config.storage.output.default:

--- a/tests/integration/output/test_v2_output_storage.py
+++ b/tests/integration/output/test_v2_output_storage.py
@@ -184,7 +184,8 @@ def test_archive_and_unarchive(admin_client: TestClient, study_id: str, output_n
 
     output_archives_dir = tmp_path / "output_archives"
 
-    # Check the archive is already present in the expected output
+    # Check the archive is already present in the expected dir
+    # Checks an implementation detail, but allows to verify the config is correcly taken into account
     files = os.listdir(output_archives_dir)
     assert len(files) == 1
     assert files[0] == f"{study_id}-{output_name}"

--- a/tests/integration/output/test_v2_output_storage.py
+++ b/tests/integration/output/test_v2_output_storage.py
@@ -202,9 +202,6 @@ def test_archive_and_unarchive(admin_client: TestClient, study_id: str, output_n
     task = wait_task_completion(client, None, task_id)
     assert task.status == TaskStatus.COMPLETED
 
-    # Check the archive dir was correctly taken into account
-    assert len(os.listdir(output_archives_dir)) == 1
-
     # Verify archived
     res = client.get(f"/v1/studies/{study_id}/outputs")
     v2_output = next(o for o in res.json() if o["name"] == output_name)

--- a/tests/integration/output/test_v2_output_storage.py
+++ b/tests/integration/output/test_v2_output_storage.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 import io
+import os
 import zipfile
 from pathlib import Path
 
@@ -177,9 +178,16 @@ def test_delete_study_linked_to_output(admin_client: TestClient, study_id: str) 
     assert res.status_code == 200
 
 
-def test_archive_and_unarchive(admin_client: TestClient, study_id: str, output_name: str) -> None:
+def test_archive_and_unarchive(admin_client: TestClient, study_id: str, output_name: str, tmp_path: Path) -> None:
     """Test archiving and unarchiving a V2 output."""
     client = admin_client
+
+    output_archives_dir = tmp_path / "output_archives"
+
+    # Check the archive is already present in the expected output
+    files = os.listdir(output_archives_dir)
+    assert len(files) == 1
+    assert files[0] == f"{study_id}-{output_name}"
 
     # Verify not archived initially
     res = client.get(f"/v1/studies/{study_id}/outputs")
@@ -193,6 +201,9 @@ def test_archive_and_unarchive(admin_client: TestClient, study_id: str, output_n
     assert task_id is not None
     task = wait_task_completion(client, None, task_id)
     assert task.status == TaskStatus.COMPLETED
+
+    # Check the archive dir was correctly taken into account
+    assert len(os.listdir(output_archives_dir)) == 1
 
     # Verify archived
     res = client.get(f"/v1/studies/{study_id}/outputs")


### PR DESCRIPTION

The configured dir for storing output archives was not correcly taken into account.