### PR TITLE
fix(ui-reserves): sync certifications with cluster changes and show activation state

### DIFF
--- a/webapp/public/locales/en/main.json
+++ b/webapp/public/locales/en/main.json
@@ -674,6 +674,7 @@
   "study.modeling.reserves.certifications.certifiedClusters": "Certified clusters",
   "study.modeling.reserves.certifications.incomplete": "Incomplete certification: Max Power must be greater than 0",
   "study.modeling.reserves.certifications.removeWarning": "These clusters will lose their certification parameters: {{clusters, list}}",
+  "study.modeling.reserves.certifications.field.enabled": "Enabled",
   "study.modeling.reserves.certifications.field.participationCost": "P.Cost (€/MW)",
   "study.modeling.reserves.certifications.field.participationCostOff": "P.Cost-off (€/MW)",
   "study.modeling.reserves.certifications.field.maxPower": "Max Power (MW)",

--- a/webapp/public/locales/fr/main.json
+++ b/webapp/public/locales/fr/main.json
@@ -674,6 +674,7 @@
   "study.modeling.reserves.certifications.certifiedClusters": "Clusters certifiés",
   "study.modeling.reserves.certifications.incomplete": "Certification incomplète : la puissance maximale doit être supérieure à 0",
   "study.modeling.reserves.certifications.removeWarning": "Ces clusters perdront leurs paramètres de certification : {{clusters, list}}",
+  "study.modeling.reserves.certifications.field.enabled": "Activé",
   "study.modeling.reserves.certifications.field.participationCost": "Coût de participation (€/MW)",
   "study.modeling.reserves.certifications.field.participationCostOff": "Coût en désactivation (€/MW)",
   "study.modeling.reserves.certifications.field.maxPower": "Puissance maximale (MW)",

--- a/webapp/src/queries/reserves/queries.ts
+++ b/webapp/src/queries/reserves/queries.ts
@@ -25,7 +25,7 @@ import type {
 import { getOptimization } from "@/services/api/studies/config/optimization";
 import type { AreaWithId } from "@/types/types";
 import { queryOptions } from "@tanstack/react-query";
-import { queryListOptions } from "../utils";
+import { EXTERNALLY_MUTATED, queryListOptions } from "../utils";
 import { reserveKeys } from "./keys";
 import type { Study } from "@/services/api/studies/types";
 
@@ -62,6 +62,9 @@ export const reserveQueries = {
     return queryOptions({
       queryKey: reserveKeys.certifications(studyId, areaId, productionType),
       queryFn: () => getReservesCertifications({ studyId, areaId, productionType }),
+      // Deleting a cluster elsewhere (Thermals page, table mode) cascades to its
+      // certifications server-side without invalidating this cache.
+      ...EXTERNALLY_MUTATED,
     });
   },
 };

--- a/webapp/src/queries/thermals/keys.ts
+++ b/webapp/src/queries/thermals/keys.ts
@@ -12,12 +12,13 @@
  * This file is part of the Antares project.
  */
 
-import type { AreaWithId, StudyMetadata } from "@/types/types";
+import type { AreaWithId } from "@/types/types";
 import { areaKeys } from "../areas/keys";
