### PR TITLE
fix(db-dao): remove matrix:// prefix

### DIFF
--- a/antarest/study/dao/database/database_hydro_dao.py
+++ b/antarest/study/dao/database/database_hydro_dao.py
@@ -29,7 +29,6 @@ from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound
 from antarest.core.utils.polars import create_polars_dataframe
-from antarest.matrixstore.service import MATRIX_PROTOCOL_PREFIX
 from antarest.study.business.model.config.compatibility_parameters_model import (
     HydroPmax,
 )
@@ -701,7 +700,7 @@ class DatabaseHydroDao(HydroDao):
         if hydro_pmax == HydroPmax.HOURLY:
             area_ids = self.get_impl().get_all_area_ids()
             generator = self.get_impl().generator_matrix_constants
-            hourly_matrix_id = generator.get_null_matrix().removeprefix(MATRIX_PROTOCOL_PREFIX)
+            hourly_matrix_id = generator.get_null_matrix()
             daily_matrix_id = generator.matrix_service.create(create_polars_dataframe(np.full((365, 1), 24)))
 
             hourly_rows = [

--- a/antarest/study/dao/file/common.py
+++ b/antarest/study/dao/file/common.py
@@ -12,7 +12,6 @@
 from typing import TYPE_CHECKING, Callable
 
 from antarest.core.exceptions import AreaNotFound
-from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.study.dao.common import AreaId, AreaSeriesMapping
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.factory import FileStudy
@@ -61,6 +60,6 @@ def save_area_matrices(
         url = url_getter(area_id)
         node = study_data.tree.get_node(url)
         assert isinstance(node, MatrixNode)
-        matrix_id = extract_matrix_id(series_id)
+        matrix_id = series_id
         matrices_mapping.setdefault(matrix_id, []).append(node)
     file_study_dao.save_matrices(matrices_mapping)

--- a/antarest/study/dao/file/file_study_constraint_dao.py
+++ b/antarest/study/dao/file/file_study_constraint_dao.py
@@ -18,7 +18,6 @@ from antares.study.version import StudyVersion
 from typing_extensions import override
 
 from antarest.core.exceptions import BindingConstraintNotFound
-from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.study.business.model.binding_constraint_model import (
     OPERATOR_MATRICES_MAP,
     OPERATOR_MATRIX_FILE_MAP,
@@ -233,7 +232,7 @@ class FileStudyConstraintDao(ConstraintDao, ABC):
             if constraint_id in series:
                 # We only want to save the series for given constraints and the method returned them all
                 series_id = series[constraint_id]
-                matrix_id = extract_matrix_id(series_id)
+                matrix_id = series_id
                 matrices_mapping.setdefault(matrix_id, []).append(node)
 
         # Validate that all the binding constraint ids are present in the study

--- a/antarest/study/dao/file/file_study_dao.py
+++ b/antarest/study/dao/file/file_study_dao.py
@@ -17,6 +17,7 @@ from typing_extensions import override
 
 from antarest.core.exceptions import NotAMatrixError
 from antarest.core.interfaces.cache import ICache, update_cache
+from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.dao.file.file_study_adequacy_patch_parameters_dao import FileStudyAdequacyPatchParametersDao
 from antarest.study.dao.file.file_study_advanced_parameters import FileStudyAdvancedParametersDao
@@ -186,7 +187,7 @@ class FileStudyTreeDao(
                 # For the normalized nodes, we simply get the matrix id from the matrix mapper.
                 matrix_id = matrix_node.matrix_mapper.get_link_content(matrix_node)
                 assert isinstance(matrix_id, str)
-                result[matrix_node] = matrix_id
+                result[matrix_node] = extract_matrix_id(matrix_id)
             else:
                 denormalized_nodes.append(matrix_node)
 

--- a/antarest/study/dao/file/file_study_hydro_dao.py
+++ b/antarest/study/dao/file/file_study_hydro_dao.py
@@ -16,7 +16,6 @@ import numpy as np
 import polars as pl
 
 from antarest.core.exceptions import AreaNotFound, ChildNotFoundError
-from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.study.business.model.hydro_allocation_model import HydroAllocation, HydroAllocationArea
 from antarest.study.business.model.hydro_correlation_model import (
     HydroCorrelation,
@@ -34,7 +33,6 @@ if TYPE_CHECKING:
 from typing_extensions import override
 
 from antarest.core.utils.polars import create_polars_dataframe
-from antarest.matrixstore.service import MATRIX_PROTOCOL_PREFIX
 from antarest.study.business.model.config.compatibility_parameters_model import HydroPmax
 from antarest.study.business.model.hydro_model import HydroManagement, HydroProperties, InflowStructure
 from antarest.study.dao.api.hydro_dao import HydroDao
@@ -428,7 +426,7 @@ class FileStudyHydroDao(HydroDao):
             if area_id in series:
                 # We only want to save the series for given area and the method returned them all
                 series_id = series[area_id]
-                matrix_id = extract_matrix_id(series_id)
+                matrix_id = series_id
                 matrices_mapping.setdefault(matrix_id, []).append(node)
 
         # Validate that all the area ids are present in the study
@@ -511,7 +509,7 @@ class FileStudyHydroDao(HydroDao):
         areas = file_study.config.areas.keys()
 
         hourly_matrix_id = self.get_impl().generator_matrix_constants.get_null_matrix()
-        daily_matrix_id = MATRIX_PROTOCOL_PREFIX + matrix_service.create(create_polars_dataframe(np.full((365, 1), 24)))
+        daily_matrix_id = matrix_service.create(create_polars_dataframe(np.full((365, 1), 24)))
 
         if hydro_pmax == HydroPmax.HOURLY:
             max_hourly_gen_power = {}

--- a/antarest/study/dao/file/file_study_link_dao.py
+++ b/antarest/study/dao/file/file_study_link_dao.py
@@ -17,7 +17,6 @@ import polars as pl
 from typing_extensions import override
 
 from antarest.core.exceptions import LinkNotFound
-from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.study.business.model.link_model import (
     Link,
 )
@@ -151,7 +150,7 @@ class FileStudyLinkDao(LinkDao, ABC):
             url = url_getter(area_from, area_to)
             node = study_data.tree.get_node(url)
             assert isinstance(node, MatrixNode)
-            matrix_id = extract_matrix_id(series_id)
+            matrix_id = series_id
             matrices_mapping.setdefault(matrix_id, []).append(node)
         self.get_impl().save_matrices(matrices_mapping)
 

--- a/antarest/study/dao/file/file_study_renewable_dao.py
+++ b/antarest/study/dao/file/file_study_renewable_dao.py
@@ -17,7 +17,6 @@ import polars as pl
 from typing_extensions import override
 
 from antarest.core.exceptions import ChildNotFoundError, RenewableClusterConfigNotFound, RenewableClusterNotFound
-from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.study.business.model.renewable_cluster_model import RenewableCluster
 from antarest.study.dao.api.renewable_dao import RenewableDao
 from antarest.study.dao.common import AreaId, RenewableSeriesMapping
@@ -160,7 +159,7 @@ class FileStudyRenewableDao(RenewableDao, ABC):
                 url = _get_renewable_series_path(area_id, renewable_id)
                 node = study_data.tree.get_node(url)
                 assert isinstance(node, MatrixNode)
-                matrix_id = extract_matrix_id(series_id)
+                matrix_id = series_id
                 matrices_mapping.setdefault(matrix_id, []).append(node)
         self.get_impl().save_matrices(matrices_mapping)
 

--- a/antarest/study/dao/file/file_study_st_storage_dao.py
+++ b/antarest/study/dao/file/file_study_st_storage_dao.py
@@ -18,7 +18,6 @@ import polars as pl
 from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound, ChildNotFoundError, STStorageConfigNotFound, STStorageNotFound
-from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.study.business.model.sts_model import (
     STStorage,
     STStorageAdditionalConstraint,
@@ -278,7 +277,7 @@ class FileStudySTStorageDao(STStorageDao, ABC):
                 url = url_getter(area_id, storage_id)
                 node = study_data.tree.get_node(url)
                 assert isinstance(node, MatrixNode)
-                matrix_id = extract_matrix_id(series_id)
+                matrix_id = series_id
                 matrices_mapping.setdefault(matrix_id, []).append(node)
         self.get_impl().save_matrices(matrices_mapping)
 
@@ -474,7 +473,7 @@ class FileStudySTStorageDao(STStorageDao, ABC):
                     url = _get_constraint_matrix_path(area_id, storage_id, constraint_id)
                     node = study_data.tree.get_node(url)
                     assert isinstance(node, MatrixNode)
-                    matrix_id = extract_matrix_id(series_id)
+                    matrix_id = series_id
                     matrices_mapping.setdefault(matrix_id, []).append(node)
         self.get_impl().save_matrices(matrices_mapping)
 

--- a/antarest/study/dao/file/file_study_thermal_dao.py
+++ b/antarest/study/dao/file/file_study_thermal_dao.py
@@ -22,7 +22,6 @@ from antarest.core.exceptions import (
     ThermalClusterNotFound,
 )
 from antarest.core.utils.utils import remove_first_match
-from antarest.matrixstore.matrix_uri_mapper import extract_matrix_id
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
 from antarest.study.dao.api.thermal_dao import ThermalDao
 from antarest.study.dao.common import AreaId, ThermalId, ThermalSeriesMapping
@@ -250,7 +249,7 @@ class FileStudyThermalDao(ThermalDao, ABC):
                 url = url_getter(area_id, thermal_id)
                 node = study_data.tree.get_node(url)
                 assert isinstance(node, MatrixNode)
-                matrix_id = extract_matrix_id(series_id)
+                matrix_id = series_id
                 matrices_mapping.setdefault(matrix_id, []).append(node)
         self.get_impl().save_matrices(matrices_mapping)
 

--- a/antarest/study/dao/memory/in_memory_study_dao.py
+++ b/antarest/study/dao/memory/in_memory_study_dao.py
@@ -27,7 +27,7 @@ from antarest.core.exceptions import (
 )
 from antarest.core.utils.polars import create_polars_dataframe
 from antarest.core.utils.utils import remove_first_match
-from antarest.matrixstore.service import MATRIX_PROTOCOL_PREFIX, ISimpleMatrixService
+from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.area_model import AreaInfo, AreaUI, AreaUIData
 from antarest.study.business.model.area_properties_model import AreaProperties, sort_filter_options
 from antarest.study.business.model.binding_constraint_model import (
@@ -711,10 +711,10 @@ class InMemoryStudyDao(StudyDao):
         if hydro_pmax == HydroPmax.HOURLY:
             # When converting to hourly, create and save the matrices
             for area_id in areas:
-                self.save_hydro_max_hourly_gen_power({area_id: MATRIX_PROTOCOL_PREFIX + matrix_service.create(hourly)})
-                self.save_hydro_max_hourly_pump_power({area_id: MATRIX_PROTOCOL_PREFIX + matrix_service.create(hourly)})
-                self.save_hydro_max_daily_gen_energy({area_id: MATRIX_PROTOCOL_PREFIX + matrix_service.create(daily)})
-                self.save_hydro_max_daily_pump_energy({area_id: MATRIX_PROTOCOL_PREFIX + matrix_service.create(daily)})
+                self.save_hydro_max_hourly_gen_power({area_id: matrix_service.create(hourly)})
+                self.save_hydro_max_hourly_pump_power({area_id: matrix_service.create(hourly)})
+                self.save_hydro_max_daily_gen_energy({area_id: matrix_service.create(daily)})
+                self.save_hydro_max_daily_pump_energy({area_id: matrix_service.create(daily)})
         else:
             # When converting away from hourly, remove the matrices from in-memory storage
             for area_id in areas:

--- a/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
+++ b/antarest/study/storage/variantstudy/business/matrix_constants_generator.py
@@ -14,7 +14,7 @@
 import polars as pl
 from antares.study.version import StudyVersion
 
-from antarest.matrixstore.service import MATRIX_PROTOCOL_PREFIX, ISimpleMatrixService
+from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.model import STUDY_VERSION_6_5, STUDY_VERSION_8_2
 from antarest.study.storage.variantstudy.business import matrix_constants
 from antarest.study.storage.variantstudy.business.matrix_constants.common import (
@@ -140,97 +140,97 @@ class GeneratorMatrixConstants:
 
     def get_hydro_max_power(self, version: StudyVersion) -> str:
         if version > STUDY_VERSION_6_5:
-            return MATRIX_PROTOCOL_PREFIX + self.hashes[HYDRO_COMMON_CAPACITY_MAX_POWER_V7]
+            return self.hashes[HYDRO_COMMON_CAPACITY_MAX_POWER_V7]
         else:
-            return MATRIX_PROTOCOL_PREFIX + self.hashes[NULL_MATRIX_NAME]
+            return self.hashes[NULL_MATRIX_NAME]
 
     def get_hydro_reservoir(self, version: StudyVersion) -> str:
         if version > STUDY_VERSION_6_5:
-            return MATRIX_PROTOCOL_PREFIX + self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V7]
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V6]
+            return self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V7]
+        return self.hashes[HYDRO_COMMON_CAPACITY_RESERVOIR_V6]
 
     def get_hydro_credit_modulations(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[HYDRO_COMMON_CAPACITY_CREDIT_MODULATION]
+        return self.hashes[HYDRO_COMMON_CAPACITY_CREDIT_MODULATION]
 
     def get_hydro_inflow_pattern(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[HYDRO_COMMON_CAPACITY_INFLOW_PATTERN]
+        return self.hashes[HYDRO_COMMON_CAPACITY_INFLOW_PATTERN]
 
     def get_prepro_conversion(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[PREPRO_CONVERSION]
+        return self.hashes[PREPRO_CONVERSION]
 
     def get_prepro_data(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[PREPRO_DATA]
+        return self.hashes[PREPRO_DATA]
 
     def get_thermal_prepro_data(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[THERMAL_PREPRO_DATA]
+        return self.hashes[THERMAL_PREPRO_DATA]
 
     def get_thermal_prepro_modulation(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[THERMAL_PREPRO_MODULATION]
+        return self.hashes[THERMAL_PREPRO_MODULATION]
 
     def get_link(self, version: StudyVersion) -> str:
         if version < STUDY_VERSION_8_2:
-            return MATRIX_PROTOCOL_PREFIX + self.hashes[LINK_V7]
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[LINK_V8]
+            return self.hashes[LINK_V7]
+        return self.hashes[LINK_V8]
 
     def get_link_direct(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[LINK_DIRECT]
+        return self.hashes[LINK_DIRECT]
 
     def get_link_indirect(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[LINK_INDIRECT]
+        return self.hashes[LINK_INDIRECT]
 
     def get_null_matrix(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[NULL_MATRIX_NAME]
+        return self.hashes[NULL_MATRIX_NAME]
 
     def get_default_reserves(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[RESERVES_TS]
+        return self.hashes[RESERVES_TS]
 
     def get_default_miscgen(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[MISCGEN_TS]
+        return self.hashes[MISCGEN_TS]
 
     def get_binding_constraint_hourly_86(self) -> str:
         """2D-matrix of shape (8784, 3), filled-in with zeros."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[BINDING_CONSTRAINT_HOURLY_v86]
+        return self.hashes[BINDING_CONSTRAINT_HOURLY_v86]
 
     def get_binding_constraint_daily_weekly_86(self) -> str:
         """2D-matrix of shape (366, 3), filled-in with zeros."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[BINDING_CONSTRAINT_DAILY_WEEKLY_v86]
+        return self.hashes[BINDING_CONSTRAINT_DAILY_WEEKLY_v86]
 
     def get_binding_constraint_hourly_87(self) -> str:
         """2D-matrix of shape (8784, 1), filled-in with zeros."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[BINDING_CONSTRAINT_HOURLY_v87]
+        return self.hashes[BINDING_CONSTRAINT_HOURLY_v87]
 
     def get_binding_constraint_daily_weekly_87(self) -> str:
         """2D-matrix of shape (8784, 1), filled-in with zeros."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[BINDING_CONSTRAINT_DAILY_WEEKLY_v87]
+        return self.hashes[BINDING_CONSTRAINT_DAILY_WEEKLY_v87]
 
     def get_st_storage_pmax_injection(self) -> str:
         """2D-matrix of shape (8760, 1), filled-in with ones."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[ST_STORAGE_PMAX_INJECTION]
+        return self.hashes[ST_STORAGE_PMAX_INJECTION]
 
     def get_st_storage_pmax_withdrawal(self) -> str:
         """2D-matrix of shape (8760, 1), filled-in with ones."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[ST_STORAGE_PMAX_WITHDRAWAL]
+        return self.hashes[ST_STORAGE_PMAX_WITHDRAWAL]
 
     def get_st_storage_lower_rule_curve(self) -> str:
         """2D-matrix of shape (8760, 1), filled-in with zeros."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[ST_STORAGE_LOWER_RULE_CURVE]
+        return self.hashes[ST_STORAGE_LOWER_RULE_CURVE]
 
     def get_st_storage_upper_rule_curve(self) -> str:
         """2D-matrix of shape (8760, 1), filled-in with ones."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[ST_STORAGE_UPPER_RULE_CURVE]
+        return self.hashes[ST_STORAGE_UPPER_RULE_CURVE]
 
     def get_st_storage_inflows(self) -> str:
         """2D-matrix of shape (8760, 1), filled-in with zeros."""
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[ST_STORAGE_INFLOWS]
+        return self.hashes[ST_STORAGE_INFLOWS]
 
     def get_hydro_max_hourly_gen_power(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[HYDRO_SERIES_MAX_HOURLY_GEN_POWER]
+        return self.hashes[HYDRO_SERIES_MAX_HOURLY_GEN_POWER]
 
     def get_hydro_max_hourly_pump_power(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[HYDRO_SERIES_MAX_HOURLY_PUMP_POWER]
+        return self.hashes[HYDRO_SERIES_MAX_HOURLY_PUMP_POWER]
 
     def get_hydro_max_daily_gen_energy(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[HYDRO_COMMON_CAPACITY_MAX_DAILY_GEN_ENERGY]
+        return self.hashes[HYDRO_COMMON_CAPACITY_MAX_DAILY_GEN_ENERGY]
 
     def get_hydro_max_daily_pump_energy(self) -> str:
-        return MATRIX_PROTOCOL_PREFIX + self.hashes[HYDRO_COMMON_CAPACITY_MAX_DAILY_PUMP_ENERGY]
+        return self.hashes[HYDRO_COMMON_CAPACITY_MAX_DAILY_PUMP_ENERGY]

--- a/antarest/study/storage/variantstudy/business/utils.py
+++ b/antarest/study/storage/variantstudy/business/utils.py
@@ -37,7 +37,7 @@ def validate_matrix(matrix: list[list[MatrixData]] | str, values: dict[str, Any]
               and checking the existence of matrices.
 
     Returns:
-        The ID of the validated matrix prefixed by "matrix://".
+        The plain SHA256 hash ID of the validated matrix (no prefix).
 
     Raises:
         TypeError: If the provided matrix is neither a matrix nor a link to a matrix.
@@ -46,12 +46,14 @@ def validate_matrix(matrix: list[list[MatrixData]] | str, values: dict[str, Any]
 
     matrix_service: ISimpleMatrixService = values["command_context"].matrix_service
     if isinstance(matrix, list):
-        return MATRIX_PROTOCOL_PREFIX + matrix_service.create(create_polars_dataframe(matrix))
+        return matrix_service.create(create_polars_dataframe(matrix))
     elif isinstance(matrix, str):
+        # Strip any legacy "matrix://" prefix that may have been stored in older DTOs.
+        matrix = matrix.removeprefix(MATRIX_PROTOCOL_PREFIX)
         if not matrix:
             raise ValueError("The matrix ID cannot be empty")
         elif matrix_service.exists(matrix):
-            return MATRIX_PROTOCOL_PREFIX + matrix
+            return matrix
         else:
             raise ValueError(f"Matrix with id '{matrix}' does not exist")
     else:

--- a/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
+++ b/antarest/study/storage/variantstudy/model/command/create_binding_constraint.py
@@ -40,7 +40,7 @@ from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.model import STUDY_VERSION_8_7
 from antarest.study.storage.rawstudy.model.filesystem.config.binding_constraint import parse_binding_constraint
 from antarest.study.storage.rawstudy.model.filesystem.config.identifier import transform_name_to_id
-from antarest.study.storage.variantstudy.business.utils import strip_matrix_protocol, validate_matrix
+from antarest.study.storage.variantstudy.business.utils import validate_matrix
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
@@ -137,7 +137,7 @@ class AbstractBindingConstraintCommand(ICommand, metaclass=ABCMeta):
             return None
         if isinstance(v, str):
             # Check the matrix link
-            return validate_matrix(strip_matrix_protocol(v), {"command_context": self.command_context})
+            return validate_matrix(v, {"command_context": self.command_context})
         if isinstance(v, list):
             check_matrix_values(time_step, v, self.study_version)
             return validate_matrix(v, {"command_context": self.command_context})

--- a/antarest/study/storage/variantstudy/model/command/create_cluster.py
+++ b/antarest/study/storage/variantstudy/model/command/create_cluster.py
@@ -17,7 +17,6 @@ from pydantic import Field, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import override
 
-from antarest.core.utils.utils import assert_this
 from antarest.matrixstore.model import MatrixData
 from antarest.study.business.model.thermal_cluster_model import (
     ThermalCluster,
@@ -31,7 +30,7 @@ from antarest.study.storage.rawstudy.model.filesystem.config.thermal import (
     parse_thermal_cluster,
 )
 from antarest.study.storage.rawstudy.model.filesystem.config.validation import AreaId
-from antarest.study.storage.variantstudy.business.utils import strip_matrix_protocol, validate_matrix
+from antarest.study.storage.variantstudy.business.utils import validate_matrix
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
@@ -134,8 +133,8 @@ class CreateCluster(ICommand):
             args={
                 "area_id": self.area_id,
                 "parameters": self.parameters.model_dump(mode="json", by_alias=True, exclude_none=True),
-                "prepro": strip_matrix_protocol(self.prepro),
-                "modulation": strip_matrix_protocol(self.modulation),
+                "prepro": self.prepro,
+                "modulation": self.modulation,
             },
             study_version=self.study_version,
         )
@@ -144,9 +143,9 @@ class CreateCluster(ICommand):
     def get_inner_matrices(self) -> InnerMatrices:
         matrices: list[str] = []
         if self.prepro:
-            assert_this(isinstance(self.prepro, str))
-            matrices.append(strip_matrix_protocol(self.prepro))
+            assert isinstance(self.prepro, str)
+            matrices.append(self.prepro)
         if self.modulation:
-            assert_this(isinstance(self.modulation, str))
-            matrices.append(strip_matrix_protocol(self.modulation))
+            assert isinstance(self.modulation, str)
+            matrices.append(self.modulation)
         return InnerMatrices(matrices=matrices)

--- a/antarest/study/storage/variantstudy/model/command/create_link.py
+++ b/antarest/study/storage/variantstudy/model/command/create_link.py
@@ -22,7 +22,7 @@ from antarest.study.business.model.link_model import Link, LinkCreation, LinkUpd
 from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.model import STUDY_VERSION_8_2, StudyVersionStr
 from antarest.study.storage.rawstudy.model.filesystem.config.link import parse_link
-from antarest.study.storage.variantstudy.business.utils import strip_matrix_protocol, validate_matrix
+from antarest.study.storage.variantstudy.business.utils import validate_matrix
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
@@ -78,7 +78,7 @@ class AbstractLinkCommand(AntaresBaseModel, extra="forbid"):
         }
         for attr in MATRIX_ATTRIBUTES:
             if value := getattr(self, attr, None):
-                args[attr] = strip_matrix_protocol(value)
+                args[attr] = value
         return CommandDTO(
             version=self._SERIALIZATION_VERSION,
             action=command_name.value,
@@ -91,7 +91,7 @@ class AbstractLinkCommand(AntaresBaseModel, extra="forbid"):
         for attr in MATRIX_ATTRIBUTES:
             if value := getattr(self, attr, None):
                 assert_this(isinstance(value, str))
-                list_matrices.append(strip_matrix_protocol(value))
+                list_matrices.append(value)
         return InnerMatrices(matrices=list_matrices)
 
 

--- a/antarest/study/storage/variantstudy/model/command/create_st_storage.py
+++ b/antarest/study/storage/variantstudy/model/command/create_st_storage.py
@@ -25,7 +25,7 @@ from antarest.study.storage.rawstudy.model.filesystem.config.identifier import t
 from antarest.study.storage.rawstudy.model.filesystem.config.st_storage import parse_st_storage
 from antarest.study.storage.rawstudy.model.filesystem.config.validation import AreaId
 from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
-from antarest.study.storage.variantstudy.business.utils import strip_matrix_protocol, validate_matrix
+from antarest.study.storage.variantstudy.business.utils import validate_matrix
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
@@ -228,13 +228,13 @@ class CreateSTStorage(ICommand):
         Returns:
             The DTO object representing the current command.
         """
-        args = {
+        args: dict[str, Any] = {
             "area_id": self.area_id,
             "parameters": self.parameters.model_dump(mode="json", by_alias=True, exclude_none=True),
         }
         for matrix_name, matrix_data in self._get_matrices().items():
             if matrix_data is not None:
-                args[matrix_name] = strip_matrix_protocol(matrix_data)
+                args[matrix_name] = matrix_data
         return CommandDTO(
             action=self.command_name.value,
             version=self._SERIALIZATION_VERSION,
@@ -250,7 +250,8 @@ class CreateSTStorage(ICommand):
         matrices: list[str] = []
         for matrix_name, matrix_data in self._get_matrices().items():
             if matrix_data is not None:
-                matrices.append(strip_matrix_protocol(matrix_data))
+                assert isinstance(matrix_data, str)
+                matrices.append(matrix_data)
         return InnerMatrices(matrices=matrices)
 
     def _fill_none_matrices(self) -> dict[str, str]:

--- a/antarest/study/storage/variantstudy/model/command/create_xpansion_matrix.py
+++ b/antarest/study/storage/variantstudy/model/command/create_xpansion_matrix.py
@@ -14,10 +14,9 @@
 from pydantic import Field, ValidationInfo, field_validator
 from typing_extensions import override
 
-from antarest.core.utils.utils import assert_this
 from antarest.matrixstore.model import MatrixData
 from antarest.study.dao.api.study_dao import StudyDao
-from antarest.study.storage.variantstudy.business.utils import strip_matrix_protocol, validate_matrix
+from antarest.study.storage.variantstudy.business.utils import validate_matrix
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
@@ -42,16 +41,17 @@ class AbstractCreateXpansionMatrix(ICommand):
 
     @override
     def to_dto(self) -> CommandDTO:
+        assert isinstance(self.matrix, str)
         return CommandDTO(
             action=self.command_name.value,
-            args={"filename": self.filename, "matrix": strip_matrix_protocol(self.matrix)},
+            args={"filename": self.filename, "matrix": self.matrix},
             study_version=self.study_version,
         )
 
     @override
     def get_inner_matrices(self) -> InnerMatrices:
-        assert_this(isinstance(self.matrix, str))
-        return InnerMatrices(matrices=[strip_matrix_protocol(self.matrix)])
+        assert isinstance(self.matrix, str)
+        return InnerMatrices(matrices=[self.matrix])
 
 
 class CreateXpansionWeight(AbstractCreateXpansionMatrix):

--- a/antarest/study/storage/variantstudy/model/command/replace_matrix.py
+++ b/antarest/study/storage/variantstudy/model/command/replace_matrix.py
@@ -14,11 +14,10 @@ from pathlib import PurePosixPath
 from pydantic import Field, ValidationInfo, field_validator
 from typing_extensions import override
 
-from antarest.core.utils.utils import assert_this
 from antarest.matrixstore.model import MatrixData
 from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.storage.rawstudy.raw_path_to_matrix_mapper import RawPathToMatrixMapper
-from antarest.study.storage.variantstudy.business.utils import AliasDecoder, strip_matrix_protocol, validate_matrix
+from antarest.study.storage.variantstudy.business.utils import AliasDecoder, validate_matrix
 from antarest.study.storage.variantstudy.model.command.common import (
     CommandName,
     CommandOutput,
@@ -64,11 +63,11 @@ class ReplaceMatrix(ICommand):
     def to_dto(self) -> CommandDTO:
         return CommandDTO(
             action=CommandName.REPLACE_MATRIX.value,
-            args={"target": self.target, "matrix": strip_matrix_protocol(self.matrix)},
+            args={"target": self.target, "matrix": self.matrix},
             study_version=self.study_version,
         )
 
     @override
     def get_inner_matrices(self) -> InnerMatrices:
-        assert_this(isinstance(self.matrix, str))
-        return InnerMatrices(matrices=[strip_matrix_protocol(self.matrix)])
+        assert isinstance(self.matrix, str)
+        return InnerMatrices(matrices=[self.matrix])

--- a/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
+++ b/tests/study/storage/variantstudy/business/test_matrix_constants_generator.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from antarest.core.config import InternalMatrixFormat
 from antarest.matrixstore.repository import MatrixContentRepository
-from antarest.matrixstore.service import MATRIX_PROTOCOL_PREFIX, SimpleMatrixService
+from antarest.matrixstore.service import SimpleMatrixService
 from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default import (
     default_scenario_hourly,
     default_scenario_hourly_ones,
@@ -37,29 +37,24 @@ class TestGeneratorMatrixConstants:
         generator.init_constant_matrices()
 
         ref1 = generator.get_st_storage_pmax_injection()
-        matrix_id1 = ref1.split(MATRIX_PROTOCOL_PREFIX)[1]
-        matrix_dto1 = generator.matrix_service.get(matrix_id1)
+        matrix_dto1 = generator.matrix_service.get(ref1)
 
         assert np.array_equal(matrix_dto1.to_numpy(), default_scenario_hourly_ones())
 
         ref2 = generator.get_st_storage_pmax_withdrawal()
-        matrix_id2 = ref2.split(MATRIX_PROTOCOL_PREFIX)[1]
-        matrix_dto2 = generator.matrix_service.get(matrix_id2)
+        matrix_dto2 = generator.matrix_service.get(ref2)
         assert np.array_equal(matrix_dto2.to_numpy(), default_scenario_hourly_ones())
 
         ref3 = generator.get_st_storage_lower_rule_curve()
-        matrix_id3 = ref3.split(MATRIX_PROTOCOL_PREFIX)[1]
-        matrix_dto3 = generator.matrix_service.get(matrix_id3)
+        matrix_dto3 = generator.matrix_service.get(ref3)
         assert np.array_equal(matrix_dto3.to_numpy(), default_scenario_hourly())
 
         ref4 = generator.get_st_storage_upper_rule_curve()
-        matrix_id4 = ref4.split(MATRIX_PROTOCOL_PREFIX)[1]
-        matrix_dto4 = generator.matrix_service.get(matrix_id4)
+        matrix_dto4 = generator.matrix_service.get(ref4)
         assert np.array_equal(matrix_dto4.to_numpy(), default_scenario_hourly_ones())
 
         ref5 = generator.get_st_storage_inflows()
-        matrix_id5 = ref5.split(MATRIX_PROTOCOL_PREFIX)[1]
-        matrix_dto5 = generator.matrix_service.get(matrix_id5)
+        matrix_dto5 = generator.matrix_service.get(ref5)
         assert np.array_equal(matrix_dto5.to_numpy(), default_scenario_hourly())
 
     def test_get_binding_constraint_before_v87(self, tmp_path: Path) -> None:
@@ -73,11 +68,9 @@ class TestGeneratorMatrixConstants:
         series = matrix_constants.binding_constraint.series_before_v87
 
         hourly = generator.get_binding_constraint_hourly_86()
-        hourly_matrix_id = hourly.split(MATRIX_PROTOCOL_PREFIX)[1]
-        hourly_matrix_dto = generator.matrix_service.get(hourly_matrix_id)
+        hourly_matrix_dto = generator.matrix_service.get(hourly)
         assert hourly_matrix_dto.to_numpy().all() == series.default_bc_hourly().all()
 
         daily_weekly = generator.get_binding_constraint_daily_weekly_86()
-        matrix_id = daily_weekly.split(MATRIX_PROTOCOL_PREFIX)[1]
-        matrix_dto = generator.matrix_service.get(matrix_id)
+        matrix_dto = generator.matrix_service.get(daily_weekly)
         assert matrix_dto.to_numpy().all() == series.default_bc_weekly_daily().all()

--- a/tests/variantstudy/model/command/test_create_cluster.py
+++ b/tests/variantstudy/model/command/test_create_cluster.py
@@ -58,8 +58,8 @@ class TestCreateCluster:
         assert cl.parameters == ThermalClusterCreation(
             name="Cluster1", group=ThermalClusterGroup.NUCLEAR, unit_count=2, nominal_capacity=2400
         )
-        assert cl.prepro == f"matrix://{prepro_id}"
-        assert cl.modulation == f"matrix://{modulation_id}"
+        assert cl.prepro == prepro_id
+        assert cl.modulation == modulation_id
 
     def test_validate_cluster_name(self, command_context: CommandContext) -> None:
         with pytest.raises(ValidationError, match="name"):

--- a/tests/variantstudy/model/command/test_create_st_storage.py
+++ b/tests/variantstudy/model/command/test_create_st_storage.py
@@ -368,9 +368,9 @@ class TestCreateSTStorage:
         expected = {
             "storage1": {
                 "pmax_injection": f"matrix://{pmax_injection_id}",
-                "pmax_withdrawal": constants.get_st_storage_pmax_withdrawal(),
-                "lower_rule_curve": constants.get_st_storage_lower_rule_curve(),
-                "upper_rule_curve": constants.get_st_storage_upper_rule_curve(),
+                "pmax_withdrawal": f"matrix://{constants.get_st_storage_pmax_withdrawal()}",
+                "lower_rule_curve": f"matrix://{constants.get_st_storage_lower_rule_curve()}",
+                "upper_rule_curve": f"matrix://{constants.get_st_storage_upper_rule_curve()}",
                 "inflows": f"matrix://{inflows_id}",
             }
         }

--- a/tests/variantstudy/model/command/test_create_xpansion_resource.py
+++ b/tests/variantstudy/model/command/test_create_xpansion_resource.py
@@ -65,7 +65,7 @@ class TestCreateXpansionResource:
             assert output.status, output.message
             resource_path = empty_study.config.study_path / "user" / "expansion" / "weights" / f"{file_name}.link"
             assert resource_path.exists()
-            assert resource_path.read_text().startswith("matrix://")
+            assert resource_path.read_text() and not resource_path.read_text().startswith("matrix://")
             matrix_node = empty_study.tree.get_node(["user", "expansion", "weights", file_name])
             assert isinstance(matrix_node, MatrixNode)
             matrix = matrix_node.parse_as_dataframe()
@@ -85,7 +85,7 @@ class TestCreateXpansionResource:
             assert output.status, output.message
             resource_path = empty_study.config.study_path / "user" / "expansion" / "capa" / f"{file_name}.link"
             assert resource_path.exists()
-            assert resource_path.read_text().startswith("matrix://")
+            assert resource_path.read_text() and not resource_path.read_text().startswith("matrix://")
             matrix_node = empty_study.tree.get_node(["user", "expansion", "capa", file_name])
             assert isinstance(matrix_node, MatrixNode)
             matrix = matrix_node.parse_as_dataframe()

--- a/tests/variantstudy/test_command_factory.py
+++ b/tests/variantstudy/test_command_factory.py
@@ -261,7 +261,17 @@ COMMANDS = [
             study_version=STUDY_VERSION_8_8,
             version=2,
         ),
-        None,
+        {
+            "matrices": {"greaterTermMatrix": "fake_matrix"},
+            "parameters": {
+                "enabled": False,
+                "filterSynthesis": "weekly",
+                "group": "group 1",
+                "name": "name",
+                "operator": "equal",
+                "timeStep": "hourly",
+            },
+        },
         id="create_binding_constraint",
     ),
     pytest.param(
@@ -278,7 +288,7 @@ COMMANDS = [
             study_version=STUDY_VERSION_8_8,
             version=2,
         ),
-        None,
+        [{"matrices": {"equalTermMatrix": "fake_matrix"}, "parameters": {"name": "name"}}],
         id="create_binding_constraint_list",
     ),
     pytest.param(
@@ -650,8 +660,8 @@ COMMANDS = [
         ),
         {
             "area_id": "area 1",
-            "inflows": "matrix://df9b25e1-e3f7-4a57-8182-0ff9791439e5",
-            "lower_rule_curve": "matrix://8ce4fcea-cc97-4d2c-b641-a27a53454612",
+            "inflows": "df9b25e1-e3f7-4a57-8182-0ff9791439e5",
+            "lower_rule_curve": "8ce4fcea-cc97-4d2c-b641-a27a53454612",
             "parameters": {
                 "efficiency": 1.0,
                 "enabled": True,
@@ -663,9 +673,9 @@ COMMANDS = [
                 "reservoirCapacity": 0.0,
                 "withdrawalNominalCapacity": 0.0,
             },
-            "pmax_injection": "matrix://59ea6c83-6348-466d-9530-c35c51ca4c37",
-            "pmax_withdrawal": "matrix://5f988548-dadc-4bbb-8ce8-87a544dbf756",
-            "upper_rule_curve": "matrix://8ce614c8-c687-41af-8b24-df8a49cc52af",
+            "pmax_injection": "59ea6c83-6348-466d-9530-c35c51ca4c37",
+            "pmax_withdrawal": "5f988548-dadc-4bbb-8ce8-87a544dbf756",
+            "upper_rule_curve": "8ce614c8-c687-41af-8b24-df8a49cc52af",
         },
         id="create_st_storage",
     ),
@@ -718,8 +728,8 @@ COMMANDS = [
         [
             {
                 "area_id": "area 1",
-                "inflows": "matrix://df9b25e1-e3f7-4a57-8182-0ff9791439e5",
-                "lower_rule_curve": "matrix://8ce4fcea-cc97-4d2c-b641-a27a53454612",
+                "inflows": "df9b25e1-e3f7-4a57-8182-0ff9791439e5",
+                "lower_rule_curve": "8ce4fcea-cc97-4d2c-b641-a27a53454612",
                 "parameters": {
                     "efficiency": 1.0,
                     "enabled": True,
@@ -731,14 +741,14 @@ COMMANDS = [
                     "reservoirCapacity": 0.0,
                     "withdrawalNominalCapacity": 0.0,
                 },
-                "pmax_injection": "matrix://59ea6c83-6348-466d-9530-c35c51ca4c37",
-                "pmax_withdrawal": "matrix://5f988548-dadc-4bbb-8ce8-87a544dbf756",
-                "upper_rule_curve": "matrix://8ce614c8-c687-41af-8b24-df8a49cc52af",
+                "pmax_injection": "59ea6c83-6348-466d-9530-c35c51ca4c37",
+                "pmax_withdrawal": "5f988548-dadc-4bbb-8ce8-87a544dbf756",
+                "upper_rule_curve": "8ce614c8-c687-41af-8b24-df8a49cc52af",
             },
             {
                 "area_id": "area 1",
-                "inflows": "matrix://e8923768-9bdd-40c2-a6ea-2da2523be727",
-                "lower_rule_curve": "matrix://16c7c3ae-9824-4ef2-aa68-51145884b025",
+                "inflows": "e8923768-9bdd-40c2-a6ea-2da2523be727",
+                "lower_rule_curve": "16c7c3ae-9824-4ef2-aa68-51145884b025",
                 "parameters": {
                     "efficiency": 0.94,
                     "enabled": True,
@@ -750,9 +760,9 @@ COMMANDS = [
                     "reservoirCapacity": 0.0,
                     "withdrawalNominalCapacity": 0.0,
                 },
-                "pmax_injection": "matrix://3f5b3746-3995-49b7-a6da-622633472e05",
-                "pmax_withdrawal": "matrix://4b64a31f-927b-4887-b4cd-adcddd39bdcd",
-                "upper_rule_curve": "matrix://9a6104e9-990a-415f-a6e2-57507e13b58c",
+                "pmax_injection": "3f5b3746-3995-49b7-a6da-622633472e05",
+                "pmax_withdrawal": "4b64a31f-927b-4887-b4cd-adcddd39bdcd",
+                "upper_rule_curve": "9a6104e9-990a-415f-a6e2-57507e13b58c",
             },
         ],
         id="create_st_storage_list",
@@ -1350,7 +1360,7 @@ def test_parse_create_binding_constraint_dto_v1(command_factory: CommandFactory)
     assert dto.version == 2
     assert dto.args == {
         "matrices": {
-            "lessTermMatrix": "matrix://matrix",
+            "lessTermMatrix": "matrix",
         },
         "parameters": {
             "comments": "",


### PR DESCRIPTION

- in database DAO, we currently save some matrix identifiers with their matrix:// prefix.
  This does not work, because the database schema only allows 64 chars length.

- that prefix is actually unused and will likely have no use in the future. It makes the code
  unnecessarily complex
--> let's remove it. We still need to strip it from already saved matrix IDs though (link files and commands)