### PR TITLE
feat(slurm,metrics): stable id for workers, used in metrics and slurm workspace

### DIFF
--- a/antarest/core/logging/utils.py
+++ b/antarest/core/logging/utils.py
@@ -25,6 +25,7 @@ from typing_extensions import override
 
 from antarest.core.config import Config
 from antarest.core.jwt import JWTUser
+from antarest.globals import ANTAREST_WORKER_ID
 from antarest.login.utils import current_user_context, get_current_user
 
 _request: ContextVar[Request | None] = ContextVar("_request", default=None)
@@ -96,6 +97,7 @@ def configure_logger(config: Config, handler_cls: str = "logging.FileHandler") -
                 "format": (
                     "%(asctime)s"
                     " - %(process)s"
+                    " - %(worker_id)s"
                     " - %(name)s"
                     " - %(trace_id)s"
                     " - %(task_id)s"
@@ -201,6 +203,7 @@ class ContextFilter(logging.Filter):
             record.task_id = task_id
         if current_user := get_current_user():
             record.user = current_user.id
+        record.worker_id = ANTAREST_WORKER_ID
         return True
 
 

--- a/antarest/core/metrics.py
+++ b/antarest/core/metrics.py
@@ -37,13 +37,14 @@ from antarest.core.config import Config
 from antarest.core.exceptions import ConfigurationError
 from antarest.core.tasks.model import TaskStatus, TaskType
 from antarest.core.tasks.service import TaskServiceListener
+from antarest.globals import ANTAREST_WORKER_ID
 
 logger = logging.getLogger(__name__)
 
 
 _PROMETHEUS_MULTIPROCESS_ENV_VAR = "PROMETHEUS_MULTIPROC_DIR"
 
-WORKER_ID = str(os.getpid())
+WORKER_ID = str(ANTAREST_WORKER_ID)
 
 
 def add_db_metrics(config: Config) -> None:

--- a/antarest/globals.py
+++ b/antarest/globals.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+import os
+
+# A unique ID for each worker process, in a multi process environment (gunicorn or any other way)
+# The system starting the workers is responsible for defining a value for the env var ANTAREST_WORKER_ID
+# Currently, see startup script start.sh, or gunicorn configuration conf/gunicorn.py.
+#
+# The worker ID may be used a stable ID for metrics or other purposes.
+ANTAREST_WORKER_ID: int = int(os.environ.get("ANTAREST_WORKER_ID", 0))

--- a/antarest/launcher/adapters/local_launcher/local_launcher.py
+++ b/antarest/launcher/adapters/local_launcher/local_launcher.py
@@ -68,7 +68,7 @@ class LocalLauncher(AbstractLauncher):
         logs_path = self.local_workspace / "LOGS"
         logs_path.mkdir(parents=True, exist_ok=True)
         self.log_directory = logs_path
-        self.log_tail_manager = LogTailManager(self.local_workspace)
+        self.log_tail_manager = LogTailManager()
         self.submitted_jobs: dict[str, LauncherParametersDTO] = {}
         self.job_id_to_study_id: dict[str, tuple[str, Path, subprocess.Popen]] = {}  # type: ignore
         self.logs: dict[str, str] = {}

--- a/antarest/launcher/adapters/log_manager.py
+++ b/antarest/launcher/adapters/log_manager.py
@@ -25,9 +25,8 @@ logger = logging.getLogger(__name__)
 class LogTailManager:
     BATCH_SIZE = 10
 
-    def __init__(self, log_base_dir: Path) -> None:
+    def __init__(self) -> None:
         logger.info("Initiating Log manager")
-        self.log_base_dir = log_base_dir
         self.tracked_logs: dict[str, Thread] = {}
 
     def track(self, log_path: Path | None, handler: Callable[[str], None]) -> None:

--- a/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
+++ b/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
@@ -170,6 +170,7 @@ class SlurmLauncher(AbstractLauncher):
         cache: ICache,
         use_private_workspace: bool = True,
         retrieve_existing_jobs: bool = False,
+        workspace_id: str = f"workspace-{ANTAREST_WORKER_ID}",
     ) -> None:
         super().__init__(callbacks, event_bus, cache)
         self.slurm_config: SlurmConfig = config
@@ -181,7 +182,7 @@ class SlurmLauncher(AbstractLauncher):
         self._check_config()
         self.antares_launcher_lock = threading.Lock()
 
