### PR TITLE
refactor(version)!: change format inside some endpoints

### DIFF
--- a/antarest/study/dtos.py
+++ b/antarest/study/dtos.py
@@ -18,7 +18,7 @@ from antarest.core.utils.string import to_camel_case
 from antarest.output.storage.output_storage import OutputDetails, OutputStorageType
 from antarest.study.business.model.config.general_model import Mode
 from antarest.study.business.model.district_model import District
-from antarest.study.model import StudyVersionInt
+from antarest.study.model import StudyVersionStr
 from antarest.study.storage.rawstudy.model.filesystem.config.model import (
     AreaConfig,
     BindingConstraintConfig,
@@ -61,7 +61,7 @@ class StudyDataSynthesis(AntaresBaseModel):
     """
 
     study_id: str
-    version: StudyVersionInt
+    version: StudyVersionStr
     districts: dict[str, District] = {}
     areas: dict[str, AreaConfig] = {}
     bindings: list[BindingConstraintConfig] = []
@@ -93,7 +93,7 @@ class StudySynthesis(AntaresBaseModel):
     """
 
     study_id: str
-    version: StudyVersionInt
+    version: StudyVersionStr
     districts: dict[str, District] = {}
     areas: dict[str, AreaConfig] = {}
     outputs: dict[str, OutputSynthesis] = {}

--- a/antarest/study/model.py
+++ b/antarest/study/model.py
@@ -78,9 +78,14 @@ STUDY_VERSION_9_2 = StudyVersion.parse("9.2")
 STUDY_VERSION_9_3 = NEW_DEFAULT_STUDY_VERSION
 STUDY_VERSION_10_0 = StudyVersion.parse("10.0")
 
-StudyVersionStr: TypeAlias = Annotated[StudyVersion, BeforeValidator(StudyVersion.parse), PlainSerializer(str)]
-StudyVersionInt: TypeAlias = Annotated[StudyVersion, BeforeValidator(StudyVersion.parse), PlainSerializer(int)]
 
+def _serialize_version(version: StudyVersion) -> str:
+    return f"{version:2d}"
+
+
+StudyVersionStr: TypeAlias = Annotated[
+    StudyVersion, BeforeValidator(StudyVersion.parse), PlainSerializer(_serialize_version)
+]
 
 STUDY_REFERENCE_TEMPLATES: set[StudyVersion] = {
     STUDY_VERSION_7_0,
@@ -534,7 +539,7 @@ class OwnerInfo(AntaresBaseModel):
 class StudyMetadataDTO(AntaresBaseModel):
     id: str
     name: str
-    version: StudyVersionInt
+    version: StudyVersionStr
     author: str | None = None
     editor: str | None = None
     created: str

--- a/antarest/study/storage/rawstudy/model/filesystem/config/model.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/config/model.py
@@ -35,7 +35,7 @@ from antarest.study.business.model.renewable_cluster_model import RenewableClust
 from antarest.study.business.model.sts_model import STStorage, STStorageAdditionalConstraint
 from antarest.study.business.model.study_index import StudyIndex
 from antarest.study.business.model.thermal_cluster_model import ThermalCluster
-from antarest.study.model import STUDY_VERSION_9_2, StudyVersionInt
+from antarest.study.model import STUDY_VERSION_9_2, StudyVersionStr
 
 from .validation import study_version_context
 
@@ -274,7 +274,7 @@ class FileStudyTreeConfigDTO(AntaresBaseModel):
     study_path: Path
     path: Path
     study_id: str
-    version: StudyVersionInt
+    version: StudyVersionStr
     output_path: Path | None = None
     districts: dict[str, District] = dict()
     areas: dict[str, AreaConfig] = dict()

--- a/tests/integration/studies_blueprint/assets/test_synthesis/raw_study.synthesis.json
+++ b/tests/integration/studies_blueprint/assets/test_synthesis/raw_study.synthesis.json
@@ -1,6 +1,6 @@
 {
   "study_id": "DUMMY_VALUE",
-  "version": 700,
+  "version": "7.0",
   "districts": {
     "all areas": {
       "id": "all areas",

--- a/tests/integration/studies_blueprint/assets/test_synthesis/variant_study.synthesis.json
+++ b/tests/integration/studies_blueprint/assets/test_synthesis/variant_study.synthesis.json
@@ -1,6 +1,6 @@
 {
   "study_id": "DUMMY_VALUE",
-  "version": 700,
+  "version": "7.0",
   "districts": {
     "all areas": {
       "id": "all areas",

--- a/tests/integration/studies_blueprint/test_study_version.py
+++ b/tests/integration/studies_blueprint/test_study_version.py
@@ -62,7 +62,7 @@ class TestStudyVersions:
             # Gets study information
             res = client.get(f"v1/studies/{study_id}")
             res.raise_for_status()
-            assert res.json()["version"] == 920 if f == final_path else 700
+            assert res.json()["version"] == "9.2" if f == final_path else "7.0"
 
             # Reads `study.version` file
             res = client.get(f"v1/studies/{study_id}/raw?path=study")

--- a/tests/integration/variant_blueprint/test_st_storage.py
+++ b/tests/integration/variant_blueprint/test_st_storage.py
@@ -59,7 +59,7 @@ class TestSTStorage:
         assert res.json() == {
             "id": internal_study_id,
             "name": "STA-mini",
-            "version": min_study_version,
+            "version": "8.6",
             "author": "Andrea SGATTONI",
             "editor": "Andrea SGATTONI",
             "created": ANY,  # ISO8601 Date/time

--- a/tests/storage/integration/test_STA_mini.py
+++ b/tests/storage/integration/test_STA_mini.py
@@ -464,7 +464,7 @@ def test_sta_mini_list_studies(client: TestClient) -> None:
         UUID: {
             "id": UUID,
             "name": "STA-mini",
-            "version": 700,
+            "version": "7.0",
             "author": "Andrea SGATTONI",
             "editor": None,
             "created": str(datetime.fromtimestamp(1480683452)),


### PR DESCRIPTION
[ANT-2959]

The version used to be returned as an integer like 800 or 920. Now it's a string like "8.0" or "9.2"

This will break the R scripts that need to do a new release to handle this

Impacted endpoints:

- GET /studies
- PUT /studies/{uuid}
- GET /studies/{uuid}/synthesis
- GET /studies/{uuid}/parents
- GET /studies/{uuid}/variants
