### PR TITLE
refactor(dao): introduce shared context

### DIFF
--- a/antarest/study/dao/database/common.py
+++ b/antarest/study/dao/database/common.py
@@ -36,7 +36,7 @@ def area_exists(session: Session, study_id: str, area_id: str) -> bool:
 
 
 def save_area_matrix(dao: "DatabaseStudyDao", series: AreaSeriesMapping, table: Table) -> None:
-    session = dao.get_session()
+    session = dao._db_session
     study_id = dao.get_study_id()
 
     try:

--- a/antarest/study/dao/database/dao_context.py
+++ b/antarest/study/dao/database/dao_context.py
@@ -69,10 +69,6 @@ class DatabaseDaoBase(ABC):
     def _db_session(self) -> Session:
         return self._context.session
 
-    def get_study_id(self) -> str:
-        """Get the study ID for database queries."""
-        return self._context.study_id
-
     def get_session(self) -> Session:
         """Get the SQLAlchemy session for database operations."""
         return self._context.session

--- a/antarest/study/dao/database/dao_context.py
+++ b/antarest/study/dao/database/dao_context.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Shared state of the database DAOs.
+
+`DatabaseStudyDao` is composed of one `Database*Dao` mixin per domain. They all need
+the same two things: which study they operate on, and the session to query it with.
+This module holds that state once, so the study key used to query the study data
+tables is defined in a single place.
+"""
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import Session
+
+if TYPE_CHECKING:
+    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+
+
+class StudyDaoContext:
+    """
+    Identifies the study a set of database DAOs operates on, and carries their session.
+    """
+
+    def __init__(self, study_id: str, db_session: Session) -> None:
+        """
+        Args:
+            study_id: The study ID for database queries.
+            db_session: SQLAlchemy session for database operations.
+        """
+        self._study_id = study_id
+        self._db_session = db_session
+
+    @property
+    def study_id(self) -> str:
+        """The study ID, as found in `study.id`."""
+        return self._study_id
+
+    @property
+    def session(self) -> Session:
+        """The SQLAlchemy session used for database operations."""
+        return self._db_session
+
+
+class DatabaseDaoBase(ABC):
+    """
+    Base class of the database DAO mixins, giving them access to the study context.
+    """
+
+    def __init__(self, context: StudyDaoContext) -> None:
+        self._context = context
+
+    @property
+    def _study_id(self) -> str:
+        return self._context.study_id
+
+    @property
+    def _db_session(self) -> Session:
+        return self._context.session
+
+    def get_study_id(self) -> str:
+        """Get the study ID for database queries."""
+        return self._context.study_id
+
+    def get_session(self) -> Session:
+        """Get the SQLAlchemy session for database operations."""
+        return self._context.session
+
+    @abstractmethod
+    def get_impl(self) -> "DatabaseStudyDao":
+        pass

--- a/antarest/study/dao/database/dao_context.py
+++ b/antarest/study/dao/database/dao_context.py
@@ -69,10 +69,6 @@ class DatabaseDaoBase(ABC):
     def _db_session(self) -> Session:
         return self._context.session
 
-    def get_session(self) -> Session:
-        """Get the SQLAlchemy session for database operations."""
-        return self._context.session
-
     @abstractmethod
     def get_impl(self) -> "DatabaseStudyDao":
         pass

--- a/antarest/study/dao/database/database_area_dao.py
+++ b/antarest/study/dao/database/database_area_dao.py
@@ -82,7 +82,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         """
         Retrieve all physical areas of a study.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(AREA_TABLE.c.area_id).where(AREA_TABLE.c.study_id == study_id)
@@ -98,7 +98,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         Returns:
             The list of areas with their basic information.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(AREA_TABLE.c.area_id, AREA_TABLE.c.area_name).where(AREA_TABLE.c.study_id == study_id)
@@ -121,7 +121,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         Returns:
             A dictionary mapping area IDs to their UI data.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Single query to get all areas and their UI info
@@ -180,7 +180,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         Raises:
             AreaNotFound: If the area does not exist.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Fetch both specified layer and default layer in one query
@@ -236,7 +236,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         Raises:
             AreaNotFound: If the area does not exist.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         validate_area_exists(session, study_id, area_id)
@@ -269,7 +269,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
 
     @override
     def save_area_ui(self, data: AreaUiMapping) -> None:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Set values
