### PR TITLE
refactor(task,download): use async endpoints for polling

### DIFF
--- a/antarest/core/filetransfer/service.py
+++ b/antarest/core/filetransfer/service.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 
+import asyncio
 import datetime
 import http
 import logging
@@ -34,7 +35,7 @@ from antarest.core.model import PermissionInfo, PublicMode
 from antarest.core.requests import UserHasNotPermissionError
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.core.utils.utils import current_time
-from antarest.core.utils.wait import wait_for
+from antarest.core.utils.wait import async_wait_for
 from antarest.login.utils import get_current_user, require_current_user
 
 logger = logging.getLogger(__name__)
@@ -207,7 +208,7 @@ class FileTransferManager:
 
         return download
 
-    def get_download_metadata(
+    async def get_download_metadata_async(
         self,
         download_id: str,
         wait_for_availability: bool,
@@ -215,6 +216,8 @@ class FileTransferManager:
         timeout: float = DEFAULT_DOWNLOAD_WAIT_TIMEOUT,
     ) -> FileDownloadDTO:
         """
+        Retrieve metadata for a download, optionally waiting for it to be ready or failed.
+
         Important:
         we use short scoped sessions here to guarantee that sessions are not held for a long time.
         """
@@ -228,11 +231,13 @@ class FileTransferManager:
                     return download.to_dto()
                 return None
 
-        download_dto = get_download_if_completed()
+        download_dto = await asyncio.to_thread(get_download_if_completed)
 
         # the user wants to wait for the download to be available
         if not download_dto and wait_for_availability:
-            download_dto = wait_for(get_download_if_completed, polling_interval=polling_interval, timeout=timeout)
+            download_dto = await async_wait_for(
+                get_download_if_completed, polling_interval=polling_interval, timeout=timeout
+            )
 
         if not download_dto:
             raise HTTPException(status_code=http.HTTPStatus.EXPECTATION_FAILED, detail="File is still in process.")

--- a/antarest/core/filetransfer/web.py
+++ b/antarest/core/filetransfer/web.py
@@ -52,7 +52,7 @@ def create_file_transfer_api() -> APIRouter:
         "/downloads/{download_id}/metadata",
         summary="Retrieve information on a file's state of preparation",
     )
