### PR TITLE
fix(config): revert allowing integers as group IDs

### DIFF
--- a/antarest/core/config.py
+++ b/antarest/core/config.py
@@ -55,7 +55,7 @@ class ExternalAuthConfig(ConfigBaseModel):
     url: str | None = None
     default_group_role: RoleType = RoleType.READER
     add_ext_groups: bool = False
-    group_mapping: dict[str | int, str] = Field(default_factory=dict)
+    group_mapping: dict[str, str] = Field(default_factory=dict)
 
 
 class SecurityConfig(ConfigBaseModel):

--- a/tests/storage/test_config.py
+++ b/tests/storage/test_config.py
@@ -25,7 +25,6 @@ from antarest.core.config import (
     SlurmConfig,
     StorageConfig,
 )
-from antarest.study.storage.rawstudy.model.filesystem.yaml_file_node import YAMLWriter
 
 
 @pytest.fixture
@@ -230,14 +229,3 @@ def test_output_storage_config_validation_errors() -> None:
         ValueError, match=re.escape("You cannot set v2 storage as your default storage and not enable it")
     ):
         OutputStorageConfig.model_validate(data)
-
-
-def test_parse_security_group_mapping(tmp_path: Path) -> None:
-    """Mimick production config where we declare the groups of the app"""
-    yaml_path = tmp_path / "config.yaml"
-    writer = YAMLWriter()
-    data = {"security": {"external_auth": {"group_mapping": {1: "espace_commun", "00001188": "drd"}}}}
-    writer.write(data, yaml_path)
-
-    config = Config.from_yaml_file(yaml_path)
-    assert config.security.external_auth.group_mapping == {1: "espace_commun", "00001188": "drd"}


### PR DESCRIPTION
Reverts https://github.com/AntaresSimulatorTeam/AntaREST/pull/3285 

The real fix was in actual configuration, where we had stuff like:
```yaml
    group_mapping:
      00001725: my_group
```

which actually leads to interpretation of the key as an octal integers: 00001725 gives integer value of 958.

The correct format, to ensure interpretation as a string, is:
```yaml
    group_mapping:
      "00001725": my_group
```