### PR TITLE
feat(logging): use ECS formatter, add more context fields

### DIFF
--- a/antarest/core/logging/utils.py
+++ b/antarest/core/logging/utils.py
@@ -96,6 +96,7 @@ def configure_logger(config: Config, handler_cls: str = "logging.FileHandler") -
             "json": {
                 "()": ecs_logging.StdlibFormatter,
                 "exclude_fields": ["log.original"],
+                "ensure_ascii": False,
             },
         },
         "handlers": {

--- a/antarest/core/logging/utils.py
+++ b/antarest/core/logging/utils.py
@@ -85,16 +85,7 @@ def configure_logger(config: Config, handler_cls: str = "logging.FileHandler") -
         "formatters": {
             "console": {
                 "class": "antarest.core.logging.utils.CustomDefaultFormatter",
-                "format": (
-                    "[%(asctime)s] [%(process)s] [%(name)s]"
-                    " - %(trace_id)s"
-                    " - %(task_id)s"
-                    " - %(threadName)s"
-                    " - %(ip)s"
-                    " - %(user)s"
-                    " - %(levelname)s"
-                    " - %(message)s"
-                ),
+                "format": "[%(asctime)s] [%(name)s] - %(threadName)s - %(levelname)s - %(message)s",
             },
             "json": {
                 "()": ecs_logging.StdlibFormatter,

--- a/antarest/core/logging/utils.py
+++ b/antarest/core/logging/utils.py
@@ -18,6 +18,7 @@ from collections.abc import Iterator
 from contextvars import ContextVar, Token
 from typing import Any
 
+import ecs_logging
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
@@ -93,20 +94,8 @@ def configure_logger(config: Config, handler_cls: str = "logging.FileHandler") -
                 ),
             },
             "json": {
-                "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
-                "format": (
-                    "%(asctime)s"
-                    " - %(process)s"
-                    " - %(worker_id)s"
-                    " - %(name)s"
-                    " - %(trace_id)s"
-                    " - %(task_id)s"
-                    " - %(threadName)s"
-                    " - %(ip)s"
-                    " - %(user)s"
-                    " - %(levelname)s"
-                    " - %(message)s"
-                ),
+                "()": ecs_logging.StdlibFormatter,
+                "exclude_fields": ["log.original"],
             },
         },
         "handlers": {
@@ -136,6 +125,7 @@ def configure_logger(config: Config, handler_cls: str = "logging.FileHandler") -
             },
         },
     }
