### PR TITLE
feat(output,db)!: support reading matrix indexes

### DIFF
--- a/antarest/study/adapters.py
+++ b/antarest/study/adapters.py
@@ -15,6 +15,7 @@ from typing_extensions import override
 
 from antarest.output.service import OutputService
 from antarest.output.storage.output_storage import OutputDetails, OutputMetadata
+from antarest.study.model import MatrixFrequency, MatrixIndex
 from antarest.study.service import IOutputsAccess
 
 
@@ -55,5 +56,9 @@ def adapt_output_service_to_study_service(output_service: OutputService) -> IOut
         @override
         def import_outputs(self, outputs_dir: Path, study_id: str) -> None:
             output_service.import_outputs(outputs_dir, study_id)
+
+        @override
+        def get_output_time_index(self, study_id: str, output_id: str, frequency: MatrixFrequency) -> MatrixIndex:
+            return output_service.get_output_time_index(study_id, output_id, frequency)
 
     return OutputServiceAdapter()

--- a/antarest/study/service.py
+++ b/antarest/study/service.py
@@ -169,7 +169,6 @@ from antarest.study.storage.utils import (
     extract_data_to_dir,
     extract_simulation_range_from_model,
     get_matrix_index,
-    get_start_date,
     is_managed,
     is_study_folder,
     remove_from_cache,
@@ -239,6 +238,17 @@ def _get_path_inside_user_folder(
     if url[1] == "expansion":
         raise exception_class(f"the given path is inside the `expansion` folder: {path}")
     return "/".join(url[1:])
+
+
+def _infer_output_matrix_frequency(file_name: str) -> MatrixFrequency:
+    """
+    Infers the matrix frequency from the given URL.
+    We use the fact that all Simulator output matrices end with a frequency suffix (e.g., "hourly", "daily", etc.)
+    """
+    try:
+        return MatrixFrequency(file_name.split("-")[-1])
+    except Exception as e:
+        raise ValueError(f"Unable to infer matrix frequency from file name: {file_name}") from e
 
 
 def assert_raw(study: Study) -> RawStudy:
@@ -614,6 +624,10 @@ class IOutputsAccess(ABC):
 
     @abstractmethod
     def import_outputs(self, outputs_dir: Path, study_id: str) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_output_time_index(self, study_id: str, output_id: str, frequency: MatrixFrequency) -> MatrixIndex:
         raise NotImplementedError()
 
 
@@ -1046,36 +1060,22 @@ class StudyService:
         study = self.get_study(study_id)
         assert_permission(study, StudyPermissionType.READ)
 
-        # We need to handle matrices index differently if our study is stored in DB
-        if study.storage_mode == StorageMode.DATABASE:
-            dao = self.get_study_interface(study).get_study_dao()
-            # We can give a readOnly Dao as we won't use the save methods
-            mapper = RawPathToMatrixMapper(dao)  # type: ignore
-            matrix_frequency = mapper.get_matrix_frequency_from_path(PurePosixPath(path))
-            simulation_range = extract_simulation_range_from_model(dao.get_general_config())
-            return get_matrix_index(simulation_range, False, matrix_frequency)
+        path_components = path.strip().strip("/").split("/")
+        if not path_components or len(path_components) <= 2 or path_components[0] not in {"input", "output"}:
+            raise IncorrectPathError(f"The provided path does not point to a valid matrix: '{path}'")
 
-        file_study = self.get_file_study(study)
-        output_id = None
-        frequency = MatrixFrequency.HOURLY
-        if path:
-            path_components = path.strip().strip("/").split("/")
-            if len(path_components) > 2 and path_components[0] == "output":
-                output_id = path_components[1]
-            data_node = file_study.tree.get_node(path_components)
-            if isinstance(data_node, OutputSeriesMatrix) or isinstance(data_node, InputSeriesMatrix):
-                frequency = data_node.freq
+        # We need to differentiate input from output matrices
+        if path_components[0] == "output":
+            output_id = path_components[1]
+            frequency = _infer_output_matrix_frequency(path_components[-1])
+            return self._get_outputs_access().get_output_time_index(study_id, output_id, frequency)
 
-        study_path: Path | None = None
-        output_path: Path | None = None
-        if output_id is None:
-            study_path = file_study.config.study_path
-        else:
-            # As the user gave a path like study/output/output-id/... we assume the study follows this structure
-            assert file_study.config.output_path is not None
-            output_path = file_study.config.output_path / output_id
-
-        return get_start_date(study_path, output_path, frequency)
+        dao = self.get_study_interface(study).get_study_dao()
+        # We can give a readOnly Dao as we won't use the save methods
+        mapper = RawPathToMatrixMapper(dao)  # type: ignore
+        matrix_frequency = mapper.get_matrix_frequency_from_path(PurePosixPath(path))
+        simulation_range = extract_simulation_range_from_model(dao.get_general_config())
+        return get_matrix_index(simulation_range, False, matrix_frequency)
 
     def remove_duplicates(self) -> None:
         duplicates = self.repository.list_duplicates()

--- a/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/matrix/input_series_matrix.py
@@ -27,7 +27,6 @@ from antarest.core.serde.matrix_export import write_dataframe_in_tsv_format
 from antarest.core.utils.archives import read_original_file_in_archive
 from antarest.core.utils.polars import create_polars_dataframe, read_input_dataframe
 from antarest.core.utils.utils import StopWatch
-from antarest.study.model import MatrixFrequency
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.inode import OriginalFile
 from antarest.study.storage.rawstudy.model.filesystem.lazy_node import LazyNode
@@ -89,14 +88,12 @@ class InputSeriesMatrix(LazyNode[bytes | JSON, MatrixId | MatrixContent, JSON]):
         self,
         matrix_storage_context: MatrixStorageContext,
         config: FileStudyTreeConfig,
-        freq: MatrixFrequency = MatrixFrequency.HOURLY,
         nb_columns: int | None = None,
         default_empty: MatrixSupplier | None = None,  # optional only for the capacity matrix in Xpansion
         should_exist: bool = True,
     ):
         LazyNode.__init__(self, config)
         self._matrix_storage_context = matrix_storage_context
-        self.freq = freq
         self.nb_columns = nb_columns
         self.default_empty = default_empty
         # Removes the .link suffix if the matrix is normalized

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/bindingconstraints/bindingcontraints.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/bindingconstraints/bindingcontraints.py
@@ -15,7 +15,6 @@ from antarest.study.business.model.binding_constraint_model import (
     OPERATOR_MATRICES_MAP,
     BindingConstraintFrequency,
 )
-from antarest.study.model import MatrixFrequency
 from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
 from antarest.study.storage.rawstudy.model.filesystem.inode import TREE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
@@ -45,11 +44,6 @@ class BindingConstraints(FolderNode):
     @override
     def build(self) -> TREE:
         cfg = self.config
-        frequency_mapping = {
-            BindingConstraintFrequency.HOURLY: MatrixFrequency.HOURLY,
-            BindingConstraintFrequency.DAILY: MatrixFrequency.DAILY,
-            BindingConstraintFrequency.WEEKLY: MatrixFrequency.DAILY,
-        }
         if cfg.version < 870:
             default_matrices = {
                 BindingConstraintFrequency.HOURLY: default_bc_hourly_86,
@@ -60,7 +54,6 @@ class BindingConstraints(FolderNode):
                 binding.id: InputSeriesMatrix(
                     self.matrix_storage_context,
                     self.config.next_file(f"{binding.id}.txt"),
-                    freq=frequency_mapping[binding.time_step],
                     nb_columns=3,
                     default_empty=default_matrices[binding.time_step],
                 )
@@ -81,7 +74,6 @@ class BindingConstraints(FolderNode):
                         children[matrix_id] = InputSeriesMatrix(
                             self.matrix_storage_context,
                             self.config.next_file(f"{matrix_id}.txt"),
-                            freq=frequency_mapping[binding.time_step],
                             nb_columns=1 if term in ["lt", "gt"] else None,
                             default_empty=default_matrices[binding.time_step],
                         )

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/common/capacity/capacity.py
@@ -17,7 +17,7 @@ import numpy.typing as npt
 from antares.study.version import StudyVersion
 from typing_extensions import override
 
-from antarest.study.model import STUDY_VERSION_6_5, STUDY_VERSION_9_2, MatrixFrequency
+from antarest.study.model import STUDY_VERSION_6_5, STUDY_VERSION_9_2
 from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
 from antarest.study.storage.rawstudy.model.filesystem.inode import TREE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
@@ -32,7 +32,6 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
 
 class MatrixInfo(TypedDict, total=False):
     name: str
-    freq: MatrixFrequency
     start_version: StudyVersion
     default_empty: Callable[[], npt.NDArray[np.float64]]
     should_exist: bool
@@ -43,44 +42,37 @@ INITIAL_VERSION = StudyVersion.parse(0)
 MATRICES_INFO: list[MatrixInfo] = [
     {
         "name": "maxpower",
-        "freq": MatrixFrequency.DAILY,
         "start_version": INITIAL_VERSION,
         "default_empty": default_maxpower,
     },
     {
         "name": "reservoir",
-        "freq": MatrixFrequency.DAILY,
         "start_version": INITIAL_VERSION,
         "default_empty": default_reservoir,
     },
     {
         "name": "inflowPattern",
-        "freq": MatrixFrequency.DAILY,
         "start_version": STUDY_VERSION_6_5,
         "default_empty": default_scenario_daily,
     },
     {
         "name": "creditmodulations",
-        "freq": MatrixFrequency.HOURLY,
         "start_version": STUDY_VERSION_6_5,
         "default_empty": default_credit_modulation,
     },
     {
         "name": "waterValues",
-        "freq": MatrixFrequency.DAILY,
         "start_version": STUDY_VERSION_6_5,
         "default_empty": default_water_values,
     },
     {
         "name": "maxDailyGenEnergy",
-        "freq": MatrixFrequency.DAILY,
         "start_version": STUDY_VERSION_9_2,
         "default_empty": default_scenario_daily,
         "should_exist": False,
     },
     {
         "name": "maxDailyPumpEnergy",
-        "freq": MatrixFrequency.DAILY,
         "start_version": STUDY_VERSION_9_2,
         "default_empty": default_scenario_daily,
         "should_exist": False,
@@ -99,7 +91,6 @@ class InputHydroCommonCapacity(FolderNode):
                     children[name] = InputSeriesMatrix(
                         self.matrix_storage_context,
                         self.config.next_file(f"{name}.txt"),
-                        freq=info["freq"],
                         default_empty=info["default_empty"],
                         should_exist=info.get("should_exist", True),
                     )

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/series/area/area.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/hydro/series/area/area.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from typing_extensions import override
 
-from antarest.study.model import STUDY_VERSION_6_5, STUDY_VERSION_8_6, STUDY_VERSION_9_2, MatrixFrequency
+from antarest.study.model import STUDY_VERSION_6_5, STUDY_VERSION_8_6, STUDY_VERSION_9_2
 from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
 from antarest.study.storage.rawstudy.model.filesystem.inode import TREE, INode
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
@@ -29,20 +29,17 @@ class InputHydroSeriesArea(FolderNode):
     @override
     def build(self) -> TREE:
         study_version = self.config.version
-        freq = MatrixFrequency.DAILY if study_version >= STUDY_VERSION_6_5 else MatrixFrequency.MONTHLY
         default_empty = default_scenario_daily if study_version >= STUDY_VERSION_6_5 else default_scenario_monthly
         hydro_series_matrices: dict[str, INode[Any, Any, Any]] = {
             "mod": InputSeriesMatrix(
                 self.matrix_storage_context,
                 self.config.next_file("mod.txt"),
-                freq=freq,
                 default_empty=default_empty,
             ),
             # Run of River
             "ror": InputSeriesMatrix(
                 self.matrix_storage_context,
                 self.config.next_file("ror.txt"),
-                freq=MatrixFrequency.HOURLY,
                 default_empty=default_scenario_hourly,
             ),
         }
@@ -50,7 +47,6 @@ class InputHydroSeriesArea(FolderNode):
             hydro_series_matrices["mingen"] = InputSeriesMatrix(
                 self.matrix_storage_context,
                 self.config.next_file("mingen.txt"),
-                freq=MatrixFrequency.HOURLY,
                 default_empty=default_scenario_hourly,
             )
 
@@ -58,14 +54,12 @@ class InputHydroSeriesArea(FolderNode):
             hydro_series_matrices["maxHourlyGenPower"] = InputSeriesMatrix(
                 self.matrix_storage_context,
                 self.config.next_file("maxHourlyGenPower.txt"),
-                freq=MatrixFrequency.HOURLY,
                 default_empty=default_scenario_hourly,
                 should_exist=False,
             )
             hydro_series_matrices["maxHourlyPumpPower"] = InputSeriesMatrix(
                 self.matrix_storage_context,
                 self.config.next_file("maxHourlyPumpPower.txt"),
-                freq=MatrixFrequency.HOURLY,
                 default_empty=default_scenario_hourly,
                 should_exist=False,
             )

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/thermal/prepro/area/thermal/thermal.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/thermal/prepro/area/thermal/thermal.py
@@ -12,7 +12,6 @@
 import numpy as np
 from typing_extensions import override
 
-from antarest.study.model import MatrixFrequency
 from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
 from antarest.study.storage.rawstudy.model.filesystem.inode import TREE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
@@ -42,7 +41,6 @@ class InputThermalPreproAreaThermal(FolderNode):
             "data": InputSeriesMatrix(
                 self.matrix_storage_context,
                 self.config.next_file("data.txt"),
-                freq=MatrixFrequency.DAILY,
                 default_empty=default_data_matrix,
             ),
             "modulation": InputSeriesMatrix(

--- a/antarest/study/storage/rawstudy/model/filesystem/root/input/thermal/series/area/thermal/thermal.py
+++ b/antarest/study/storage/rawstudy/model/filesystem/root/input/thermal/series/area/thermal/thermal.py
@@ -11,7 +11,6 @@
 # This file is part of the Antares project.
 from typing_extensions import override
 
-from antarest.study.model import MatrixFrequency
 from antarest.study.storage.rawstudy.model.filesystem.folder_node import FolderNode
 from antarest.study.storage.rawstudy.model.filesystem.inode import TREE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
@@ -32,14 +31,12 @@ class InputThermalSeriesAreaThermal(FolderNode):
             children["CO2Cost"] = InputSeriesMatrix(
                 self.matrix_storage_context,
                 self.config.next_file("CO2Cost.txt"),
-                freq=MatrixFrequency.HOURLY,
                 default_empty=default_scenario_hourly,
                 should_exist=False,
             )
             children["fuelCost"] = InputSeriesMatrix(
                 self.matrix_storage_context,
                 self.config.next_file("fuelCost.txt"),
-                freq=MatrixFrequency.HOURLY,
                 default_empty=default_scenario_hourly,
                 should_exist=False,
             )

--- a/tests/integration/raw_studies_blueprint/test_download_matrices.py
+++ b/tests/integration/raw_studies_blueprint/test_download_matrices.py
@@ -345,9 +345,13 @@ class TestDownloadMatrices:
             assert str(dataframe.index[0]) == "2018-01-01 00:00:00"
             assert np.array_equal(dataframe.to_numpy(), min_gen_df.to_numpy())
 
-        # test that downloading the digest file doesn't fail
+        # Test that downloading the digest file doesn't fail.
+        # The possibility does not exist anymore inside the front-end of the app, but it's still possible via API.
         digest_path = "output/20201014-1422eco-hello/economy/mc-all/grid/digest"
-        res = client.get(f"/v1/studies/{internal_study_id}/raw/download", params={"path": digest_path, "format": "tsv"})
+        res = client.get(
+            f"/v1/studies/{internal_study_id}/raw/download",
+            params={"path": digest_path, "format": "tsv", "index": False},
+        )
         assert res.status_code == 200
 
         # =============================

--- a/tests/integration/studies_blueprint/test_study_matrix_index.py
+++ b/tests/integration/studies_blueprint/test_study_matrix_index.py
@@ -9,10 +9,13 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
+import io
+
 import pytest
 from starlette.testclient import TestClient
 
 from antarest.study.model import StorageMode
+from tests.integration.assets import ASSETS_DIR
 
 
 class TestStudyMatrixIndex:
@@ -234,6 +237,13 @@ class TestStudyMatrixIndex:
         res = client.post(f"/v1/studies/{study_id}/areas/france/storages", json={"name": "st-storage"})
         res.raise_for_status()
 
+        # Import an output inside the study
+        output_path_seven_zip = ASSETS_DIR / "output_adq.7z"
+        client.post(f"/v1/studies/{study_id}/output", files={"output": io.BytesIO(output_path_seven_zip.read_bytes())})
+        # Ensures the output has been successfully imported
+        res = client.get(f"/v1/studies/{study_id}/outputs")
+        assert len(res.json()) == 1
+
         # Try to fetch the matrix index for different matrices
         url = f"/v1/studies/{study_id}/matrixindex"
         hourly_response = {"first_week_size": 7, "start_date": "2018-01-01 00:00:00", "steps": 8760, "level": "hourly"}
@@ -305,3 +315,16 @@ class TestStudyMatrixIndex:
         # We should still see the daily index for the constraint
         res = client.get(url, params={"path": bc_matrix_path})
         assert res.json() == daily_response
+
+        ############ Output matrices ############
+        daily_response = {"first_week_size": 7, "level": "daily", "start_date": "2018-01-01 00:00:00", "steps": 7}
+        monthly_response = {"first_week_size": 7, "level": "monthly", "start_date": "2018-01-01 00:00:00", "steps": 1}
+        output_id = "20221003-2342adq"
+        for path in [
+            f"output/{output_id}/adequacy/mc-all/areas/de/details-monthly",
+            f"output/{output_id}/adequacy/mc-all/areas/de/id-daily",
+            f"output/{output_id}/adequacy/mc-all/areas/es/values-monthly",
+        ]:
+            res = client.get(url, params={"path": path})
+            mapping = {"daily": daily_response, "monthly": monthly_response}
+            assert res.json() == mapping[path.split("-")[-1]]

--- a/tests/integration/studies_blueprint/test_study_matrix_index.py
+++ b/tests/integration/studies_blueprint/test_study_matrix_index.py
@@ -16,6 +16,7 @@ from starlette.testclient import TestClient
 
 from antarest.study.model import StorageMode
 from tests.integration.assets import ASSETS_DIR
+from tests.test_helpers.dates import utc_to_local
 
 
 class TestStudyMatrixIndex:
@@ -305,7 +306,8 @@ class TestStudyMatrixIndex:
         ############ Output matrices ############
         daily_response = {"first_week_size": 7, "level": "daily", "start_date": "2018-01-01 00:00:00", "steps": 7}
         monthly_response = {"first_week_size": 7, "level": "monthly", "start_date": "2018-01-01 00:00:00", "steps": 1}
-        output_id = "20221003-2342adq"
+        expected_date = utc_to_local("20221003-2142")
+        output_id = f"{expected_date}adq"
         for path in [
             f"output/{output_id}/adequacy/mc-all/areas/de/details-monthly",
             f"output/{output_id}/adequacy/mc-all/areas/de/id-daily",

--- a/tests/integration/studies_blueprint/test_study_matrix_index.py
+++ b/tests/integration/studies_blueprint/test_study_matrix_index.py
@@ -84,20 +84,6 @@ class TestStudyMatrixIndex:
         }
         assert actual == expected
 
-        # Check the default matrix index
-        # ==============================
-
-        res = client.get(f"/v1/studies/{internal_study_id}/matrixindex")
-        assert res.status_code == 200
-        actual = res.json()
-        expected = {
-            "first_week_size": 7,
-            "start_date": "2018-01-01 00:00:00",
-            "steps": 8760,
-            "level": "hourly",
-        }
-        assert actual == expected
-
         # Check the matrix index of a daily time series stored in the output folder
         # =========================================================================
 

--- a/tests/storage/repository/filesystem/matrix/test_matrix_node.py
+++ b/tests/storage/repository/filesystem/matrix/test_matrix_node.py
@@ -17,7 +17,7 @@ import polars as pl
 from typing_extensions import override
 
 from antarest.core.utils.polars import create_polars_dataframe
-from antarest.study.model import STUDY_VERSION_8_8, MatrixFrequency
+from antarest.study.model import STUDY_VERSION_8_8
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix_storage_context import MatrixStorageContext
@@ -27,7 +27,7 @@ MOCK_MATRIX = create_polars_dataframe([[1, 2], [3, 4]])
 
 class MockInputSeriesMatrix(InputSeriesMatrix):
     def __init__(self, matrix_storage_context: MatrixStorageContext, config: FileStudyTreeConfig) -> None:
-        super().__init__(config=config, matrix_storage_context=matrix_storage_context, freq=MatrixFrequency.ANNUAL)
+        super().__init__(config=config, matrix_storage_context=matrix_storage_context)
 
     @override
     def parse_as_dataframe(self) -> pl.DataFrame:

--- a/tests/storage/repository/filesystem/root/input/hydro/common/capacity/test_capacity.py
+++ b/tests/storage/repository/filesystem/root/input/hydro/common/capacity/test_capacity.py
@@ -17,7 +17,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from antarest.study.model import MatrixFrequency
 from antarest.study.storage.rawstudy.model.filesystem.config.model import AreaConfig, FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix_storage_context import MatrixStorageContext
@@ -25,24 +24,24 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.hydro.common.ca
 
 # noinspection SpellCheckingInspection
 BEFORE_650 = {
-    "maxpower_en": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "maxpower_fr": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "reservoir_en": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "reservoir_fr": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
+    "maxpower_en": {"default_empty": [[]], "nb_columns": None},
+    "maxpower_fr": {"default_empty": [[]], "nb_columns": None},
+    "reservoir_en": {"default_empty": [[]], "nb_columns": None},
+    "reservoir_fr": {"default_empty": [[]], "nb_columns": None},
 }
 
 # noinspection SpellCheckingInspection
 AFTER_650 = {
-    "creditmodulations_en": {"default_empty": [[]], "freq": MatrixFrequency.HOURLY, "nb_columns": None},
-    "creditmodulations_fr": {"default_empty": [[]], "freq": MatrixFrequency.HOURLY, "nb_columns": None},
-    "inflowPattern_en": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "inflowPattern_fr": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "maxpower_en": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "maxpower_fr": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "reservoir_en": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "reservoir_fr": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "waterValues_en": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
-    "waterValues_fr": {"default_empty": [[]], "freq": MatrixFrequency.DAILY, "nb_columns": None},
+    "creditmodulations_en": {"default_empty": [[]], "nb_columns": None},
+    "creditmodulations_fr": {"default_empty": [[]], "nb_columns": None},
+    "inflowPattern_en": {"default_empty": [[]], "nb_columns": None},
+    "inflowPattern_fr": {"default_empty": [[]], "nb_columns": None},
+    "maxpower_en": {"default_empty": [[]], "nb_columns": None},
+    "maxpower_fr": {"default_empty": [[]], "nb_columns": None},
+    "reservoir_en": {"default_empty": [[]], "nb_columns": None},
+    "reservoir_fr": {"default_empty": [[]], "nb_columns": None},
+    "waterValues_en": {"default_empty": [[]], "nb_columns": None},
+    "waterValues_fr": {"default_empty": [[]], "nb_columns": None},
 }
 
 
@@ -91,9 +90,5 @@ class TestInputHydroCommonCapacity:
         actual_obj = {}
         for key, value in actual.items():
             assert isinstance(value, InputSeriesMatrix)
-            actual_obj[key] = {
-                "default_empty": [[]],
-                "freq": value.freq,
-                "nb_columns": value.nb_columns,
-            }
+            actual_obj[key] = {"default_empty": [[]], "nb_columns": value.nb_columns}
         assert actual_obj == expected

--- a/tests/storage/repository/filesystem/root/input/hydro/series/area/test_area.py
+++ b/tests/storage/repository/filesystem/root/input/hydro/series/area/test_area.py
@@ -17,7 +17,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from antarest.study.model import MatrixFrequency
 from antarest.study.storage.rawstudy.model.filesystem.config.model import FileStudyTreeConfig
 from antarest.study.storage.rawstudy.model.filesystem.matrix.input_series_matrix import InputSeriesMatrix
 from antarest.study.storage.rawstudy.model.filesystem.matrix.matrix_storage_context import MatrixStorageContext
@@ -31,12 +30,10 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.hydro.series.ar
 BEFORE_650 = {
     "mod": {
         "default_empty": default_scenario_monthly().tolist(),
-        "freq": MatrixFrequency.MONTHLY,
         "nb_columns": None,
     },
     "ror": {
         "default_empty": default_scenario_hourly().tolist(),
-        "freq": MatrixFrequency.HOURLY,
         "nb_columns": None,
     },
 }
@@ -44,12 +41,10 @@ BEFORE_650 = {
 AFTER_650 = {
     "mod": {
         "default_empty": default_scenario_daily().tolist(),
-        "freq": MatrixFrequency.DAILY,
         "nb_columns": None,
     },
     "ror": {
         "default_empty": default_scenario_hourly().tolist(),
-        "freq": MatrixFrequency.HOURLY,
         "nb_columns": None,
     },
 }
@@ -57,17 +52,14 @@ AFTER_650 = {
 AFTER_860 = {
     "mod": {
         "default_empty": default_scenario_daily().tolist(),
-        "freq": MatrixFrequency.DAILY,
         "nb_columns": None,
     },
     "ror": {
         "default_empty": default_scenario_hourly().tolist(),
-        "freq": MatrixFrequency.HOURLY,
         "nb_columns": None,
     },
     "mingen": {
         "default_empty": default_scenario_hourly().tolist(),
-        "freq": MatrixFrequency.HOURLY,
         "nb_columns": None,
     },
 }
@@ -109,9 +101,5 @@ class TestInputHydroSeriesArea:
         actual_obj = {}
         for key, value in actual.items():
             assert isinstance(value, InputSeriesMatrix)
-            actual_obj[key] = {
-                "default_empty": value.default_empty().tolist(),
-                "freq": value.freq,
-                "nb_columns": value.nb_columns,
-            }
+            actual_obj[key] = {"default_empty": value.default_empty().tolist(), "nb_columns": value.nb_columns}
         assert actual_obj == expected

--- a/tests/study/service/test_service.py
+++ b/tests/study/service/test_service.py
@@ -57,6 +57,8 @@ from antarest.study.directory_service import DirectoryService
 from antarest.study.model import (
     DEFAULT_WORKSPACE_NAME,
     STUDY_VERSION_7_2,
+    MatrixFrequency,
+    MatrixIndex,
     OwnerInfo,
     RawStudy,
     StorageMode,
@@ -191,6 +193,10 @@ def build_study_service(
         @override
         def import_outputs(self, outputs_dir: Path, study_id: str) -> None:
             pass
+
+        @override
+        def get_output_time_index(self, study_id: str, output_id: str, frequency: MatrixFrequency) -> MatrixIndex:
+            return MatrixIndex()
 
     service.register_output_access(OutputsAccessMock())
     return service


### PR DESCRIPTION
The following endpoints are impacted:
- GET `/matrixindex` now only works for matrices, before it returned a default response for wrong paths
- GET `/raw/download` can no longer be called with `index=True` for some matrices that do not have a frequency (digest for instance)