-        self.local_workspace = self._init_workspace(use_private_workspace)
+        self.local_workspace = self._init_workspace(use_private_workspace, workspace_id)
 
         self.log_tail_manager = LogTailManager()
 
@@ -200,11 +201,11 @@ class SlurmLauncher(AbstractLauncher):
             self.slurm_config.local_workspace.exists() and self.slurm_config.local_workspace.is_dir()
         )  # and check write permission
 
-    def _init_workspace(self, use_private_workspace: bool) -> Path:
+    def _init_workspace(self, use_private_workspace: bool, workspace_id: str) -> Path:
         if not use_private_workspace:
             return Path(self.slurm_config.local_workspace)
 
-        workspace_dir = self.slurm_config.local_workspace / f"workspace-{ANTAREST_WORKER_ID}"
+        workspace_dir = self.slurm_config.local_workspace / workspace_id
         if workspace_dir.exists() and workspace_dir.is_dir():
             logger.info(f"Initiating slurm workspace into existing directory {workspace_dir}")
         else:

--- a/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
+++ b/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
@@ -15,7 +15,6 @@ import logging
 import os
 import re
 import shutil
-import tempfile
 import threading
 import time
 import traceback
@@ -28,7 +27,6 @@ from antareslauncher.data_repo.data_repo_tinydb import DataRepoTinydb
 from antareslauncher.main import MainParameters, run_with
 from antareslauncher.main_option_parser import MainOptionParser, ParserParameters
 from antareslauncher.study_dto import StudyDTO
-from filelock import FileLock
 from typing_extensions import override
 
 from antarest.core.config import NbCoresConfig, SlurmConfig, TimeLimitConfig
@@ -40,6 +38,7 @@ from antarest.core.serde.ini_reader import read_ini
 from antarest.core.serde.ini_writer import write_ini_file
 from antarest.core.utils.archives import unzip
 from antarest.core.utils.utils import assert_this
+from antarest.globals import ANTAREST_WORKER_ID
 from antarest.launcher.adapters.abstractlauncher import AbstractLauncher, LauncherCallbacks, SimulationLogs
 from antarest.launcher.adapters.log_manager import LogTailManager
 from antarest.launcher.model import JobStatus, LauncherLoadDTO, LauncherParametersDTO, LogType, XpansionParametersDTO
@@ -50,7 +49,6 @@ from antarest.login.utils import current_user_context, require_current_user
 logger = logging.getLogger(__name__)
 logging.getLogger("paramiko").setLevel("WARN")
 
-WORKSPACE_LOCK_FILE_NAME = ".lock"
 LOCK_FILE_NAME = "slurm_launcher_init.lock"
 LOG_DIR_NAME = "LOGS"
 STUDIES_INPUT_DIR_NAME = "STUDIES_IN"
@@ -183,14 +181,12 @@ class SlurmLauncher(AbstractLauncher):
         self._check_config()
         self.antares_launcher_lock = threading.Lock()
 
-        # use an absolute path instead of `LOCK_FILE_NAME`:
-        local_workspace_dir = Path(self.slurm_config.local_workspace)
-        with FileLock(local_workspace_dir.joinpath(LOCK_FILE_NAME)):
-            self.local_workspace = self._init_workspace(use_private_workspace)
-        self.log_tail_manager = LogTailManager(local_workspace_dir)
+        self.local_workspace = self._init_workspace(use_private_workspace)
 
