### PR TITLE
fix(ui-api): pass target_version as query parameter instead of json to upgrade studies

### DIFF
--- a/webapp/src/services/api/study.ts
+++ b/webapp/src/services/api/study.ts
@@ -188,8 +188,10 @@ export const unarchiveStudy = async (sid: string): Promise<void> => {
 };
 
 export const upgradeStudy = async (studyId: string, targetVersion: string): Promise<void> => {
-  await client.put(`/v1/studies/${studyId}/upgrade`, {
-    target_version: compactSemanticVersion(targetVersion),
+  await client.put(`/v1/studies/${studyId}/upgrade`, null, {
+    params: {
+      target_version: compactSemanticVersion(targetVersion),
+    },
   });
 };
 


### PR DESCRIPTION
Hello @TheoPascoli !

Allow me to propose this PR to solve #3118 

After some investigation it turns out that the front end sends `target_version` embedded in a JSON object :
```json
{
  "target_version" : "9.3"
}
```
while the backend expects a string, hence the bug where every upgrade of a study's version would just upgrade to the next one.

To solve this I implemented a model `StudyVersionModel` to allow fastapi to parse JSON then retrieve `target_version` as expected.

I would be very happy to get your opinion on the matter / my patch.
Feel free also to either get inspiration from this or leave me some recommendations, as you prefer :wink: 