+import type { Study } from "@/services/api/studies/types";
 
 export const thermalKeys = {
   all: () => [...areaKeys.all(), "thermals"],
-  list: (studyId: StudyMetadata["id"], areaId: AreaWithId["id"]) => {
+  list: (studyId: Study["id"], areaId: AreaWithId["id"]) => {
     return [...thermalKeys.all(), { studyId, areaId }];
   },
 };

--- a/webapp/src/queries/thermals/keys.ts
+++ b/webapp/src/queries/thermals/keys.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026, RTE (https://www.rte-france.com)
+ *
+ * See AUTHORS.txt
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This file is part of the Antares project.
+ */
+
+import type { AreaWithId, StudyMetadata } from "@/types/types";
+import { areaKeys } from "../areas/keys";
+
+export const thermalKeys = {
+  all: () => [...areaKeys.all(), "thermals"],
+  list: (studyId: StudyMetadata["id"], areaId: AreaWithId["id"]) => {
+    return [...thermalKeys.all(), { studyId, areaId }];
+  },
+};

--- a/webapp/src/queries/thermals/queries.ts
+++ b/webapp/src/queries/thermals/queries.ts
@@ -12,15 +12,13 @@
  * This file is part of the Antares project.
  */
 
-import { thermalKeys } from "@/queries/thermals/keys";
+import { getThermalClusters } from "@/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/thermals/-utils";
 import type { Study } from "@/services/api/studies/types";
 import type { AreaWithId } from "@/types/types";
 import { queryOptions } from "@tanstack/react-query";
-import { getThermalClusters } from "../thermals/-utils";
+import { thermalKeys } from "./keys";
 
-// Thermal clusters have no query layer yet (their API service still lives in the
-// thermals route folder), so the query options are defined here for now.
-export const thermalClustersQueries = {
+export const thermalQueries = {
   list: (studyId: Study["id"], areaId: AreaWithId["id"]) => {
     return queryOptions({
       queryKey: thermalKeys.list(studyId, areaId),

--- a/webapp/src/queries/thermals/queries.ts
+++ b/webapp/src/queries/thermals/queries.ts
@@ -16,6 +16,7 @@ import { getThermalClusters } from "@/routes/_authenticated/studies/$studyId/exp
 import type { Study } from "@/services/api/studies/types";
 import type { AreaWithId } from "@/types/types";
 import { queryOptions } from "@tanstack/react-query";
+import { EXTERNALLY_MUTATED } from "../utils";
 import { thermalKeys } from "./keys";
 
 export const thermalQueries = {
@@ -23,6 +24,9 @@ export const thermalQueries = {
     return queryOptions({
       queryKey: thermalKeys.list(studyId, areaId),
       queryFn: () => getThermalClusters(studyId, areaId),
+      // Clusters are mutated by the legacy Thermals pages and table mode, none of
+      // which invalidate this cache.
+      ...EXTERNALLY_MUTATED,
     });
   },
 };

--- a/webapp/src/queries/utils.ts
+++ b/webapp/src/queries/utils.ts
@@ -21,6 +21,23 @@ import {
 import { queryClient } from "./queryClient";
 
 ////////////////////////////////////////////////////////////////
+// Externally Mutated Data
+////////////////////////////////////////////////////////////////
+
+/**
+ * Options for queries whose data can be mutated outside react-query's knowledge (legacy pages,
+ * table mode, debug view, variant commands, server-side cascades), so the cache can't be
+ * reliably invalidated.
+ *
+ * Data is treated as always stale: it refetches on every mount and window focus. Concurrent
+ * readers of the same key still share a single fetch.
+ *
+ * Drop this only once ALL writers of the query invalidate the cache.
+ */
+
+export const EXTERNALLY_MUTATED = { staleTime: 0 } as const;
+
+////////////////////////////////////////////////////////////////
 // Query List
 ////////////////////////////////////////////////////////////////
 

--- a/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/-components/CertificationsTable.tsx
+++ b/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/-components/CertificationsTable.tsx
@@ -20,7 +20,7 @@ import type {
   ReserveCertification,
 } from "@/services/api/studies/areas/reserves/types";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
-import { Box, Stack, Tooltip } from "@mui/material";
+import { Box, Chip, Stack, Tooltip, Typography } from "@mui/material";
 import {
   createMRTColumnHelper,
   MaterialReactTable,
@@ -36,6 +36,7 @@ export interface ClusterRow {
   kind: "cluster";
   id: string;
   name: string;
+  enabled: boolean;
   productionType: CertificationProductionType;
   reserveId: Reserve["id"];
   clusterId: string;
@@ -103,9 +104,36 @@ function CertificationsTable({ rows, readOnly, isLoading, onReserveClick, onClus
                 {renderedCellValue}
               </Box>
             )}
+            {row.original.kind === "reserve" && (
+              <Tooltip title={t("study.modeling.reserves.certifications.certifiedClusters")}>
+                <Typography variant="caption" color="text.secondary">
+                  ({row.original.subRows.length})
+                </Typography>
+              </Tooltip>
+            )}
           </Stack>
         ),
         ...getTableOptionsForAlign("left"),
+      }),
+      columnHelper.accessor((row) => (row.kind === "cluster" ? row.enabled : null), {
+        id: "enabled",
+        header: t("study.modeling.reserves.certifications.field.enabled"),
+        size: 80,
+        Cell: ({ cell }) => {
+          const value = cell.getValue();
+
+          if (value === null) {
+            return null;
+          }
+
+          return (
+            <Chip
+              label={value ? t("button.yes") : t("button.no")}
+              color={value ? "success" : "error"}
+              sx={{ minWidth: 40 }}
+            />
+          );
+        },
       }),
       columnHelper.accessor(
         (row) => (row.kind === "cluster" ? row.certification.participationCost : null),

--- a/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/-components/UpdateCertificationDrawer.tsx
+++ b/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/-components/UpdateCertificationDrawer.tsx
@@ -19,11 +19,13 @@ import type { SubmitHandlerPlus } from "@/components/Form/types";
 import type { ReserveCertification } from "@/services/api/studies/areas/reserves/types";
 import { validateNumber } from "@/utils/validation/number";
 import EditIcon from "@mui/icons-material/Edit";
+import { Chip, Stack, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 interface Props {
   open: boolean;
   clusterName: string;
+  clusterEnabled: boolean;
   certification: ReserveCertification;
   onClose: VoidFunction;
   onSubmit: (values: ReserveCertification) => Promise<ReserveCertification>;
@@ -31,7 +33,14 @@ interface Props {
 
 // Updates the certification parameters of a cluster for a reserve. Adding or
 // removing the certification itself is handled by `UpdateReserveClustersDrawer`.
-function UpdateCertificationDrawer({ open, clusterName, certification, onClose, onSubmit }: Props) {
+function UpdateCertificationDrawer({
+  open,
+  clusterName,
+  clusterEnabled,
+  certification,
+  onClose,
+  onSubmit,
+}: Props) {
   const { t } = useTranslation();
 
   ////////////////////////////////////////////////////////////////
@@ -58,6 +67,16 @@ function UpdateCertificationDrawer({ open, clusterName, certification, onClose, 
     >
       {({ control }) => (
         <Fieldset fullFieldWidth>
+          <Stack direction="row" alignItems="center" gap={1.5}>
+            <Typography variant="body2" color="text.secondary">
+              {t("study.modeling.reserves.certifications.field.enabled")}
+            </Typography>
+            <Chip
+              label={clusterEnabled ? t("button.yes") : t("button.no")}
+              color={clusterEnabled ? "success" : "error"}
+              sx={{ minWidth: 40 }}
+            />
+          </Stack>
           <NumberFE
             label={t("study.modeling.reserves.certifications.field.participationCost")}
             name="participationCost"

--- a/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/-components/UpdateReserveClustersDrawer.tsx
+++ b/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/-components/UpdateReserveClustersDrawer.tsx
@@ -17,6 +17,7 @@ import Fieldset from "@/components/Fieldset";
 import FormDrawer from "@/components/FormDrawer";
 import type { SubmitHandlerPlus } from "@/components/Form/types";
 import { reserveQueries } from "@/queries/reserves/queries";
+import { thermalQueries } from "@/queries/thermals/queries";
 import useStudy from "@/routes/_authenticated/studies/$studyId/-hooks/useStudy";
 import useArea from "@/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/-hooks/useArea";
 import type {
@@ -27,7 +28,6 @@ import FactoryIcon from "@mui/icons-material/Factory";
 import { Alert, Typography } from "@mui/material";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { thermalClustersQueries } from "../-utils";
 
 // One entry per production type ("thermals" for now, "storages" and "hydro" coming soon)
 export type ClustersFormValues = Record<CertificationProductionType, string[]>;
@@ -48,7 +48,7 @@ function UpdateReserveClustersDrawer({ open, reserveId, defaultValues, onClose, 
   const { id: areaId } = useArea();
 
   const { data: reserves } = useSuspenseQuery(reserveQueries.list(studyId, areaId));
-  const { data: thermalClusters } = useSuspenseQuery(thermalClustersQueries.list(studyId, areaId));
+  const { data: thermalClusters } = useSuspenseQuery(thermalQueries.list(studyId, areaId));
 
   const reserveName = reserves.find(({ id }) => id === reserveId)?.name ?? reserveId;
 

--- a/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/-utils.ts
+++ b/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/-utils.ts
@@ -12,7 +12,7 @@
  * This file is part of the Antares project.
  */
 
-import { areaKeys } from "@/queries/areas/keys";
+import { thermalKeys } from "@/queries/thermals/keys";
 import type { Study } from "@/services/api/studies/types";
 import type { AreaWithId } from "@/types/types";
 import { queryOptions } from "@tanstack/react-query";
@@ -23,7 +23,7 @@ import { getThermalClusters } from "../thermals/-utils";
 export const thermalClustersQueries = {
   list: (studyId: Study["id"], areaId: AreaWithId["id"]) => {
     return queryOptions({
-      queryKey: [...areaKeys.all(), "thermals", { studyId, areaId }],
+      queryKey: thermalKeys.list(studyId, areaId),
       queryFn: () => getThermalClusters(studyId, areaId),
     });
   },

--- a/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/certifications.tsx
+++ b/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/certifications.tsx
@@ -14,6 +14,7 @@
 
 import { reserveMutations } from "@/queries/reserves/mutations";
 import { reserveQueries } from "@/queries/reserves/queries";
+import { thermalQueries } from "@/queries/thermals/queries";
 import type {
   CertificationProductionType,
   Reserve,
@@ -25,7 +26,6 @@ import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-q
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { thermalClustersQueries } from "./-utils";
 import CertificationsTable, {
   type ClusterRow,
   type ReserveRow,
@@ -69,7 +69,7 @@ function ReservesCertifications() {
     reserveQueries.certifications(studyId, areaId, "thermals"),
   );
 
-  const { data: thermalClusters } = useSuspenseQuery(thermalClustersQueries.list(studyId, areaId));
+  const { data: thermalClusters } = useSuspenseQuery(thermalQueries.list(studyId, areaId));
 
   // Certifications mapping per production type. "storages" and "hydro" will be
   // added once their endpoints are released.

--- a/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/certifications.tsx
+++ b/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/reserves/certifications.tsx
@@ -88,7 +88,7 @@ function ReservesCertifications() {
   });
 
   const rows = useMemo<ReserveRow[]>(() => {
-    const clusterNamesById = new Map(thermalClusters.map(({ id, name }) => [id, name]));
+    const clustersById = new Map(thermalClusters.map((cluster) => [cluster.id, cluster]));
 
     return reserves.map((reserve) => ({
       kind: "reserve",
@@ -101,7 +101,8 @@ function ReservesCertifications() {
           // Prefixed with the reserve ID because a cluster can be certified for
           // several reserves and row IDs must be unique across the table
           id: `${reserve.id}/${clusterId}`,
-          name: clusterNamesById.get(clusterId) ?? clusterId,
+          name: clustersById.get(clusterId)?.name ?? clusterId,
+          enabled: clustersById.get(clusterId)?.enabled ?? false,
           productionType: "thermals",
           reserveId: reserve.id,
           clusterId,
@@ -232,6 +233,7 @@ function ReservesCertifications() {
           key={editingCluster.id}
           open={isUpdateDrawerOpen}
           clusterName={editingCluster.name}
+          clusterEnabled={editingCluster.enabled}
           certification={editingCluster.certification}
           onClose={() => setIsUpdateDrawerOpen(false)}
           onSubmit={handleCertificationSubmit}

--- a/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/thermals/index.tsx
+++ b/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/thermals/index.tsx
@@ -127,28 +127,29 @@ function Thermals() {
   // Event handlers
   ////////////////////////////////////////////////////////////////
 
-  // The Certifications table (under Reserves) keeps its own cache of thermal
-  // clusters, so it must be invalidated whenever a cluster is added or removed here.
-  const invalidateCertificationsClusters = () => {
+  // This page doesn't use the shared `thermalQueries.list` cache itself (it fetches
+  // through `usePromiseWithSnackbarError` instead), but other consumers do (e.g. the
+  // Reserves certifications view), so it must be kept in sync whenever clusters change here.
+  const invalidateThermalClustersQuery = () => {
     return queryClient.invalidateQueries({ queryKey: thermalKeys.list(study.id, areaId) });
   };
 
   const handleCreate = async (values: RowData) => {
     const cluster = await createThermalCluster(study.id, areaId, values);
-    await invalidateCertificationsClusters();
+    await invalidateThermalClustersQuery();
     return addClusterCapacity(cluster);
   };
 
   const handleDuplicate = async (row: ThermalClusterWithCapacity, newName: string) => {
     const cluster = await duplicateThermalCluster(study.id, areaId, row.id, newName);
-    await invalidateCertificationsClusters();
+    await invalidateThermalClustersQuery();
     return { ...row, ...cluster };
   };
 
   const handleDelete = async (rows: ThermalClusterWithCapacity[]) => {
     const ids = rows.map((row) => row.id);
     await deleteThermalClusters(study.id, areaId, ids);
-    await invalidateCertificationsClusters();
+    await invalidateThermalClustersQuery();
   };
 
   ////////////////////////////////////////////////////////////////

--- a/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/thermals/index.tsx
+++ b/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/thermals/index.tsx
@@ -16,7 +16,6 @@ import GroupedDataTable from "@/components/GroupedDataTable";
 import BooleanCell from "@/components/GroupedDataTable/cellRenderers/BooleanCell";
 import type { RowData } from "@/components/GroupedDataTable/types";
 import usePromiseWithSnackbarError from "@/hooks/usePromiseWithSnackbarError";
-import { thermalKeys } from "@/queries/thermals/keys";
 import useStudy from "@/routes/_authenticated/studies/$studyId/-hooks/useStudy";
 import {
   addClusterCapacity,
@@ -25,7 +24,6 @@ import {
   toCapacityString,
 } from "@/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/-clustersUtils";
 import { Box } from "@mui/material";
-import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, linkOptions } from "@tanstack/react-router";
 import { createMRTColumnHelper } from "material-react-table";
 import { useMemo, useState } from "react";
@@ -52,7 +50,6 @@ function Thermals() {
   const study = useStudy();
   const { areaId } = Route.useParams();
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
 
   const {
     data: clustersWithCapacity = [],
@@ -127,29 +124,19 @@ function Thermals() {
   // Event handlers
   ////////////////////////////////////////////////////////////////
 
-  // This page doesn't use the shared `thermalQueries.list` cache itself (it fetches
-  // through `usePromiseWithSnackbarError` instead), but other consumers do (e.g. the
-  // Reserves certifications view), so it must be kept in sync whenever clusters change here.
-  const invalidateThermalClustersQuery = () => {
-    return queryClient.invalidateQueries({ queryKey: thermalKeys.list(study.id, areaId) });
-  };
-
   const handleCreate = async (values: RowData) => {
     const cluster = await createThermalCluster(study.id, areaId, values);
-    await invalidateThermalClustersQuery();
     return addClusterCapacity(cluster);
   };
 
   const handleDuplicate = async (row: ThermalClusterWithCapacity, newName: string) => {
     const cluster = await duplicateThermalCluster(study.id, areaId, row.id, newName);
-    await invalidateThermalClustersQuery();
     return { ...row, ...cluster };
   };
 
-  const handleDelete = async (rows: ThermalClusterWithCapacity[]) => {
+  const handleDelete = (rows: ThermalClusterWithCapacity[]) => {
     const ids = rows.map((row) => row.id);
-    await deleteThermalClusters(study.id, areaId, ids);
-    await invalidateThermalClustersQuery();
+    return deleteThermalClusters(study.id, areaId, ids);
   };
 
   ////////////////////////////////////////////////////////////////

--- a/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/thermals/index.tsx
+++ b/webapp/src/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/thermals/index.tsx
@@ -16,6 +16,7 @@ import GroupedDataTable from "@/components/GroupedDataTable";
 import BooleanCell from "@/components/GroupedDataTable/cellRenderers/BooleanCell";
 import type { RowData } from "@/components/GroupedDataTable/types";
 import usePromiseWithSnackbarError from "@/hooks/usePromiseWithSnackbarError";
+import { thermalKeys } from "@/queries/thermals/keys";
 import useStudy from "@/routes/_authenticated/studies/$studyId/-hooks/useStudy";
 import {
   addClusterCapacity,
@@ -24,6 +25,7 @@ import {
   toCapacityString,
 } from "@/routes/_authenticated/studies/$studyId/explore/modeling/areas/$areaId/-clustersUtils";
 import { Box } from "@mui/material";
+import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, linkOptions } from "@tanstack/react-router";
 import { createMRTColumnHelper } from "material-react-table";
 import { useMemo, useState } from "react";
@@ -50,6 +52,7 @@ function Thermals() {
   const study = useStudy();
   const { areaId } = Route.useParams();
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
 
   const {
     data: clustersWithCapacity = [],
@@ -124,20 +127,28 @@ function Thermals() {
   // Event handlers
   ////////////////////////////////////////////////////////////////
 
+  // The Certifications table (under Reserves) keeps its own cache of thermal
+  // clusters, so it must be invalidated whenever a cluster is added or removed here.
+  const invalidateCertificationsClusters = () => {
+    return queryClient.invalidateQueries({ queryKey: thermalKeys.list(study.id, areaId) });
+  };
+
   const handleCreate = async (values: RowData) => {
     const cluster = await createThermalCluster(study.id, areaId, values);
+    await invalidateCertificationsClusters();
     return addClusterCapacity(cluster);
   };
 
   const handleDuplicate = async (row: ThermalClusterWithCapacity, newName: string) => {
     const cluster = await duplicateThermalCluster(study.id, areaId, row.id, newName);
-
+    await invalidateCertificationsClusters();
     return { ...row, ...cluster };
   };
 
-  const handleDelete = (rows: ThermalClusterWithCapacity[]) => {
+  const handleDelete = async (rows: ThermalClusterWithCapacity[]) => {
     const ids = rows.map((row) => row.id);
-    return deleteThermalClusters(study.id, areaId, ids);
+    await deleteThermalClusters(study.id, areaId, ids);
+    await invalidateCertificationsClusters();
   };
 
   ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Added an "Enabled" indicator (Yes/No chip) to the certifications table and to the single-cluster certification drawer, so activation state is visible everywhere a cluster shows up.
- Added a certified cluster count next to each reserve name for a quicker overview.
- Introduced a shared `thermalKeys` query key factory and invalidate it after create/duplicate/delete on the Thermals page, so the certifications cluster list stays in sync.