### PR TITLE
fix(logs): logs dir must be shared between workers

### DIFF
--- a/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
+++ b/antarest/launcher/adapters/slurm_launcher/slurm_launcher.py
@@ -49,7 +49,6 @@ from antarest.login.utils import current_user_context, require_current_user
 logger = logging.getLogger(__name__)
 logging.getLogger("paramiko").setLevel("WARN")
 
-LOCK_FILE_NAME = "slurm_launcher_init.lock"
 LOG_DIR_NAME = "LOGS"
 STUDIES_INPUT_DIR_NAME = "STUDIES_IN"
 STUDIES_OUTPUT_DIR_NAME = "OUTPUT"
@@ -184,6 +183,10 @@ class SlurmLauncher(AbstractLauncher):
 
         self.local_workspace = self._init_workspace(use_private_workspace, workspace_id)
 
+        # Important: in a multi-process environment, the log directory must be shared between workers,
+        # so that all workers can expose logs of any simulation in the API
+        self.log_dir = config.local_workspace / LOG_DIR_NAME
+
         self.log_tail_manager = LogTailManager()
 
         self.launcher_args = self._init_launcher_arguments()
@@ -257,7 +260,7 @@ class SlurmLauncher(AbstractLauncher):
             default_time_limit=self.slurm_config.time_limit.default * 3600,
             default_n_cpu=self.slurm_config.nb_cores.default,
             studies_in_dir=str(self.local_workspace / STUDIES_INPUT_DIR_NAME),
-            log_dir=str(self.local_workspace / LOG_DIR_NAME),
+            log_dir=str(self.log_dir),
             finished_dir=str(self.local_workspace / STUDIES_OUTPUT_DIR_NAME),
             ssh_config_file_is_required=False,
             ssh_configfile_path_alternate1=None,

--- a/tests/launcher/test_slurm_launcher.py
+++ b/tests/launcher/test_slurm_launcher.py
@@ -97,6 +97,38 @@ def test_init_slurm_launcher_arguments(tmp_path: Path) -> None:
     assert Path(arguments.log_dir) == config.local_workspace / "LOGS"
 
 
+def test_init_slurm_launcher_arguments_multi_worker(tmp_path: Path) -> None:
+    config = SlurmConfig(
+        id="slurm_id",
+        name="slurm",
+        default_wait_time=42,
+        time_limit=TimeLimitConfig(),
+        nb_cores=NbCoresConfig(min=1, default=30, max=36),
+        local_workspace=tmp_path,
+    )
+
+    slurm_launcher = SlurmLauncher(
+        config=config, callbacks=Mock(), event_bus=Mock(), cache=Mock(), workspace_id="workspace-5"
+    )
+
+    arguments = slurm_launcher._init_launcher_arguments()
+
+    assert not arguments.wait_mode
+    assert not arguments.check_queue
+    assert not arguments.wait_mode
+    assert not arguments.check_queue
+    assert arguments.json_ssh_config is None
+    assert arguments.job_id_to_kill is None
+    assert not arguments.xpansion_mode
+    assert not arguments.version
+    assert not arguments.post_processing
+
+    assert config is not None
+    assert Path(arguments.studies_in) == config.local_workspace / "workspace-5" / "STUDIES_IN"
+    assert Path(arguments.output_dir) == config.local_workspace / "workspace-5" / "OUTPUT"
+    assert Path(arguments.log_dir) == config.local_workspace / "LOGS"  # Log dir is shared between workers
+
+
 def test_init_slurm_launcher_parameters(tmp_path: Path) -> None:
     config = SlurmConfig(
         id="slurm_id",
@@ -121,6 +153,45 @@ def test_init_slurm_launcher_parameters(tmp_path: Path) -> None:
     main_parameters = slurm_launcher._init_launcher_parameters()
     assert config is not None
     assert main_parameters.json_dir == config.local_workspace
+    assert main_parameters.default_json_db_name == config.default_json_db_name
+    assert main_parameters.slurm_script_path == config.slurm_script_path
+    assert main_parameters.partition == config.partition
+    assert main_parameters.antares_versions_on_remote_server == config.antares_versions_on_remote_server
+    assert main_parameters.default_ssh_dict == {
+        "username": config.username,
+        "hostname": config.hostname,
+        "port": config.port,
+        "private_key_file": config.private_key_file,
+        "key_password": config.key_password,
+        "password": config.password,
+    }
+    assert main_parameters.db_primary_key == "name"
+
+
+def test_init_slurm_launcher_parameters_multi_worker(tmp_path: Path) -> None:
+    config = SlurmConfig(
+        id="slurm_id",
+        name="slurm",
+        local_workspace=tmp_path,
+        default_json_db_name="default_json_db_name",
+        slurm_script_path="slurm_script_path",
+        partition="fake_partition",
+        antares_versions_on_remote_server=[SolverVersion.parse(840), SolverVersion.parse("10.0")],
+        username="username",
+        hostname="hostname",
+        port=42,
+        private_key_file=Path("private_key_file"),
+        key_password="key_password",
+        password="password",
+    )
+
+    slurm_launcher = SlurmLauncher(
+        config=config, callbacks=Mock(), event_bus=Mock(), cache=Mock(), workspace_id="workspace-5"
+    )
+
+    main_parameters = slurm_launcher._init_launcher_parameters()
+    assert config is not None
+    assert main_parameters.json_dir == config.local_workspace / "workspace-5"
     assert main_parameters.default_json_db_name == config.default_json_db_name
     assert main_parameters.slurm_script_path == config.slurm_script_path
     assert main_parameters.partition == config.partition
@@ -481,7 +552,6 @@ def test_kill_job(
 @patch("antarest.launcher.adapters.slurm_launcher.slurm_launcher.run_with")
 def test_launcher_workspace_init(run_with_mock: Any, tmp_path: Path, launcher_config: SlurmConfig) -> None:
     callbacks = Mock()
-    (tmp_path / LOG_DIR_NAME).mkdir()
 
     slurm_launcher = SlurmLauncher(
         config=launcher_config,


### PR DESCRIPTION

Fixes regression introduced in https://github.com/AntaresSimulatorTeam/AntaREST/pull/3177 

In a multi-worker environment, all workers need to be able to retrieve logs of any simulation,
including simulations running in other workers.
This was not the case any more, returning empty logs for simulations of other workers.

The behaviour is restored by having a log directory shared between workers.

