### PR TITLE
fix(download): use short transactions when polling for download readiness

### DIFF
--- a/antarest/core/filetransfer/repository.py
+++ b/antarest/core/filetransfer/repository.py
@@ -24,7 +24,8 @@ class FileDownloadRepository:
 
     def get(self, download_id: str) -> FileDownload | None:
         download = db.session.get(FileDownload, download_id)
-        db.session.refresh(download)
+        if download:
+            db.session.refresh(download)
         return download
 
     def save(self, download: FileDownload) -> None:

--- a/antarest/core/filetransfer/service.py
+++ b/antarest/core/filetransfer/service.py
@@ -15,7 +15,6 @@ import http
 import logging
 import os
 import tempfile
-import time
 import uuid
 from pathlib import Path
 
@@ -33,11 +32,16 @@ from antarest.core.filetransfer.repository import FileDownloadRepository
 from antarest.core.interfaces.eventbus import Event, EventType, IEventBus
 from antarest.core.model import PermissionInfo, PublicMode
 from antarest.core.requests import UserHasNotPermissionError
-from antarest.core.tasks.service import DEFAULT_AWAIT_MAX_TIMEOUT
+from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import current_time
+from antarest.core.utils.wait import wait_for
 from antarest.login.utils import get_current_user, require_current_user
 
 logger = logging.getLogger(__name__)
+
+
+DEFAULT_DOWNLOAD_POLLING_INTERVAL = 2.0
+DEFAULT_DOWNLOAD_WAIT_TIMEOUT = 3600
 
 
 class FileTransferManager:
@@ -203,28 +207,40 @@ class FileTransferManager:
 
         return download
 
-    def get_download_metadata(self, download_id: str, wait_for_availability: bool) -> FileDownloadDTO:
-        download = self.repository.get(download_id)
-        if not download:
-            raise FileDownloadNotFound()
+    def get_download_metadata(
+        self,
+        download_id: str,
+        wait_for_availability: bool,
+        polling_interval: float = DEFAULT_DOWNLOAD_POLLING_INTERVAL,
+        timeout: float = DEFAULT_DOWNLOAD_WAIT_TIMEOUT,
+    ) -> FileDownloadDTO:
+        """
+        Important:
+        we use short scoped sessions here to guarantee that sessions are not held for a long time.
+        """
+
+        def get_download_if_completed() -> FileDownloadDTO | None:
+            with db():
+                download = self.repository.get(download_id)
+                if not download:
+                    raise FileDownloadNotFound()
+                if download.ready or download.failed:
+                    return download.to_dto()
+                return None
+
+        download_dto = get_download_if_completed()
 
         # the user wants to wait for the download to be available
-        if wait_for_availability:
-            end = time.time() + DEFAULT_AWAIT_MAX_TIMEOUT
+        if not download_dto and wait_for_availability:
+            download_dto = wait_for(get_download_if_completed, polling_interval=polling_interval, timeout=timeout)
 
-            # disable download variable typing since it will always be defined
-            while time.time() < end and not download.ready and not download.failed:
-                download = self.repository.get(download_id)
-                assert download is not None
-                time.sleep(2)
-
-        if download.failed:
-            raise HTTPException(
-                status_code=http.HTTPStatus.UNPROCESSABLE_ENTITY,
-                detail=f"File was not successfully processed: {download.error_message}.",
-            )
-
-        if not download.ready:
+        if not download_dto:
             raise HTTPException(status_code=http.HTTPStatus.EXPECTATION_FAILED, detail="File is still in process.")
 
-        return download.to_dto()
+        if download_dto.failed:
+            raise HTTPException(
+                status_code=http.HTTPStatus.UNPROCESSABLE_ENTITY,
+                detail=f"File was not successfully processed: {download_dto.error_message}.",
+            )
+
+        return download_dto

--- a/antarest/core/filetransfer/web.py
+++ b/antarest/core/filetransfer/web.py
@@ -11,8 +11,10 @@
 # This file is part of the Antares project.
 import logging
 from pathlib import Path
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from fastapi.params import Query
 from starlette.responses import FileResponse
 
 from antarest.core.api_types import UuidStr