@@ -334,7 +334,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         if not self.get_impl().layer_exists(layer_id):
             raise LayerNotFound(layer_id)
 
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Get all areas and which ones already have this layer
@@ -414,7 +414,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
     def _create_new_ui(self, area_id: str, layer: str, area_ui: AreaUI) -> None:
         r, g, b = area_ui.color_rgb
         stmt_insert = insert(AREA_UI_TABLE).values(
-            study_id=self.get_study_id(),
+            study_id=self._study_id,
             area_id=area_id,
             layer_id=layer,
             x=area_ui.x,
@@ -433,7 +433,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         return str(row.matrix_id)
 
     def _get_matrix_row(self, area_id: str, table: Table) -> Row[Any] | None:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
         stmt = select(table).where((table.c.study_id == study_id) & (table.c.area_id == area_id))
 

--- a/antarest/study/dao/database/database_area_dao.py
+++ b/antarest/study/dao/database/database_area_dao.py
@@ -17,7 +17,7 @@ This module provides database-backed storage for areas when storage_mode=DATABAS
 """
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import polars as pl
 from sqlalchemy import Row, Table, case, delete, insert, select, update
@@ -53,9 +53,6 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
     default_8_fixed_hourly,
     default_scenario_hourly,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 class DatabaseAreaDao(AreaDao, DatabaseDaoBase):

--- a/antarest/study/dao/database/database_area_dao.py
+++ b/antarest/study/dao/database/database_area_dao.py
@@ -17,13 +17,11 @@ This module provides database-backed storage for areas when storage_mode=DATABAS
 """
 
 import json
-from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
 from sqlalchemy import Row, Table, case, delete, insert, select, update
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound, LayerNotFound
@@ -38,6 +36,7 @@ from antarest.study.dao.database.common import (
     serialize_frequency_filters,
     validate_area_exists,
 )
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.area import (
     AREA_TABLE,
     AREA_UI_TABLE,
@@ -56,34 +55,11 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
 )
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
-class DatabaseAreaDao(AreaDao):
+class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
     """Database implementation of AreaDao"""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        """
-        Initialize DatabaseAreaDao with dependencies.
-
-        Args:
-            study_id: The study ID for database queries.
-            db_session: SQLAlchemy session for database operations.
-        """
-        self._study_id = study_id
-        self._db_session = db_session
-
-    def get_study_id(self) -> str:
-        """Get the study ID for database queries."""
-        return self._study_id
-
-    def get_session(self) -> Session:
-        """Get the SQLAlchemy session for database operations."""
-        return self._db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     def _convert_area_properties_to_row(
         self, area_properties: AreaProperties, area_id: AreaId, area_name: AreaName

--- a/antarest/study/dao/database/database_area_dao.py
+++ b/antarest/study/dao/database/database_area_dao.py
@@ -83,7 +83,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         Retrieve all physical areas of a study.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(AREA_TABLE.c.area_id).where(AREA_TABLE.c.study_id == study_id)
         result = session.execute(stmt)
@@ -99,7 +99,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
             The list of areas with their basic information.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(AREA_TABLE.c.area_id, AREA_TABLE.c.area_name).where(AREA_TABLE.c.study_id == study_id)
         result = session.execute(stmt)
@@ -122,7 +122,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
             A dictionary mapping area IDs to their UI data.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Single query to get all areas and their UI info
         stmt = select(AREA_UI_TABLE).where(AREA_UI_TABLE.c.study_id == study_id)
@@ -181,7 +181,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
             AreaNotFound: If the area does not exist.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Fetch both specified layer and default layer in one query
         layers_to_fetch = [layer, DEFAULT_LAYER_ID] if layer != DEFAULT_LAYER_ID else [DEFAULT_LAYER_ID]
@@ -215,7 +215,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
 
         stmt = insert(AREA_TABLE).values(values)
         try:
-            session = self.get_session()
+            session = self._db_session
             session.execute(stmt)
             session.commit()
         except IntegrityError as e:
@@ -237,7 +237,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
             AreaNotFound: If the area does not exist.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         validate_area_exists(session, study_id, area_id)
 
@@ -270,7 +270,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
     @override
     def save_area_ui(self, data: AreaUiMapping) -> None:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Set values
         values = []
@@ -335,7 +335,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
             raise LayerNotFound(layer_id)
 
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Get all areas and which ones already have this layer
         stmt = (
@@ -423,8 +423,8 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
             color_g=g,
             color_b=b,
         )
-        self.get_session().execute(stmt_insert)
-        self.get_session().commit()
+        self._db_session.execute(stmt_insert)
+        self._db_session.commit()
 
     def _get_matrix(self, area_id: str, table: Table) -> SeriesId:
         row = self._get_matrix_row(area_id, table)
@@ -434,7 +434,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
 
     def _get_matrix_row(self, area_id: str, table: Table) -> Row[Any] | None:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
         stmt = select(table).where((table.c.study_id == study_id) & (table.c.area_id == area_id))
 
         return session.execute(stmt).fetchone()

--- a/antarest/study/dao/database/database_area_properties_dao.py
+++ b/antarest/study/dao/database/database_area_properties_dao.py
@@ -53,7 +53,7 @@ class DatabaseAreaPropertiesDao(AreaPropertiesDao, DatabaseDaoBase):
     @override
     def get_area_properties(self, area_id: str) -> AreaProperties:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(AREA_TABLE).where((AREA_TABLE.c.study_id == study_id) & (AREA_TABLE.c.area_id == area_id))
 
@@ -65,7 +65,7 @@ class DatabaseAreaPropertiesDao(AreaPropertiesDao, DatabaseDaoBase):
     @override
     def get_all_area_properties(self) -> dict[str, AreaProperties]:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Single query to get all areas and their properties
         stmt = select(AREA_TABLE).where(AREA_TABLE.c.study_id == study_id)
@@ -75,7 +75,7 @@ class DatabaseAreaPropertiesDao(AreaPropertiesDao, DatabaseDaoBase):
     @override
     def save_area_properties(self, area_id: str, area_properties: AreaProperties) -> None:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt_update = (
             update(AREA_TABLE)

--- a/antarest/study/dao/database/database_area_properties_dao.py
+++ b/antarest/study/dao/database/database_area_properties_dao.py
@@ -16,11 +16,9 @@ Database implementation of AreaDao using SQLAlchemy Core.
 This module provides database-backed storage for areas when storage_mode=DATABASE.
 """
 
-from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import CursorResult, select, update
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound
@@ -30,10 +28,11 @@ from antarest.study.dao.database.common import (
     parse_frequency_filters,
     serialize_frequency_filters,
 )
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.area import AREA_TABLE
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
 def _convert_db_properties_to_model(db_row: Any) -> AreaProperties:
@@ -51,24 +50,8 @@ def _convert_db_properties_to_model(db_row: Any) -> AreaProperties:
     )
 
 
-class DatabaseAreaPropertiesDao(AreaPropertiesDao):
+class DatabaseAreaPropertiesDao(AreaPropertiesDao, DatabaseDaoBase):
     """Database implementation of AreaPropertiesDao"""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    def get_study_id(self) -> str:
-        """Get the study ID for database queries."""
-        return self._study_id
-
-    def get_session(self) -> Session:
-        """Get the SQLAlchemy session for database operations."""
-        return self._db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     @override
     def get_area_properties(self, area_id: str) -> AreaProperties:

--- a/antarest/study/dao/database/database_area_properties_dao.py
+++ b/antarest/study/dao/database/database_area_properties_dao.py
@@ -16,7 +16,7 @@ Database implementation of AreaDao using SQLAlchemy Core.
 This module provides database-backed storage for areas when storage_mode=DATABASE.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from sqlalchemy import CursorResult, select, update
 from typing_extensions import override
@@ -30,9 +30,6 @@ from antarest.study.dao.database.common import (
 )
 from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.area import AREA_TABLE
-
-if TYPE_CHECKING:
-    pass
 
 
 def _convert_db_properties_to_model(db_row: Any) -> AreaProperties:

--- a/antarest/study/dao/database/database_area_properties_dao.py
+++ b/antarest/study/dao/database/database_area_properties_dao.py
@@ -52,7 +52,7 @@ class DatabaseAreaPropertiesDao(AreaPropertiesDao, DatabaseDaoBase):
 
     @override
     def get_area_properties(self, area_id: str) -> AreaProperties:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(AREA_TABLE).where((AREA_TABLE.c.study_id == study_id) & (AREA_TABLE.c.area_id == area_id))
@@ -64,7 +64,7 @@ class DatabaseAreaPropertiesDao(AreaPropertiesDao, DatabaseDaoBase):
 
     @override
     def get_all_area_properties(self) -> dict[str, AreaProperties]:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Single query to get all areas and their properties
@@ -74,7 +74,7 @@ class DatabaseAreaPropertiesDao(AreaPropertiesDao, DatabaseDaoBase):
 
     @override
     def save_area_properties(self, area_id: str, area_properties: AreaProperties) -> None:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt_update = (

--- a/antarest/study/dao/database/database_binding_constraint_dao.py
+++ b/antarest/study/dao/database/database_binding_constraint_dao.py
@@ -16,7 +16,7 @@ Database implementation of ConstraintDao.
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, NewType, Sequence
+from typing import Any, NewType, Sequence
 
 import polars as pl
 from antares.study.version import StudyVersion
@@ -133,10 +133,6 @@ class _MatrixChanges:
 
     def add_insertion(self, constraint_id: ConstraintId, matrix_type: _MatrixType, matrix_id: _MatrixID) -> None:
         self.insertions.append(_MatrixInsertion(constraint_id, matrix_type, matrix_id))
-
-
-if TYPE_CHECKING:
-    pass
 
 
 class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):

--- a/antarest/study/dao/database/database_binding_constraint_dao.py
+++ b/antarest/study/dao/database/database_binding_constraint_dao.py
@@ -14,7 +14,6 @@
 Database implementation of ConstraintDao.
 """
 
-from abc import abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, NewType, Sequence
@@ -23,7 +22,6 @@ import polars as pl
 from antares.study.version import StudyVersion
 from sqlalchemy import Row, Table, delete, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from sqlalchemy.sql import outerjoin
 from typing_extensions import override
 
@@ -42,6 +40,7 @@ from antarest.study.business.model.binding_constraint_model import (
 )
 from antarest.study.dao.api.binding_constraint_dao import ConstraintDao
 from antarest.study.dao.common import BindingConstraintSeriesMapping, SeriesId
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.binding_constraint import (
     BINDING_CONSTRAINT_CLUSTER_TERM_TABLE as CT,
 )
@@ -137,18 +136,10 @@ class _MatrixChanges:
 
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
-class DatabaseBindingConstraintDao(ConstraintDao):
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
-
+class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
     def _fetch_constraints(self, constraint_ids: list[ConstraintId]) -> dict[ConstraintId, BindingConstraint]:
         """
         Two steps in this function

--- a/antarest/study/dao/database/database_blob_usage_provider.py
+++ b/antarest/study/dao/database/database_blob_usage_provider.py
@@ -11,20 +11,17 @@
 # This file is part of the Antares project.
 from collections.abc import Iterable
 
-from sqlalchemy import select
 from typing_extensions import override
 
 from antarest.blobstore.blob_usage_provider import IBlobUsageProvider
 from antarest.blobstore.model import BlobReference
 from antarest.core.utils.fastapi_sqlalchemy import db
-from antarest.study.dao.database.models.user_resources import USER_RESOURCES_TABLE
+from antarest.study.dao.database.study_data_queries import yield_used_blobs
 
 
 class DatabaseBlobUsageProvider(IBlobUsageProvider):
     @override
     def get_blob_usage(self) -> Iterable[BlobReference]:
         with db():
-            stmt = select(USER_RESOURCES_TABLE).where(USER_RESOURCES_TABLE.c.blob_id.isnot(None))
-            rows = db.session.execute(stmt).fetchall()
-            for row in rows:
-                yield BlobReference(blob_id=row.blob_id, use_description=f"Used by study {row.study_id}")
+            for blob_id, study_id in yield_used_blobs(db.session):
+                yield BlobReference(blob_id=blob_id, use_description=f"Used by study {study_id}")

--- a/antarest/study/dao/database/database_district_dao.py
+++ b/antarest/study/dao/database/database_district_dao.py
@@ -55,7 +55,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
 
         If the district already exists, it will be overwritten.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Validate that all areas exist
@@ -81,7 +81,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         """
         Remove a district from a study.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         result = session.execute(
@@ -100,7 +100,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         """
         Returns the list of districts in this study.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(DISTRICT_TABLE).where(DISTRICT_TABLE.c.study_id == study_id)
@@ -113,7 +113,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         """
         Get the district with the given id.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(DISTRICT_TABLE).where(
@@ -130,7 +130,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         """
         Returns whether a district with the given id exists in the study.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(DISTRICT_TABLE.c.district_id).where(

--- a/antarest/study/dao/database/database_district_dao.py
+++ b/antarest/study/dao/database/database_district_dao.py
@@ -18,7 +18,7 @@ This module provides database-backed storage for districts when storage_mode=DAT
 
 import json
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from sqlalchemy import CursorResult, delete, select
 from typing_extensions import override
@@ -29,9 +29,6 @@ from antarest.study.business.model.district_model import District
 from antarest.study.dao.api.district_dao import DistrictDao
 from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.district import DISTRICT_TABLE
-
-if TYPE_CHECKING:
-    pass
 
 
 def _convert_db_row_to_district(db_row: Any) -> District:

--- a/antarest/study/dao/database/database_district_dao.py
+++ b/antarest/study/dao/database/database_district_dao.py
@@ -17,22 +17,21 @@ This module provides database-backed storage for districts when storage_mode=DAT
 """
 
 import json
-from abc import abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import CursorResult, delete, select
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound, DistrictConfigNotFound
 from antarest.core.utils.sql_utils import upsert_one
 from antarest.study.business.model.district_model import District
 from antarest.study.dao.api.district_dao import DistrictDao
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.district import DISTRICT_TABLE
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
 def _convert_db_row_to_district(db_row: Any) -> District:
@@ -47,33 +46,10 @@ def _convert_db_row_to_district(db_row: Any) -> District:
     )
 
 
-class DatabaseDistrictDao(DistrictDao):
+class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
     """
     Database implementation of DistrictDao.
     """
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        """
-        Initialize DatabaseDistrictDao with dependencies.
-
-        Args:
-            study_id: The study ID for database queries.
-            db_session: SQLAlchemy session for database operations.
-        """
-        self._study_id = study_id
-        self._db_session = db_session
-
-    def get_study_id(self) -> str:
-        """Get the study ID for database queries."""
-        return self._study_id
-
-    def get_session(self) -> Session:
-        """Get the SQLAlchemy session for database operations."""
-        return self._db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     @override
     def save_district(self, district: District) -> None:

--- a/antarest/study/dao/database/database_district_dao.py
+++ b/antarest/study/dao/database/database_district_dao.py
@@ -56,7 +56,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         If the district already exists, it will be overwritten.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Validate that all areas exist
         invalid_areas = self.get_impl().get_invalid_area_ids(district.add_areas + district.subtract_areas)
@@ -82,7 +82,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         Remove a district from a study.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         result = session.execute(
             delete(DISTRICT_TABLE).where(
@@ -101,7 +101,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         Returns the list of districts in this study.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(DISTRICT_TABLE).where(DISTRICT_TABLE.c.study_id == study_id)
         district_rows = session.execute(stmt).fetchall()
@@ -114,7 +114,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         Get the district with the given id.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(DISTRICT_TABLE).where(
             (DISTRICT_TABLE.c.study_id == study_id) & (DISTRICT_TABLE.c.district_id == district_id)
@@ -131,7 +131,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         Returns whether a district with the given id exists in the study.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(DISTRICT_TABLE.c.district_id).where(
             (DISTRICT_TABLE.c.study_id == study_id) & (DISTRICT_TABLE.c.district_id == district_id)

--- a/antarest/study/dao/database/database_hydro_dao.py
+++ b/antarest/study/dao/database/database_hydro_dao.py
@@ -111,7 +111,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             ValueError: If the area exists but has no hydro management configuration.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(HYDRO_MANAGEMENT_TABLE).where(
             (HYDRO_MANAGEMENT_TABLE.c.study_id == study_id) & (HYDRO_MANAGEMENT_TABLE.c.area_id == area_id)
@@ -146,7 +146,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             AreaNotFound: If the area does not exist.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         values = []
         for area_id, management in hydro_management.items():
@@ -176,7 +176,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             ValueError: If the area exists but has no inflow structure configuration.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(HYDRO_INFLOW_STRUCTURE_TABLE).where(
             (HYDRO_INFLOW_STRUCTURE_TABLE.c.study_id == study_id) & (HYDRO_INFLOW_STRUCTURE_TABLE.c.area_id == area_id)
@@ -193,7 +193,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
     def save_inflow_structure(self, inflow_structure: dict[AreaId, InflowStructure]) -> None:
         """Save inflow structure configuration for several areas"""
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         values = []
         for area_id, inflow in inflow_structure.items():
@@ -222,7 +222,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             Dictionary mapping area_id to HydroProperties (management_options + inflow_structure).
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = (
             select(
@@ -268,7 +268,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             ValueError: If the area exists but has no allocation data.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(HYDRO_ALLOCATION_TABLE).where(
             (HYDRO_ALLOCATION_TABLE.c.study_id == study_id) & (HYDRO_ALLOCATION_TABLE.c.source_area_id == area_id)
@@ -296,7 +296,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             ValueError: If no hydro allocation data is found for the study.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         stmt = select(HYDRO_ALLOCATION_TABLE).where(HYDRO_ALLOCATION_TABLE.c.study_id == study_id)
         rows = session.execute(stmt).fetchall()
@@ -321,7 +321,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         This will replace any existing allocation for the given areas.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Delete existing allocations for the source areas
         stmt_delete = delete(HYDRO_ALLOCATION_TABLE).where(
@@ -387,7 +387,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             Returns identity matrix (self=1.0, rest=0.0) if no correlations stored.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Get all area IDs from the study
         area_ids = self.get_impl().get_all_area_ids()
@@ -417,7 +417,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         This will replace any existing correlation for the given areas.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Validate self-correlation if provided
         for area_id, correlation in correlation_dict.items():
@@ -481,7 +481,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
 
     def _get_hydro_matrix(self, area_id: str, table: Table) -> SeriesId:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
         stmt = select(table).where((table.c.study_id == study_id) & (table.c.area_id == area_id))
         row = session.execute(stmt).fetchone()
         if not row:
@@ -667,7 +667,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             return
 
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         if hydro_pmax == HydroPmax.HOURLY:
             area_ids = self.get_impl().get_all_area_ids()

--- a/antarest/study/dao/database/database_hydro_dao.py
+++ b/antarest/study/dao/database/database_hydro_dao.py
@@ -17,7 +17,7 @@ This module provides database-backed storage for hydro configuration when storag
 """
 
 import math
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 import polars as pl
@@ -79,9 +79,6 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
 )
 
 _MANAGEMENT_COLS = [c for c in HYDRO_MANAGEMENT_TABLE.c if c.name not in ("study_id", "area_id")]
-
-if TYPE_CHECKING:
-    pass
 
 
 class DatabaseHydroDao(HydroDao, DatabaseDaoBase):

--- a/antarest/study/dao/database/database_hydro_dao.py
+++ b/antarest/study/dao/database/database_hydro_dao.py
@@ -17,14 +17,12 @@ This module provides database-backed storage for hydro configuration when storag
 """
 
 import math
-from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import polars as pl
 from sqlalchemy import Row, Table, delete, insert, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound
@@ -47,6 +45,7 @@ from antarest.study.dao.database.common import (
     save_area_matrix,
     validate_area_exists,
 )
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.area import AREA_TABLE
 from antarest.study.dao.database.models.hydro import (
     HYDRO_ALLOCATION_TABLE,
@@ -82,34 +81,11 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
 _MANAGEMENT_COLS = [c for c in HYDRO_MANAGEMENT_TABLE.c if c.name not in ("study_id", "area_id")]
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
-class DatabaseHydroDao(HydroDao):
+class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
     """Database implementation of HydroDao"""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        """
-        Initialize DatabaseHydroDao with dependencies.
-
-        Args:
-            study_id: The study ID for database queries.
-            db_session: SQLAlchemy session for database operations.
-        """
-        self._study_id = study_id
-        self._db_session = db_session
-
-    def get_study_id(self) -> str:
-        """Get the study ID for database queries."""
-        return self._study_id
-
-    def get_session(self) -> Session:
-        """Get the SQLAlchemy session for database operations."""
-        return self._db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     @staticmethod
     def _convert_row_to_hydro_management(row: Row[Any]) -> HydroManagement:

--- a/antarest/study/dao/database/database_hydro_dao.py
+++ b/antarest/study/dao/database/database_hydro_dao.py
@@ -110,7 +110,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             AreaNotFound: If the area does not exist.
             ValueError: If the area exists but has no hydro management configuration.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(HYDRO_MANAGEMENT_TABLE).where(
@@ -145,7 +145,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         Raises:
             AreaNotFound: If the area does not exist.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         values = []
@@ -175,7 +175,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             AreaNotFound: If the area does not exist.
             ValueError: If the area exists but has no inflow structure configuration.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(HYDRO_INFLOW_STRUCTURE_TABLE).where(
@@ -192,7 +192,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
     @override
     def save_inflow_structure(self, inflow_structure: dict[AreaId, InflowStructure]) -> None:
         """Save inflow structure configuration for several areas"""
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         values = []
@@ -221,7 +221,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         Returns:
             Dictionary mapping area_id to HydroProperties (management_options + inflow_structure).
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = (
@@ -267,7 +267,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             AreaNotFound: If the area does not exist.
             ValueError: If the area exists but has no allocation data.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(HYDRO_ALLOCATION_TABLE).where(
@@ -295,7 +295,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         Raises:
             ValueError: If no hydro allocation data is found for the study.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         stmt = select(HYDRO_ALLOCATION_TABLE).where(HYDRO_ALLOCATION_TABLE.c.study_id == study_id)
@@ -320,7 +320,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
 
         This will replace any existing allocation for the given areas.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Delete existing allocations for the source areas
@@ -386,7 +386,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             HydroCorrelationMatrix with all area correlations.
             Returns identity matrix (self=1.0, rest=0.0) if no correlations stored.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Get all area IDs from the study
@@ -416,7 +416,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
 
         This will replace any existing correlation for the given areas.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Validate self-correlation if provided
@@ -480,7 +480,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
     # ==================== Matrix Methods ====================
 
     def _get_hydro_matrix(self, area_id: str, table: Table) -> SeriesId:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
         stmt = select(table).where((table.c.study_id == study_id) & (table.c.area_id == area_id))
         row = session.execute(stmt).fetchone()
@@ -666,7 +666,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         if compatibility_data.hydro_pmax == hydro_pmax:
             return
 
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         if hydro_pmax == HydroPmax.HOURLY:

--- a/antarest/study/dao/database/database_layer_dao.py
+++ b/antarest/study/dao/database/database_layer_dao.py
@@ -46,7 +46,7 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
         Other layers contain the areas that have UI entries for that layer.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Get all layer names from LAYER_TABLE
         stmt_layers = select(LAYER_TABLE).where(LAYER_TABLE.c.study_id == study_id)
@@ -84,7 +84,7 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
         Does not persist area associations, use save_layer_areas() for that.
         """
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         values = {"study_id": study_id, "layer_id": layer.id, "name": layer.name}
         upsert_one(session, LAYER_TABLE, values)
@@ -102,7 +102,7 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
             raise LayerNotAllowedToBeDeleted()
 
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         result = session.execute(
             delete(LAYER_TABLE).where((LAYER_TABLE.c.study_id == study_id) & (LAYER_TABLE.c.layer_id == layer_id))
@@ -126,7 +126,7 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
             return True
 
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
 
         # Check if layer exists in LAYER_TABLE
         stmt = select(LAYER_TABLE.c.layer_id).where(

--- a/antarest/study/dao/database/database_layer_dao.py
+++ b/antarest/study/dao/database/database_layer_dao.py
@@ -45,7 +45,7 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
         The default layer (id="0") always contains all areas.
         Other layers contain the areas that have UI entries for that layer.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Get all layer names from LAYER_TABLE
@@ -83,7 +83,7 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
 
         Does not persist area associations, use save_layer_areas() for that.
         """
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         values = {"study_id": study_id, "layer_id": layer.id, "name": layer.name}
@@ -101,7 +101,7 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
         if layer_id == DEFAULT_LAYER_ID:
             raise LayerNotAllowedToBeDeleted()
 
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         result = session.execute(
@@ -125,7 +125,7 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
         if layer_id == DEFAULT_LAYER_ID:
             return True
 
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
 
         # Check if layer exists in LAYER_TABLE

--- a/antarest/study/dao/database/database_layer_dao.py
+++ b/antarest/study/dao/database/database_layer_dao.py
@@ -16,13 +16,11 @@ Database implementation of LayerDao.
 This module provides database-backed storage for layers when storage_mode=DATABASE.
 """
 
-from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from sqlalchemy import CursorResult, delete, select
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import LayerNotAllowedToBeDeleted, LayerNotFound
@@ -30,40 +28,18 @@ from antarest.core.utils.sql_utils import upsert_one
 from antarest.study.business.model.area_model import DEFAULT_LAYER_ID
 from antarest.study.business.model.layer_model import Layer
 from antarest.study.dao.api.layer_dao import LayerDao
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.area import AREA_UI_TABLE
 from antarest.study.dao.database.models.layer import LAYER_TABLE
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
-class DatabaseLayerDao(LayerDao):
+class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
     """
     Database implementation of LayerDao.
     """
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        """
-        Initialize DatabaseLayerDao with dependencies.
-
-        Args:
-            study_id: The study ID for database queries.
-            db_session: SQLAlchemy session for database operations.
-        """
-        self._study_id = study_id
-        self._db_session = db_session
-
-    def get_study_id(self) -> str:
-        """Get the study ID for database queries."""
-        return self._study_id
-
-    def get_session(self) -> Session:
-        """Get the SQLAlchemy session for database operations."""
-        return self._db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     @override
     def get_layers(self) -> Sequence[Layer]:

--- a/antarest/study/dao/database/database_layer_dao.py
+++ b/antarest/study/dao/database/database_layer_dao.py
@@ -18,7 +18,6 @@ This module provides database-backed storage for layers when storage_mode=DATABA
 
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 from sqlalchemy import CursorResult, delete, select
 from typing_extensions import override
@@ -31,9 +30,6 @@ from antarest.study.dao.api.layer_dao import LayerDao
 from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.area import AREA_UI_TABLE
 from antarest.study.dao.database.models.layer import LAYER_TABLE
-
-if TYPE_CHECKING:
-    pass
 
 
 class DatabaseLayerDao(LayerDao, DatabaseDaoBase):

--- a/antarest/study/dao/database/database_link_dao.py
+++ b/antarest/study/dao/database/database_link_dao.py
@@ -75,7 +75,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
 
     @override
     def save_links(self, links: Sequence[Link]) -> None:
-        session = self.get_session()
+        session = self._db_session
         values = []
         for link in links:
             values.append({"study_id": self._study_id, **link.model_dump()})
@@ -90,7 +90,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
     @override
     def delete_link(self, link: Link) -> None:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
         stmt = delete(LINK_TABLE).where(
             (LINK_TABLE.c.study_id == study_id)
             & (LINK_TABLE.c.area1 == link.area1)
@@ -106,7 +106,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
     @override
     def get_links(self) -> Sequence[Link]:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
         stmt = select(LINK_TABLE).where(LINK_TABLE.c.study_id == study_id)
         rows = session.execute(stmt).fetchall()
         return [_convert_db_rows_to_model(row) for row in rows]
@@ -126,7 +126,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
     def _get_row(self, area1_id: str, area2_id: str, table: Table) -> Row[Any] | None:
         area1, area2 = sorted((area1_id, area2_id))
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
         stmt = select(table).where((table.c.study_id == study_id) & (table.c.area1 == area1) & (table.c.area2 == area2))
         return session.execute(stmt).fetchone()
 
@@ -137,7 +137,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
         return str(row.matrix_id)
 
     def _save_link_matrices(self, series: LinkSeriesMapping, table: Table) -> None:
-        session = self.get_session()
+        session = self._db_session
         study_id = self._study_id
 
         values = []

--- a/antarest/study/dao/database/database_link_dao.py
+++ b/antarest/study/dao/database/database_link_dao.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from abc import abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -17,7 +16,6 @@ import polars as pl
 from sqlalchemy import Row, Table, delete, select
 from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound, LinkNotFound, LinksNotFound
@@ -26,6 +24,7 @@ from antarest.dbmodel import get_row_representation_as_dict
 from antarest.study.business.model.link_model import Link
 from antarest.study.dao.api.link_dao import LinkDao
 from antarest.study.dao.common import LinkSeriesMapping, SeriesId
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.link import (
     LINK_DIRECT_CAPACITY_TABLE,
     LINK_INDIRECT_CAPACITY_TABLE,
@@ -40,7 +39,7 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
 )
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
 def _convert_db_rows_to_model(db_row: Any) -> Link:
@@ -49,24 +48,8 @@ def _convert_db_rows_to_model(db_row: Any) -> Link:
     return Link(**data)
 
 
-class DatabaseLinkDao(LinkDao):
+class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
     """Database implementation of LinkDao"""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    def get_study_id(self) -> str:
-        """Get the study ID for database queries."""
-        return self._study_id
-
-    def get_session(self) -> Session:
-        """Get the SQLAlchemy session for database operations."""
-        return self._db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     def _raise_the_right_link_exception(self, links: Sequence[Link], exc: IntegrityError | None = None) -> None:
         # Happens if some link's areas did not exist -> ForeignKey constraint fails

--- a/antarest/study/dao/database/database_link_dao.py
+++ b/antarest/study/dao/database/database_link_dao.py
@@ -78,7 +78,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
         session = self.get_session()
         values = []
         for link in links:
-            values.append({"study_id": self.get_study_id(), **link.model_dump()})
+            values.append({"study_id": self._study_id, **link.model_dump()})
 
         try:
             upsert_multiple(session, LINK_TABLE, values)
@@ -89,7 +89,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
 
     @override
     def delete_link(self, link: Link) -> None:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
         stmt = delete(LINK_TABLE).where(
             (LINK_TABLE.c.study_id == study_id)
@@ -105,7 +105,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
 
     @override
     def get_links(self) -> Sequence[Link]:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
         stmt = select(LINK_TABLE).where(LINK_TABLE.c.study_id == study_id)
         rows = session.execute(stmt).fetchall()
@@ -125,7 +125,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
 
     def _get_row(self, area1_id: str, area2_id: str, table: Table) -> Row[Any] | None:
         area1, area2 = sorted((area1_id, area2_id))
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
         stmt = select(table).where((table.c.study_id == study_id) & (table.c.area1 == area1) & (table.c.area2 == area2))
         return session.execute(stmt).fetchone()
@@ -138,7 +138,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
 
     def _save_link_matrices(self, series: LinkSeriesMapping, table: Table) -> None:
         session = self.get_session()
-        study_id = self.get_study_id()
+        study_id = self._study_id
 
         values = []
         for key, series_id in series.items():

--- a/antarest/study/dao/database/database_link_dao.py
+++ b/antarest/study/dao/database/database_link_dao.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import polars as pl
 from sqlalchemy import Row, Table, delete, select
@@ -37,9 +37,6 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
     default_8_fixed_hourly,
     default_scenario_hourly,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 def _convert_db_rows_to_model(db_row: Any) -> Link:

--- a/antarest/study/dao/database/database_renewable_dao.py
+++ b/antarest/study/dao/database/database_renewable_dao.py
@@ -14,14 +14,12 @@
 Database implementation of ThermalDao.
 """
 
-from abc import abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import polars as pl
 from sqlalchemy import CursorResult, Select, delete, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import (
@@ -38,30 +36,16 @@ from antarest.study.business.model.renewable_cluster_model import (
 from antarest.study.dao.api.renewable_dao import RenewableDao
 from antarest.study.dao.common import AreaId, RenewableId, RenewableSeriesMapping
 from antarest.study.dao.database.common import validate_area_exists
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.renewable import RENEWABLE_CLUSTER_TABLE, RENEWABLE_SERIES_TABLE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default import default_scenario_hourly
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
-class DatabaseRenewableDao(RenewableDao):
+class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
     """Database implementation of RenewableDao"""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        """
-        Initialize DatabaseRenewableDao with dependencies.
-
-        Args:
-            study_id: The study ID for database queries.
-            db_session: SQLAlchemy session for database operations.
-        """
-        self._study_id = study_id
-        self._db_session = db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     def _convert_db_row_to_renewable(self, row: Any) -> RenewableCluster:
         data = get_row_representation_as_dict(row)

--- a/antarest/study/dao/database/database_renewable_dao.py
+++ b/antarest/study/dao/database/database_renewable_dao.py
@@ -15,7 +15,7 @@ Database implementation of ThermalDao.
 """
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import Any, NoReturn
 
 import polars as pl
 from sqlalchemy import CursorResult, Select, delete, select
@@ -39,9 +39,6 @@ from antarest.study.dao.database.common import validate_area_exists
 from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.renewable import RENEWABLE_CLUSTER_TABLE, RENEWABLE_SERIES_TABLE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default import default_scenario_hourly
-
-if TYPE_CHECKING:
-    pass
 
 
 class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):

--- a/antarest/study/dao/database/database_reserve_certification_dao.py
+++ b/antarest/study/dao/database/database_reserve_certification_dao.py
@@ -9,12 +9,10 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from sqlalchemy import Row, Select, delete, insert, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import (
@@ -29,10 +27,11 @@ from antarest.study.business.model.thermal_reserve_certification_model import (
 )
 from antarest.study.dao.api.reserve_certification_dao import ReserveCertificationDao
 from antarest.study.dao.common import AreaId
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.thermal_reserve_certification import THERMAL_RESERVE_CERTIFICATION_TABLE
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
 _THERMAL_TABLE = THERMAL_RESERVE_CERTIFICATION_TABLE
@@ -56,12 +55,8 @@ def _convert_model_to_row(
     return values
 
 
-class DatabaseReserveCertificationDao(ReserveCertificationDao):
+class DatabaseReserveCertificationDao(ReserveCertificationDao, DatabaseDaoBase):
     """Database implementation of ReserveCertificationDao."""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
 
     def _select_one(self, area_id: str, thermal_id: str, reserve_id: str) -> Select[Any]:
         return select(_THERMAL_TABLE).where(
@@ -70,10 +65,6 @@ class DatabaseReserveCertificationDao(ReserveCertificationDao):
             & (_THERMAL_TABLE.c.thermal_id == thermal_id)
             & (_THERMAL_TABLE.c.reserve_id == reserve_id)
         )
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     @override
     def get_all_thermal_reserve_certifications(self) -> dict[AreaId, ThermalReserveCertificationMapping]:

--- a/antarest/study/dao/database/database_reserve_certification_dao.py
+++ b/antarest/study/dao/database/database_reserve_certification_dao.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import Any, NoReturn
 
 from sqlalchemy import Row, Select, delete, insert, select
 from sqlalchemy.exc import IntegrityError
@@ -29,10 +29,6 @@ from antarest.study.dao.api.reserve_certification_dao import ReserveCertificatio
 from antarest.study.dao.common import AreaId
 from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.thermal_reserve_certification import THERMAL_RESERVE_CERTIFICATION_TABLE
-
-if TYPE_CHECKING:
-    pass
-
 
 _THERMAL_TABLE = THERMAL_RESERVE_CERTIFICATION_TABLE
 

--- a/antarest/study/dao/database/database_reserve_definition_dao.py
+++ b/antarest/study/dao/database/database_reserve_definition_dao.py
@@ -10,14 +10,12 @@
 #
 # This file is part of the Antares project.
 
-from abc import abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
 from sqlalchemy import CursorResult, Row, Select, delete, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound, ReserveDefinitionNotFound, ReserveDefinitionsNotFound
@@ -28,12 +26,13 @@ from antarest.study.dao.api.common import remove_reserve_symmetries_by_cascade
 from antarest.study.dao.api.reserve_definition_dao import ReserveDefinitionDao
 from antarest.study.dao.common import AreaId, ReserveDefinitionsMapping, ReserveNeedsMapping
 from antarest.study.dao.database.common import area_exists, validate_area_exists
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.reserve_definition import RESERVE_DEFINITION_TABLE
 from antarest.study.dao.database.models.reserve_need import RESERVE_NEED_MATRIX_TABLE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default import default_scenario_hourly
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 _TABLE = RESERVE_DEFINITION_TABLE
 _NEED_TABLE = RESERVE_NEED_MATRIX_TABLE
@@ -55,16 +54,8 @@ def _convert_model_to_row(study_id: str, area_id: str, reserve: ReserveDefinitio
     return values
 
 
-class DatabaseReserveDefinitionDao(ReserveDefinitionDao):
+class DatabaseReserveDefinitionDao(ReserveDefinitionDao, DatabaseDaoBase):
     """Database implementation of ReserveDefinitionDao."""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     def _select_reserve(self, area_id: str, reserve_id: str) -> Select[Any]:
         return select(_TABLE).where(

--- a/antarest/study/dao/database/database_reserve_definition_dao.py
+++ b/antarest/study/dao/database/database_reserve_definition_dao.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import polars as pl
 from sqlalchemy import CursorResult, Row, Select, delete, select
@@ -30,9 +30,6 @@ from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.reserve_definition import RESERVE_DEFINITION_TABLE
 from antarest.study.dao.database.models.reserve_need import RESERVE_NEED_MATRIX_TABLE
 from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default import default_scenario_hourly
-
-if TYPE_CHECKING:
-    pass
 
 _TABLE = RESERVE_DEFINITION_TABLE
 _NEED_TABLE = RESERVE_NEED_MATRIX_TABLE

--- a/antarest/study/dao/database/database_reserve_symmetries_dao.py
+++ b/antarest/study/dao/database/database_reserve_symmetries_dao.py
@@ -10,12 +10,10 @@
 #
 # This file is part of the Antares project.
 import json
-from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import Row, delete, insert, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound, ReserveDefinitionNotFound, ThermalReserveCertificationNotFound
@@ -28,10 +26,11 @@ from antarest.study.dao.common import (
     ThermalId,
     ThermalReserveSymmetriesMapping,
 )
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.thermal_reserve_symmetries import THERMAL_RESERVE_SYMMETRIES_TABLE
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
 _THERMAL_TABLE = THERMAL_RESERVE_SYMMETRIES_TABLE
@@ -65,16 +64,8 @@ def _checks_foreign_key_integrity(
                         raise ReserveDefinitionNotFound(area_id, reserve_id)
 
 
-class DatabaseReserveSymmetriesDao(ReserveSymmetriesDao):
+class DatabaseReserveSymmetriesDao(ReserveSymmetriesDao, DatabaseDaoBase):
     """Database implementation of ReserveSymmetriesDao."""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     @override
     def get_all_thermal_reserve_symmetries(self) -> ThermalReserveSymmetriesMapping:

--- a/antarest/study/dao/database/database_reserve_symmetries_dao.py
+++ b/antarest/study/dao/database/database_reserve_symmetries_dao.py
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 import json
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from sqlalchemy import Row, delete, insert, select
 from sqlalchemy.exc import IntegrityError
@@ -28,10 +28,6 @@ from antarest.study.dao.common import (
 )
 from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.thermal_reserve_symmetries import THERMAL_RESERVE_SYMMETRIES_TABLE
-
-if TYPE_CHECKING:
-    pass
-
 
 _THERMAL_TABLE = THERMAL_RESERVE_SYMMETRIES_TABLE
 

--- a/antarest/study/dao/database/database_reserves_global_parameters_dao.py
+++ b/antarest/study/dao/database/database_reserves_global_parameters_dao.py
@@ -47,7 +47,7 @@ class DatabaseReservesGlobalParametersDao(ReservesGlobalParametersDao, DatabaseD
     @override
     def get_reserves_global_parameters(self, area_id: str) -> ReservesGlobalParameters:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
         stmt = select(_TABLE).where((_TABLE.c.study_id == study_id) & (_TABLE.c.area_id == area_id))
         row = session.execute(stmt).fetchone()
         if not row:
@@ -58,14 +58,14 @@ class DatabaseReservesGlobalParametersDao(ReservesGlobalParametersDao, DatabaseD
     @override
     def get_all_reserves_global_parameters(self) -> ReservesGlobalParametersMapping:
         study_id = self._study_id
-        session = self.get_session()
+        session = self._db_session
         stmt = select(_TABLE).where(_TABLE.c.study_id == study_id)
         rows = session.execute(stmt)
         return {row.area_id: _convert_row_to_model(row) for row in rows}
 
     @override
     def save_reserves_global_parameters(self, mapping: ReservesGlobalParametersMapping) -> None:
-        session = self.get_session()
+        session = self._db_session
         study_id = self._study_id
         values = [
             {

--- a/antarest/study/dao/database/database_reserves_global_parameters_dao.py
+++ b/antarest/study/dao/database/database_reserves_global_parameters_dao.py
@@ -46,7 +46,7 @@ class DatabaseReservesGlobalParametersDao(ReservesGlobalParametersDao, DatabaseD
 
     @override
     def get_reserves_global_parameters(self, area_id: str) -> ReservesGlobalParameters:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
         stmt = select(_TABLE).where((_TABLE.c.study_id == study_id) & (_TABLE.c.area_id == area_id))
         row = session.execute(stmt).fetchone()
@@ -57,7 +57,7 @@ class DatabaseReservesGlobalParametersDao(ReservesGlobalParametersDao, DatabaseD
 
     @override
     def get_all_reserves_global_parameters(self) -> ReservesGlobalParametersMapping:
-        study_id = self.get_study_id()
+        study_id = self._study_id
         session = self.get_session()
         stmt = select(_TABLE).where(_TABLE.c.study_id == study_id)
         rows = session.execute(stmt)
@@ -66,7 +66,7 @@ class DatabaseReservesGlobalParametersDao(ReservesGlobalParametersDao, DatabaseD
     @override
     def save_reserves_global_parameters(self, mapping: ReservesGlobalParametersMapping) -> None:
         session = self.get_session()
-        study_id = self.get_study_id()
+        study_id = self._study_id
         values = [
             {
                 "study_id": study_id,

--- a/antarest/study/dao/database/database_reserves_global_parameters_dao.py
+++ b/antarest/study/dao/database/database_reserves_global_parameters_dao.py
@@ -26,6 +26,7 @@ from antarest.study.business.model.reserves_global_parameters_model import Reser
 from antarest.study.dao.api.reserves_global_parameters_dao import ReservesGlobalParametersDao
 from antarest.study.dao.common import ReservesGlobalParametersMapping
 from antarest.study.dao.database.common import validate_area_exists
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.area import RESERVES_GLOBAL_PARAMETERS_TABLE
 
 _TABLE = RESERVES_GLOBAL_PARAMETERS_TABLE
@@ -40,18 +41,8 @@ def _convert_row_to_model(row: Row[Any]) -> ReservesGlobalParameters:
     )
 
 
-class DatabaseReservesGlobalParametersDao(ReservesGlobalParametersDao):
+class DatabaseReservesGlobalParametersDao(ReservesGlobalParametersDao, DatabaseDaoBase):
     """Database implementation of ReservesGlobalParametersDao"""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    def get_study_id(self) -> str:
-        return self._study_id
-
-    def get_session(self) -> Session:
-        return self._db_session
 
     @override
     def get_reserves_global_parameters(self, area_id: str) -> ReservesGlobalParameters:

--- a/antarest/study/dao/database/database_reserves_global_parameters_dao.py
+++ b/antarest/study/dao/database/database_reserves_global_parameters_dao.py
@@ -18,7 +18,6 @@ from typing import Any
 
 from sqlalchemy import Row, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.utils.sql_utils import upsert_multiple

--- a/antarest/study/dao/database/database_scenario_builder_dao.py
+++ b/antarest/study/dao/database/database_scenario_builder_dao.py
@@ -9,11 +9,9 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import delete, insert, select
-from sqlalchemy.orm import Session
 from sqlalchemy.sql.schema import Table
 from typing_extensions import override
 
@@ -27,6 +25,7 @@ from antarest.study.business.model.scenario_builder_model import (
 )
 from antarest.study.business.model.study_index import StudyIndex
 from antarest.study.dao.api.scenario_builder_dao import ScenarioBuilderDao
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.ruleset import (
     SCENARIO_BINDING_CONSTRAINTS_TABLE,
     SCENARIO_HYDRO_FINAL_LEVEL_TABLE,
@@ -44,7 +43,7 @@ from antarest.study.dao.database.models.ruleset import (
 )
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 _LINK_SEPARATOR = " / "
 
@@ -66,18 +65,10 @@ _AREA_ITEM_TABLE_MAP: dict[ScenarioType, tuple[Table, str]] = {
 }
 
 
-class DatabaseScenarioBuilderDao(ScenarioBuilderDao):
+class DatabaseScenarioBuilderDao(ScenarioBuilderDao, DatabaseDaoBase):
     """
     Database implementation of ScenarioBuilderDao.
     """
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     @override
     def save_scenario_builder(self, ruleset: Ruleset) -> None:

--- a/antarest/study/dao/database/database_scenario_builder_dao.py
+++ b/antarest/study/dao/database/database_scenario_builder_dao.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from sqlalchemy import delete, insert, select
 from sqlalchemy.sql.schema import Table
@@ -41,9 +41,6 @@ from antarest.study.dao.database.models.ruleset import (
     SCENARIO_THERMAL_TABLE,
     SCENARIO_WIND_TABLE,
 )
-
-if TYPE_CHECKING:
-    pass
 
 _LINK_SEPARATOR = " / "
 

--- a/antarest/study/dao/database/database_st_storage_dao.py
+++ b/antarest/study/dao/database/database_st_storage_dao.py
@@ -15,7 +15,7 @@ Database implementation of StStorageDao.
 """
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import Any, NoReturn
 
 import polars as pl
 from sqlalchemy import CursorResult, Row, Table, select
@@ -67,9 +67,6 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
     default_scenario_hourly,
     default_scenario_hourly_ones,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):

--- a/antarest/study/dao/database/database_st_storage_dao.py
+++ b/antarest/study/dao/database/database_st_storage_dao.py
@@ -14,14 +14,12 @@
 Database implementation of StStorageDao.
 """
 
-from abc import abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import polars as pl
 from sqlalchemy import CursorResult, Row, Table, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import (
@@ -48,6 +46,7 @@ from antarest.study.dao.common import (
     StStorageSeriesMapping,
 )
 from antarest.study.dao.database.common import validate_area_exists
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.st_storage import (
     COST_INJECTION_TABLE,
     COST_LEVEL_TABLE,
@@ -70,28 +69,13 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
 )
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
-class DatabaseStStorageDao(STStorageDao):
+class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
     """
     Database implementation of StStorageDao.
     """
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        """
-        Initialize DatabaseStStorageDao with dependencies.
-
-        Args:
-            study_id: The study ID for database queries.
-            db_session: SQLAlchemy session for database operations.
-        """
-        self._study_id = study_id
-        self._db_session = db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     def _convert_st_storage_to_row(self, area_id: str, st_storage: STStorage) -> dict[str, Any]:
         values = dict(study_id=self._study_id, area_id=area_id, **st_storage.model_dump())

--- a/antarest/study/dao/database/database_study_dao.py
+++ b/antarest/study/dao/database/database_study_dao.py
@@ -108,7 +108,7 @@ class DatabaseStudyDao(
         """
         DatabaseDaoBase.__init__(self, StudyDaoContext(study_id, db_session))
         self._matrix_service = matrix_service
-        self._blob_service_impl = blob_service
+        self._blob_service = blob_service
         self._generator_matrix_constants = generator_matrix_constants
 
     @override
@@ -118,8 +118,8 @@ class DatabaseStudyDao(
 
     @property
     @override
-    def _blob_service(self) -> IBlobService:
-        return self._blob_service_impl
+    def blob_service(self) -> IBlobService:
+        return self._blob_service
 
     @override
     @property

--- a/antarest/study/dao/database/database_study_dao.py
+++ b/antarest/study/dao/database/database_study_dao.py
@@ -31,6 +31,7 @@ from antarest.core.utils.sql_utils import upsert_one
 from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.area_properties_model import AreaProperties, sort_filter_options
 from antarest.study.dao.api.study_dao import StudyDao
+from antarest.study.dao.database.dao_context import DatabaseDaoBase, StudyDaoContext
 from antarest.study.dao.database.database_area_dao import DatabaseAreaDao
 from antarest.study.dao.database.database_area_properties_dao import DatabaseAreaPropertiesDao
 from antarest.study.dao.database.database_binding_constraint_dao import DatabaseBindingConstraintDao
@@ -105,30 +106,20 @@ class DatabaseStudyDao(
             blob_service: Blobs storage service
             generator_matrix_constants: Predefined matrix constants generator
         """
-        DatabaseAreaDao.__init__(self, study_id, db_session)
-        DatabaseAreaPropertiesDao.__init__(self, study_id, db_session)
-        DatabaseDistrictDao.__init__(self, study_id, db_session)
-        DatabaseLinkDao.__init__(self, study_id, db_session)
-        DatabaseLayerDao.__init__(self, study_id, db_session)
-        DatabaseHydroDao.__init__(self, study_id, db_session)
-        DatabaseThermalDao.__init__(self, study_id, db_session)
-        DatabaseStudySettingsDao.__init__(self, study_id, db_session)
-        DatabaseRenewableDao.__init__(self, study_id, db_session)
-        DatabaseUserResourcesDao.__init__(self, study_id, db_session, blob_service)
-        DatabaseStStorageDao.__init__(self, study_id, db_session)
-        DatabaseThematicTrimmingDao.__init__(self, study_id, db_session)
-        DatabaseScenarioBuilderDao.__init__(self, study_id, db_session)
-        DatabaseXpansionDao.__init__(self, study_id, db_session)
-        DatabaseBindingConstraintDao.__init__(self, study_id, db_session)
-        DatabaseReservesGlobalParametersDao.__init__(self, study_id, db_session)
-        DatabaseReserveDefinitionDao.__init__(self, study_id, db_session)
+        DatabaseDaoBase.__init__(self, StudyDaoContext(study_id, db_session))
         self._matrix_service = matrix_service
+        self._blob_service_impl = blob_service
         self._generator_matrix_constants = generator_matrix_constants
 
     @override
     @property
     def matrix_service(self) -> ISimpleMatrixService:
         return self._matrix_service
+
+    @property
+    @override
+    def _blob_service(self) -> IBlobService:
+        return self._blob_service_impl
 
     @override
     @property

--- a/antarest/study/dao/database/database_study_settings_dao.py
+++ b/antarest/study/dao/database/database_study_settings_dao.py
@@ -10,11 +10,9 @@
 #
 # This file is part of the Antares project.
 import logging
-from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import StudyNotFoundError
@@ -37,6 +35,7 @@ from antarest.study.dao.api.general_config_dao import GeneralConfigDao
 from antarest.study.dao.api.optimization_preferences_dao import OptimizationPreferencesDao
 from antarest.study.dao.api.playlist_config_dao import PlaylistConfigDao
 from antarest.study.dao.api.timeseries_config_dao import TimeSeriesConfigDao
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.settings import (
     ADEQUACY_PATCH_PARAMETERS_TABLE,
     ADVANCED_PARAMETERS_TABLE,
@@ -48,7 +47,7 @@ from antarest.study.dao.database.models.settings import (
 )
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
 logger = logging.getLogger(__name__)
@@ -70,24 +69,9 @@ class DatabaseStudySettingsDao(
     AdequacyPatchParametersDao,
     TimeSeriesConfigDao,
     PlaylistConfigDao,
+    DatabaseDaoBase,
 ):
     """Database implementation of all study settings DAOs"""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    def get_study_id(self) -> str:
-        """Get the study ID for database queries."""
-        return self._study_id
-
-    def get_session(self) -> Session:
-        """Get the SQLAlchemy session for database operations."""
-        return self._db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     @override
     def save_general_config(self, config: GeneralConfig) -> None:

--- a/antarest/study/dao/database/database_study_settings_dao.py
+++ b/antarest/study/dao/database/database_study_settings_dao.py
@@ -71,7 +71,7 @@ class DatabaseStudySettingsDao(
     @override
     def save_general_config(self, config: GeneralConfig) -> None:
         values = dict(study_id=self._study_id, **config.model_dump())
-        session = self.get_session()
+        session = self._db_session
         upsert_one(session, GENERAL_CONFIG_TABLE, values)
         session.commit()
 
@@ -79,7 +79,7 @@ class DatabaseStudySettingsDao(
     def get_general_config(self) -> GeneralConfig:
         study_id = self._study_id
         stmt = select(GENERAL_CONFIG_TABLE).where(GENERAL_CONFIG_TABLE.c.study_id == study_id)
-        row = self.get_session().execute(stmt).fetchone()
+        row = self._db_session.execute(stmt).fetchone()
         if not row:
             raise StudyNotFoundError(study_id)
         data = get_row_representation_as_dict(row)
@@ -96,7 +96,7 @@ class DatabaseStudySettingsDao(
             mps = config.export_mps
         values["export_mps"] = mps
 
-        session = self.get_session()
+        session = self._db_session
         upsert_one(session, OPTIMIZATION_PREFERENCES_TABLE, values)
         session.commit()
 
@@ -104,7 +104,7 @@ class DatabaseStudySettingsDao(
     def get_optimization_preferences(self) -> OptimizationPreferences:
         study_id = self._study_id
         stmt = select(OPTIMIZATION_PREFERENCES_TABLE).where(OPTIMIZATION_PREFERENCES_TABLE.c.study_id == study_id)
-        row = self.get_session().execute(stmt).fetchone()
+        row = self._db_session.execute(stmt).fetchone()
         if not row:
             raise StudyNotFoundError(study_id)
 
@@ -125,7 +125,7 @@ class DatabaseStudySettingsDao(
     @override
     def save_advanced_parameters(self, parameters: AdvancedParameters) -> None:
         values = dict(study_id=self._study_id, **parameters.model_dump())
-        session = self.get_session()
+        session = self._db_session
         upsert_one(session, ADVANCED_PARAMETERS_TABLE, values)
         session.commit()
 
@@ -133,7 +133,7 @@ class DatabaseStudySettingsDao(
     def get_advanced_parameters(self) -> AdvancedParameters:
         study_id = self._study_id
         stmt = select(ADVANCED_PARAMETERS_TABLE).where(ADVANCED_PARAMETERS_TABLE.c.study_id == study_id)
-        row = self.get_session().execute(stmt).fetchone()
+        row = self._db_session.execute(stmt).fetchone()
         if not row:
             raise StudyNotFoundError(study_id)
 
@@ -145,7 +145,7 @@ class DatabaseStudySettingsDao(
     def get_compatibility_parameters(self) -> CompatibilityParameters:
         study_id = self._study_id
         stmt = select(COMPATIBILITY_PARAMETERS_TABLE).where(COMPATIBILITY_PARAMETERS_TABLE.c.study_id == study_id)
-        row = self.get_session().execute(stmt).fetchone()
+        row = self._db_session.execute(stmt).fetchone()
         if not row:
             raise StudyNotFoundError(study_id)
         return CompatibilityParameters(hydro_pmax=row.hydro_pmax)
@@ -153,14 +153,14 @@ class DatabaseStudySettingsDao(
     @override
     def save_compatibility_parameters(self, parameters: CompatibilityParameters) -> None:
         values = dict(study_id=self._study_id, hydro_pmax=parameters.hydro_pmax)
-        session = self.get_session()
+        session = self._db_session
         upsert_one(session, COMPATIBILITY_PARAMETERS_TABLE, values)
         session.commit()
 
     @override
     def save_adequacy_patch_parameters(self, parameters: AdequacyPatchParameters) -> None:
         values = dict(study_id=self._study_id, **parameters.model_dump())
-        session = self.get_session()
+        session = self._db_session
         upsert_one(session, ADEQUACY_PATCH_PARAMETERS_TABLE, values)
         session.commit()
 
@@ -168,7 +168,7 @@ class DatabaseStudySettingsDao(
     def get_adequacy_patch_parameters(self) -> AdequacyPatchParameters:
         study_id = self._study_id
         stmt = select(ADEQUACY_PATCH_PARAMETERS_TABLE).where(ADEQUACY_PATCH_PARAMETERS_TABLE.c.study_id == study_id)
-        row = self.get_session().execute(stmt).fetchone()
+        row = self._db_session.execute(stmt).fetchone()
         if not row:
             raise StudyNotFoundError(study_id)
 
@@ -179,7 +179,7 @@ class DatabaseStudySettingsDao(
     @override
     def save_timeseries_config(self, config: TimeSeriesConfiguration) -> None:
         values = dict(study_id=self._study_id, thermal_number=config.thermal.number)
-        session = self.get_session()
+        session = self._db_session
         upsert_one(session, TIMESERIES_CONFIG_TABLE, values)
         session.commit()
 
@@ -187,7 +187,7 @@ class DatabaseStudySettingsDao(
     def get_timeseries_config(self) -> TimeSeriesConfiguration:
         study_id = self._study_id
         stmt = select(TIMESERIES_CONFIG_TABLE).where(TIMESERIES_CONFIG_TABLE.c.study_id == study_id)
-        row = self.get_session().execute(stmt).fetchone()
+        row = self._db_session.execute(stmt).fetchone()
         if not row:
             raise StudyNotFoundError(study_id)
         return TimeSeriesConfiguration(thermal=TimeSeriesType(number=row.thermal_number))
@@ -205,7 +205,7 @@ class DatabaseStudySettingsDao(
             )
         years = {y: v for y, v in playlist.years.items() if 1 <= y <= nb_years}
         values = dict(study_id=self._study_id, years=to_json_string(years))
-        session = self.get_session()
+        session = self._db_session
         upsert_one(session, PLAYLIST_TABLE, values)
         session.commit()
 
@@ -213,7 +213,7 @@ class DatabaseStudySettingsDao(
     def get_playlist_config(self) -> Playlist:
         study_id = self._study_id
         stmt = select(PLAYLIST_TABLE).where(PLAYLIST_TABLE.c.study_id == study_id)
-        row = self.get_session().execute(stmt).fetchone()
+        row = self._db_session.execute(stmt).fetchone()
         if not row:
             raise StudyNotFoundError(study_id)
         sparse = Playlist(years=from_json(row.years))

--- a/antarest/study/dao/database/database_study_settings_dao.py
+++ b/antarest/study/dao/database/database_study_settings_dao.py
@@ -10,7 +10,6 @@
 #
 # This file is part of the Antares project.
 import logging
-from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 from typing_extensions import override
@@ -45,10 +44,6 @@ from antarest.study.dao.database.models.settings import (
     PLAYLIST_TABLE,
     TIMESERIES_CONFIG_TABLE,
 )
-
-if TYPE_CHECKING:
-    pass
-
 
 logger = logging.getLogger(__name__)
 

--- a/antarest/study/dao/database/database_study_settings_dao.py
+++ b/antarest/study/dao/database/database_study_settings_dao.py
@@ -70,7 +70,7 @@ class DatabaseStudySettingsDao(
 
     @override
     def save_general_config(self, config: GeneralConfig) -> None:
-        values = dict(study_id=self.get_study_id(), **config.model_dump())
+        values = dict(study_id=self._study_id, **config.model_dump())
         session = self.get_session()
         upsert_one(session, GENERAL_CONFIG_TABLE, values)
         session.commit()
@@ -88,7 +88,7 @@ class DatabaseStudySettingsDao(
 
     @override
     def save_optimization_preferences(self, config: OptimizationPreferences) -> None:
-        values = dict(study_id=self.get_study_id(), **config.model_dump(exclude={"export_mps"}))
+        values = dict(study_id=self._study_id, **config.model_dump(exclude={"export_mps"}))
         # Handle `export_mps` differently as it can either be a string or a boolean but will be stored as String in DB.
         if isinstance(config.export_mps, bool):
             mps = str(config.export_mps)
@@ -124,7 +124,7 @@ class DatabaseStudySettingsDao(
 
     @override
     def save_advanced_parameters(self, parameters: AdvancedParameters) -> None:
-        values = dict(study_id=self.get_study_id(), **parameters.model_dump())
+        values = dict(study_id=self._study_id, **parameters.model_dump())
         session = self.get_session()
         upsert_one(session, ADVANCED_PARAMETERS_TABLE, values)
         session.commit()
@@ -152,14 +152,14 @@ class DatabaseStudySettingsDao(
 
     @override
     def save_compatibility_parameters(self, parameters: CompatibilityParameters) -> None:
-        values = dict(study_id=self.get_study_id(), hydro_pmax=parameters.hydro_pmax)
+        values = dict(study_id=self._study_id, hydro_pmax=parameters.hydro_pmax)
         session = self.get_session()
         upsert_one(session, COMPATIBILITY_PARAMETERS_TABLE, values)
         session.commit()
 
     @override
     def save_adequacy_patch_parameters(self, parameters: AdequacyPatchParameters) -> None:
-        values = dict(study_id=self.get_study_id(), **parameters.model_dump())
+        values = dict(study_id=self._study_id, **parameters.model_dump())
         session = self.get_session()
         upsert_one(session, ADEQUACY_PATCH_PARAMETERS_TABLE, values)
         session.commit()
@@ -178,7 +178,7 @@ class DatabaseStudySettingsDao(
 
     @override
     def save_timeseries_config(self, config: TimeSeriesConfiguration) -> None:
-        values = dict(study_id=self.get_study_id(), thermal_number=config.thermal.number)
+        values = dict(study_id=self._study_id, thermal_number=config.thermal.number)
         session = self.get_session()
         upsert_one(session, TIMESERIES_CONFIG_TABLE, values)
         session.commit()
@@ -200,11 +200,11 @@ class DatabaseStudySettingsDao(
             logger.warning(
                 "Dropping playlist entries for years outside [1, %d] on study %s: %s",
                 nb_years,
-                self.get_study_id(),
+                self._study_id,
                 sorted(out_of_range),
             )
         years = {y: v for y, v in playlist.years.items() if 1 <= y <= nb_years}
-        values = dict(study_id=self.get_study_id(), years=to_json_string(years))
+        values = dict(study_id=self._study_id, years=to_json_string(years))
         session = self.get_session()
         upsert_one(session, PLAYLIST_TABLE, values)
         session.commit()

--- a/antarest/study/dao/database/database_thematic_trimming_dao.py
+++ b/antarest/study/dao/database/database_thematic_trimming_dao.py
@@ -10,12 +10,10 @@
 #
 # This file is part of the Antares project.
 
-from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import StudyNotFoundError
@@ -25,22 +23,15 @@ from antarest.study.business.model.thematic_trimming_model import (
     check_thematic_trimming_complete,
 )
 from antarest.study.dao.api.thematic_trimming_dao import ThematicTrimmingDao
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.thematic_trimming import THEMATIC_TRIMMING_TABLE
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
-class DatabaseThematicTrimmingDao(ThematicTrimmingDao):
+class DatabaseThematicTrimmingDao(ThematicTrimmingDao, DatabaseDaoBase):
     """Database implementation of ThematicTrimmingDao"""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     @override
     def get_thematic_trimming(self) -> ThematicTrimming:

--- a/antarest/study/dao/database/database_thematic_trimming_dao.py
+++ b/antarest/study/dao/database/database_thematic_trimming_dao.py
@@ -10,7 +10,6 @@
 #
 # This file is part of the Antares project.
 
-from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -25,9 +24,6 @@ from antarest.study.business.model.thematic_trimming_model import (
 from antarest.study.dao.api.thematic_trimming_dao import ThematicTrimmingDao
 from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.thematic_trimming import THEMATIC_TRIMMING_TABLE
-
-if TYPE_CHECKING:
-    pass
 
 
 class DatabaseThematicTrimmingDao(ThematicTrimmingDao, DatabaseDaoBase):

--- a/antarest/study/dao/database/database_thermal_dao.py
+++ b/antarest/study/dao/database/database_thermal_dao.py
@@ -14,14 +14,12 @@
 Database implementation of ThermalDao.
 """
 
-from abc import abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import polars as pl
 from sqlalchemy import CursorResult, Row, Select, Table, delete, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.core.exceptions import AreaNotFound, ThermalClusterNotFound, ThermalClustersNotFound
@@ -35,6 +33,7 @@ from antarest.study.business.model.thermal_cluster_model import (
 from antarest.study.dao.api.thermal_dao import ThermalDao
 from antarest.study.dao.common import AreaId, SeriesId, ThermalId, ThermalSeriesMapping
 from antarest.study.dao.database.common import validate_area_exists
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.thermal import (
     THERMAL_CLUSTER_TABLE,
     THERMAL_CO2_COST_TABLE,
@@ -50,31 +49,16 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.thermal.prepro.
 )
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
-class DatabaseThermalDao(ThermalDao):
+class DatabaseThermalDao(ThermalDao, DatabaseDaoBase):
     """
     Database implementation of ThermalDao.
 
     TODO: decide IDs handling, and in particular should we be case insensitive when searching
           for a cluster (same question for areas etc)
     """
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        """
-        Initialize DatabaseThermalDao with dependencies.
-
-        Args:
-            study_id: The study ID for database queries.
-            db_session: SQLAlchemy session for database operations.
-        """
-        self._study_id = study_id
-        self._db_session = db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
 
     def _convert_db_row_to_thermal(self, row: Any) -> ThermalCluster:
         data = get_row_representation_as_dict(row)

--- a/antarest/study/dao/database/database_thermal_dao.py
+++ b/antarest/study/dao/database/database_thermal_dao.py
@@ -15,7 +15,7 @@ Database implementation of ThermalDao.
 """
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import Any, NoReturn
 
 import polars as pl
 from sqlalchemy import CursorResult, Row, Select, Table, delete, select
@@ -47,9 +47,6 @@ from antarest.study.storage.rawstudy.model.filesystem.root.input.thermal.prepro.
     default_data_matrix,
     default_modulation_matrix,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 class DatabaseThermalDao(ThermalDao, DatabaseDaoBase):

--- a/antarest/study/dao/database/database_user_resources.py
+++ b/antarest/study/dao/database/database_user_resources.py
@@ -46,7 +46,7 @@ class DatabaseUserResourcesDao(UserResourcesDao, DatabaseDaoBase):
 
     @property
     @abstractmethod
-    def _blob_service(self) -> IBlobService:
+    def blob_service(self) -> IBlobService:
         """Blobs storage service, provided by the concrete DAO."""
 
     @override
@@ -168,7 +168,7 @@ class DatabaseUserResourcesDao(UserResourcesDao, DatabaseDaoBase):
             raise UserResourceIsAFolder(resource_path.as_posix())
 
         assert data.blob_id is not None
-        return self._blob_service.get(data.blob_id)
+        return self.blob_service.get(data.blob_id)
 
     def _build_resources_tree(self) -> dict[PurePosixPath, UserResourcesDatabaseData]:
         stmt = select(_TABLE).where(_TABLE.c.study_id == self._study_id)

--- a/antarest/study/dao/database/database_user_resources.py
+++ b/antarest/study/dao/database/database_user_resources.py
@@ -15,12 +15,12 @@ Database implementation of UserResourcesDao.
 """
 
 import uuid
+from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.blobstore.service import IBlobService
@@ -28,6 +28,7 @@ from antarest.core.exceptions import UserResourceIsAFolder, UserResourceNotFound
 from antarest.core.utils.sql_utils import upsert_multiple
 from antarest.study.business.model.user_model import ResourceType, UserResourceDataCreation
 from antarest.study.dao.api.user_resources_dao import UserResourcesDao
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.user_resources import USER_RESOURCES_TABLE
 
 _TABLE = USER_RESOURCES_TABLE
@@ -40,20 +41,13 @@ class UserResourcesDatabaseData:
     resource_type: ResourceType
 
 
-class DatabaseUserResourcesDao(UserResourcesDao):
+class DatabaseUserResourcesDao(UserResourcesDao, DatabaseDaoBase):
     """Database implementation of UserResourcesDao"""
 
-    def __init__(self, study_id: str, db_session: Session, blob_service: IBlobService) -> None:
-        """
-        Initialize DatabaseUserResourcesDao with dependencies.
-
-        Args:
-            study_id: The study ID for database queries.
-            db_session: SQLAlchemy session for database operations.
-        """
-        self._study_id = study_id
-        self._db_session = db_session
-        self._blob_service = blob_service
+    @property
+    @abstractmethod
+    def _blob_service(self) -> IBlobService:
+        """Blobs storage service, provided by the concrete DAO."""
 
     @override
     def save_user_resources(self, resource_data: list[UserResourceDataCreation]) -> None:

--- a/antarest/study/dao/database/database_xpansion_dao.py
+++ b/antarest/study/dao/database/database_xpansion_dao.py
@@ -14,7 +14,7 @@
 Database implementation of XpansionDao.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import polars as pl
 from sqlalchemy import CursorResult, Table, asc, delete, insert, or_, select, update
@@ -57,9 +57,6 @@ from antarest.study.dao.database.models.xpansion import (
     XPANSION_SETTINGS_TABLE,
     XPANSION_WEIGHT_TABLE,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):

--- a/antarest/study/dao/database/database_xpansion_dao.py
+++ b/antarest/study/dao/database/database_xpansion_dao.py
@@ -14,13 +14,11 @@
 Database implementation of XpansionDao.
 """
 
-from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
 from sqlalchemy import CursorResult, Table, asc, delete, insert, or_, select, update
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 from typing_extensions import override
 
@@ -48,6 +46,7 @@ from antarest.study.business.model.xpansion_model import (
 )
 from antarest.study.dao.api.xpansion_dao import XpansionDao
 from antarest.study.dao.common import XpansionCapacitiesMapping, XpansionConstraintsMapping, XpansionWeightsMapping
+from antarest.study.dao.database.dao_context import DatabaseDaoBase
 from antarest.study.dao.database.models.xpansion import (
     XPANSION_ADEQUACY_CRITERION_TABLE,
     XPANSION_ADEQUACY_PATTERN_TABLE,
@@ -60,23 +59,11 @@ from antarest.study.dao.database.models.xpansion import (
 )
 
 if TYPE_CHECKING:
-    from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+    pass
 
 
-class DatabaseXpansionDao(XpansionDao):
+class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     """Database implementation of XpansionDao."""
-
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        self._study_id = study_id
-        self._db_session = db_session
-
-    @abstractmethod
-    def get_impl(self) -> "DatabaseStudyDao":
-        pass
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
 
     def _settings_row_exists(self) -> bool:
         stmt = select(XPANSION_SETTINGS_TABLE.c.study_id).where(XPANSION_SETTINGS_TABLE.c.study_id == self._study_id)

--- a/antarest/study/dao/database/study_data_queries.py
+++ b/antarest/study/dao/database/study_data_queries.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Queries on the study data tables that are not scoped to a single `DatabaseStudyDao`.
+
+The garbage collectors (matrices, blobs) walk these tables across all studies, so they
+cannot go through a per-study DAO. Gathering their queries here keeps the way study data
+rows are linked back to a study in one place.
+"""
+
+from collections.abc import Iterator, Sequence
+
+from sqlalchemy import ColumnElement, Table, select
+from sqlalchemy.orm import Session
+
+from antarest.study.dao.database.models.user_resources import USER_RESOURCES_TABLE
+
+
+def belongs_to_study(table: Table, study_id: str) -> ColumnElement[bool]:
+    """
+    Predicate restricting a study data table to the rows of the given study.
+
+    Args:
+        table: Any study data table, i.e. any table keyed by a study.
+        study_id: The study ID, as found in `study.id`.
+    """
+    return table.c.study_id == study_id
+
+
+def yield_matrix_ids(session: Session, tables: Sequence[Table], study_id: str) -> Iterator[tuple[Table, str]]:
+    """
+    Yield `(table, matrix_id)` for every matrix referenced by the given study.
+
+    Used by the matrix garbage collector: a matrix missing from this listing is
+    considered unused and becomes eligible for deletion.
+    """
+    for table in tables:
+        stmt = select(table.c.matrix_id).where(belongs_to_study(table, study_id))
+        for row in session.execute(stmt).fetchall():
+            yield table, row.matrix_id
+
+
+def yield_used_blobs(session: Session) -> Iterator[tuple[str, str]]:
+    """
+    Yield `(blob_id, study_id)` for every blob referenced by a user resource, across all studies.
+
+    Used by the blob garbage collector: a blob missing from this listing is considered
+    unused and becomes eligible for deletion.
+    """
+    stmt = select(USER_RESOURCES_TABLE).where(USER_RESOURCES_TABLE.c.blob_id.isnot(None))
+    for row in session.execute(stmt).fetchall():
+        yield row.blob_id, row.study_id

--- a/antarest/study/storage/database_storage.py
+++ b/antarest/study/storage/database_storage.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Iterator
 
 from antares.study.version import StudyVersion
-from sqlalchemy import delete, select
+from sqlalchemy import delete
 from typing_extensions import override
 
 from antarest.core.config import Config
@@ -75,6 +75,7 @@ from antarest.study.dao.database.models.thermal import (
     THERMAL_SERIES_TABLE,
 )
 from antarest.study.dao.database.models.xpansion import XPANSION_CAPACITY_TABLE, XPANSION_WEIGHT_TABLE
+from antarest.study.dao.database.study_data_queries import yield_matrix_ids
 from antarest.study.dao.file.file_study_factory_dao import FileStudyDaoFactory
 from antarest.study.dao.study_conversion.study_converter import StudyConverter
 from antarest.study.model import RawStudy, Study, StudyMetadataCopy, StudyMetadataCreation
@@ -247,12 +248,9 @@ class DatabaseStudyStorage(IStudyStorage):
     @override
     def yield_matrix_references(self, study: Study) -> Iterator[MatrixReference]:
         with db():
-            for table in MATRIX_TABLES:
-                stmt = select(table.c.matrix_id).where(table.c.study_id == study.id)
-                rows = db.session.execute(stmt).fetchall()
-                for row in rows:
-                    description = f"Matrix used inside table {table.name}, for study {study.id}"
-                    yield MatrixReference(matrix_id=row.matrix_id, use_description=description)
+            for table, matrix_id in yield_matrix_ids(db.session, MATRIX_TABLES, study.id):
+                description = f"Matrix used inside table {table.name}, for study {study.id}"
+                yield MatrixReference(matrix_id=matrix_id, use_description=description)
 
     @override
     def normalize_study(self, study: Study) -> None:

--- a/tests/study/dao/test_database_user_resources_dao.py
+++ b/tests/study/dao/test_database_user_resources_dao.py
@@ -65,7 +65,7 @@ def test_update_blob_id(dao: StudyDao, blob_service: InMemoryBlobService) -> Non
 
     # Specific DB test. Ensure we only have one entry in DB, as we updated the existing one rather than creating a new.
     if isinstance(dao, DatabaseStudyDao):
-        assert len(dao.get_session().execute(select(USER_RESOURCES_TABLE)).all()) == 1
+        assert len(dao._db_session.execute(select(USER_RESOURCES_TABLE)).all()) == 1
 
     result = list(dao.get_all_user_resources())
     assert len(result) == 1
@@ -157,7 +157,7 @@ def test_save_same_resource_twice(dao: StudyDao) -> None:
 
     # Specific DB test. Ensure we only have 2 entries in DB: `folderB` and `subfolderB`
     if isinstance(dao, DatabaseStudyDao):
-        assert len(dao.get_session().execute(select(USER_RESOURCES_TABLE)).all()) == 2
+        assert len(dao._db_session.execute(select(USER_RESOURCES_TABLE)).all()) == 2
 
 
 def test_save_folder_inside_an_existing_one(dao: StudyDao) -> None:
@@ -215,7 +215,7 @@ def test_save_folders_which_share_the_same_parent(dao: StudyDao, blob_service: I
 
     # Specific DB test. Ensure we only have 3 entries in DB: `a`, `b` and `c`. Not `a` twice.
     if isinstance(dao, DatabaseStudyDao):
-        assert len(dao.get_session().execute(select(USER_RESOURCES_TABLE)).all()) == 3
+        assert len(dao._db_session.execute(select(USER_RESOURCES_TABLE)).all()) == 3
 
 
 def test_get_resource_out_of_user_folder(dao: StudyDao) -> None:
@@ -235,5 +235,5 @@ def test_save_relative_folder_use_the_longest_parent(db_dao: DatabaseStudyDao) -
     res = db_dao.get_all_user_resources()
     assert len(res) == 2  # Should only be 'a/b' and 'a/c/d'
 
-    rows = db_dao.get_session().execute(select(USER_RESOURCES_TABLE)).fetchall()
+    rows = db_dao._db_session.execute(select(USER_RESOURCES_TABLE)).fetchall()
     assert len(rows) == 4  # Should only be 'a', 'b', 'c' and 'd'


### PR DESCRIPTION

Refactor to simplify a little the database DAO code, introducing a base mixin
for all parts of the DAO which provides the objects they all need:
- session
- study id 
- ...

This will help further refactorings, in particular introducing a new ID for study_data,
independent from the study ID itself.