### PR TITLE
fix(launcher): solve possibly conflicting URLs for launchers config

### DIFF
--- a/antarest/launcher/web.py
+++ b/antarest/launcher/web.py
@@ -251,7 +251,7 @@ def create_launcher_api() -> APIRouter:
         service.delete_solver_presets(solver_presets_id)
 
     @bp.get(
-        "/{launcher_id}/config",
+        "/launchers/{launcher_id}/config",
         summary="Get the runtime configuration of a launcher",
     )
     def get_launcher_config(service: LauncherServiceDep, launcher_id: SanitizedStr) -> LauncherRuntimeConfig:
@@ -259,7 +259,7 @@ def create_launcher_api() -> APIRouter:
         return service.get_runtime_config(launcher_id)
 
     @bp.put(
-        "/{launcher_id}/config",
+        "/launchers/{launcher_id}/config",
         summary="Replace the runtime configuration of a launcher (admin only)",
     )
     def update_launcher_config(

--- a/tests/integration/launcher_blueprint/test_launcher_local.py
+++ b/tests/integration/launcher_blueprint/test_launcher_local.py
@@ -15,11 +15,7 @@ from starlette.testclient import TestClient
 from antarest.core.config import LocalConfig
 
 
-def test_get_launchers(
-    self,
-    client: TestClient,
-    user_access_token: str,
-) -> None:
+def test_get_launchers(client: TestClient, user_access_token: str) -> None:
     # NOTE: we have `enable_nb_cores_detection: True` in `tests/integration/assets/config.template.yml`.
     local_config = LocalConfig.model_validate(
         {"id": "local_id", "type": "local", "name": "local", "enable_nb_cores_detection": True}
@@ -52,12 +48,7 @@ def test_get_launchers(
     assert actual["defaultLauncher"] == "local_id"
 
 
-def test_jobs_permissions(
-    self,
-    client: TestClient,
-    user_access_token: str,
-    admin_access_token: str,
-) -> None:
+def test_jobs_permissions(client: TestClient, user_access_token: str, admin_access_token: str) -> None:
     # create an admin study with no permissions
     res = client.post(
         "/v1/studies",

--- a/tests/integration/launcher_blueprint/test_launcher_local.py
+++ b/tests/integration/launcher_blueprint/test_launcher_local.py
@@ -15,81 +15,76 @@ from starlette.testclient import TestClient
 from antarest.core.config import LocalConfig
 
 
-# noinspection SpellCheckingInspection
-class TestLauncherConfiguration:
-    """
-    The purpose of this unit test is to check the `/v1/launcher/launchers` endpoint.
-    """
+def test_get_launchers(
+    self,
+    client: TestClient,
+    user_access_token: str,
+) -> None:
+    # NOTE: we have `enable_nb_cores_detection: True` in `tests/integration/assets/config.template.yml`.
+    local_config = LocalConfig.model_validate(
+        {"id": "local_id", "type": "local", "name": "local", "enable_nb_cores_detection": True}
+    )
+    expected_launchers = [
+        {
+            "id": "local_id",
+            "name": "local",
+            "nbCores": {
+                "min": local_config.nb_cores.min,
+                "max": local_config.nb_cores.max,
+                "default": local_config.nb_cores.default,
+            },
+            "timeLimit": {
+                "min": local_config.time_limit.min,
+                "max": local_config.time_limit.max,
+                "default": local_config.time_limit.default,
+            },
+            "versions": ["7.0", "8.8", "9.3"],
+        }
+    ]
 
-    def test_get_launchers(
-        self,
-        client: TestClient,
-        user_access_token: str,
-    ) -> None:
-        # NOTE: we have `enable_nb_cores_detection: True` in `tests/integration/assets/config.template.yml`.
-        local_config = LocalConfig.model_validate(
-            {"id": "local_id", "type": "local", "name": "local", "enable_nb_cores_detection": True}
-        )
-        expected_launchers = [
-            {
-                "id": "local_id",
-                "name": "local",
-                "nbCores": {
-                    "min": local_config.nb_cores.min,
-                    "max": local_config.nb_cores.max,
-                    "default": local_config.nb_cores.default,
-                },
-                "timeLimit": {
-                    "min": local_config.time_limit.min,
-                    "max": local_config.time_limit.max,
-                    "default": local_config.time_limit.default,
-                },
-                "versions": ["7.0", "8.8", "9.3"],
-            }
-        ]
+    res = client.get(
+        "/v1/launcher/launchers",
+        headers={"Authorization": f"Bearer {user_access_token}"},
+    )
+    res.raise_for_status()
+    actual = res.json()
+    assert actual["launchers"] == expected_launchers
+    assert actual["defaultLauncher"] == "local_id"
 
-        res = client.get(
-            "/v1/launcher/launchers",
-            headers={"Authorization": f"Bearer {user_access_token}"},
-        )
-        res.raise_for_status()
-        actual = res.json()
-        assert actual["launchers"] == expected_launchers
-        assert actual["defaultLauncher"] == "local_id"
 
-    def test_jobs_permissions(
-        self,
-        client: TestClient,
-        user_access_token: str,
-        admin_access_token: str,
-    ) -> None:
-        # create an admin study with no permissions
-        res = client.post(
-            "/v1/studies",
-            headers={"Authorization": f"Bearer {admin_access_token}"},
-            params={"name": "study_admin"},
-        )
-        res.raise_for_status()
-        # get the study_id
-        study_id = res.json()
+def test_jobs_permissions(
+    self,
+    client: TestClient,
+    user_access_token: str,
+    admin_access_token: str,
+) -> None:
+    # create an admin study with no permissions
+    res = client.post(
+        "/v1/studies",
+        headers={"Authorization": f"Bearer {admin_access_token}"},
+        params={"name": "study_admin"},
+    )
+    res.raise_for_status()
+    # get the study_id
+    study_id = res.json()
 
-        # launch a job with the admin user
-        res = client.post(f"/v1/launcher/run/{study_id}", headers={"Authorization": f"Bearer {admin_access_token}"})
-        res.raise_for_status()
-        job_id = res.json()["job_id"]
+    # launch a job with the admin user
+    res = client.post(f"/v1/launcher/run/{study_id}", headers={"Authorization": f"Bearer {admin_access_token}"})
+    res.raise_for_status()
+    job_id = res.json()["job_id"]
 
-        # check that the user cannot see the job
-        res = client.get(
-            "/v1/launcher/jobs",
-            headers={"Authorization": f"Bearer {user_access_token}"},
-        )
-        res.raise_for_status()
-        assert job_id not in [job.get("id") for job in res.json()]
+    # check that the user cannot see the job
+    res = client.get(
+        "/v1/launcher/jobs",
+        headers={"Authorization": f"Bearer {user_access_token}"},
+    )
+    res.raise_for_status()
+    assert job_id not in [job.get("id") for job in res.json()]
 
-        # check that the admin can see the job
-        res = client.get(
-            "/v1/launcher/jobs",
-            headers={"Authorization": f"Bearer {admin_access_token}"},
-        )
-        res.raise_for_status()
-        assert job_id in [job.get("id") for job in res.json()]
+    # check that the admin can see the job
+    res = client.get(
+        "/v1/launcher/jobs",
+        headers={"Authorization": f"Bearer {admin_access_token}"},
+    )
+    res.raise_for_status()
+    assert job_id in [job.get("id") for job in res.json()]

--- a/tests/launcher/test_web.py
+++ b/tests/launcher/test_web.py
@@ -24,7 +24,16 @@ from antarest.core.config import Config, SecurityConfig
 from antarest.core.jwt import JWTGroup, JWTUser
 from antarest.core.roles import RoleType
 from antarest.dependencies import AppState
-from antarest.launcher.model import JobResult, JobResultDTO, JobStatus, LauncherParametersDTO, LogType
+from antarest.launcher.model import (
+    JobResult,
+    JobResultDTO,
+    JobStatus,
+    LauncherParametersDTO,
+    LauncherRuntimeConfig,
+    LogType,
+    SlurmRuntimeConfig,
+)
+from antarest.launcher.service import LauncherServiceNotAvailableException
 from antarest.launcher.web import create_launcher_api
 from antarest.main import add_exception_handlers
 
@@ -230,3 +239,44 @@ def test_kill_job() -> None:
     res = client.post(f"/v1/launcher/jobs/{job_id}/kill")
     assert res.status_code == 200
     service.kill_job.assert_called_once_with(job_id=job_id)
+
+
+def test_get_runtime_config() -> None:
+
+    service = Mock()
+    service.get_runtime_config.side_effect = [
+        LauncherRuntimeConfig(slurm=SlurmRuntimeConfig(oversubscribe_core_threshold=10)),
+        LauncherServiceNotAvailableException("wrong-launcher"),
+    ]
+
+    app = create_app(service)
+    client = TestClient(app, raise_server_exceptions=False)
+    res = client.get("/v1/launcher/launchers/my-launcher/config")
+    service.get_runtime_config.assert_called_once_with("my-launcher")
+    assert res.status_code == 200
+    assert res.json() == {"slurm": {"oversubscribeCoreThreshold": 10}}
+
+    res = client.get("/v1/launcher/launchers/my-launcher/config")
+    assert res.status_code == 400
+
+
+def test_post_runtime_config() -> None:
+
+    service = Mock()
+    service.update_runtime_config.side_effect = [
+        LauncherRuntimeConfig(slurm=SlurmRuntimeConfig(oversubscribe_core_threshold=10)),
+        LauncherServiceNotAvailableException("wrong-launcher"),
+    ]
+
+    app = create_app(service)
+    client = TestClient(app, raise_server_exceptions=False)
+    res = client.put("/v1/launcher/launchers/my-launcher/config", json={"slurm": {"oversubscribeCoreThreshold": 10}})
+    service.update_runtime_config.assert_called_once_with(
+        "my-launcher",
+        LauncherRuntimeConfig(slurm=SlurmRuntimeConfig(oversubscribe_core_threshold=10)),
+    )
+    assert res.status_code == 200
+    assert res.json() == {"slurm": {"oversubscribeCoreThreshold": 10}}
+
+    res = client.put("/v1/launcher/launchers/my-launcher/config", json={"slurm": {"oversubscribeCoreThreshold": 10}})
+    assert res.status_code == 400


### PR DESCRIPTION

The endpoints for getting / putting the lauchers configuration are moved
from `/v1/launcher/{launcher_id}/config` to `/v1/launcher/launchers/{launcher_id}/config`,
i.e under the **launchers** resources inside the `launcher` API.

This is consistent with GET `/v1/launcher/launchers`, and avoids conflicting with
other endpoints of the launcher API.

Added unit tests for the web part at the same time.