### PR TITLE
fix(parquet): ensure reasonably large row group size

### DIFF
--- a/antarest/core/serde/parquet_writer.py
+++ b/antarest/core/serde/parquet_writer.py
@@ -35,7 +35,7 @@ class BatchParquetWriter:
 
     It's very important to use not too small row groups, in order to:
      - have efficient IO
-     - avoid excessive memory usage for metadata (as shown by experienced)
+     - avoid excessive memory usage for metadata (as shown by experience)
 
     """
 

--- a/antarest/core/serde/parquet_writer.py
+++ b/antarest/core/serde/parquet_writer.py
@@ -12,6 +12,7 @@
 
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any, Literal
 
 import pandas as pd
 import polars as pl
@@ -20,9 +21,62 @@ from pyarrow.parquet import ParquetFile, ParquetWriter
 
 from antarest.output.filestudy.utils import MCYEAR_COL, TIME_ID_COL
 
+# 1M rows, which is the default in pyarrow parquet too
+DEFAULT_ROW_GROUP_SIZE = 1024 * 1024
+# Best performance/compression ratio
+PARQUET_COMPRESSION: Literal["zstd"] = "zstd"
+# Could probably use 2.4 or 2.6 if we need
+PARQUET_DATA_PAGE_VERSION: Literal["2.0"] = "2.0"
 
-def _parquet_writer(output_file: Path, schema: pa.Schema) -> ParquetWriter:
-    return ParquetWriter(output_file, schema, compression="zstd", data_page_version="2.0")
+
+class BatchParquetWriter:
+    """
+    Wrapper around a plain parquet writer to ensure we write row groups of at least some target size.
+
+    It's very important to use not too small row groups, in order to:
+     - have efficient IO
+     - avoid excessive memory usage for metadata (as shown by experienced)
+
+    """
+
+    def __init__(self, output_file: Path, schema: pa.Schema, row_group_size: int = DEFAULT_ROW_GROUP_SIZE):
+        self._row_group_size = row_group_size
+        self._writer = ParquetWriter(
+            output_file, schema, compression=PARQUET_COMPRESSION, data_page_version=PARQUET_DATA_PAGE_VERSION
+        )
+
+        self._current_batch: list[pa.Table] = []
+        self._current_batch_size = 0
+        self._closed = False
+
+    def __enter__(self) -> "BatchParquetWriter":
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        self.close()
+
+    def add_table(self, table: pa.Table) -> None:
+        if self._closed:
+            raise ValueError("Writer is closed")
+        self._current_batch.append(table)
+        self._current_batch_size += table.num_rows
+        if self._current_batch_size >= self._row_group_size:
+            self._write_tables()
+
+    def _write_tables(self) -> None:
+        if self._current_batch:
+            self._writer.write_table(pa.concat_tables(self._current_batch))
+            self._current_batch = []
+            self._current_batch_size = 0
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        try:
+            self._write_tables()
+        finally:
+            self._writer.close()
+            self._closed = True
 
 
 def _adapt_polars_schema(df: pl.DataFrame) -> pl.DataFrame:
@@ -60,8 +114,8 @@ def write_dataframes_in_parquet_format_by_column_sets(
 
         first_df = _adapt_polars_schema(first_df)
         table = first_df.to_arrow()
-        current_writer = _parquet_writer(file_path, table.schema)
-        current_writer.write_table(table)
+        current_writer = BatchParquetWriter(file_path, table.schema)
+        current_writer.add_table(table)
 
         while True:
             try:
@@ -87,9 +141,9 @@ def write_dataframes_in_parquet_format_by_column_sets(
                     file_paths.append(file_path)
                     file_counter += 1
 
-                    current_writer = _parquet_writer(file_path, table.schema)
+                    current_writer = BatchParquetWriter(file_path, table.schema)
 
-                current_writer.write_table(table)
+                current_writer.add_table(table)
 
             except StopIteration:
                 return file_paths, new_index
@@ -126,8 +180,8 @@ def write_dataframes_stream_parquet(path: Path, dataframes: Iterator[pd.DataFram
     except StopIteration:
         raise ValueError("No dataframe provided")
 
-    with _parquet_writer(path, schema) as writer:
-        writer.write_table(first_table)
+    with BatchParquetWriter(path, schema) as writer:
+        writer.add_table(first_table)
         for df in dataframes:
             table = pa.Table.from_pandas(df)
-            writer.write_table(table)
+            writer.add_table(table)

--- a/tests/core/serde/test_parquet_writer.py
+++ b/tests/core/serde/test_parquet_writer.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import polars as pl
+import pytest
 from pyarrow.parquet import ParquetFile
 
 from antarest.core.serde.parquet_writer import (
@@ -121,3 +122,13 @@ def test_batch_parquet_writer_writes_multiple_batches_when_size_exceeds_threshol
     with ParquetFile(parquet_file) as pf:
         assert pf.num_row_groups == 2
         assert pf.metadata.num_rows == 8
+
+
+def test_batch_parquet_writer_cannot_add_table_to_closed_writer(tmp_path: Path) -> None:
+    parquet_file = tmp_path / "file.parquet"
+    table = pl.DataFrame(data=[(1, 2), (3, 4)], schema=["A", "B"], orient="row").to_arrow()
+    with BatchParquetWriter(parquet_file, schema=table.schema, row_group_size=5) as writer:
+        writer.add_table(table)
+
+    with pytest.raises(ValueError):
+        writer.add_table(table)

--- a/tests/core/serde/test_parquet_writer.py
+++ b/tests/core/serde/test_parquet_writer.py
@@ -15,8 +15,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import polars as pl
+from pyarrow.parquet import ParquetFile
 
 from antarest.core.serde.parquet_writer import (
+    BatchParquetWriter,
     write_dataframes_in_parquet_format_by_column_sets,
     yield_dataframes_from_parquet,
 )
@@ -93,3 +95,35 @@ def test_no_dataframes_given(tmp_path: Path) -> None:
     all_df_names, all_cols = write_dataframes_in_parquet_format_by_column_sets(tmp_path, dataframes)
     assert all_df_names == []
     assert all_cols == []
+
+
+def test_batch_parquet_writer_writes_one_batch(tmp_path: Path) -> None:
+    parquet_file = tmp_path / "file.parquet"
+    tables = [
+        pl.DataFrame(data=[(1, 2), (3, 4)], schema=["A", "B"], orient="row").to_arrow(),
+        pl.DataFrame(data=[(5, 6), (7, 8)], schema=["A", "B"], orient="row").to_arrow(),
+    ]
+    with BatchParquetWriter(parquet_file, schema=tables[0].schema, row_group_size=5) as writer:
+        for t in tables:
+            writer.add_table(t)
+
+    with ParquetFile(parquet_file) as pf:
+        assert pf.num_row_groups == 1
+        assert pf.metadata.num_rows == 4
+
+
+def test_batch_parquet_writer_writes_multiple_batches_when_size_exceeds_threshold(tmp_path: Path) -> None:
+    parquet_file = tmp_path / "file.parquet"
+    tables = [
+        pl.DataFrame(data=[(1, 2), (3, 4)], schema=["A", "B"], orient="row").to_arrow(),
+        pl.DataFrame(data=[(5, 6), (7, 8)], schema=["A", "B"], orient="row").to_arrow(),
+        pl.DataFrame(data=[(5, 6), (7, 8)], schema=["A", "B"], orient="row").to_arrow(),
+        pl.DataFrame(data=[(5, 6), (7, 8)], schema=["A", "B"], orient="row").to_arrow(),
+    ]
+    with BatchParquetWriter(parquet_file, schema=tables[0].schema, row_group_size=5) as writer:
+        for t in tables:
+            writer.add_table(t)
+
+    with ParquetFile(parquet_file) as pf:
+        assert pf.num_row_groups == 2
+        assert pf.metadata.num_rows == 8

--- a/tests/core/serde/test_parquet_writer.py
+++ b/tests/core/serde/test_parquet_writer.py
@@ -54,23 +54,18 @@ def test_different_columns(tmp_path: Path) -> None:
     )
     pd.testing.assert_frame_equal(next(dfs), expected_first_df, check_dtype=False)
 
-    expected_second_df = pd.DataFrame(data=[(5, 6, 7, np.nan), (8, 9, 10, np.nan)], columns=["A", "B", "C", "D"])
+    expected_second_df = pd.DataFrame(
+        data=[(5, 6, 7, np.nan), (8, 9, 10, np.nan), (11, 12, np.nan, np.nan), (13, 14, np.nan, np.nan)],
+        columns=["A", "B", "C", "D"],
+    )
     pd.testing.assert_frame_equal(next(dfs), expected_second_df, check_dtype=False)
 
-    expected_third_df = pd.DataFrame(
-        data=[(11, 12, np.nan, np.nan), (13, 14, np.nan, np.nan)], columns=["A", "B", "C", "D"]
-    )
-    pd.testing.assert_frame_equal(next(dfs), expected_third_df, check_dtype=False)
-
     # values of A and B are correctly "inverted"
-    expected_fourth_df = pd.DataFrame(data=[(16, 15, np.nan, 17), (19, 18, np.nan, 20)], columns=["A", "B", "C", "D"])
-    pd.testing.assert_frame_equal(next(dfs), expected_fourth_df, check_dtype=False)
-
-    # values of C and D are correctly
-    expected_fifth_df = pd.DataFrame(
-        data=[(np.nan, np.nan, 21, 22), (np.nan, np.nan, 23, 24)], columns=["A", "B", "C", "D"]
+    expected_fourth_df = pd.DataFrame(
+        data=[(16, 15, np.nan, 17), (19, 18, np.nan, 20), (np.nan, np.nan, 21, 22), (np.nan, np.nan, 23, 24)],
+        columns=["A", "B", "C", "D"],
     )
-    pd.testing.assert_frame_equal(next(dfs), expected_fifth_df, check_dtype=False)
+    pd.testing.assert_frame_equal(next(dfs), expected_fourth_df, check_dtype=False)
 
 
 def test_same_columns(tmp_path: Path) -> None:
@@ -84,8 +79,7 @@ def test_same_columns(tmp_path: Path) -> None:
 
     dfs = yield_dataframes_from_parquet(files, all_cols)
 
-    pd.testing.assert_frame_equal(next(dfs), df1.to_pandas(), check_dtype=False)
-    pd.testing.assert_frame_equal(next(dfs), df2.to_pandas(), check_dtype=False)
+    pd.testing.assert_frame_equal(next(dfs), pl.concat([df1, df2]).to_pandas(), check_dtype=False)
 
 
 def test_no_dataframes_given(tmp_path: Path) -> None:


### PR DESCRIPTION

Solves 2 issues at once:

- mainly, we observed in production that using too many row groups for one parquet file caused the metadata for those row groups to occupy a LOT of memory, which caused OOM killer to take action
- in any case, it was an anti-pattern for IO to have such small row groups (as small as 1 row), which were only the consequence of the input text files.

We now use a row group size in line with recommendations, of 1M.

We may scale it down a little if needed if:
- we find that this makes too large row groups in memory, which may happen if we get too many columns
- we find that it's more efficient to retrieve data from slightly smaller row groups

**Consequence:**
Now memory usage will not increase anymore (only marginally) with the number of rows, but only with the number of columns. The number of columns is mostly contained. It can only be increased by additional "groups" defined in input data (cluster groups etc.)

**Test results:**
 - For aggregation of links output data on a large study, resident memory:
     - before: 1.2G
     - after: 500 Mo
 - For aggregation of areas output data on a large study, resident memory:
     - before: 500 Mo
     - after: 800 Mo --> larger than for links, because there are more columns. But it will stay flat when adding more rows (more areas)