-        self.launcher_args = self._init_launcher_arguments(self.local_workspace)
-        self.launcher_params = self._init_launcher_parameters(self.local_workspace)
+        self.log_tail_manager = LogTailManager()
+
+        self.launcher_args = self._init_launcher_arguments()
+        self.launcher_params = self._init_launcher_parameters()
 
         self.data_repo_tinydb = DataRepoTinydb(
             database_file_path=(self.launcher_params.json_dir / self.launcher_params.default_json_db_name),
@@ -208,22 +204,13 @@ class SlurmLauncher(AbstractLauncher):
         if not use_private_workspace:
             return Path(self.slurm_config.local_workspace)
 
-        for existing_workspace in self.slurm_config.local_workspace.iterdir():
-            lock_file = existing_workspace / WORKSPACE_LOCK_FILE_NAME
-            if (
-                existing_workspace.is_dir()
-                and existing_workspace != self.slurm_config.local_workspace / LOG_DIR_NAME
-                and not lock_file.exists()
-            ):
-                logger.info(f"Initiating slurm workspace into existing directory {existing_workspace}")
-                lock_file.touch()
-                return existing_workspace
-
-        new_workspace = Path(tempfile.mkdtemp(dir=str(self.slurm_config.local_workspace)))
-        lock_file = new_workspace / WORKSPACE_LOCK_FILE_NAME
-        lock_file.touch()
-        logger.info(f"Initiating slurm workspace in new directory {new_workspace}")
-        return new_workspace
+        workspace_dir = self.slurm_config.local_workspace / f"workspace-{ANTAREST_WORKER_ID}"
+        if workspace_dir.exists() and workspace_dir.is_dir():
+            logger.info(f"Initiating slurm workspace into existing directory {workspace_dir}")
+        else:
+            logger.info(f"Initiating slurm workspace in new directory {workspace_dir}")
+            os.makedirs(workspace_dir)
+        return workspace_dir
 
     def _retrieve_running_jobs(self) -> None:
         if len(self.data_repo_tinydb.get_list_of_studies()) > 0:
@@ -263,14 +250,14 @@ class SlurmLauncher(AbstractLauncher):
         self.thread = None
         logger.info("slurm_launcher loop stopped")
 
-    def _init_launcher_arguments(self, local_workspace: Path | None = None) -> argparse.Namespace:
+    def _init_launcher_arguments(self) -> argparse.Namespace:
         main_options_parameters = ParserParameters(
             default_wait_time=self.slurm_config.default_wait_time,
             default_time_limit=self.slurm_config.time_limit.default * 3600,
             default_n_cpu=self.slurm_config.nb_cores.default,
-            studies_in_dir=str(Path(local_workspace or self.slurm_config.local_workspace) / STUDIES_INPUT_DIR_NAME),
-            log_dir=str(Path(self.slurm_config.local_workspace) / LOG_DIR_NAME),
-            finished_dir=str(Path(local_workspace or self.slurm_config.local_workspace) / STUDIES_OUTPUT_DIR_NAME),
+            studies_in_dir=str(self.local_workspace / STUDIES_INPUT_DIR_NAME),
+            log_dir=str(self.local_workspace / LOG_DIR_NAME),
+            finished_dir=str(self.local_workspace / STUDIES_OUTPUT_DIR_NAME),
             ssh_config_file_is_required=False,
             ssh_configfile_path_alternate1=None,
             ssh_configfile_path_alternate2=None,
@@ -292,9 +279,9 @@ class SlurmLauncher(AbstractLauncher):
 
         return arguments
 
-    def _init_launcher_parameters(self, local_workspace: Path | None = None) -> MainParameters:
+    def _init_launcher_parameters(self) -> MainParameters:
         return MainParameters(
-            json_dir=local_workspace or self.slurm_config.local_workspace,
+            json_dir=self.local_workspace,
             default_json_db_name=self.slurm_config.default_json_db_name,
             slurm_script_path=self.slurm_config.slurm_script_path,
             partition=self.slurm_config.partition,

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -70,7 +70,6 @@ from antarest.study.web.study_data_blueprint import create_study_data_routes
 from antarest.study.web.variant_blueprint import create_study_variant_routes
 from antarest.study.web.watcher_blueprint import create_watcher_routes
 from antarest.study.web.xpansion_studies_blueprint import create_xpansion_routes
-from antarest.tools.admin_lib import clean_locks
 
 logger = logging.getLogger(__name__)
 
@@ -411,7 +410,6 @@ LOGGING_CONFIG["formatters"]["access"]["fmt"] = (
 def main() -> None:
     arguments = parse_arguments()
     if arguments.module == Module.APP:
-        clean_locks(arguments.config_file)
         app = fastapi_app(
             arguments.config_file,
             mount_front=not arguments.no_front,

--- a/antarest/main.py
+++ b/antarest/main.py
@@ -49,6 +49,7 @@ from antarest.eventbus.web import register_websocket_routes
 from antarest.fastapi_jwt_auth.exceptions import AuthJWTException
 from antarest.favorite.web import create_favorite_routes
 from antarest.front import add_front_app
+from antarest.globals import ANTAREST_WORKER_ID
 from antarest.launcher.web import create_launcher_api
 from antarest.login.model import init_admin_user
 from antarest.login.web import create_login_api, create_user_api
@@ -377,7 +378,7 @@ def fastapi_app(
 
     configure_logger(config)
 
-    logger.info("Initiating application")
+    logger.info(f"Initiating application (worker {ANTAREST_WORKER_ID})")
 
     app = base_fastapi_app(config.api_prefix, config.root_path)
 

--- a/antarest/tools/admin.py
+++ b/antarest/tools/admin.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 import click
 
-from antarest.tools.admin_lib import clean_locks as do_clean_locks
 from antarest.tools.admin_lib import fix_interrupted_tasks_status
 from antarest.tools.admin_lib import reindex_table as do_reindex_table
 
@@ -26,20 +25,6 @@ logger = logging.getLogger(__name__)
 @click.group()
 def commands() -> None:
     pass
-
-
-@commands.command()
-@click.option(
-    "--config",
-    "-c",
-    nargs=1,
-    required=True,
-    type=click.Path(exists=True),
-    help="Application config",
-)
-def clean_locks(config: str) -> None:
-    """Clean app locks"""
-    do_clean_locks(Path(config))
 
 
 @commands.command()

--- a/antarest/tools/admin_lib.py
+++ b/antarest/tools/admin_lib.py
@@ -19,7 +19,6 @@ from sqlalchemy import Engine, create_engine, update
 from antarest.core.config import Config
 from antarest.core.tasks.model import TaskJob, TaskStatus
 from antarest.core.utils.utils import current_time, get_local_path
-from antarest.launcher.adapters.slurm_launcher.slurm_launcher import WORKSPACE_LOCK_FILE_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -34,23 +33,6 @@ def _create_config(config_path: Path) -> Config:
     res = get_local_path() / "resources"
     config_obj = Config.from_yaml_file(res=res, file=config_path)
     return config_obj
-
-
-def clean_locks_from_config(config: Config) -> None:
-    for slurm_config in config.launcher.get_slurm_configs():
-        slurm_workspace = slurm_config.local_workspace
-        if slurm_workspace.exists() and slurm_workspace.is_dir():
-            for workspace in slurm_workspace.iterdir():
-                lock_file = workspace / WORKSPACE_LOCK_FILE_NAME
-                if lock_file.exists():
-                    logger.info(f"Removing slurm workspace lock file {lock_file}")
-                    lock_file.unlink()
-
-
-def clean_locks(config: Path) -> None:
-    """Clean app locks"""
-    config_obj = _create_config(config)
-    clean_locks_from_config(config_obj)
 
 
 def reindex_table(config: Path) -> None:

--- a/conf/gunicorn.py
+++ b/conf/gunicorn.py
@@ -42,20 +42,19 @@ def child_exit(server, worker):
     multiprocess.mark_process_dead(worker.pid)
     worker_id = getattr(worker, "_antarest_worker_id", None)
     if worker_id is not None:
-        _worker_ids[worker_id] = 0
+        _taken_worker_ids.discard(worker_id)
 
 
 # Below: logic to assign a unique identifier to each worker, from 1 to workers count.
-# Index 0 is unused so that worker IDs are 1-based (matching the range 1..workers).
-_worker_ids = [0 for _ in range(workers + 1)]
+_taken_worker_ids: set[int] = set()
 
 
 def pre_fork(server, worker):
     # Runs in master before fork — find a free slot and attach it to the worker object.
     # worker.pid is not yet set at this point, so we store the slot on the worker itself.
     for i in range(1, workers + 1):
-        if _worker_ids[i] == 0:
-            _worker_ids[i] = 1  # mark as taken
+        if i not in _taken_worker_ids:
+            _taken_worker_ids.add(i)
             worker._antarest_worker_id = i
             break
 

--- a/conf/gunicorn.py
+++ b/conf/gunicorn.py
@@ -20,6 +20,8 @@ https://docs.gunicorn.org/en/stable/design.html#how-many-workers
 workers = os.getenv("GUNICORN_WORKERS")
 if workers == "ALL_AVAILABLE" or workers is None:
     workers = multiprocessing.cpu_count() * 2 + 1
+else:
+    workers = int(workers)
 
 timeout = 10 * 60  # 10 minutes
 keepalive = 24 * 60 * 60  # 1 day
@@ -37,3 +39,31 @@ def child_exit(server, worker):
     Notify prometheus that this worker stops
     """
     multiprocess.mark_process_dead(worker.pid)
+
+
+# Below: logic to assign a unique identifier to each worker, from 1 to workers count
+_worker_ids = [0 for _ in range(workers)]
+
+
+def pre_fork(server, worker):
+    # Runs in master — assign a free slot to this worker's PID
+    for i in range(1, workers + 1):
+        if _worker_ids[i] == 0:
+            _worker_ids[i] = worker.pid
+            break
+
+
+def post_fork(server, worker):
+    # Runs in child — find our PID in the inherited array and read our slot
+    for i in range(1, workers + 1):
+        if _worker_ids[i] == worker.pid:
+            os.environ["ANTAREST_WORKER_ID"] = str(i)
+            break
+
+
+def worker_exit(server, worker):
+    # Runs in master — release the slot
+    for i in range(1, workers + 1):
+        if _worker_ids[i] == worker.pid:
+            _worker_ids[i] = 0
+            break

--- a/conf/gunicorn.py
+++ b/conf/gunicorn.py
@@ -36,34 +36,31 @@ preload_app = False
 
 def child_exit(server, worker):
     """
-    Notify prometheus that this worker stops
+    Notify prometheus that this worker stops, and release its ID slot.
+    Runs in master process.
     """
     multiprocess.mark_process_dead(worker.pid)
+    worker_id = getattr(worker, "_antarest_worker_id", None)
+    if worker_id is not None:
+        _worker_ids[worker_id] = 0
 
 
-# Below: logic to assign a unique identifier to each worker, from 1 to workers count
-_worker_ids = [0 for _ in range(workers)]
+# Below: logic to assign a unique identifier to each worker, from 1 to workers count.
+# Index 0 is unused so that worker IDs are 1-based (matching the range 1..workers).
+_worker_ids = [0 for _ in range(workers + 1)]
 
 
 def pre_fork(server, worker):
-    # Runs in master — assign a free slot to this worker's PID
+    # Runs in master before fork — find a free slot and attach it to the worker object.
+    # worker.pid is not yet set at this point, so we store the slot on the worker itself.
     for i in range(1, workers + 1):
         if _worker_ids[i] == 0:
-            _worker_ids[i] = worker.pid
+            _worker_ids[i] = 1  # mark as taken
+            worker._antarest_worker_id = i
             break
 
 
 def post_fork(server, worker):
-    # Runs in child — find our PID in the inherited array and read our slot
-    for i in range(1, workers + 1):
-        if _worker_ids[i] == worker.pid:
-            os.environ["ANTAREST_WORKER_ID"] = str(i)
-            break
-
-
-def worker_exit(server, worker):
-    # Runs in master — release the slot
-    for i in range(1, workers + 1):
-        if _worker_ids[i] == worker.pid:
-            _worker_ids[i] = 0
-            break
+    # Runs in child after fork — export the pre-assigned slot as an env var so that
+    # antarest.globals.ANTAREST_WORKER_ID (read at import time) picks it up.
+    os.environ["ANTAREST_WORKER_ID"] = str(getattr(worker, "_antarest_worker_id", 0))

--- a/scripts/pre-start.sh
+++ b/scripts/pre-start.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Executes some setup tasks before the actual start of the web application:
 # - database migration if needed
-# - cleaning up lock files
 # - fixing status of tasks that have been interrupted by previous shutdown
 #
 set -e
@@ -14,5 +13,4 @@ alembic upgrade head
 cd -
 
 export PYTHONPATH=$BASE_DIR
-python "$BASE_DIR/antarest/tools/admin.py" clean-locks -c "$ANTAREST_CONF"
 python "$BASE_DIR/antarest/tools/admin.py" fix-tasks-status -c "$ANTAREST_CONF"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -54,7 +54,8 @@ elif [ "$use_uvicorn" = true ]; then
   do
     # we still use gunicorn in that case to restart workers in case they are killed,
     # although each gunicorn instance has only one worker
-    gunicorn --worker-class=uvicorn.workers.UvicornWorker \
+    #
+    ANTAREST_WORKER_ID=$((1 + $i)) gunicorn --worker-class=uvicorn.workers.UvicornWorker \
              --bind=0.0.0.0:$((5000 + $i)) \
              --workers=1 \
              --log-level info \

--- a/tests/launcher/test_log_manager.py
+++ b/tests/launcher/test_log_manager.py
@@ -20,7 +20,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def test_reading(tmp_path: Path) -> None:
-    log_manager = LogTailManager(tmp_path)
+    log_manager = LogTailManager()
 
     logs = []
 

--- a/tests/launcher/test_slurm_launcher.py
+++ b/tests/launcher/test_slurm_launcher.py
@@ -33,7 +33,6 @@ from antarest.core.jwt import JWTUser
 from antarest.launcher.adapters.abstractlauncher import SimulationLogs
 from antarest.launcher.adapters.slurm_launcher.slurm_launcher import (
     LOG_DIR_NAME,
-    WORKSPACE_LOCK_FILE_NAME,
     SlurmLauncher,
     VersionNotSupportedError,
 )
@@ -76,7 +75,9 @@ def test_init_slurm_launcher_arguments(tmp_path: Path) -> None:
         local_workspace=tmp_path,
     )
 
-    slurm_launcher = SlurmLauncher(config=config, callbacks=Mock(), event_bus=Mock(), cache=Mock())
+    slurm_launcher = SlurmLauncher(
+        config=config, callbacks=Mock(), event_bus=Mock(), cache=Mock(), use_private_workspace=False
+    )
 
     arguments = slurm_launcher._init_launcher_arguments()
 
@@ -113,7 +114,9 @@ def test_init_slurm_launcher_parameters(tmp_path: Path) -> None:
         password="password",
     )
 
-    slurm_launcher = SlurmLauncher(config=config, callbacks=Mock(), event_bus=Mock(), cache=Mock())
+    slurm_launcher = SlurmLauncher(
+        config=config, callbacks=Mock(), event_bus=Mock(), cache=Mock(), use_private_workspace=False
+    )
 
     main_parameters = slurm_launcher._init_launcher_parameters()
     assert config is not None
@@ -486,10 +489,11 @@ def test_launcher_workspace_init(run_with_mock: Any, tmp_path: Path, launcher_co
         event_bus=Mock(),
         retrieve_existing_jobs=True,
         cache=Mock(),
+        workspace_id="workspace-12",
     )
     workspaces = [p for p in tmp_path.iterdir() if p.is_dir() and p.name != LOG_DIR_NAME]
-    assert len(workspaces) == 1
-    assert (workspaces[0] / WORKSPACE_LOCK_FILE_NAME).exists()
+    assert workspaces[0] == tmp_path / "workspace-12"
+    assert workspaces[0].is_dir()
 
     slurm_launcher.data_repo_tinydb.save_study(StudyDTO(path="some_path"))
     run_with_mock.assert_not_called()
@@ -501,19 +505,8 @@ def test_launcher_workspace_init(run_with_mock: Any, tmp_path: Path, launcher_co
         event_bus=Mock(),
         retrieve_existing_jobs=True,
         cache=Mock(),
+        workspace_id="workspace-12",
     )
     workspaces = [p for p in tmp_path.iterdir() if p.is_dir() and p.name != LOG_DIR_NAME]
-    assert len(workspaces) == 2
-
-    run_with_mock.reset_mock()
-    # will create a new one since there is a lock on previous one
-    SlurmLauncher(
-        config=launcher_config,
-        callbacks=callbacks,
-        event_bus=Mock(),
-        retrieve_existing_jobs=True,
-        cache=Mock(),
-    )
-    workspaces = [p for p in tmp_path.iterdir() if p.is_dir() and p.name != LOG_DIR_NAME]
-    assert len(workspaces) == 3
-    run_with_mock.assert_not_called()
+    assert len(workspaces) == 1
+    assert workspaces[0] == tmp_path / "workspace-12"


### PR DESCRIPTION

This PR assigns to each worker a stable integer ID between 1 and workers count.

This is used for:
- worker ID in metrics
- slurm workspace name

In particular, this will solve the following issue:
- on worker kill (OOM typically), gunicorn will restart it, but will not clean up the corresponding slurm lock file.
  Therefore the workspace monitored by this worker will not be picked up on startup of the replacing worker,
  and **computations will be lost**

Implementation:
- in single gunicorn - multiple workers env, the master process manages the list of available identifiers,
  then the worker picks the identifier and puts it in the ANTAREST_WORKER_ID env var
- in multiple gunicorn - single worker per gunicorn, the startup script defines the env variable ANTAREST_WORKER_ID
- else, the worker ID is 0