-    def get_download_metadata(
+    async def get_download_metadata(
         filetransfer_manager: FileTransferManagerDep,
         download_id: UuidStr,
         wait_for_availability: Annotated[
@@ -60,6 +60,6 @@ def create_file_transfer_api() -> APIRouter:
         ] = False,
     ) -> FileDownloadDTO:
         logger.info(f"Retrieving metadata for download {download_id} (waiting: {wait_for_availability}).")
-        return filetransfer_manager.get_download_metadata(download_id, wait_for_availability)
+        return await filetransfer_manager.get_download_metadata_async(download_id, wait_for_availability)
 
     return bp

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -415,8 +415,8 @@ class TaskJobService(ITaskService):
                 raise
         else:
             logger.warning(f"Task '{task_id}' not handled by this worker, will poll for task completion from db")
-            end = asyncio.get_event_loop().time() + timeout_sec
-            while asyncio.get_event_loop().time() < end:
+            end = time.time() + timeout_sec
+            while time.time() < end:
 
                 def _check_status() -> int | None:
                     with db():

--- a/antarest/core/tasks/service.py
+++ b/antarest/core/tasks/service.py
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+import asyncio
 import logging
 import time
 from abc import ABC, abstractmethod
@@ -103,6 +104,17 @@ class ITaskService(ABC):
     def await_task(self, task_id: str, timeout_sec: int = DEFAULT_AWAIT_MAX_TIMEOUT) -> None:
         """
         Waits for the completion of task for the specified time.
+
+        Raises:
+            TimeoutError: if the task is not completed before the timeout
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def await_task_async(self, task_id: str, timeout_sec: int = DEFAULT_AWAIT_MAX_TIMEOUT) -> None:
+        """
+        Asynchronously waits for the completion of a task for the specified time.
+        Prefer this over `await_task` when calling from an async context.
 
         Raises:
             TimeoutError: if the task is not completed before the timeout
@@ -382,6 +394,42 @@ class TaskJobService(ITaskService):
                         return
                 logger.info("💤 Sleeping 2 seconds...")
                 time.sleep(2)
+            error_msg = f"Timeout while awaiting task '{task_id}'"
+            logger.warning(error_msg)
+            raise TimeoutError(error_msg)
+
+    @override
+    async def await_task_async(self, task_id: str, timeout_sec: int = DEFAULT_AWAIT_MAX_TIMEOUT) -> None:
+        if task_id in self.tasks:
+            try:
+                logger.info(f"🤔 Awaiting task '{task_id}' {timeout_sec}s...")
+                future: Future[None] = self.tasks[task_id]
+                await asyncio.wait_for(asyncio.wrap_future(future), timeout=timeout_sec)
+                logger.info(f"📌 Task '{task_id}' done.")
+            except TimeoutError as timeout_exc:
+                error_msg = f"Timeout while awaiting task '{task_id}'"
+                logger.warning(error_msg)
+                raise TimeoutError(error_msg) from timeout_exc
+            except Exception as exc:
+                logger.critical(f"🤕 Task '{task_id}' failed: {exc}.")
+                raise
+        else:
+            logger.warning(f"Task '{task_id}' not handled by this worker, will poll for task completion from db")
+            end = asyncio.get_event_loop().time() + timeout_sec
+            while asyncio.get_event_loop().time() < end:
+
+                def _check_status() -> int | None:
+                    with db():
+                        return db.session.execute(select(TaskJob.status).where(TaskJob.id == task_id)).scalar()
+
+                task_status = await asyncio.to_thread(_check_status)
+                if task_status is None:
+                    logger.error(f"Awaited task '{task_id}' was not found")
+                    return
+                if TaskStatus(task_status).is_final():
+                    return
+                logger.info("💤 Sleeping 2 seconds...")
+                await asyncio.sleep(2)
             error_msg = f"Timeout while awaiting task '{task_id}'"
             logger.warning(error_msg)
             raise TimeoutError(error_msg)

--- a/antarest/core/tasks/web.py
+++ b/antarest/core/tasks/web.py
@@ -38,7 +38,7 @@ def create_tasks_api() -> APIRouter:
         return service.list_tasks(task_filter)
 
     @bp.get("/tasks/{task_id}")
-    def get_task(
+    async def get_task(
         service: TaskServiceDep,
         task_id: UuidStr,
         wait_for_completion: bool = False,
@@ -66,7 +66,8 @@ def create_tasks_api() -> APIRouter:
             # Ensure 0 <= timeout <= 48 h
             timeout = min(max(0, timeout), DEFAULT_AWAIT_MAX_TIMEOUT)
             try:
-                service.await_task(task_id, timeout_sec=timeout)
+                # Prefer the async implementation to avoid blocking the event loop.
+                await service.await_task_async(task_id, timeout_sec=timeout)
             except TimeoutError as exc:  # pragma: no cover
                 # Note that if the task does not complete within the specified time,
                 # the task will continue running but the user will receive a timeout.

--- a/antarest/core/tasks/web.py
+++ b/antarest/core/tasks/web.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 
+import asyncio
 import http
 import logging
 from http import HTTPStatus
@@ -48,6 +49,9 @@ def create_tasks_api() -> APIRouter:
         """
         Retrieve information about a specific task.
 
+        Important: this endpoint is one of the few ASYNC endpoint, because it performs polling.
+                   this avoid to block other sync endpoints while we are just waiting for the task to complete.
+
         Args:
         - `task_id`: Unique identifier of the task.
         - `wait_for_completion`: Set to `True` to wait for task completion.
@@ -60,7 +64,7 @@ def create_tasks_api() -> APIRouter:
         Returns:
             TaskDTO: Information about the specified task.
         """
-        task_status = service.status_task(task_id, with_logs)
+        task_status = await asyncio.to_thread(service.status_task, task_id, with_logs)
 
         if wait_for_completion and not task_status.status.is_final():
             # Ensure 0 <= timeout <= 48 h
@@ -77,7 +81,7 @@ def create_tasks_api() -> APIRouter:
                     detail="The request timed out while waiting for task completion.",
                 ) from exc
 
-        return service.status_task(task_id, with_logs)
+        return await asyncio.to_thread(service.status_task, task_id, with_logs)
 
     @bp.put("/tasks/{task_id}/cancel", status_code=HTTPStatus.ACCEPTED)
     def cancel_task(service: TaskServiceDep, task_id: UuidStr) -> None:

--- a/antarest/core/utils/wait.py
+++ b/antarest/core/utils/wait.py
@@ -9,8 +9,10 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+import asyncio
 import time
-from typing import Callable, TypeVar
+from collections.abc import Callable
+from typing import TypeVar
 
 T = TypeVar("T")
 
@@ -39,3 +41,28 @@ def wait_for(fn: Callable[[], T | None], polling_interval: float, timeout: float
 
     # one last try
     return fn()
+
+
+async def async_wait_for(fn: Callable[[], T | None], polling_interval: float, timeout: float) -> T | None:
+    """
+    Async equivalent of `wait_for`. Polls `fn` (which may do blocking I/O) in a thread
+    and yields the event loop between polls.
+
+    Args:
+        fn: polling function, may contain blocking calls (e.g. DB queries)
+        polling_interval: wait time in seconds between 2 calls of fn
+        timeout: maximum time to wait.
+
+    Returns:
+        None if timed out, else the result of the function.
+    """
+    end = time.time() + timeout
+
+    while time.time() < end:
+        result = await asyncio.to_thread(fn)
+        if result is not None:
+            return result
+        await asyncio.sleep(polling_interval)
+
+    # one last try
+    return await asyncio.to_thread(fn)

--- a/tests/conftest_services.py
+++ b/tests/conftest_services.py
@@ -31,7 +31,7 @@ from antarest.core.config import Config, InternalMatrixFormat, StorageConfig, Wo
 from antarest.core.interfaces.cache import ICache
 from antarest.core.interfaces.eventbus import IEventBus
 from antarest.core.tasks.model import CustomTaskEventMessages, TaskDTO, TaskListFilter, TaskResult, TaskStatus, TaskType
-from antarest.core.tasks.service import ITaskService, NoopNotifier, Task
+from antarest.core.tasks.service import DEFAULT_AWAIT_MAX_TIMEOUT, ITaskService, NoopNotifier, Task
 from antarest.core.utils.fastapi_sqlalchemy import DBSessionMiddleware
 from antarest.core.utils.utils import current_time
 from antarest.eventbus.business.local_eventbus import LocalEventBus
@@ -111,6 +111,10 @@ class SynchTaskService(ITaskService):
 
     @override
     def await_task(self, task_id: str, timeout_sec: t.Optional[int] = None) -> None:
+        pass
+
+    @override
+    async def await_task_async(self, task_id: str, timeout_sec: int = DEFAULT_AWAIT_MAX_TIMEOUT) -> None:
         pass
 
     @override

--- a/tests/core/test_file_transfer.py
+++ b/tests/core/test_file_transfer.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 
+import asyncio
 import datetime
 import time
 from pathlib import Path
@@ -112,8 +113,8 @@ def test_wait_for_download_metadata(tmp_path: Path) -> None:
         thread.start()
 
         events_counter = create_db_event_counter(get_session_factory())
-        download_dto = ftm.get_download_metadata(
-            download.id, wait_for_availability=True, polling_interval=0.1, timeout=10
+        download_dto = asyncio.run(
+            ftm.get_download_metadata_async(download.id, wait_for_availability=True, polling_interval=0.1, timeout=10)
         )
 
         assert download_dto.id == download.id

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -20,7 +20,7 @@ from antarest.core.filetransfer.model import FileDownload
 from antarest.core.filetransfer.repository import FileDownloadRepository
 from antarest.core.filetransfer.service import FileTransferManager
 from antarest.core.tasks.model import CustomTaskEventMessages, TaskDTO, TaskListFilter, TaskStatus, TaskType
-from antarest.core.tasks.service import ITaskService, NoopNotifier, Task
+from antarest.core.tasks.service import DEFAULT_AWAIT_MAX_TIMEOUT, ITaskService, NoopNotifier, Task
 from antarest.core.utils.utils import current_time
 
 
@@ -61,6 +61,10 @@ class SimpleSyncTaskService(ITaskService):
 
     @override
     def await_task(self, task_id: str, timeout_sec: int | None = None) -> None:
+        pass
+
+    @override
+    async def await_task_async(self, task_id: str, timeout_sec: int = DEFAULT_AWAIT_MAX_TIMEOUT) -> None:
         pass
 
     @override


### PR DESCRIPTION
Currently, 2 endpoints implement a polling logic. They can block other endpoints while performing no work.
We make them async so that fastapi thread pool is not affected anymore, and they can scale independently.