+
     if config.logging.logfile is not None:
         if handler_cls == "logging.FileHandler":
             logging_config["handlers"]["default"] = {
@@ -179,6 +169,11 @@ def configure_logger(config: Config, handler_cls: str = "logging.FileHandler") -
 
 
 class LoggingMiddleware(BaseHTTPMiddleware):
+    """
+    This actually only sets the current request as a global context variable,
+    so that it's accessible at log time.
+    """
+
     @override
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         with RequestContext(request):
@@ -193,16 +188,48 @@ class LoggingMiddleware(BaseHTTPMiddleware):
 
 
 class ContextFilter(logging.Filter):
+    """
+    Enriches logs with more context, trying to respect ECS format where relevant.
+    """
+
     @override
     def filter(self, record: logging.LogRecord) -> bool:
         if request := _request.get():
-            record.ip = request.scope.get("client", "undefined")[0]
+            # Client information
+            if client := request.client:
+                setattr(record, "client.ip", client.host)
+                setattr(record, "client.port", client.port)
+
+            # User agent
+            if user_agent := request.headers.get("user-agent", None):
+                setattr(record, "user_agent.original", user_agent)
+
+            # HTTP information
+            if http_version := request.scope.get("http_version", None):
+                setattr(record, "http.version", http_version)
+            setattr(record, "http.request.method", request.method)
+            if referrer := request.headers.get("referer", None):
+                setattr(record, "http.request.referrer", referrer)
+            # Note: route is not part of ECS format, but is part of OTel
+            if route := request.scope.get("route", None):
+                endpoint = request.scope["root_path"] + route.path
+                setattr(record, "http.route", endpoint)
+
+            # Basic URL information
+            url = request.url
+            setattr(record, "url.original", str(url))
+            setattr(record, "url.path", url.path)
+            setattr(record, "url.query", url.query)
+            setattr(record, "url.scheme", url.scheme)
+            setattr(record, "url.port", url.port)
+            setattr(record, "url.fragment", url.fragment)
+
         if request_id := _request_id.get():
             record.trace_id = request_id
         if task_id := _task_id.get():
             record.task_id = task_id
         if current_user := get_current_user():
-            record.user = current_user.id
+            setattr(record, "user.id", current_user.id)
         record.worker_id = ANTAREST_WORKER_ID
         return True
 

--- a/antarest/core/logging/utils.py
+++ b/antarest/core/logging/utils.py
@@ -35,6 +35,9 @@ _task_id: ContextVar[str | None] = ContextVar("_task_id", default=None)
 
 logger = logging.getLogger(__name__)
 
+# Those endpoints may expose secrets, we restrict what we log for them
+SENSITIVE_ENDPOINTS = ("/v1/login", "/v1/ws")
+
 
 class CustomDefaultFormatter(logging.Formatter):
     """
@@ -196,6 +199,8 @@ class ContextFilter(logging.Filter):
     @override
     def filter(self, record: logging.LogRecord) -> bool:
         if request := _request.get():
+            is_sensitive = any(endpoint in request.url.path for endpoint in SENSITIVE_ENDPOINTS)
+
             # Client information
             if client := request.client:
                 setattr(record, "client.ip", client.host)
@@ -209,8 +214,9 @@ class ContextFilter(logging.Filter):
             if http_version := request.scope.get("http_version", None):
                 setattr(record, "http.version", http_version)
             setattr(record, "http.request.method", request.method)
-            if referrer := request.headers.get("referer", None):
-                setattr(record, "http.request.referrer", referrer)
+            if not is_sensitive:
+                if referrer := request.headers.get("referer", None):
+                    setattr(record, "http.request.referrer", referrer)
             # Note: route is not part of ECS format, but is part of OTel
             if route := request.scope.get("route", None):
                 endpoint = request.scope["root_path"] + route.path
@@ -218,12 +224,13 @@ class ContextFilter(logging.Filter):
 
             # Basic URL information
             url = request.url
-            setattr(record, "url.original", str(url))
             setattr(record, "url.path", url.path)
-            setattr(record, "url.query", url.query)
             setattr(record, "url.scheme", url.scheme)
             setattr(record, "url.port", url.port)
             setattr(record, "url.fragment", url.fragment)
+            if not is_sensitive:
+                setattr(record, "url.original", str(url))
+                setattr(record, "url.query", url.query)
 
         if request_id := _request_id.get():
             record.trace_id = request_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "tables==3.10.2",
     "typing_extensions~=4.15.0",
     "xlsxwriter~=3.2.0",
-    "ecs-logging>=2.3.0",
+    "ecs-logging~=2.3.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "tables==3.10.2",
     "typing_extensions~=4.15.0",
     "xlsxwriter~=3.2.0",
+    "ecs-logging>=2.3.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "pyarrow~=23.0.1",
     "py7zr~=0.22.0",
     "prometheus-client==0.24.1",
-    "python-json-logger~=2.0.7",
     "PyYAML~=6.0.3",
     # Note: celery[redis]~=5.5.x requires redis<6.0.0
     "celery[redis]~=5.6.2",

--- a/uv.lock
+++ b/uv.lock
@@ -116,6 +116,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "celery", extra = ["redis"] },
     { name = "click" },
+    { name = "ecs-logging" },
     { name = "fastapi" },
     { name = "filelock" },
     { name = "gunicorn" },
@@ -204,6 +205,7 @@ requires-dist = [
     { name = "bcrypt", specifier = "~=5.0.0" },
     { name = "celery", extras = ["redis"], specifier = "~=5.6.2" },
     { name = "click", specifier = "~=8.3.0" },
+    { name = "ecs-logging", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = "==0.135.1" },
     { name = "filelock", specifier = "~=3.25.2" },
     { name = "gunicorn", specifier = "~=23.0.0" },
@@ -932,6 +934,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ecs-logging"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/9e/ea78919dd88d06a4bf622717e0127c763d3017bdb550e42d9f4b3e4007b1/ecs_logging-2.3.0.tar.gz", hash = "sha256:be7f618e71e10c33a61165aea58813ebd702f6c0044538155871cb9a1609ab4e", size = 11498, upload-time = "2026-01-19T10:28:29.032Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6f/187826c34511e73c7b9f9595465fd8a029ed467c8c2e57ef76f7dbc8a810/ecs_logging-2.3.0-py3-none-any.whl", hash = "sha256:42da72191a98bd724d105e126ca8d7c81fc82b0d7bbbe4bb1584c34e61042cfc", size = 14791, upload-time = "2026-01-19T10:28:27.408Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -995,6 +1006,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1005,6 +1017,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1015,6 +1028,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1025,6 +1039,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,6 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyjwt" },
-    { name = "python-json-logger" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "redis" },
@@ -231,7 +230,6 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.12.5" },
     { name = "pyjwt", specifier = "~=2.12.0" },
     { name = "pyqt6", marker = "extra == 'desktop'", specifier = "~=6.10.2" },
-    { name = "python-json-logger", specifier = "~=2.0.7" },
     { name = "python-multipart", specifier = "~=0.0.26" },
     { name = "pyyaml", specifier = "~=6.0.3" },
     { name = "redis", specifier = "~=5.3.1" },
@@ -2667,15 +2665,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
-]
-
-[[package]]
-name = "python-json-logger"
-version = "2.0.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/da/95963cebfc578dabd323d7263958dfb68898617912bb09327dd30e9c8d13/python-json-logger-2.0.7.tar.gz", hash = "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c", size = 10508, upload-time = "2023-02-21T17:40:06.209Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/a6/145655273568ee78a581e734cf35beb9e33a370b29c5d3c8fee3744de29f/python_json_logger-2.0.7-py3-none-any.whl", hash = "sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd", size = 8067, upload-time = "2023-02-21T17:40:05.117Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces python-json-logger in favor of ecs-logging, so that we natively get ECS compliant logs.

The ecs-logging library provides out of the box a few more contextual information (log line, PID, thread information, ...).

The PR also adds more ECS-compliant information about requests: the URL, the client, quite importantly the "route" that was called, the query params, etc.
This will enable us to have more log analysis capacities.

Will also allow to simplify filebeat configurations, since the logs will now be natively compliant with ECS.

Also, simplifies non-JSON logs, where noisy information has been removed.