### PR TITLE
fix(output): clean all output data when deleting DB studies

### DIFF
--- a/antarest/output/service.py
+++ b/antarest/output/service.py
@@ -590,6 +590,15 @@ class OutputService:
 
         logger.info(f"Output {output_name} deleted from study {uuid}")
 
+    def delete_outputs(self, uuid: str) -> None:
+        """
+        Delete all outputs simulation in the study
+        """
+        logger.info(f"Deleting all outputs from study {uuid}")
+        self._studies_repository.assert_permission(uuid, StudyPermissionType.WRITE)
+        for storage in self._storages:
+            storage.delete_outputs(uuid)
+
     def archive_outputs(self, study_id: str) -> list[str]:
         logger.info(f"Archiving all outputs for study {study_id}")
         self._studies_repository.assert_permission(study_id, StudyPermissionType.WRITE)

--- a/antarest/output/storage/file/abstract_storage.py
+++ b/antarest/output/storage/file/abstract_storage.py
@@ -347,6 +347,11 @@ class AbstractFileOutputStorage(IOutputStorage):
         remove_from_cache(self._cache, study_id)
 
     @override
+    def delete_outputs(self, study_id: str) -> None:
+        outputs_path = self._outputs_provider.get_outputs(study_id).outputs_path
+        shutil.rmtree(outputs_path, ignore_errors=True)  # Contains both archived and unarchived outputs
+
+    @override
     def write_output_to_dir(self, study_id: str, output_id: str, parent: Path) -> None:
         """
         Writes outputs in filestudy format into parent directory

--- a/antarest/output/storage/file/abstract_storage.py
+++ b/antarest/output/storage/file/abstract_storage.py
@@ -344,12 +344,16 @@ class AbstractFileOutputStorage(IOutputStorage):
         if archived_output_path.exists():
             archived_output_path.unlink()
 
+        self._repository.clean_output_variables_list(study_id, output_id)
+
         remove_from_cache(self._cache, study_id)
 
     @override
     def delete_outputs(self, study_id: str) -> None:
         outputs_path = self._outputs_provider.get_outputs(study_id).outputs_path
-        shutil.rmtree(outputs_path, ignore_errors=True)  # Contains both archived and unarchived outputs
+        # `outputs_path` contains both archived and unarchived outputs
+        shutil.rmtree(outputs_path, ignore_errors=True)
+        # No need to clean the repository, it will be done automatically when the study is deleted via ForeignKey.
 
     @override
     def write_output_to_dir(self, study_id: str, output_id: str, parent: Path) -> None:

--- a/antarest/output/storage/file/repository.py
+++ b/antarest/output/storage/file/repository.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 import gzip
 
-from sqlalchemy import ForeignKey, Integer, LargeBinary, PrimaryKeyConstraint, String
+from sqlalchemy import ForeignKey, Integer, LargeBinary, PrimaryKeyConstraint, String, delete
 from sqlalchemy.orm import Mapped, mapped_column
 
 from antarest.core.utils.fastapi_sqlalchemy import db
@@ -61,4 +61,11 @@ class FileOutputRepository:
     def save_output_variables_list(self, study_id: str, output_id: str, variables_list: OutputVariablesList) -> None:
         db_model = DbOutputVariables.from_model(study_id, output_id, variables_list)
         db.session.add(db_model)
+        db.session.commit()
+
+    def clean_output_variables_list(self, study_id: str, output_id: str) -> None:
+        stmt = delete(DbOutputVariables).where(
+            DbOutputVariables.study_id == study_id, DbOutputVariables.output_id == output_id
+        )
+        db.session.execute(stmt)
         db.session.commit()

--- a/antarest/output/storage/output_storage.py
+++ b/antarest/output/storage/output_storage.py
@@ -199,6 +199,12 @@ class IOutputStorage(ABC):
         """
 
     @abstractmethod
