### PR TITLE
fix(variant): snapshot save full lineage information

### DIFF
--- a/alembic/versions/d53f532e9b78_add_snapshot_lineage_versions.py
+++ b/alembic/versions/d53f532e9b78_add_snapshot_lineage_versions.py
@@ -1,0 +1,38 @@
+"""add snapshot lineage versions
+
+Revision ID: d53f532e9b78
+Revises: e56b1130bc1f
+Create Date: 2026-07-24 09:57:59.297868
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d53f532e9b78"
+down_revision = "e56b1130bc1f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "variant_study_snapshot_lineage",
+        sa.Column("snapshot_id", sa.String(length=36), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("variant_id", sa.String(length=36), nullable=False),
+        sa.Column("commands_version", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["snapshot_id"],
+            ["variant_study_snapshot.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("snapshot_id", "position"),
+        sa.UniqueConstraint("snapshot_id", "variant_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("variant_study_snapshot_lineage")

--- a/alembic/versions/ddf84474ec89_add_snapshot_generation_id.py
+++ b/alembic/versions/ddf84474ec89_add_snapshot_generation_id.py
@@ -1,0 +1,27 @@
+"""add snapshot generation ID
+
+Revision ID: ddf84474ec89
+Revises: d53f532e9b78
+Create Date: 2026-07-24 14:12:37.276111
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ddf84474ec89"
+down_revision = "d53f532e9b78"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("variant_study_snapshot", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("generation_id", sa.String(length=36), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("variant_study_snapshot", schema=None) as batch_op:
+        batch_op.drop_column("generation_id")

--- a/antarest/study/storage/variantstudy/model/dbmodel.py
+++ b/antarest/study/storage/variantstudy/model/dbmodel.py
@@ -14,7 +14,7 @@ import datetime
 import uuid
 from typing import Any
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing_extensions import override
 
@@ -48,12 +48,36 @@ class VariantStudySnapshot(Base):
     )
     version: Mapped[int] = mapped_column(Integer)
     last_executed_command: Mapped[str | None] = mapped_column(String(), nullable=True)
+    lineage: Mapped[list["VariantStudySnapshotLineage"]] = relationship(
+        cascade="all, delete, delete-orphan",
+        order_by="VariantStudySnapshotLineage.position",
+    )
 
     __mapper_args__ = {"polymorphic_identity": "variant_study_snapshot"}
 
     @override
     def __str__(self) -> str:
         return f"[Snapshot] id={self.id}, version={self.version}"
+
+
+class VariantStudySnapshotLineage(Base):
+    """
+    A variant command-list version captured while generating a snapshot.
+
+    Rows are ordered from the root-most variant to the snapshot's own variant.
+    """
+
+    __tablename__ = "variant_study_snapshot_lineage"
+    __table_args__ = (UniqueConstraint("snapshot_id", "variant_id"),)
+
+    snapshot_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("variant_study_snapshot.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    position: Mapped[int] = mapped_column(Integer, primary_key=True)
+    variant_id: Mapped[str] = mapped_column(String(36))
+    commands_version: Mapped[int] = mapped_column(Integer)
 
 
 class CommandBlock(Base):

--- a/antarest/study/storage/variantstudy/model/dbmodel.py
+++ b/antarest/study/storage/variantstudy/model/dbmodel.py
@@ -47,6 +47,7 @@ class VariantStudySnapshot(Base):
         primary_key=True,
     )
     version: Mapped[int] = mapped_column(Integer)
+    generation_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     last_executed_command: Mapped[str | None] = mapped_column(String(), nullable=True)
     lineage: Mapped[list["VariantStudySnapshotLineage"]] = relationship(
         cascade="all, delete, delete-orphan",

--- a/antarest/study/storage/variantstudy/repository.py
+++ b/antarest/study/storage/variantstudy/repository.py
@@ -12,7 +12,7 @@
 
 from collections.abc import Sequence
 
-from sqlalchemy import select
+from sqlalchemy import literal, select
 from sqlalchemy.orm import Session, joinedload, with_polymorphic
 from sqlalchemy.sql.selectable import CTE
 from typing_extensions import override
@@ -26,6 +26,7 @@ from antarest.study.storage.variantstudy.model.dbmodel import (
     CommandBlock,
     CommandsListVersion,
     VariantStudy,
+    VariantStudySnapshot,
 )
 
 
@@ -89,11 +90,17 @@ class VariantStudyRepository(StudyMetadataRepository):
 
     def _ancestor_or_self_cte(self, variant_id: str) -> CTE:
         """
-        Build a recursive CTE yielding (id, parent_id) for `variant_id` and every ancestor.
+        Build a recursive CTE yielding (id, parent_id, depth) for `variant_id` and every ancestor.
         See: https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE
         """
-        top_q = select(Study.id, Study.parent_id).where(Study.id == variant_id).cte("study_cte", recursive=True)
-        bot_q = select(Study.id, Study.parent_id).join(top_q, Study.id == top_q.c.parent_id)
+        top_q = (
+            select(Study.id, Study.parent_id, literal(0).label("depth"))
+            .where(Study.id == variant_id)
+            .cte("study_cte", recursive=True)
+        )
+        bot_q = select(Study.id, Study.parent_id, (top_q.c.depth + 1).label("depth")).join(
+            top_q, Study.id == top_q.c.parent_id
+        )
         return top_q.union_all(bot_q)
 
     def get_ancestor_or_self_ids(self, variant_id: str) -> Sequence[str]:
@@ -109,7 +116,7 @@ class VariantStudyRepository(StudyMetadataRepository):
             Ordered list of study identifiers.
         """
         cte = self._ancestor_or_self_cte(variant_id)
-        result = self.session.execute(select(cte.c.id))
+        result = self.session.execute(select(cte.c.id).order_by(cte.c.depth))
         return [r[0] for r in result]
 
     def get_root_ancestor_id(self, variant_id: str) -> str | None:
@@ -193,7 +200,10 @@ class VariantStudyRepository(StudyMetadataRepository):
         session.commit()
 
     def is_snapshot_up_to_date(self, study_id: str) -> bool:
-        join_query = [joinedload(VariantStudy.snapshot), joinedload(VariantStudy.commands_version)]
+        join_query = [
+            joinedload(VariantStudy.snapshot).joinedload(VariantStudySnapshot.lineage),
+            joinedload(VariantStudy.commands_version),
+        ]
         variant: VariantStudy | None = self.session.get(VariantStudy, study_id, options=join_query)
 
         if not variant:
@@ -202,7 +212,32 @@ class VariantStudyRepository(StudyMetadataRepository):
         if not variant.snapshot:
             return False
 
-        return variant.snapshot.version == variant.commands_version.version  # type: ignore
+        return self.snapshot_matches_current_lineage(variant.snapshot, study_id)
+
+    def get_current_lineage(self, variant_id: str) -> tuple[tuple[str, int], ...]:
+        """
+        Return the current root-to-target variant lineage and command-list versions.
+        """
+        cte = self._ancestor_or_self_cte(variant_id)
+        stmt = (
+            select(CommandsListVersion.variant_id, CommandsListVersion.version)
+            .join(cte, CommandsListVersion.variant_id == cte.c.id)
+            .order_by(cte.c.depth.desc())
+        )
+        return tuple((variant_id, version) for variant_id, version in self.session.execute(stmt).tuples())
+
+    def snapshot_matches_current_lineage(self, snapshot: VariantStudySnapshot, variant_id: str) -> bool:
+        """
+        Return whether a snapshot was generated from the current variant lineage.
+
+        Snapshots created before lineage metadata was introduced have no lineage
+        rows and are deliberately treated as stale.
+        """
+        if not snapshot.lineage:
+            return False
+
+        stored_lineage = tuple((entry.variant_id, entry.commands_version) for entry in snapshot.lineage)
+        return stored_lineage == self.get_current_lineage(variant_id)
 
     def get_study_tree(self, study_ids: Sequence[str]) -> tuple[RawStudy, list[VariantStudy]]:
         """
@@ -215,7 +250,7 @@ class VariantStudyRepository(StudyMetadataRepository):
         join_query = [
             joinedload(study_w_p.owner),
             joinedload(study_w_p.groups),
-            joinedload(study_w_p.VariantStudy.snapshot),
+            joinedload(study_w_p.VariantStudy.snapshot).joinedload(VariantStudySnapshot.lineage),
             joinedload(study_w_p.VariantStudy.commands_version),
             joinedload(study_w_p.VariantStudy.commands),
         ]

--- a/antarest/study/storage/variantstudy/repository.py
+++ b/antarest/study/storage/variantstudy/repository.py
@@ -239,6 +239,17 @@ class VariantStudyRepository(StudyMetadataRepository):
         stored_lineage = tuple((entry.variant_id, entry.commands_version) for entry in snapshot.lineage)
         return stored_lineage == self.get_current_lineage(variant_id)
 
+    def has_snapshot_generation_id(self, study_id: str, generation_id: str) -> bool:
+        """
+        Return whether a snapshot with this exact publication ID still exists.
+        """
+        stmt = (
+            select(VariantStudySnapshot.generation_id)
+            .where(VariantStudySnapshot.id == study_id)
+            .execution_options(populate_existing=True)
+        )
+        return self.session.execute(stmt).scalar_one_or_none() == generation_id
+
     def get_study_tree(self, study_ids: Sequence[str]) -> tuple[RawStudy, list[VariantStudy]]:
         """
         Returns the parent study and the list of its variants based on the given ids.

--- a/antarest/study/storage/variantstudy/repository.py
+++ b/antarest/study/storage/variantstudy/repository.py
@@ -257,14 +257,11 @@ class VariantStudyRepository(StudyMetadataRepository):
     def get_study_tree(self, study_ids: Sequence[str]) -> tuple[RawStudy, list[VariantStudy]]:
         """
         Returns the parent study and the list of its variants based on the given ids.
-        Loads metadata at the same time for permission checks.
         Also loads commands and snapshot at the same time to avoid multiple queries.
         """
         study_w_p = with_polymorphic(Study, [VariantStudy])
 
         join_query = [
-            joinedload(study_w_p.owner),
-            joinedload(study_w_p.groups),
             joinedload(study_w_p.VariantStudy.snapshot).joinedload(VariantStudySnapshot.lineage),
             joinedload(study_w_p.VariantStudy.commands_version),
             joinedload(study_w_p.VariantStudy.commands),

--- a/antarest/study/storage/variantstudy/repository.py
+++ b/antarest/study/storage/variantstudy/repository.py
@@ -156,7 +156,9 @@ class VariantStudyRepository(StudyMetadataRepository):
         stmt = select(CommandBlock)
         return list(self.session.execute(stmt).scalars().all())
 
-    def get_study_with_commands(self, variant_id: str, with_lock: bool = False) -> VariantStudy:
+    def get_study_with_commands(
+        self, variant_id: str, with_lock: bool = False, with_snapshot: bool = False
+    ) -> VariantStudy:
         """
         Use a single JOIN query to retrieve a variant study with its associated command blocks and their version.
         It returns a `VariantStudy` object with its associated `owner`, `groups` to be able to check user permissions efficiently.
@@ -173,6 +175,8 @@ class VariantStudyRepository(StudyMetadataRepository):
             joinedload(VariantStudy.commands),
             joinedload(VariantStudy.commands_version),
         ]
+        if with_snapshot:
+            join_query.append(joinedload(VariantStudy.snapshot).joinedload(VariantStudySnapshot.lineage))
         stmt = select(VariantStudy).options(*join_query).where(VariantStudy.id == variant_id)
 
         variant_study: VariantStudy | None = self.session.execute(stmt).unique().scalar_one_or_none()

--- a/antarest/study/storage/variantstudy/repository.py
+++ b/antarest/study/storage/variantstudy/repository.py
@@ -12,7 +12,7 @@
 
 from collections.abc import Sequence
 
-from sqlalchemy import literal, select
+from sqlalchemy import delete, insert, literal, select, update
 from sqlalchemy.orm import Session, joinedload, with_polymorphic
 from sqlalchemy.sql.selectable import CTE
 from typing_extensions import override
@@ -20,6 +20,7 @@ from typing_extensions import override
 from antarest.core.exceptions import StudyNotFoundError
 from antarest.core.interfaces.cache import ICache
 from antarest.core.utils.fastapi_sqlalchemy import db
+from antarest.core.utils.utils import current_time
 from antarest.study.model import RawStudy, Study
 from antarest.study.repository import StudyMetadataRepository
 from antarest.study.storage.variantstudy.model.dbmodel import (
@@ -27,6 +28,7 @@ from antarest.study.storage.variantstudy.model.dbmodel import (
     CommandsListVersion,
     VariantStudy,
     VariantStudySnapshot,
+    VariantStudySnapshotLineage,
 )
 
 
@@ -157,7 +159,11 @@ class VariantStudyRepository(StudyMetadataRepository):
         return list(self.session.execute(stmt).scalars().all())
 
     def get_study_with_commands(
-        self, variant_id: str, with_lock: bool = False, with_snapshot: bool = False
+        self,
+        variant_id: str,
+        with_lock: bool = False,
+        with_snapshot: bool = False,
+        with_permissions: bool = True,
     ) -> VariantStudy:
         """
         Use a single JOIN query to retrieve a variant study with its associated command blocks and their version.
@@ -169,12 +175,9 @@ class VariantStudyRepository(StudyMetadataRepository):
             self.session.execute(
                 select(CommandsListVersion).where(CommandsListVersion.variant_id == variant_id).with_for_update()
             )
-        join_query = [
-            joinedload(VariantStudy.owner),
-            joinedload(VariantStudy.groups),
-            joinedload(VariantStudy.commands),
-            joinedload(VariantStudy.commands_version),
-        ]
+        join_query = [joinedload(VariantStudy.commands), joinedload(VariantStudy.commands_version)]
+        if with_permissions:
+            join_query.extend([joinedload(VariantStudy.owner), joinedload(VariantStudy.groups)])
         if with_snapshot:
             join_query.append(joinedload(VariantStudy.snapshot).joinedload(VariantStudySnapshot.lineage))
         stmt = select(VariantStudy).options(*join_query).where(VariantStudy.id == variant_id)
@@ -253,6 +256,44 @@ class VariantStudyRepository(StudyMetadataRepository):
             .execution_options(populate_existing=True)
         )
         return self.session.execute(stmt).scalar_one_or_none() == generation_id
+
+    def invalidate_snapshot(self, study_id: str) -> None:
+        """
+        Remove snapshot metadata without loading authorization relationships.
+        """
+        session = self.session
+        session.execute(delete(VariantStudySnapshot).where(VariantStudySnapshot.id == study_id))
+        session.execute(update(Study).where(Study.id == study_id).values(updated_at=current_time()))
+        session.commit()
+
+    def save_snapshot(self, snapshot: VariantStudySnapshot) -> None:
+        """
+        Persist snapshot metadata without loading study authorization relationships.
+        """
+        session = self.session
+        session.execute(
+            insert(VariantStudySnapshot).values(
+                id=snapshot.id,
+                version=snapshot.version,
+                generation_id=snapshot.generation_id,
+                last_executed_command=snapshot.last_executed_command,
+            )
+        )
+        if snapshot.lineage:
+            session.execute(
+                insert(VariantStudySnapshotLineage),
+                [
+                    {
+                        "snapshot_id": entry.snapshot_id,
+                        "position": entry.position,
+                        "variant_id": entry.variant_id,
+                        "commands_version": entry.commands_version,
+                    }
+                    for entry in snapshot.lineage
+                ],
+            )
+        session.commit()
+        session.expire_all()
 
     def get_study_tree(self, study_ids: Sequence[str]) -> tuple[RawStudy, list[VariantStudy]]:
         """

--- a/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
+++ b/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
@@ -65,6 +65,10 @@ def _get_aggregated_command_blocks(variants: Sequence[VariantStudy]) -> list[Com
     return [cmd for variant in variants for cmd in variant.commands]
 
 
+def _copy_command_blocks(command_blocks: Sequence[CommandBlock]) -> list[CommandBlock]:
+    return [CommandBlock(**command_block.to_dict()) for command_block in command_blocks]
+
+
 def _get_lineage_versions(variants: Sequence[VariantStudy]) -> tuple[LineageVersion, ...]:
     return tuple(
         LineageVersion(variant_id=variant.id, commands_version=variant.commands_version.version) for variant in variants
@@ -111,10 +115,22 @@ class SnapshotGenerator:
             raise UnsupportedOperationOnArchivedStudy(root_study.id)
         search_result = self.search_ref_study(root_study, descendants, from_scratch=from_scratch)
 
-        ref_study = search_result.ref_study
-        cmd_blocks = search_result.cmd_blocks
+        variant_study = descendants[-1]
+        previous_last_executed_command = (
+            variant_study.snapshot.last_executed_command if variant_study.snapshot is not None else None
+        )
+        cmd_blocks = _copy_command_blocks(search_result.cmd_blocks)
+        ref_study_id = search_result.ref_study.id
 
-        # Get snapshot directory
+        # Persist this before modifying snapshot data. Commands are copied
+        # above so the invalidation commit cannot reload different inputs.
+        self.variant_study_service.invalidate_snapshot(variant_study)
+        root_study, descendants = self._retrieve_descendants(variant_study_id)
+        assert_permission_on_studies([root_study, *descendants], StudyPermissionType.READ)
+        if root_study.archived:
+            raise UnsupportedOperationOnArchivedStudy(root_study.id)
+
+        ref_study = root_study if root_study.id == ref_study_id else descendants[-1]
         variant_study = descendants[-1]
 
         try:
@@ -132,8 +148,8 @@ class SnapshotGenerator:
             last_executed_command = None
             if cmd_blocks:
                 last_executed_command = cmd_blocks[-1].id
-            elif variant_study.snapshot:
-                last_executed_command = variant_study.snapshot.last_executed_command
+            else:
+                last_executed_command = previous_last_executed_command
             variant_study.snapshot = VariantStudySnapshot(
                 id=variant_study_id,
                 version=search_result.version,

--- a/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
+++ b/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
@@ -166,7 +166,7 @@ class SnapshotGenerator:
         ref_study = self.repository.get(ref_study_id)
         if ref_study is None:
             raise StudyNotFoundError(ref_study_id)
-        variant_study = self.repository.get_study_with_commands(variant_study_id, with_snapshot=True)
+        variant_study = self.repository.get_study_with_commands(variant_study_id, with_permissions=False)
 
         try:
             if search_result.force_regenerate:
@@ -191,7 +191,7 @@ class SnapshotGenerator:
                 last_executed_command = cmd_blocks[-1].id
             else:
                 last_executed_command = previous_last_executed_command
-            variant_study.snapshot = VariantStudySnapshot(
+            snapshot = VariantStudySnapshot(
                 id=variant_study_id,
                 version=search_result.version,
                 generation_id=str(uuid.uuid4()),
@@ -206,7 +206,7 @@ class SnapshotGenerator:
                     for position, lineage_version in enumerate(search_result.lineage)
                 ],
             )
-            self.repository.save(variant_study)
+            self.repository.save_snapshot(snapshot)
 
             if results.should_invalidate_cache:
                 # We need to remove the cache

--- a/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
+++ b/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
@@ -29,7 +29,12 @@ from antarest.study.storage.utils import (
     format_timestamp,
     remove_from_cache,
 )
-from antarest.study.storage.variantstudy.model.dbmodel import CommandBlock, VariantStudy, VariantStudySnapshot
+from antarest.study.storage.variantstudy.model.dbmodel import (
+    CommandBlock,
+    VariantStudy,
+    VariantStudySnapshot,
+    VariantStudySnapshotLineage,
+)
 from antarest.study.storage.variantstudy.model.model import GenerationResultInfoDTO
 from antarest.study.storage.variantstudy.variant_command_generator import apply_commands_to_variant
 
@@ -47,11 +52,27 @@ class RefStudySearchResult(NamedTuple):
     ref_study: Study
     cmd_blocks: list[CommandBlock]
     version: int
+    lineage: tuple["LineageVersion", ...]
     force_regenerate: bool = False
+
+
+class LineageVersion(NamedTuple):
+    variant_id: str
+    commands_version: int
 
 
 def _get_aggregated_command_blocks(variants: Sequence[VariantStudy]) -> list[CommandBlock]:
     return [cmd for variant in variants for cmd in variant.commands]
+
+
+def _get_lineage_versions(variants: Sequence[VariantStudy]) -> tuple[LineageVersion, ...]:
+    return tuple(
+        LineageVersion(variant_id=variant.id, commands_version=variant.commands_version.version) for variant in variants
+    )
+
+
+def _snapshot_matches_lineage(snapshot: VariantStudySnapshot, lineage: tuple[LineageVersion, ...]) -> bool:
+    return tuple((entry.variant_id, entry.commands_version) for entry in snapshot.lineage) == lineage
 
 
 class SnapshotGenerator:
@@ -114,7 +135,18 @@ class SnapshotGenerator:
             elif variant_study.snapshot:
                 last_executed_command = variant_study.snapshot.last_executed_command
             variant_study.snapshot = VariantStudySnapshot(
-                id=variant_study_id, version=search_result.version, last_executed_command=last_executed_command
+                id=variant_study_id,
+                version=search_result.version,
+                last_executed_command=last_executed_command,
+                lineage=[
+                    VariantStudySnapshotLineage(
+                        snapshot_id=variant_study_id,
+                        position=position,
+                        variant_id=lineage_version.variant_id,
+                        commands_version=lineage_version.commands_version,
+                    )
+                    for position, lineage_version in enumerate(search_result.lineage)
+                ],
             )
             self.repository.save(variant_study)
 
@@ -190,6 +222,7 @@ class SnapshotGenerator:
             The reference study and the commands to use for snapshot generation.
         """
         current_variant = descendants[-1]
+        lineage = _get_lineage_versions(descendants)
 
         if from_scratch:
             # In the case of a from scratch generation, the root study will be used as the reference study.
@@ -201,6 +234,7 @@ class SnapshotGenerator:
                 cmd_blocks=command_blocks,
                 force_regenerate=True,
                 version=commands_version,
+                lineage=lineage,
             )
 
         # 1st case: The variant snapshot is already up to date -> No-op.
@@ -212,7 +246,7 @@ class SnapshotGenerator:
         # We only have to check if we can reuse the snapshot to minimize the generation time.
         # We can reuse the snapshot if the last executed command is still present in the variant commands list.
         # It's not always the case as the user could have removed a command or replaced them all.
-        if current_variant.snapshot is not None:
+        if current_variant.snapshot is not None and _snapshot_matches_lineage(current_variant.snapshot, lineage):
             if last_executed_cmd_id := current_variant.snapshot.last_executed_command:
                 for command_block in current_variant.commands:
                     if command_block.id == last_executed_cmd_id:
@@ -222,6 +256,7 @@ class SnapshotGenerator:
                             cmd_blocks=current_variant.commands[last_exec_index + 1 :],
                             force_regenerate=False,
                             version=current_variant.commands_version.version,
+                            lineage=lineage,
                         )
 
         # Final case: The variant has no snapshot, or its `last_executed_command` does not exist anymore.
@@ -234,4 +269,5 @@ class SnapshotGenerator:
             cmd_blocks=command_blocks,
             force_regenerate=True,
             version=commands_version,
+            lineage=lineage,
         )

--- a/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
+++ b/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
@@ -50,30 +50,8 @@ class RefStudySearchResult(NamedTuple):
     force_regenerate: bool = False
 
 
-def _get_sorted_command_blocks(variants: Sequence[VariantStudy]) -> list[CommandBlock]:
+def _get_aggregated_command_blocks(variants: Sequence[VariantStudy]) -> list[CommandBlock]:
     return [cmd for variant in variants for cmd in variant.commands]
-
-
-def _find_last_snapshot_up_to_date(
-    variants: Sequence[VariantStudy],
-) -> tuple[VariantStudy | None, list[CommandBlock]]:
-    """
-    Finds the most recent snapshot that is up to date.
-
-    Assumes the variants are sorted from the most recent to the oldest.
-
-    If no variant is up to date, it returns None.
-
-    It also returns the list of commands to apply in order (from the oldest to the most recent command).
-    """
-    for k, variant in enumerate(variants):
-        if variant.snapshot is None:
-            continue
-        if variant.snapshot.version == variant.commands_version.version:
-            commands = _get_sorted_command_blocks(variants[:k][::-1])
-            return variant, commands
-    commands = _get_sorted_command_blocks(variants[::-1])
-    return None, commands
 
 
 class SnapshotGenerator:
@@ -217,7 +195,7 @@ class SnapshotGenerator:
             # In the case of a from scratch generation, the root study will be used as the reference study.
             # We need to retrieve all commands from the descendants of variants to apply them on the reference study.
             commands_version = current_variant.commands_version.version
-            command_blocks = _get_sorted_command_blocks(descendants)
+            command_blocks = _get_aggregated_command_blocks(descendants)
             return RefStudySearchResult(
                 ref_study=root_study,
                 cmd_blocks=command_blocks,
@@ -247,18 +225,13 @@ class SnapshotGenerator:
                         )
 
         # Final case: The variant has no snapshot, or its `last_executed_command` does not exist anymore.
-        # We search for a variant with an up-to-date snapshot to use it as a reference study.
-        # If no such variant is found, we use the root study as a reference study.
-
-        ref_study = root_study
-        # Give the list in reverse order to find the most recent variants first.
-        ref_variant_study, commands = _find_last_snapshot_up_to_date(descendants[-2::-1])
-        if ref_variant_study is not None:
-            ref_study = ref_variant_study
-
+        # we perform a generation "from scratch". We don't try to re-use intermediate snapshots, which
+        # might be modified concurrently.
+        commands_version = current_variant.commands_version.version
+        command_blocks = _get_aggregated_command_blocks(descendants)
         return RefStudySearchResult(
-            ref_study=ref_study,
-            cmd_blocks=commands + current_variant.commands,
+            ref_study=root_study,
+            cmd_blocks=command_blocks,
             force_regenerate=True,
-            version=current_variant.commands_version.version,
+            version=commands_version,
         )

--- a/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
+++ b/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
@@ -19,7 +19,7 @@ import uuid
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, NamedTuple
 
-from antarest.core.exceptions import UnsupportedOperationOnArchivedStudy, VariantGenerationError
+from antarest.core.exceptions import StudyNotFoundError, UnsupportedOperationOnArchivedStudy, VariantGenerationError
 from antarest.core.model import StudyPermissionType
 from antarest.core.tasks.service import ITaskNotifier, NoopNotifier
 from antarest.study.dao.api.study_dao import StudyDao
@@ -169,17 +169,10 @@ class SnapshotGenerator:
         # Persist this before modifying snapshot data. Commands are copied
         # above so the invalidation commit cannot reload different inputs.
         self.variant_study_service.invalidate_snapshot(variant_study)
-        root_study, descendants = self._retrieve_descendants(variant_study_id)
-        assert_permission_on_studies([root_study, *descendants], StudyPermissionType.READ)
-        if root_study.archived:
-            raise UnsupportedOperationOnArchivedStudy(root_study.id)
-
-        ref_study = (
-            root_study
-            if root_study.id == ref_study_id
-            else next(variant for variant in descendants if variant.id == ref_study_id)
-        )
-        variant_study = descendants[-1]
+        ref_study = self.repository.get(ref_study_id)
+        if ref_study is None:
+            raise StudyNotFoundError(ref_study_id)
+        variant_study = self.repository.get_study_with_commands(variant_study_id, with_snapshot=True)
 
         try:
             if search_result.force_regenerate:

--- a/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
+++ b/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
@@ -15,6 +15,7 @@ This module dedicated to variant snapshot generation.
 """
 
 import logging
+import uuid
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -53,12 +54,25 @@ class RefStudySearchResult(NamedTuple):
     cmd_blocks: list[CommandBlock]
     version: int
     lineage: tuple["LineageVersion", ...]
+    source_snapshot: "SourceSnapshotToken | None" = None
     force_regenerate: bool = False
 
 
 class LineageVersion(NamedTuple):
     variant_id: str
     commands_version: int
+
+
+class SourceSnapshotToken(NamedTuple):
+    study_id: str
+    generation_id: str
+
+
+class SourceSnapshotChanged(Exception):
+    pass
+
+
+MAX_SOURCE_SNAPSHOT_RETRIES = 2
 
 
 def _get_aggregated_command_blocks(variants: Sequence[VariantStudy]) -> list[CommandBlock]:
@@ -99,6 +113,36 @@ class SnapshotGenerator:
         from_scratch: bool = False,
         notifier: ITaskNotifier = NoopNotifier(),
     ) -> GenerationResultInfoDTO:
+        for attempt in range(MAX_SOURCE_SNAPSHOT_RETRIES + 1):
+            try:
+                return self._generate_snapshot(
+                    variant_study_id,
+                    dao_factory=dao_factory,
+                    from_scratch=from_scratch,
+                    notifier=notifier,
+                )
+            except SourceSnapshotChanged:
+                if attempt == MAX_SOURCE_SNAPSHOT_RETRIES:
+                    raise VariantGenerationError(
+                        f"Source snapshot changed repeatedly while generating variant {variant_study_id}"
+                    ) from None
+                logger.info(
+                    "Source snapshot changed while generating variant '%s'; retrying (%s/%s)",
+                    variant_study_id,
+                    attempt + 1,
+                    MAX_SOURCE_SNAPSHOT_RETRIES,
+                )
+
+        raise AssertionError("Unreachable")
+
+    def _generate_snapshot(
+        self,
+        variant_study_id: str,
+        *,
+        dao_factory: StudyFactoryDao,
+        from_scratch: bool = False,
+        notifier: ITaskNotifier = NoopNotifier(),
+    ) -> GenerationResultInfoDTO:
         # ATTENTION: since we are making changes to disk, a file lock is needed.
         # The locking is currently done in the `VariantStudyService.generate_task` function
         # when starting the task. However, it is not enough, because the snapshot generation
@@ -130,7 +174,11 @@ class SnapshotGenerator:
         if root_study.archived:
             raise UnsupportedOperationOnArchivedStudy(root_study.id)
 
-        ref_study = root_study if root_study.id == ref_study_id else descendants[-1]
+        ref_study = (
+            root_study
+            if root_study.id == ref_study_id
+            else next(variant for variant in descendants if variant.id == ref_study_id)
+        )
         variant_study = descendants[-1]
 
         try:
@@ -145,6 +193,12 @@ class SnapshotGenerator:
 
             # Finally, we can update the database.
             logger.info(f"Saving new snapshot for study {variant_study_id}")
+            if search_result.source_snapshot and not self.repository.has_snapshot_generation_id(
+                search_result.source_snapshot.study_id,
+                search_result.source_snapshot.generation_id,
+            ):
+                raise SourceSnapshotChanged()
+
             last_executed_command = None
             if cmd_blocks:
                 last_executed_command = cmd_blocks[-1].id
@@ -153,6 +207,7 @@ class SnapshotGenerator:
             variant_study.snapshot = VariantStudySnapshot(
                 id=variant_study_id,
                 version=search_result.version,
+                generation_id=str(uuid.uuid4()),
                 last_executed_command=last_executed_command,
                 lineage=[
                     VariantStudySnapshotLineage(
@@ -275,9 +330,24 @@ class SnapshotGenerator:
                             lineage=lineage,
                         )
 
-        # Final case: The variant has no snapshot, or its `last_executed_command` does not exist anymore.
-        # we perform a generation "from scratch". We don't try to re-use intermediate snapshots, which
-        # might be modified concurrently.
+        for index in range(len(descendants) - 2, -1, -1):
+            candidate = descendants[index]
+            candidate_lineage = _get_lineage_versions(descendants[: index + 1])
+            if (
+                candidate.snapshot is not None
+                and candidate.snapshot.generation_id is not None
+                and _snapshot_matches_lineage(candidate.snapshot, candidate_lineage)
+            ):
+                return RefStudySearchResult(
+                    ref_study=candidate,
+                    cmd_blocks=_get_aggregated_command_blocks(descendants[index + 1 :]),
+                    force_regenerate=True,
+                    version=current_variant.commands_version.version,
+                    lineage=lineage,
+                    source_snapshot=SourceSnapshotToken(candidate.id, candidate.snapshot.generation_id),
+                )
+
+        # Final case: no usable snapshot is available in the lineage.
         commands_version = current_variant.commands_version.version
         command_blocks = _get_aggregated_command_blocks(descendants)
         return RefStudySearchResult(

--- a/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
+++ b/antarest/study/storage/variantstudy/snapshot/snapshot_generator.py
@@ -20,16 +20,11 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, NamedTuple
 
 from antarest.core.exceptions import StudyNotFoundError, UnsupportedOperationOnArchivedStudy, VariantGenerationError
-from antarest.core.model import StudyPermissionType
 from antarest.core.tasks.service import ITaskNotifier, NoopNotifier
 from antarest.study.dao.api.study_dao import StudyDao
 from antarest.study.dao.api.study_factory_dao import StudyFactoryDao
 from antarest.study.model import Study, StudyMetadataUpdate
-from antarest.study.storage.utils import (
-    assert_permission_on_studies,
-    format_timestamp,
-    remove_from_cache,
-)
+from antarest.study.storage.utils import format_timestamp, remove_from_cache
 from antarest.study.storage.variantstudy.model.dbmodel import (
     CommandBlock,
     VariantStudy,
@@ -154,7 +149,6 @@ class SnapshotGenerator:
         logger.info(f"Generating variant study snapshot for '{variant_study_id}'")
 
         root_study, descendants = self._retrieve_descendants(variant_study_id)
-        assert_permission_on_studies([root_study, *descendants], StudyPermissionType.READ)
         if root_study.archived:
             raise UnsupportedOperationOnArchivedStudy(root_study.id)
         search_result = self.search_ref_study(root_study, descendants, from_scratch=from_scratch)

--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -407,6 +407,9 @@ class VariantStudyService(AbstractStudyService):
     def on_parent_change(self, study_id: str) -> None:
         """
         Takes all necessary actions on children when a study history has changed.
+
+        TODO: still needed when changing the root study of a study tree, but we should handle that
+              through versioning of the root study, like we do now for the list of commands, instead.
         """
         # TODO: optimize to not perform one request per child
         for child in self.get_children(parent_id=study_id):

--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -181,8 +181,7 @@ class VariantStudyService(AbstractStudyService):
         Invalidates snapshot so that it is regenerated from scratch
         next time the study is accessed.
         """
-        variant_study.snapshot = None
-        self.repository.save(metadata=variant_study)
+        self.repository.invalidate_snapshot(variant_study.id)
 
     def clear_snapshot(self, variant_study: VariantStudy) -> None:
         self._snapshot_manager_mapping[variant_study.storage_mode].clear_snapshot(variant_study)

--- a/antarest/study/storage/variantstudy/variant_study_service.py
+++ b/antarest/study/storage/variantstudy/variant_study_service.py
@@ -182,16 +182,16 @@ class VariantStudyService(AbstractStudyService):
         next time the study is accessed.
         """
         variant_study.snapshot = None
-        variant_study.updated_at = current_time()
         self.repository.save(metadata=variant_study)
 
     def clear_snapshot(self, variant_study: VariantStudy) -> None:
         self._snapshot_manager_mapping[variant_study.storage_mode].clear_snapshot(variant_study)
         self.invalidate_snapshot(variant_study)
 
-    def _update_editor(self, study: VariantStudy) -> None:
+    def _update_edittion_metadata(self, study: VariantStudy) -> None:
         user_name = get_current_user_name()
         study.editor = user_name
+        study.updated_at = current_time()
         self.repository.save(study)
 
     def get_commands(self, study_id: str) -> list[CommandDTOAPI]:
@@ -248,7 +248,6 @@ class VariantStudyService(AbstractStudyService):
         assert_permission(study, StudyPermissionType.WRITE)
 
         command_ids = self._modify_commands(study, commands, replace_commands=False)
-        self.on_variant_advance(study)
         self.generate(study)
         return command_ids
 
@@ -265,7 +264,6 @@ class VariantStudyService(AbstractStudyService):
         assert_permission(study, StudyPermissionType.WRITE)
 
         self._modify_commands(study, commands, replace_commands=True)
-        self.on_variant_rebase(study)
         self.generate(study)
         return study_id
 
@@ -304,7 +302,7 @@ class VariantStudyService(AbstractStudyService):
         study.commands_version.version += 1
 
         # Update the editor
-        self._update_editor(study)
+        self._update_edittion_metadata(study)
         return [c.id for c in new_commands]
 
     def remove_command(self, study_id: str, command_id: str) -> None:
@@ -336,8 +334,7 @@ class VariantStudyService(AbstractStudyService):
         study.commands = new_commands
         study.commands_version.version += 1
 
-        self._update_editor(study)
-        self.on_parent_change(study.id)
+        self._update_edittion_metadata(study)
         self.generate(study)
 
     def remove_all_commands(self, study_id: str) -> None:
@@ -356,8 +353,7 @@ class VariantStudyService(AbstractStudyService):
         study.commands = []
         study.commands_version.version = current_cmd_version + 1
 
-        self._update_editor(study)
-        self.on_variant_rebase(study)
+        self._update_edittion_metadata(study)
         self.clear_snapshot(study)
 
     def _get_variant_study(self, study_id: str) -> VariantStudy:
@@ -402,30 +398,11 @@ class VariantStudyService(AbstractStudyService):
         assert_permission(study, StudyPermissionType.READ)
         return study
 
-    def on_variant_advance(self, study: VariantStudy) -> None:
-        """
-        Takes necessary actions when some study commands have been appended to this study.
-        It will need a snapshot generation (NOT from scratch),
-        and children need to be notified of their parent change.
-        """
-        study.updated_at = current_time()
-        self.repository.save(metadata=study)
-        self.on_parent_change(study.id)
-
     def get_children(self, parent_id: str) -> list[VariantStudy]:
         """
         Get the direct children of the specified study (in chronological creation order).
         """
         return self.repository.get_children(parent_id=parent_id)
-
-    def on_variant_rebase(self, study: VariantStudy) -> None:
-        """
-        This variant has been "rebased" in the sense of git (history changed):
-        it will need a generation from scratch, and children need
-        to be rebased too.
-        """
-        self.invalidate_snapshot(study)
-        self.on_parent_change(study.id)
 
     def on_parent_change(self, study_id: str) -> None:
         """
@@ -433,7 +410,8 @@ class VariantStudyService(AbstractStudyService):
         """
         # TODO: optimize to not perform one request per child
         for child in self.get_children(parent_id=study_id):
-            self.on_variant_rebase(child)
+            self.invalidate_snapshot(child)
+            self.on_parent_change(child.id)
 
     def has_children(self, study: Study) -> bool:
         return self.repository.has_children(study.id)

--- a/tests/study/storage/variantstudy/model/test_dbmodel.py
+++ b/tests/study/storage/variantstudy/model/test_dbmodel.py
@@ -31,6 +31,7 @@ from antarest.study.storage.variantstudy.model.dbmodel import (
     CommandsListVersion,
     VariantStudy,
     VariantStudySnapshot,
+    VariantStudySnapshotLineage,
 )
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 from tests.helpers import create_raw_study, create_variant_study, with_db_context
@@ -131,6 +132,33 @@ class TestVariantStudySnapshot:
         assert obj.id == variant_study_id
         assert obj.version == 2
         assert obj.last_executed_command == command_id
+
+    def test_init__with_lineage(self, db_session: Session, variant_study_id: str) -> None:
+        with db_session:
+            snapshot = VariantStudySnapshot(
+                id=variant_study_id,
+                version=2,
+                lineage=[
+                    VariantStudySnapshotLineage(
+                        snapshot_id=variant_study_id,
+                        position=0,
+                        variant_id=variant_study_id,
+                        commands_version=2,
+                    )
+                ],
+            )
+            db_session.add(snapshot)
+            db_session.commit()
+
+        snapshot = db_session.get(VariantStudySnapshot, variant_study_id)
+        assert snapshot is not None
+        assert [(entry.variant_id, entry.commands_version) for entry in snapshot.lineage] == [(variant_study_id, 2)]
+
+        with db_session:
+            db_session.delete(snapshot)
+            db_session.commit()
+
+        assert db_session.query(VariantStudySnapshotLineage).count() == 0
 
 
 class TestCommandBlock:
@@ -274,24 +302,73 @@ def test_is_snapshot_up_to_date(variant_study_service: VariantStudyService, raw_
     variant = session.get(VariantStudy, variant_id)
     assert variant_study_service.repository.is_snapshot_up_to_date(variant_id) is False
 
-    # 2nd case: Add the snapshot in DB with a version 0 which matches the command blocks version -> Up to date
+    # 2nd case: A legacy snapshot with no lineage must be regenerated.
     variant.snapshot = VariantStudySnapshot(id=variant_id, version=0, last_executed_command=None)
     session.add(variant)
     session.commit()
 
-    variant = session.get(VariantStudy, variant_id)
+    assert variant_study_service.repository.is_snapshot_up_to_date(variant_id) is False
+
+    # 3rd case: A matching lineage is up to date.
+    variant.snapshot.lineage = [
+        VariantStudySnapshotLineage(
+            snapshot_id=variant_id,
+            position=0,
+            variant_id=variant_id,
+            commands_version=0,
+        )
+    ]
+    session.add(variant)
+    session.commit()
     assert variant_study_service.repository.is_snapshot_up_to_date(variant_id) is True
 
-    # 3rd case: Changes the version in `commands_list_version` table -> Not up to date
+    # 4th case: Changes the version in `commands_list_version` table -> Not up to date
     upsert_one(session, CommandsListVersion.__table__, {"variant_id": variant_id, "version": 1})
     session.commit()
 
-    variant = session.get(VariantStudy, variant_id)
     assert variant_study_service.repository.is_snapshot_up_to_date(variant_id) is False
 
-    # 4th case: Adapt the version in the study snapshot to match the commands one -> Up to date
-    variant.snapshot.version = 1
+    # 5th case: Adapt the captured lineage to match the command list -> Up to date
+    variant.snapshot.lineage[0].commands_version = 1
     session.add(variant)
     session.commit()
 
     assert variant_study_service.repository.is_snapshot_up_to_date(variant_id) is True
+
+
+@with_db_context
+def test_snapshot_with_stale_parent_lineage_is_not_up_to_date(
+    variant_study_service: VariantStudyService, raw_study_id: int, user_id: int
+) -> None:
+    session = db.session
+    parent_id = _set_up(session, raw_study_id, user_id)
+    child_id = _set_up(session, parent_id, user_id)
+    child = session.get(VariantStudy, child_id)
+    assert child is not None
+    child.snapshot = VariantStudySnapshot(
+        id=child_id,
+        version=0,
+        lineage=[
+            VariantStudySnapshotLineage(
+                snapshot_id=child_id,
+                position=0,
+                variant_id=parent_id,
+                commands_version=0,
+            ),
+            VariantStudySnapshotLineage(
+                snapshot_id=child_id,
+                position=1,
+                variant_id=child_id,
+                commands_version=0,
+            ),
+        ],
+    )
+    session.add(child)
+    session.commit()
+
+    assert variant_study_service.repository.is_snapshot_up_to_date(child_id) is True
+
+    upsert_one(session, CommandsListVersion.__table__, {"variant_id": parent_id, "version": 1})
+    session.commit()
+
+    assert variant_study_service.repository.is_snapshot_up_to_date(child_id) is False

--- a/tests/study/storage/variantstudy/model/test_dbmodel.py
+++ b/tests/study/storage/variantstudy/model/test_dbmodel.py
@@ -134,10 +134,12 @@ class TestVariantStudySnapshot:
         assert obj.last_executed_command == command_id
 
     def test_init__with_lineage(self, db_session: Session, variant_study_id: str) -> None:
+        generation_id = str(uuid.uuid4())
         with db_session:
             snapshot = VariantStudySnapshot(
                 id=variant_study_id,
                 version=2,
+                generation_id=generation_id,
                 lineage=[
                     VariantStudySnapshotLineage(
                         snapshot_id=variant_study_id,
@@ -152,6 +154,7 @@ class TestVariantStudySnapshot:
 
         snapshot = db_session.get(VariantStudySnapshot, variant_study_id)
         assert snapshot is not None
+        assert snapshot.generation_id == generation_id
         assert [(entry.variant_id, entry.commands_version) for entry in snapshot.lineage] == [(variant_study_id, 2)]
 
         with db_session:
@@ -310,6 +313,8 @@ def test_is_snapshot_up_to_date(variant_study_service: VariantStudyService, raw_
     assert variant_study_service.repository.is_snapshot_up_to_date(variant_id) is False
 
     # 3rd case: A matching lineage is up to date.
+    generation_id = str(uuid.uuid4())
+    variant.snapshot.generation_id = generation_id
     variant.snapshot.lineage = [
         VariantStudySnapshotLineage(
             snapshot_id=variant_id,
@@ -321,6 +326,8 @@ def test_is_snapshot_up_to_date(variant_study_service: VariantStudyService, raw_
     session.add(variant)
     session.commit()
     assert variant_study_service.repository.is_snapshot_up_to_date(variant_id) is True
+    assert variant_study_service.repository.has_snapshot_generation_id(variant_id, generation_id) is True
+    assert variant_study_service.repository.has_snapshot_generation_id(variant_id, str(uuid.uuid4())) is False
 
     # 4th case: Changes the version in `commands_list_version` table -> Not up to date
     upsert_one(session, CommandsListVersion.__table__, {"variant_id": variant_id, "version": 1})

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -1038,10 +1038,18 @@ class TestSnapshotGenerator:
         existing_study = variant_study_service.repository.get(variant_study_id)
         assert isinstance(existing_study, VariantStudy)
         assert existing_study.snapshot is not None
+        retrieve_descendants = generator._retrieve_descendants
+        retrieval_count = 0
+
+        def count_retrievals(study_id: str) -> t.Any:
+            nonlocal retrieval_count
+            retrieval_count += 1
+            return retrieve_descendants(study_id)
 
         def interrupt_generation(*args: object, **kwargs: object) -> t.NoReturn:
             raise SnapshotGenerationInterrupted()
 
+        monkeypatch.setattr(generator, "_retrieve_descendants", count_retrievals)
         monkeypatch.setattr(generator, "_apply_commands", interrupt_generation)
 
         with pytest.raises(SnapshotGenerationInterrupted):
@@ -1050,6 +1058,7 @@ class TestSnapshotGenerator:
         interrupted_study = variant_study_service.repository.get(variant_study_id)
         assert isinstance(interrupted_study, VariantStudy)
         assert interrupted_study.snapshot is None
+        assert retrieval_count == 1
 
     @with_admin_user
     @with_db_context

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -1293,7 +1293,7 @@ class TestSnapshotGenerator:
             # We expect 8 queries:
             # - 2 queries to fetch the tree before invalidating the snapshot
             # - 2 queries to remove the snapshot and its lineage metadata
-            # - 2 queries to reload the tree after the invalidation commit
+            # - 2 queries to reload the captured reference and target studies
             # - 2 queries to publish the new snapshot and lineage
 
             assert len(db_recorder.sql_statements) == 8, str(db_recorder)
@@ -1339,6 +1339,11 @@ class TestSnapshotGenerator:
             results = generator.generate_snapshot(variant_5_id, dao_factory=factory, from_scratch=False)
             assert results.success is True
 
-            # We expect a constant number of queries regardless of tree depth.
+            # We expect 9 queries regardless of tree depth:
+            # - 2 queries to fetch the tree before invalidating the snapshot
+            # - 2 queries to remove the snapshot and its lineage metadata
+            # - 2 queries to reload the captured reference and target studies
+            # - 1 query to verify that the reference snapshot was not republished
+            # - 2 queries to publish the new snapshot and lineage
 
-            assert len(db_recorder.sql_statements) == 7, str(db_recorder)
+            assert len(db_recorder.sql_statements) == 9, str(db_recorder)

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -295,8 +295,9 @@ class TestSearchRefStudy:
         """
         Case where we have 3 variants.
         The 1st and 2nd one are up-to-date. The 3rd one has no snapshot.
-        We expect to have a reference study corresponding to the 2nd variant as it's closer to the 3rd than the 1st.
-        We also expect to have the list of commands of the third variant.
+
+        We don't try anymore to restart from intermediate snapshots, to avoid concurrency issues:
+        we expect to restart from the root study, and have all commands applied.
         """
         root_study = create_study(id=str(uuid.uuid4()), name="root")
 
@@ -356,8 +357,8 @@ class TestSearchRefStudy:
         references = [variant1, variant2, variant3]
         generator = _build_generator(variant_study_service)
         search_result = generator.search_ref_study(root_study, references, from_scratch=False)
-        assert search_result.ref_study == variant2
-        assert search_result.cmd_blocks == variant3.commands
+        assert search_result.ref_study == root_study
+        assert search_result.cmd_blocks == variant1.commands + variant2.commands + variant3.commands
         assert search_result.force_regenerate is True
 
     @with_db_context
@@ -498,7 +499,7 @@ class TestSearchRefStudy:
         Case where the variant has a snapshot but is not up to date.
         It points to a command that no longer exists. It is possible, as the user can remove or replace commands.
 
-        We expect the reference study to be the variant and the list of commands to be all of its commands
+        We expect a generation from the root study.
         """
         root_study = create_study(id=str(uuid.uuid4()), name="root")
 
@@ -553,8 +554,8 @@ class TestSearchRefStudy:
         references = [variant1, variant2]
         generator = _build_generator(variant_study_service)
         search_result = generator.search_ref_study(root_study, references, from_scratch=False)
-        assert search_result.ref_study == variant1
-        assert search_result.cmd_blocks == variant2.commands
+        assert search_result.ref_study == root_study
+        assert search_result.cmd_blocks == variant1.commands + variant2.commands
         assert search_result.force_regenerate is True
 
 

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -644,6 +644,10 @@ class FailingNotifier(ITaskNotifier):
         return
 
 
+class SnapshotGenerationInterrupted(BaseException):
+    pass
+
+
 class TestSnapshotGenerator:
     """
     Test the `SnapshotGenerator` class.
@@ -955,6 +959,32 @@ class TestSnapshotGenerator:
 
     @with_admin_user
     @with_db_context
+    def test_generate__interruption_invalidates_snapshot(
+        self,
+        variant_study_id: str,
+        variant_study_service: VariantStudyService,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        generator = _build_generator(variant_study_service)
+        factory = _get_dao_factory(variant_study_id, variant_study_service)
+        existing_study = variant_study_service.repository.get(variant_study_id)
+        assert isinstance(existing_study, VariantStudy)
+        assert existing_study.snapshot is not None
+
+        def interrupt_generation(*args: object, **kwargs: object) -> t.NoReturn:
+            raise SnapshotGenerationInterrupted()
+
+        monkeypatch.setattr(generator, "_apply_commands", interrupt_generation)
+
+        with pytest.raises(SnapshotGenerationInterrupted):
+            generator.generate_snapshot(variant_study_id, from_scratch=True, dao_factory=factory)
+
+        interrupted_study = variant_study_service.repository.get(variant_study_id)
+        assert isinstance(interrupted_study, VariantStudy)
+        assert interrupted_study.snapshot is None
+
+    @with_admin_user
+    @with_db_context
     def test_generate__with_invalid_command(
         self, variant_study_id: str, variant_study_service: VariantStudyService
     ) -> None:
@@ -1183,12 +1213,13 @@ class TestSnapshotGenerator:
             results = generator.generate_snapshot(variant_study_id, dao_factory=factory, from_scratch=True)
             assert results.success is True
 
-            # We expect 4 queries:
-            # - 2 queries to fetch the whole tree of studies (with join query on owner, groups, commands, snapshot and command_version)
-            # - 1 query to update the variant study snapshot
-            # - 1 query to update its lineage metadata
+            # We expect 8 queries:
+            # - 2 queries to fetch the tree before invalidating the snapshot
+            # - 2 queries to remove the snapshot and its lineage metadata
+            # - 2 queries to reload the tree after the invalidation commit
+            # - 2 queries to publish the new snapshot and lineage
 
-            assert len(db_recorder.sql_statements) == 4, str(db_recorder)
+            assert len(db_recorder.sql_statements) == 8, str(db_recorder)
 
         # `is_snapshot_up_to_date` method
         with DBStatementRecorder(db.session.bind) as db_recorder:
@@ -1231,6 +1262,6 @@ class TestSnapshotGenerator:
             results = generator.generate_snapshot(variant_5_id, dao_factory=factory, from_scratch=False)
             assert results.success is True
 
-            # We expect the same amount of queries as the previous generation from scratch.
+            # We expect a constant number of queries regardless of tree depth.
 
-            assert len(db_recorder.sql_statements) == 4, str(db_recorder)
+            assert len(db_recorder.sql_statements) == 6, str(db_recorder)

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -48,6 +48,7 @@ from antarest.study.storage.variantstudy.model.dbmodel import (
     CommandsListVersion,
     VariantStudy,
     VariantStudySnapshot,
+    VariantStudySnapshotLineage,
 )
 from antarest.study.storage.variantstudy.model.model import CommandDTO
 from antarest.study.storage.variantstudy.snapshot.snapshot_generator import SnapshotGenerator
@@ -103,6 +104,18 @@ def _create_variant(
 
 def _build_generator(variant_study_service: VariantStudyService) -> SnapshotGenerator:
     return SnapshotGenerator(variant_study_service)
+
+
+def _set_snapshot_lineage(snapshot: VariantStudySnapshot, variants: list[VariantStudy]) -> None:
+    snapshot.lineage = [
+        VariantStudySnapshotLineage(
+            snapshot_id=snapshot.id,
+            position=position,
+            variant_id=variant.id,
+            commands_version=variant.commands_version.version,
+        )
+        for position, variant in enumerate(variants)
+    ]
 
 
 def _get_dao_factory(variant_id: str, variant_study_service: VariantStudyService) -> StudyFactoryDao:
@@ -410,6 +423,7 @@ class TestSearchRefStudy:
             ),
         ]
         variant1.snapshot.last_executed_command = variant1.commands[-1].id
+        _set_snapshot_lineage(variant1.snapshot, [variant1])
 
         # Save the studies in DB
         variant_study_service.raw_study_service.repository.save(root_study)
@@ -477,6 +491,7 @@ class TestSearchRefStudy:
 
         # The last executed command is the penultimate command.
         variant1.snapshot.last_executed_command = variant1.commands[0].id
+        _set_snapshot_lineage(variant1.snapshot, [variant1])
 
         # Save the studies in DB
         variant_study_service.raw_study_service.repository.save(root_study)
@@ -554,6 +569,46 @@ class TestSearchRefStudy:
         references = [variant1, variant2]
         generator = _build_generator(variant_study_service)
         search_result = generator.search_ref_study(root_study, references, from_scratch=False)
+        assert search_result.ref_study == root_study
+        assert search_result.cmd_blocks == variant1.commands + variant2.commands
+        assert search_result.force_regenerate is True
+
+    @with_db_context
+    def test_search_ref_study__stale_parent_lineage(
+        self, tmp_path: Path, variant_study_service: VariantStudyService
+    ) -> None:
+        root_study = create_study(id=str(uuid.uuid4()), name="root")
+        variant1 = _create_variant(tmp_path, "variant1", root_study.id, with_snapshot=False)
+        variant2 = _create_variant(tmp_path, "variant2", variant1.id, with_snapshot=True)
+        variant1.commands = [
+            CommandBlock(
+                id=str(uuid.uuid4()),
+                study_id=variant1.id,
+                index=0,
+                command="create_area",
+                version=1,
+                args='{"area_name": "DE"}',
+                study_version="9.3",
+            )
+        ]
+        variant2.commands = [
+            CommandBlock(
+                id=str(uuid.uuid4()),
+                study_id=variant2.id,
+                index=0,
+                command="create_thermal_cluster",
+                version=1,
+                args='{"area_name": "DE", "cluster_name": "DE", "cluster_type": "thermal"}',
+                study_version="9.3",
+            )
+        ]
+        variant2.snapshot.last_executed_command = variant2.commands[-1].id
+        _set_snapshot_lineage(variant2.snapshot, [variant1, variant2])
+        variant2.snapshot.lineage[0].commands_version = -1
+
+        generator = _build_generator(variant_study_service)
+        search_result = generator.search_ref_study(root_study, [variant1, variant2], from_scratch=False)
+
         assert search_result.ref_study == root_study
         assert search_result.cmd_blocks == variant1.commands + variant2.commands
         assert search_result.force_regenerate is True
@@ -820,6 +875,9 @@ class TestSnapshotGenerator:
             assert study is not None
             assert study.snapshot is not None
             assert study.snapshot.last_executed_command == study.commands[-1].id
+            assert [(entry.variant_id, entry.commands_version) for entry in study.snapshot.lineage] == [
+                (study.id, study.commands_version.version)
+            ]
             assert study.author == "john.doe"
 
         # Check: the cache is updated with the new variant configuration.
@@ -1125,20 +1183,22 @@ class TestSnapshotGenerator:
             results = generator.generate_snapshot(variant_study_id, dao_factory=factory, from_scratch=True)
             assert results.success is True
 
-            # We expect 3 queries:
+            # We expect 4 queries:
             # - 2 queries to fetch the whole tree of studies (with join query on owner, groups, commands, snapshot and command_version)
-            # - 1 query to insert the variant study snapshot
+            # - 1 query to update the variant study snapshot
+            # - 1 query to update its lineage metadata
 
-            assert len(db_recorder.sql_statements) == 3, str(db_recorder)
+            assert len(db_recorder.sql_statements) == 4, str(db_recorder)
 
         # `is_snapshot_up_to_date` method
         with DBStatementRecorder(db.session.bind) as db_recorder:
             variant_study_service.repository.is_snapshot_up_to_date(variant_study_id)
 
-            # We expect 1 query:
-            # - 1 query to fetch the variant study snapshot and its associated command versions in the same query
+            # We expect 2 queries:
+            # - 1 query to fetch the variant study snapshot and its saved lineage
+            # - 1 recursive query to fetch command versions for the current lineage
 
-            assert len(db_recorder.sql_statements) == 1, str(db_recorder)
+            assert len(db_recorder.sql_statements) == 2, str(db_recorder)
 
         # Create a big variant tree to ensure we do not perform N+1 requests
         variant1 = _create_variant(tmp_path, "variant1", variant_study_id, with_snapshot=False)
@@ -1173,4 +1233,4 @@ class TestSnapshotGenerator:
 
             # We expect the same amount of queries as the previous generation from scratch.
 
-            assert len(db_recorder.sql_statements) == 3, str(db_recorder)
+            assert len(db_recorder.sql_statements) == 4, str(db_recorder)

--- a/tests/study/storage/variantstudy/test_snapshot_generator.py
+++ b/tests/study/storage/variantstudy/test_snapshot_generator.py
@@ -51,7 +51,10 @@ from antarest.study.storage.variantstudy.model.dbmodel import (
     VariantStudySnapshotLineage,
 )
 from antarest.study.storage.variantstudy.model.model import CommandDTO
-from antarest.study.storage.variantstudy.snapshot.snapshot_generator import SnapshotGenerator
+from antarest.study.storage.variantstudy.snapshot.snapshot_generator import (
+    SnapshotGenerator,
+    SourceSnapshotChanged,
+)
 from antarest.study.storage.variantstudy.variant_study_service import VariantStudyService
 from tests.db_statement_recorder import DBStatementRecorder
 from tests.helpers import (
@@ -116,6 +119,10 @@ def _set_snapshot_lineage(snapshot: VariantStudySnapshot, variants: list[Variant
         )
         for position, variant in enumerate(variants)
     ]
+
+
+def _set_snapshot_generation_id(snapshot: VariantStudySnapshot) -> None:
+    snapshot.generation_id = str(uuid.uuid4())
 
 
 def _get_dao_factory(variant_id: str, variant_study_service: VariantStudyService) -> StudyFactoryDao:
@@ -373,6 +380,48 @@ class TestSearchRefStudy:
         assert search_result.ref_study == root_study
         assert search_result.cmd_blocks == variant1.commands + variant2.commands + variant3.commands
         assert search_result.force_regenerate is True
+
+    @with_db_context
+    def test_search_ref_study__uses_nearest_intermediate_snapshot(
+        self, tmp_path: Path, variant_study_service: VariantStudyService
+    ) -> None:
+        root_study = create_study(id=str(uuid.uuid4()), name="root")
+        variant1 = _create_variant(tmp_path, "variant1", root_study.id, with_snapshot=True)
+        variant2 = _create_variant(tmp_path, "variant2", variant1.id, with_snapshot=False)
+        variant1.commands = [
+            CommandBlock(
+                id=str(uuid.uuid4()),
+                study_id=variant1.id,
+                index=0,
+                command="create_area",
+                version=1,
+                args='{"area_name": "DE"}',
+                study_version="9.3",
+            )
+        ]
+        variant2.commands = [
+            CommandBlock(
+                id=str(uuid.uuid4()),
+                study_id=variant2.id,
+                index=0,
+                command="create_thermal_cluster",
+                version=1,
+                args='{"area_name": "DE", "cluster_name": "DE", "cluster_type": "thermal"}',
+                study_version="9.3",
+            )
+        ]
+        _set_snapshot_lineage(variant1.snapshot, [variant1])
+        _set_snapshot_generation_id(variant1.snapshot)
+
+        generator = _build_generator(variant_study_service)
+        search_result = generator.search_ref_study(root_study, [variant1, variant2], from_scratch=False)
+
+        assert search_result.ref_study == variant1
+        assert search_result.cmd_blocks == variant2.commands
+        assert search_result.force_regenerate is True
+        assert search_result.source_snapshot is not None
+        assert search_result.source_snapshot.study_id == variant1.id
+        assert search_result.source_snapshot.generation_id == variant1.snapshot.generation_id
 
     @with_db_context
     def test_search_ref_study__one_variant_completely_uptodate(
@@ -755,6 +804,24 @@ class TestSnapshotGenerator:
         assert generator.study_factory == variant_study_service.study_factory
         assert generator.repository == variant_study_service.repository
 
+    def test_generate__retries_changed_source(
+        self, variant_study_service: VariantStudyService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        generator = _build_generator(variant_study_service)
+        attempt_count = 0
+
+        def source_changed(*args: object, **kwargs: object) -> t.NoReturn:
+            nonlocal attempt_count
+            attempt_count += 1
+            raise SourceSnapshotChanged()
+
+        monkeypatch.setattr(generator, "_generate_snapshot", source_changed)
+
+        with pytest.raises(VariantGenerationError, match="Source snapshot changed repeatedly"):
+            generator.generate_snapshot("target-study", dao_factory=Mock())
+
+        assert attempt_count == 3
+
     @with_admin_user
     @with_db_context
     def test_generate__nominal_case(self, variant_study_id: str, variant_study_service: VariantStudyService) -> None:
@@ -878,6 +945,7 @@ class TestSnapshotGenerator:
             study = variant_study_service.repository.get(variant_study.id)
             assert study is not None
             assert study.snapshot is not None
+            assert study.snapshot.generation_id is not None
             assert study.snapshot.last_executed_command == study.commands[-1].id
             assert [(entry.variant_id, entry.commands_version) for entry in study.snapshot.lineage] == [
                 (study.id, study.commands_version.version)
@@ -1264,4 +1332,4 @@ class TestSnapshotGenerator:
 
             # We expect a constant number of queries regardless of tree depth.
 
-            assert len(db_recorder.sql_statements) == 6, str(db_recorder)
+            assert len(db_recorder.sql_statements) == 7, str(db_recorder)


### PR DESCRIPTION

The goal is to solve race conditions when modifying parents of a study while a snapshot 
is being generated.

 - save the full "lineage" information together with the snapshot, instead
   of only the commands version
 - also fixes the behaviour in case of crash during snapshot generation:
   we must not consider the modified snapshot data as consistent with the snapshot metadata,
   therefore we now invalidate it at generation start
 - finally, if the source snapshot has been changed during the generation, we restart it
   (optimistic concurrency handling: in a large majority of cases, source will not have changed)

Removes permission checks from snapshot generation, it does not belong here and adds
burden to the study tree query with 2 additional joins
