### PR TITLE
fix(api): harmonize usage of `response_model_exclude_none`

### DIFF
--- a/antarest/study/web/study_data_blueprint.py
+++ b/antarest/study/web/study_data_blueprint.py
@@ -422,6 +422,7 @@ def create_study_data_routes() -> APIRouter:
     @bp.put(
         "/studies/{uuid}/areas/{area_id}/hydro/form",
         summary="Set Hydro config with values from form",
+        response_model_exclude_none=True,
     )
     def set_hydro_form_values(
         study_service: StudyServiceDep,
@@ -507,6 +508,7 @@ def create_study_data_routes() -> APIRouter:
     @bp.put(
         path="/studies/{uuid}/config/thematictrimming/form",
         summary="Set thematic trimming config",
+        response_model_exclude_none=True,
     )
     def set_thematic_trimming(
         study_service: StudyServiceDep,
@@ -712,6 +714,7 @@ def create_study_data_routes() -> APIRouter:
     @bp.put(
         path="/studies/{uuid}/config/general/form",
         summary="Set General config with values from form",
+        response_model_exclude_none=True,
     )
     def set_general_form_values(
         study_service: StudyServiceDep,
@@ -740,6 +743,7 @@ def create_study_data_routes() -> APIRouter:
     @bp.put(
         path="/studies/{uuid}/config/optimization/form",
         summary="Set optimization config with values from form",
+        response_model_exclude_none=True,
     )
     def set_optimization_form_values(
         study_service: StudyServiceDep,
@@ -768,6 +772,7 @@ def create_study_data_routes() -> APIRouter:
     @bp.put(
         path="/studies/{uuid}/config/adequacypatch/form",
         summary="Set adequacy patch config with values from form",
+        response_model_exclude_none=True,
     )
     def set_adequacy_patch_form_values(
         study_service: StudyServiceDep,
@@ -796,6 +801,7 @@ def create_study_data_routes() -> APIRouter:
     @bp.put(
         path="/studies/{uuid}/timeseries/config",
         summary="Sets the TS Generation config",
+        response_model_exclude_none=True,
     )
     def set_ts_generation_config(
         study_service: StudyServiceDep,
@@ -1432,6 +1438,7 @@ def create_study_data_routes() -> APIRouter:
     @bp.put(
         path="/studies/{uuid}/config/advancedparameters/form",
         summary="Set Advanced parameters new values",
+        response_model_exclude_none=True,
     )
     def set_advanced_parameters(
         study_service: StudyServiceDep,
@@ -1462,6 +1469,7 @@ def create_study_data_routes() -> APIRouter:
     @bp.put(
         path="/studies/{uuid}/config/compatibility/form",
         summary="Set Compatibility parameters new values",
+        response_model_exclude_none=True,
     )
     def set_compatibility_parameters(
         study_service: StudyServiceDep,

--- a/tests/integration/study_data_blueprint/test_advanced_parameters.py
+++ b/tests/integration/study_data_blueprint/test_advanced_parameters.py
@@ -79,7 +79,6 @@ class TestAdvancedParametersForm:
         assert res.status_code == HTTPStatus.OK, res.json()
         assert res.json() == {
             "accuracyOnCorrelation": "",
-            "accurateShavePeaksIncludeShortTermStorage": None,
             "dayAheadReserveManagement": "global",
             "hydroHeuristicPolicy": "accommodate rule curves",
             "hydroPricingMode": "fast",

--- a/tests/integration/study_data_blueprint/test_config_general.py
+++ b/tests/integration/study_data_blueprint/test_config_general.py
@@ -77,7 +77,6 @@ class TestConfigGeneralForm:
             "firstJanuary": "Monday",
             "firstMonth": "january",
             "firstWeekDay": "Monday",
-            "geographicTrimming": None,
             "horizon": "2020",
             "lastDay": 7,
             "leapYear": False,
@@ -86,6 +85,5 @@ class TestConfigGeneralForm:
             "nbYears": 1,
             "selectionMode": True,
             "simulationSynthesis": True,
-            "thematicTrimming": None,
             "yearByYear": False,
         }


### PR DESCRIPTION
Impacted endpoints:
- PUT **"/studies/{uuid}/areas/{area_id}/hydro/form"**
- PUT **"/studies/{uuid}/config/thematictrimming/form"**
- PUT **"/studies/{uuid}/config/general/form"**
- PUT **"/studies/{uuid}/config/optimization/form"**
- PUT **"/studies/{uuid}/config/adequacypatch/form"**
- PUT **"/studies/{uuid}/timeseries/config"**
- PUT **"/studies/{uuid}/config/advancedparameters/form"**
- PUT **"/studies/{uuid}/config/compatibility/form"**