+    def delete_outputs(self, study_id: str) -> None:
+        """
+        Delete all outputs for a study
+        """
+
+    @abstractmethod
     def write_output_to_dir(self, study_id: str, output_id: str, parent: Path) -> None:
         """
         Writes outputs in filestudy format into the specified parent directory.

--- a/antarest/output/storage/v2/repository.py
+++ b/antarest/output/storage/v2/repository.py
@@ -147,6 +147,11 @@ class OutputV2Repository:
         self.session.execute(stmt)
         self.session.commit()
 
+    def delete_outputs(self, study_id: str) -> None:
+        stmt = delete(DbOutputMetadataV2).where(DbOutputMetadataV2.study_id == study_id)
+        self.session.execute(stmt)
+        self.session.commit()
+
     def save_log(self, study_id: str, output_name: str, log_type: LogType, log_content: str) -> None:
         upsert_one(
             self.session,

--- a/antarest/output/storage/v2/storage.py
+++ b/antarest/output/storage/v2/storage.py
@@ -321,11 +321,14 @@ class V2OutputStorage(IOutputStorage):
 
     @override
     def delete_outputs(self, study_id: str) -> None:
-        for output_metadata in self._repository.search_output_metadata(study_id):
+        outputs = self._repository.search_output_metadata(study_id)
+        for output_metadata in outputs:
             output_id = output_metadata.output_name
             self._archive_storage.delete_file(_archive_id(study_id, output_id))
             shutil.rmtree(parquet_output_dir(self._variables_dir, study_id, output_id), ignore_errors=True)
-        self._repository.delete_outputs(study_id)
+
+        if outputs:
+            self._repository.delete_outputs(study_id)  # Needed as we don't have a ForeignKey to the `Study` table
 
     @override
     def export_output(self, study_id: str, output_id: str, target: Path) -> None:

--- a/antarest/output/storage/v2/storage.py
+++ b/antarest/output/storage/v2/storage.py
@@ -320,6 +320,14 @@ class V2OutputStorage(IOutputStorage):
         self._repository.delete_output(study_id, output_id)
 
     @override
+    def delete_outputs(self, study_id: str) -> None:
+        for output_metadata in self._repository.search_output_metadata(study_id):
+            output_id = output_metadata.output_name
+            self._archive_storage.delete_file(_archive_id(study_id, output_id))
+            shutil.rmtree(parquet_output_dir(self._variables_dir, study_id, output_id), ignore_errors=True)
+        self._repository.delete_outputs(study_id)
+
+    @override
     def export_output(self, study_id: str, output_id: str, target: Path) -> None:
         logger.info(f"Exporting output {study_id}/{output_id} from internal storage.")
         self._require_metadata(study_id, output_id)

--- a/antarest/study/adapters.py
+++ b/antarest/study/adapters.py
@@ -37,8 +37,8 @@ def adapt_output_service_to_study_service(output_service: OutputService) -> IOut
             return output_service.copy_output(src_study_id, target_study_id, output_id)
 
         @override
-        def delete_output(self, study_id: str, output_id: str) -> None:
-            output_service.delete_output(study_id, output_id)
+        def delete_outputs(self, study_id: str) -> None:
+            output_service.delete_outputs(study_id)
 
         @override
         def write_output_to_dir(self, study_id: str, output_id: str, parent_dir: Path) -> None:

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -597,7 +597,7 @@ class IOutputsAccess(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def delete_output(self, study_id: str, output_id: str) -> None:
+    def delete_outputs(self, study_id: str) -> None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -1568,8 +1568,7 @@ class StudyService:
 
         self._await_generation_tasks(studies_to_delete.values())
         for study in studies_to_delete.values():
-            for output in self._get_outputs_access().list_outputs(study.id):
-                self._get_outputs_access().delete_output(study.id, output.id)
+            self._get_outputs_access().delete_outputs(study.id)
         self.repository.delete(*studies_to_delete.keys())
 
         for study in studies_to_delete.values():

--- a/tests/output/storage/file/test_file_output_storage.py
+++ b/tests/output/storage/file/test_file_output_storage.py
@@ -13,7 +13,7 @@ import os
 import shutil
 import zipfile
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 from typing_extensions import override
@@ -44,6 +44,7 @@ from antarest.output.storage.output_storage import (
 )
 from antarest.study.model import DEFAULT_WORKSPACE_NAME
 from antarest.study.storage.rawstudy.model.filesystem.config.model import Mode
+from tests.helpers import with_db_context
 from tests.test_helpers.dates import utc_to_local
 
 
@@ -285,6 +286,7 @@ def test_file_output_storage(output_storage: IOutputStorage) -> None:
         output_storage.get_output_details("unknown")
 
 
+@with_db_context
 def test_output_deletion(output_storage: IOutputStorage, tmp_path: Path) -> None:
     outputs = output_storage.list_outputs("STA-mini")
     assert len(outputs) == 6
@@ -315,6 +317,12 @@ def test_output_deletion(output_storage: IOutputStorage, tmp_path: Path) -> None
     outputs = output_storage.list_outputs("STA-mini")
     assert len(outputs) == 4
     assert "20201014-1422eco-hello" not in [o.id for o in outputs]
+
+    # Ensures the DB was cleaned up
+    assert sorted(output_storage._repository.clean_output_variables_list.call_args_list) == [
+        call("STA-mini", "20201014-1422eco-hello"),
+        call("STA-mini", "20201014-1427eco"),
+    ]
 
 
 def test_output_archival(output_storage: IOutputStorage, tmp_path: Path) -> None:

--- a/tests/study/service/test_service.py
+++ b/tests/study/service/test_service.py
@@ -173,7 +173,7 @@ def build_study_service(
             pass
 
         @override
-        def delete_output(self, study_id: str, output_id: str) -> None:
+        def delete_outputs(self, study_id: str) -> None:
             pass
 
         @override


### PR DESCRIPTION
- Clean the `DbOutputVariables` table when deleting one output (before it was still in DB)
- When deleting a study, delete all the outputs a little bit faster (removes a N+1 query on the outputs number)
- Also removes the output folder related to a DB study when deleting it (before it was still there, empty)