@@ -53,7 +55,9 @@ def create_file_transfer_api() -> APIRouter:
     def get_download_metadata(
         filetransfer_manager: FileTransferManagerDep,
         download_id: UuidStr,
-        wait_for_availability: bool = False,
+        wait_for_availability: Annotated[
+            bool, Query(description="If true, will wait for the download to be either ready or failed (max 1h).")
+        ] = False,
     ) -> FileDownloadDTO:
         logger.info(f"Retrieving metadata for download {download_id} (waiting: {wait_for_availability}).")
         return filetransfer_manager.get_download_metadata(download_id, wait_for_availability)

--- a/antarest/core/utils/fastapi_sqlalchemy/middleware.py
+++ b/antarest/core/utils/fastapi_sqlalchemy/middleware.py
@@ -99,6 +99,16 @@ def _default_create_session() -> Session:
     raise SessionNotInitialisedError()
 
 
+def get_session_factory() -> sessionmaker[Session]:
+    """
+    Returns the global sessionmaker singleton.
+    Should not be used in prod code but only for testing purposes.
+    """
+    if isinstance(_Session, sessionmaker):
+        return _Session
+    raise SessionNotInitialisedError()
+
+
 class DBSession(metaclass=DBSessionMeta):
     def __init__(
         self,

--- a/antarest/core/utils/wait.py
+++ b/antarest/core/utils/wait.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+import time
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
+def wait_for(fn: Callable[[], T | None], polling_interval: float, timeout: float) -> T | None:
+    """
+    Polls at regular intervals the provided function for a non-None result, until timeout (seconds) is expired.
+
+    Note that this method will not raise on timeout, you may check for None result instead.
+
+    Args:
+        fn: polling function
+        polling_interval: wait time between 2 calls of fn
+        timeout: maximum time to wait.
+
+    Returns:
+        None if timed out, else the result of the function.
+    """
+    end = time.time() + timeout
+
+    while time.time() < end:
+        result = fn()
+        if result is not None:
+            return result
+        time.sleep(polling_interval)
+
+    result = fn()
+    if result is not None:
+        return result
+    return None

--- a/antarest/core/utils/wait.py
+++ b/antarest/core/utils/wait.py
@@ -37,7 +37,5 @@ def wait_for(fn: Callable[[], T | None], polling_interval: float, timeout: float
             return result
         time.sleep(polling_interval)
 
-    result = fn()
-    if result is not None:
-        return result
-    return None
+    # one last try
+    return fn()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ no_implicit_reexport = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-log_cli = false  # you may set it to true for debugging purpose
+log_cli = true  # you may set it to true for debugging purpose
 log_cli_level = "info"
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ no_implicit_reexport = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-log_cli = true  # you may set it to true for debugging purpose
+log_cli = false  # you may set it to true for debugging purpose
 log_cli_level = "info"
 
 [tool.coverage.run]

--- a/tests/core/test_file_transfer.py
+++ b/tests/core/test_file_transfer.py
@@ -11,7 +11,9 @@
 # This file is part of the Antares project.
 
 import datetime
+import time
 from pathlib import Path
+from threading import Thread
 from unittest.mock import Mock
 
 import pytest
@@ -25,8 +27,10 @@ from antarest.core.interfaces.eventbus import Event, EventType
 from antarest.core.model import PermissionInfo, PublicMode
 from antarest.core.requests import MustBeAuthenticatedError
 from antarest.core.utils.fastapi_sqlalchemy import db
+from antarest.core.utils.fastapi_sqlalchemy.middleware import get_session_factory
 from antarest.login.utils import current_user_context
 from tests.helpers import with_admin_user
+from tests.test_helpers.db import create_db_event_counter
 
 
 def test_file_request() -> None:
@@ -85,3 +89,40 @@ def test_lifecycle(tmp_path: Path) -> None:
         ftm.repository.save(filedownload)
         downloads = ftm.list_downloads()
         assert len(downloads) == 0
+
+
+@with_admin_user
+def test_wait_for_download_metadata(tmp_path: Path) -> None:
+
+    with db():
+        ftm = FileTransferManager(
+            repository=FileDownloadRepository(),
+            event_bus=Mock(),
+            config=Config(storage=StorageConfig(tmp_dir=tmp_path)),
+        )
+        download = ftm.request_download("some file", "some name")
+        assert download.id is not None
+
+        def set_ready_after_1s() -> None:
+            time.sleep(1)
+            with db():
+                ftm.set_ready(download.id)
+
+        thread = Thread(target=set_ready_after_1s)
+        thread.start()
+
+        events_counter = create_db_event_counter(get_session_factory())
+        download_dto = ftm.get_download_metadata(
+            download.id, wait_for_availability=True, polling_interval=0.1, timeout=10
+        )
+
+        assert download_dto.id == download.id
+        assert download_dto.ready
+
+        # We check there's been only 1 commit (set ready)
+        # and that the polling used short transactions (begin/rollback each time)
+        assert events_counter.commit == 1
+        assert events_counter.begin >= 8
+        assert events_counter.rollback >= 8
+
+        thread.join()

--- a/tests/core/utils/test_db_session_middleware.py
+++ b/tests/core/utils/test_db_session_middleware.py
@@ -9,59 +9,29 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from dataclasses import dataclass
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.event import listens_for
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 from antarest.core.utils.fastapi_sqlalchemy import db
-
-
-@dataclass
-class EventCounter:
-    transaction_start: int = 0
-    transaction_end: int = 0
-    begin: int = 0
-    rollback: int = 0
-    commit: int = 0
+from tests.test_helpers.db import DbEventCounter, create_db_event_counter
 
 
 @pytest.fixture
-def session_factory():
+def session_factory() -> sessionmaker[Session]:
     engine = create_engine("sqlite:///:memory:")
     return sessionmaker(bind=engine)
 
 
 @pytest.fixture
-def events_counter(session_factory):
-    counter = EventCounter()
-
-    @listens_for(session_factory, "after_begin")
-    def after_begin(session, transaction, connection):
-        counter.begin = counter.begin + 1
-
-    @listens_for(session_factory, "after_rollback")
-    def after_rollback(session):
-        counter.rollback = counter.rollback + 1
-
-    @listens_for(session_factory, "after_commit")
-    def after_commit(session):
-        counter.commit = counter.commit + 1
-
-    @listens_for(session_factory, "after_transaction_create")
-    def on_transaction_start(session, transaction):
-        counter.transaction_start = counter.transaction_start + 1
-
-    @listens_for(session_factory, "after_transaction_end")
-    def on_transaction_end(session, transaction):
-        counter.transaction_end = counter.transaction_end + 1
-
-    return counter
+def events_counter(session_factory: sessionmaker[Session]) -> DbEventCounter:
+    return create_db_event_counter(session_factory)
 
 
-def test_db_session_is_rollbacked_on_exit(session_factory, events_counter):
+def test_db_session_is_rollbacked_on_exit(
+    session_factory: sessionmaker[Session], events_counter: DbEventCounter
+) -> None:
     # it's important that transactions are rollbacked on exit, otherwise some
     # transactions can be seen as unclosed (in case an exception happens on close)
 
@@ -76,7 +46,9 @@ def test_db_session_is_rollbacked_on_exit(session_factory, events_counter):
 
 
 @pytest.mark.parametrize("commit_on_exit", [False, True])
-def test_db_session_is_rollbacked_on_exception(session_factory, events_counter, commit_on_exit):
+def test_db_session_is_rollbacked_on_exception(
+    session_factory: sessionmaker[Session], events_counter: DbEventCounter, commit_on_exit: bool
+) -> None:
     with db(session_factory):
         db.session.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
         assert events_counter.begin == 1
@@ -87,7 +59,9 @@ def test_db_session_is_rollbacked_on_exception(session_factory, events_counter, 
     assert events_counter.commit == 0
 
 
-def test_db_session_is_committed_on_autocommit(session_factory, events_counter):
+def test_db_session_is_committed_on_autocommit(
+    session_factory: sessionmaker[Session], events_counter: DbEventCounter
+) -> None:
     with db(session_factory, commit_on_exit=True):
         db.session.execute(text("CREATE TABLE test (id INTEGER PRIMARY KEY)"))
         assert events_counter.begin == 1

--- a/tests/core/utils/test_wait.py
+++ b/tests/core/utils/test_wait.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+import pytest
+
+from antarest.core.utils.wait import wait_for
+
+
+def test_wait_1st_call():
+    call_count = 0
+
+    def return_1():
+        nonlocal call_count
+        call_count += 1
+        return 1
+
+    res = wait_for(return_1, polling_interval=0.1, timeout=10)
+    assert res == 1
+    assert call_count == 1
+
+
+def test_wait_returns_none_after_timeout():
+    call_count = 0
+
+    def return_none():
+        nonlocal call_count
+        call_count += 1
+        return None
+
+    res = wait_for(return_none, polling_interval=0.01, timeout=0.1)
+    assert res is None
+    assert call_count > 0
+
+
+def test_wait_returns_when_fn_returns_not_none():
+    call_count = 0
+
+    def return_1_after_10_times():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 10:
+            return None
+        return 1
+
+    call_count = 0
+    res = wait_for(return_1_after_10_times, polling_interval=0.01, timeout=1)
+    assert res == 1
+    assert call_count == 10
+
+
+def test_wait_raises():
+
+    def raising_function():
+        raise ValueError("Failed")
+
+    with pytest.raises(ValueError):
+        wait_for(raising_function, polling_interval=0.01, timeout=1)

--- a/tests/test_helpers/db.py
+++ b/tests/test_helpers/db.py
@@ -29,22 +29,22 @@ def create_db_event_counter(session_factory: sessionmaker[Session]) -> DbEventCo
 
     @listens_for(session_factory, "after_begin")
     def after_begin(session, transaction, connection):
-        counter.begin = counter.begin + 1
+        counter.begin += 1
 
     @listens_for(session_factory, "after_rollback")
     def after_rollback(session):
-        counter.rollback = counter.rollback + 1
+        counter.rollback += 1
 
     @listens_for(session_factory, "after_commit")
     def after_commit(session):
-        counter.commit = counter.commit + 1
+        counter.commit += 1
 
     @listens_for(session_factory, "after_transaction_create")
     def on_transaction_start(session, transaction):
-        counter.transaction_start = counter.transaction_start + 1
+        counter.transaction_start += 1
 
     @listens_for(session_factory, "after_transaction_end")
     def on_transaction_end(session, transaction):
-        counter.transaction_end = counter.transaction_end + 1
+        counter.transaction_end += 1
 
     return counter

--- a/tests/test_helpers/db.py
+++ b/tests/test_helpers/db.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+from dataclasses import dataclass
+
+from sqlalchemy.event import listens_for
+from sqlalchemy.orm import Session, sessionmaker
+
+
+@dataclass
+class DbEventCounter:
+    transaction_start: int = 0
+    transaction_end: int = 0
+    begin: int = 0
+    rollback: int = 0
+    commit: int = 0
+
+
+def create_db_event_counter(session_factory: sessionmaker[Session]) -> DbEventCounter:
+    counter = DbEventCounter()
+
+    @listens_for(session_factory, "after_begin")
+    def after_begin(session, transaction, connection):
+        counter.begin = counter.begin + 1
+
+    @listens_for(session_factory, "after_rollback")
+    def after_rollback(session):
+        counter.rollback = counter.rollback + 1
+
+    @listens_for(session_factory, "after_commit")
+    def after_commit(session):
+        counter.commit = counter.commit + 1
+
+    @listens_for(session_factory, "after_transaction_create")
+    def on_transaction_start(session, transaction):
+        counter.transaction_start = counter.transaction_start + 1
+
+    @listens_for(session_factory, "after_transaction_end")
+    def on_transaction_end(session, transaction):
+        counter.transaction_end = counter.transaction_end + 1
+
+    return counter


### PR DESCRIPTION

ANT-4939

Using a long transaction for polling block un-necessarily a DB session for a long time.

It happens to cause deadlocks from time to time with `set_ready`, probably because
of a bug in our old version of pgpool.