### PR TITLE
refactor(db-study): add an intermediate study_data_id as a bigint

### DIFF
--- a/alembic/versions/1f0c9b2e7a34_use_surrogate_study_data_key.py
+++ b/alembic/versions/1f0c9b2e7a34_use_surrogate_study_data_key.py
@@ -1,0 +1,409 @@
+"""use_surrogate_study_data_key
+
+Replace the 36 chars `study_id` carried by every study data table with the bigint surrogate
+key `study_data.study_data_id`.
+
+Revision ID: 1f0c9b2e7a34
+Revises: 6012b0407e38
+Create Date: 2026-08-11 09:00:00.000000
+
+"""
+
+import hashlib
+import logging
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1f0c9b2e7a34"
+down_revision = "6012b0407e38"
+branch_labels = None
+depends_on = None
+
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+REFERENCE_TABLE = "study_data"
+STRING_KEY = "study_id"
+STRING_KEY_TYPE = sa.String(36)
+SURROGATE_KEY = "study_data_id"
+# `BigInteger` alone does not autoincrement on SQLite: only `INTEGER PRIMARY KEY` aliases the rowid.
+SURROGATE_KEY_TYPE = sa.BigInteger().with_variant(sa.Integer, "sqlite")
+
+# PostgreSQL silently truncates identifiers beyond this length, which could make two generated
+# names collide.
+MAX_IDENTIFIER_LENGTH = 63
+
+
+def _identifier(*parts: str) -> str:
+    """
+    Build a deterministic constraint name, short enough for PostgreSQL to keep it unique.
+    """
+    name = "_".join(parts)
+    if len(name) <= MAX_IDENTIFIER_LENGTH:
+        return name
+    digest = hashlib.md5(name.encode()).hexdigest()[:8]
+    return f"{name[: MAX_IDENTIFIER_LENGTH - 9]}_{digest}"
+
+
+def _quoted(identifier: str) -> str:
+    return f'"{identifier}"'
+
+
+def _swap(columns: Sequence[str], source: str, target: str) -> List[str]:
+    return [target if column == source else column for column in columns]
+
+
+def _key_column(name: str, *, nullable: bool) -> "sa.Column[Any]":
+    column_type = SURROGATE_KEY_TYPE if name == SURROGATE_KEY else STRING_KEY_TYPE
+    return sa.Column(name, column_type, nullable=nullable)
+
+
+def _data_tables(foreign_keys: Dict[str, List[Any]], key: str) -> List[str]:
+    """
+    All tables transitively keyed on `study_data` through `key`, parents before children.
+
+    The set is discovered rather than hard-coded so that this migration keeps describing the
+    schema as it stands at this revision, whatever the models become later on.
+    """
+    known = {REFERENCE_TABLE}
+    frontier = {REFERENCE_TABLE}
+    while frontier:
+        frontier = {
+            table
+            for table, fks in foreign_keys.items()
+            if table not in known
+            and any(fk["referred_table"] in known and key in fk["constrained_columns"] for fk in fks)
+        }
+        known |= frontier
+    known.discard(REFERENCE_TABLE)
+
+    # Topological sort: a table is emitted once every data table it references is emitted.
+    # Self-references (`user_resources.parent_id`) are not a real dependency.
+    pending = {
+        table: {fk["referred_table"] for fk in foreign_keys[table] if fk["referred_table"] in known} - {table}
+        for table in known
+    }
+    ordered: List[str] = []
+    while pending:
+        ready = sorted(table for table, parents in pending.items() if not parents - set(ordered))
+        if not ready:
+            raise RuntimeError(f"Cyclic foreign keys between study data tables: {sorted(pending)}")
+        ordered.extend(ready)
+        for table in ready:
+            del pending[table]
+    return ordered
+
+
+class _Snapshot:
+    """
+    Reflection taken once, before any DDL is emitted: an inspector used while the schema is being
+    rewritten would return a mix of old and new definitions.
+    """
+
+    def __init__(self, key: str) -> None:
+        inspector = sa.inspect(op.get_bind())
+        self.foreign_keys: Dict[str, List[Any]] = {
+            table: list(inspector.get_foreign_keys(table)) for table in inspector.get_table_names()
+        }
+        self.tables = _data_tables(self.foreign_keys, key)
+        self.primary_keys: Dict[str, List[str]] = {}
+        # SQLite leaves primary key constraints unnamed; only the PostgreSQL path needs the names.
+        self.primary_key_names: Dict[str, Optional[str]] = {}
+        for table in [REFERENCE_TABLE, *self.tables]:
+            primary_key = inspector.get_pk_constraint(table)
+            self.primary_keys[table] = list(primary_key["constrained_columns"])
+            self.primary_key_names[table] = primary_key["name"]
+        # Tables whose study key column is rewritten, hence whose foreign keys must be retargeted.
+        self.referenced: Set[str] = {REFERENCE_TABLE, *self.tables}
+
+    def key_foreign_keys(self, table: str, key: str) -> List[Any]:
+        """
+        Foreign keys of `table` built on the study key, i.e. all of them but the self-reference
+        of `user_resources.parent_id`.
+        """
+        return [fk for fk in self.foreign_keys[table] if key in fk["constrained_columns"]]
+
+
+def _drop_key_foreign_keys(snapshot: _Snapshot, key: str) -> None:
+    """
+    Every foreign key on the study key must go before the primary keys they depend on.
+    """
+    for table in snapshot.tables:
+        for fk in snapshot.key_foreign_keys(table, key):
+            op.drop_constraint(fk["name"], table, type_="foreignkey")
+
+
+def _primary_key_name(snapshot: _Snapshot, table: str) -> str:
+    name = snapshot.primary_key_names[table]
+    if not name:
+        raise RuntimeError(f"Table {table} has no named primary key constraint, it cannot be dropped")
+    return name
+
+
+def _swap_primary_keys(snapshot: _Snapshot, *, source: str, target: str) -> None:
+    """
+    Replace `source` by `target` in the primary key of the reference table and of every data table
+    keyed on it, keeping it the leading column so that index coverage is preserved.
+    """
+    op.drop_constraint(_primary_key_name(snapshot, REFERENCE_TABLE), REFERENCE_TABLE, type_="primary")
+    op.create_primary_key(_identifier(REFERENCE_TABLE, "pkey"), REFERENCE_TABLE, [target])
+
+    for table in snapshot.tables:
+        primary_key = snapshot.primary_keys[table]
+        if source not in primary_key:
+            continue
+        op.drop_constraint(_primary_key_name(snapshot, table), table, type_="primary")
+        op.create_primary_key(_identifier(table, "pkey"), table, _swap(primary_key, source, target))
+
+
+def _create_foreign_keys(snapshot: _Snapshot, *, source: str, target: str) -> None:
+    for table in snapshot.tables:
+        for fk in snapshot.key_foreign_keys(table, source):
+            local = _swap(fk["constrained_columns"], source, target)
+            referred = _swap(fk["referred_columns"], source, target)
+            op.create_foreign_key(
+                _identifier("fk", table, *local),
+                table,
+                fk["referred_table"],
+                local,
+                referred,
+                ondelete=fk["options"].get("ondelete"),
+                onupdate=fk["options"].get("onupdate"),
+            )
+
+
+#
+# PostgreSQL: constraints can be dropped and recreated, so tables stay in place.
+#
+# The new key column is therefore appended rather than kept in first position, which PostgreSQL
+# cannot change without rewriting the table. Only its position in the primary key matters, and
+# that one is preserved.
+#
+
+
+def _upgrade_postgresql(snapshot: _Snapshot) -> None:
+    # `BIGSERIAL` creates the sequence and fills existing rows in a single statement.
+    op.execute(sa.text(f'ALTER TABLE "{REFERENCE_TABLE}" ADD COLUMN {SURROGATE_KEY} BIGSERIAL'))
+    op.create_unique_constraint(_identifier("uq", REFERENCE_TABLE, STRING_KEY), REFERENCE_TABLE, [STRING_KEY])
+
+    for table in snapshot.tables:
+        op.add_column(table, sa.Column(SURROGATE_KEY, sa.BigInteger(), nullable=True))
+        op.execute(
+            sa.text(
+                f'UPDATE "{table}" SET {SURROGATE_KEY} = sd.{SURROGATE_KEY} '
+                f'FROM "{REFERENCE_TABLE}" AS sd WHERE sd.{STRING_KEY} = "{table}".{STRING_KEY}'
+            )
+        )
+        op.alter_column(table, SURROGATE_KEY, existing_type=sa.BigInteger(), nullable=False)
+
+    _drop_key_foreign_keys(snapshot, STRING_KEY)
+    _swap_primary_keys(snapshot, source=STRING_KEY, target=SURROGATE_KEY)
+
+    for table in snapshot.tables:
+        if SURROGATE_KEY not in snapshot.primary_keys[table]:
+            # Not covered by the primary key: neither PostgreSQL nor SQLite indexes foreign keys.
+            op.create_index(_identifier("ix", table, SURROGATE_KEY), table, [SURROGATE_KEY])
+        op.drop_column(table, STRING_KEY)
+
+    _create_foreign_keys(snapshot, source=STRING_KEY, target=SURROGATE_KEY)
+
+
+def _downgrade_postgresql(snapshot: _Snapshot) -> None:
+    for table in reversed(snapshot.tables):
+        op.execute(sa.text(f'DELETE FROM "{table}"'))
+
+    _drop_key_foreign_keys(snapshot, SURROGATE_KEY)
+    for table in snapshot.tables:
+        # The tables are empty, so the column can be added `NOT NULL` right away.
+        op.add_column(table, _key_column(STRING_KEY, nullable=False))
+
+    _swap_primary_keys(snapshot, source=SURROGATE_KEY, target=STRING_KEY)
+
+    op.drop_constraint(_identifier("uq", REFERENCE_TABLE, STRING_KEY), REFERENCE_TABLE, type_="unique")
+    # The owned `BIGSERIAL` sequence goes away with the column, as do the indexes on the data tables.
+    op.drop_column(REFERENCE_TABLE, SURROGATE_KEY)
+    for table in snapshot.tables:
+        op.drop_column(table, SURROGATE_KEY)
+
+    _create_foreign_keys(snapshot, source=SURROGATE_KEY, target=STRING_KEY)
+
+
+#
+# SQLite: foreign keys cannot be dropped, so every table is rebuilt.
+#
+
+
+def _upgrade_sqlite(snapshot: _Snapshot) -> None:
+    metadata = sa.MetaData()
+    metadata.reflect(bind=op.get_bind(), only=[*snapshot.tables])
+
+    # The reference table goes first: the data tables read their new key from it.
+    op.create_table(
+        f"{REFERENCE_TABLE}_new",
+        sa.Column(SURROGATE_KEY, SURROGATE_KEY_TYPE, primary_key=True, autoincrement=True),
+        sa.Column(STRING_KEY, STRING_KEY_TYPE, nullable=False, unique=True),
+        sa.ForeignKeyConstraint(
+            [STRING_KEY], ["study.id"], name=_identifier("fk", REFERENCE_TABLE, STRING_KEY), ondelete="CASCADE"
+        ),
+    )
+    op.execute(
+        sa.text(f'INSERT INTO "{REFERENCE_TABLE}_new" ({STRING_KEY}) SELECT {STRING_KEY} FROM "{REFERENCE_TABLE}"')
+    )
+    op.drop_table(REFERENCE_TABLE)
+    op.rename_table(f"{REFERENCE_TABLE}_new", REFERENCE_TABLE)
+
+    for table in snapshot.tables:
+        _rebuild_sqlite_table(
+            metadata.tables[table],
+            snapshot,
+            source=STRING_KEY,
+            target=SURROGATE_KEY,
+            copy_data=True,
+            index_key=True,
+        )
+
+
+def _downgrade_sqlite(snapshot: _Snapshot) -> None:
+    metadata = sa.MetaData()
+    metadata.reflect(bind=op.get_bind(), only=[*snapshot.tables])
+
+    op.create_table(
+        f"{REFERENCE_TABLE}_new",
+        sa.Column(STRING_KEY, STRING_KEY_TYPE, primary_key=True, nullable=False),
+        sa.ForeignKeyConstraint(
+            [STRING_KEY], ["study.id"], name=_identifier("fk", REFERENCE_TABLE, STRING_KEY), ondelete="CASCADE"
+        ),
+    )
+    op.execute(
+        sa.text(f'INSERT INTO "{REFERENCE_TABLE}_new" ({STRING_KEY}) SELECT {STRING_KEY} FROM "{REFERENCE_TABLE}"')
+    )
+    op.drop_table(REFERENCE_TABLE)
+    op.rename_table(f"{REFERENCE_TABLE}_new", REFERENCE_TABLE)
+
+    for table in snapshot.tables:
+        _rebuild_sqlite_table(
+            metadata.tables[table],
+            snapshot,
+            source=SURROGATE_KEY,
+            target=STRING_KEY,
+            copy_data=False,
+            index_key=False,
+        )
+
+
+def _rebuild_sqlite_table(
+    table: sa.Table,
+    snapshot: _Snapshot,
+    *,
+    source: str,
+    target: str,
+    copy_data: bool,
+    index_key: bool,
+) -> None:
+    """
+    Recreate `table` in place with `source` replaced by `target`, in the same column position.
+
+    When `copy_data` is set, rows are carried over and the new key is read from the reference
+    table, which must already expose both columns. `index_key` adds an explicit index on the new
+    key for the tables that do not carry it in their primary key.
+    """
+    name = table.name
+    columns = [
+        _key_column(target, nullable=False) if column.name == source else _copied_column(column)
+        for column in table.columns
+    ]
+    primary_key = snapshot.primary_keys[name]
+    op.create_table(
+        f"{name}_new",
+        *columns,
+        sa.PrimaryKeyConstraint(*_swap(primary_key, source, target), name=_identifier(name, "pkey")),
+        *_rebuilt_foreign_keys(table, snapshot, source=source, target=target),
+    )
+
+    if copy_data:
+        # Column names are quoted: some of them (`group`, `order`) are SQL keywords.
+        inserted = [_quoted(column.name) for column in columns]
+        selected = [
+            f"sd.{target}" if column.name == target else f"{_quoted(name)}.{_quoted(column.name)}" for column in columns
+        ]
+        op.execute(
+            sa.text(
+                f"INSERT INTO {_quoted(f'{name}_new')} ({', '.join(inserted)}) "
+                f"SELECT {', '.join(selected)} "
+                f"FROM {_quoted(name)} JOIN {_quoted(REFERENCE_TABLE)} AS sd "
+                f"ON sd.{source} = {_quoted(name)}.{source}"
+            )
+        )
+
+    op.drop_table(name)
+    op.rename_table(f"{name}_new", name)
+
+    if index_key and target not in primary_key:
+        op.create_index(_identifier("ix", name, target), name, [target])
+
+
+def _copied_column(column: "sa.Column[Any]") -> "sa.Column[Any]":
+    return sa.Column(
+        column.name,
+        column.type,
+        nullable=column.nullable,
+        server_default=column.server_default,
+    )
+
+
+def _rebuilt_foreign_keys(
+    table: sa.Table, snapshot: _Snapshot, *, source: str, target: str
+) -> List[sa.ForeignKeyConstraint]:
+    constraints = []
+    for constraint in table.foreign_key_constraints:
+        local = []
+        referred_table = ""
+        referred = []
+        for element in constraint.elements:
+            local.append(element.parent.name)
+            referred_table, referred_column = element.target_fullname.rsplit(".", 1)
+            referred.append(referred_column)
+        if referred_table in snapshot.referenced:
+            referred = _swap(referred, source, target)
+        local = _swap(local, source, target)
+        constraints.append(
+            sa.ForeignKeyConstraint(
+                local,
+                [f"{referred_table}.{column}" for column in referred],
+                name=_identifier("fk", table.name, *local),
+                ondelete=constraint.ondelete,
+                onupdate=constraint.onupdate,
+            )
+        )
+    return constraints
+
+
+def _run(postgresql: Callable[[_Snapshot], None], sqlite: Callable[[_Snapshot], None], *, key: str) -> None:
+    snapshot = _Snapshot(key)
+    dialect_name = op.get_context().dialect.name
+    if dialect_name == "sqlite":
+        sqlite(snapshot)
+    elif dialect_name == "postgresql":
+        postgresql(snapshot)
+    else:
+        raise NotImplementedError(
+            f"Unsupported database dialect '{dialect_name}'. Only sqlite and postgresql are supported."
+        )
+
+
+def upgrade() -> None:
+    _run(_upgrade_postgresql, _upgrade_sqlite, key=STRING_KEY)
+
+
+def downgrade() -> None:
+    logger.warning(
+        "Downgrading %s: every table storing study data in the database is rebuilt empty. "
+        "All database-stored study content (areas, clusters, settings, matrix references) is lost. "
+        "The studies themselves are preserved.",
+        revision,
+    )
+    _run(_downgrade_postgresql, _downgrade_sqlite, key=SURROGATE_KEY)

--- a/alembic/versions/1f0c9b2e7a34_use_surrogate_study_data_key.py
+++ b/alembic/versions/1f0c9b2e7a34_use_surrogate_study_data_key.py
@@ -204,7 +204,9 @@ def _upgrade_postgresql(snapshot: _Snapshot) -> None:
     _swap_primary_keys(snapshot, source=STRING_KEY, target=SURROGATE_KEY)
 
     for table in snapshot.tables:
-        if SURROGATE_KEY not in snapshot.primary_keys[table]:
+        # The snapshot predates the DDL above, so the primary key is tested on the column the
+        # surrogate key took the place of.
+        if STRING_KEY not in snapshot.primary_keys[table]:
             # Not covered by the primary key: neither PostgreSQL nor SQLite indexes foreign keys.
             op.create_index(_identifier("ix", table, SURROGATE_KEY), table, [SURROGATE_KEY])
         op.drop_column(table, STRING_KEY)
@@ -342,7 +344,8 @@ def _rebuild_sqlite_table(
     op.drop_table(name)
     op.rename_table(f"{name}_new", name)
 
-    if index_key and target not in primary_key:
+    # `primary_key` is the one reflected before the rebuild, hence tested on `source`.
+    if index_key and source not in primary_key:
         op.create_index(_identifier("ix", name, target), name, [target])
 
 

--- a/antarest/study/dao/api/study_factory_dao.py
+++ b/antarest/study/dao/api/study_factory_dao.py
@@ -32,5 +32,8 @@ class StudyFactoryDao(ABC):
     def get_study_dao(self, study_id: str, is_study_managed: bool) -> StudyDao:
         """
         Creates a DAO instance for a study which already contains data.
+
+        Raises:
+            StudyNotFoundError: if there is no existing data for that study
         """
         raise NotImplementedError()

--- a/antarest/study/dao/api/study_factory_dao.py
+++ b/antarest/study/dao/api/study_factory_dao.py
@@ -17,10 +17,20 @@ from antarest.study.model import StudyMetadataCreation
 
 
 class StudyFactoryDao(ABC):
+    """
+    In charge of creating DAO instances
+    """
+
     @abstractmethod
     def create_study_dao(self, metadata: StudyMetadataCreation) -> StudyDao:
+        """
+        Initializes data for that study and returns the corresponding DAO instance.
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def get_study_dao(self, study_id: str, is_study_managed: bool) -> StudyDao:
+        """
+        Creates a DAO instance for a study which already contains data.
+        """
         raise NotImplementedError()

--- a/antarest/study/dao/database/common.py
+++ b/antarest/study/dao/database/common.py
@@ -25,24 +25,26 @@ if TYPE_CHECKING:
     from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
 
 
-def validate_area_exists(session: Session, study_id: str, area_id: str) -> None:
-    if not area_exists(session, study_id, area_id):
+def validate_area_exists(session: Session, study_data_id: int, area_id: str) -> None:
+    if not area_exists(session, study_data_id, area_id):
         raise AreaNotFound(area_id)
 
 
-def area_exists(session: Session, study_id: str, area_id: str) -> bool:
-    stmt = select(AREA_TABLE.c.area_id).where((AREA_TABLE.c.study_id == study_id) & (AREA_TABLE.c.area_id == area_id))
+def area_exists(session: Session, study_data_id: int, area_id: str) -> bool:
+    stmt = select(AREA_TABLE.c.area_id).where(
+        (AREA_TABLE.c.study_data_id == study_data_id) & (AREA_TABLE.c.area_id == area_id)
+    )
     return session.execute(stmt).fetchone() is not None
 
 
 def save_area_matrix(dao: "DatabaseStudyDao", series: AreaSeriesMapping, table: Table) -> None:
     session = dao._db_session
-    study_id = dao.get_study_id()
+    study_data_id = dao._study_data_id
 
     try:
         values = []
         for area_id, series_id in series.items():
-            data = {"study_id": study_id, "area_id": area_id, "matrix_id": series_id}
+            data = {"study_data_id": study_data_id, "area_id": area_id, "matrix_id": series_id}
             values.append(data)
         upsert_multiple(session, table, values)
 
@@ -57,8 +59,8 @@ def save_area_matrix(dao: "DatabaseStudyDao", series: AreaSeriesMapping, table: 
     session.commit()
 
 
-def get_all_area_matrices(study_id: str, session: Session, table: Table) -> AreaSeriesMapping:
-    stmt = select(table).where((table.c.study_id == study_id))
+def get_all_area_matrices(study_data_id: int, session: Session, table: Table) -> AreaSeriesMapping:
+    stmt = select(table).where((table.c.study_data_id == study_data_id))
     rows = session.execute(stmt).fetchall()
     return {row.area_id: row.matrix_id for row in rows}
 

--- a/antarest/study/dao/database/dao_context.py
+++ b/antarest/study/dao/database/dao_context.py
@@ -22,7 +22,11 @@ tables is defined in a single place.
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
+
+from antarest.core.exceptions import StudyNotFoundError
+from antarest.study.dao.database.models import STUDY_DATA_TABLE
 
 if TYPE_CHECKING:
     from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
@@ -41,11 +45,41 @@ class StudyDaoContext:
         """
         self._study_id = study_id
         self._db_session = db_session
+        self._study_data_id: int | None = None
 
     @property
     def study_id(self) -> str:
         """The study ID, as found in `study.id`."""
         return self._study_id
+
+    @property
+    def study_data_id(self) -> int:
+        """
+        The surrogate key of the study, as found in `study_data.study_data_id`.
+
+        This is the key all study data tables are keyed by. It is resolved lazily, because
+        a DAO is built before its `study_data` row exists (see `create_study_dao`), and
+        cached, because it is needed by nearly every query.
+
+        Note:
+            A context must not outlive the `study_data` row it resolved: deleting the row
+            and re-creating it (unarchive, snapshot regeneration, ...) generates a new id,
+            and a stale cache would then write into another study's rows. Every such path
+            builds a fresh DAO, which is the invariant this cache relies on.
+        """
+        if self._study_data_id is None:
+            stmt = select(STUDY_DATA_TABLE.c.study_data_id).where(STUDY_DATA_TABLE.c.study_id == self._study_id)
+            study_data_id = self._db_session.execute(stmt).scalar_one_or_none()
+            if study_data_id is None:
+                raise StudyNotFoundError(self._study_id)
+            self._study_data_id = study_data_id
+        return self._study_data_id
+
+    def set_study_data_id(self, study_data_id: int) -> None:
+        """
+        Prime the cache with the id of a freshly inserted `study_data` row, sparing a lookup.
+        """
+        self._study_data_id = study_data_id
 
     @property
     def session(self) -> Session:
@@ -64,6 +98,10 @@ class DatabaseDaoBase(ABC):
     @property
     def _study_id(self) -> str:
         return self._context.study_id
+
+    @property
+    def _study_data_id(self) -> int:
+        return self._context.study_data_id
 
     @property
     def _db_session(self) -> Session:

--- a/antarest/study/dao/database/dao_context.py
+++ b/antarest/study/dao/database/dao_context.py
@@ -20,71 +20,24 @@ tables is defined in a single place.
 """
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select
 from sqlalchemy.orm import Session
-
-from antarest.core.exceptions import StudyNotFoundError
-from antarest.study.dao.database.models import STUDY_DATA_TABLE
 
 if TYPE_CHECKING:
     from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
 
 
+@dataclass(frozen=True)
 class StudyDaoContext:
     """
     Identifies the study a set of database DAOs operates on, and carries their session.
     """
 
-    def __init__(self, study_id: str, db_session: Session) -> None:
-        """
-        Args:
-            study_id: The study ID for database queries.
-            db_session: SQLAlchemy session for database operations.
-        """
-        self._study_id = study_id
-        self._db_session = db_session
-        self._study_data_id: int | None = None
-
-    @property
-    def study_id(self) -> str:
-        """The study ID, as found in `study.id`."""
-        return self._study_id
-
-    @property
-    def study_data_id(self) -> int:
-        """
-        The surrogate key of the study, as found in `study_data.study_data_id`.
-
-        This is the key all study data tables are keyed by. It is resolved lazily, because
-        a DAO is built before its `study_data` row exists (see `create_study_dao`), and
-        cached, because it is needed by nearly every query.
-
-        Note:
-            A context must not outlive the `study_data` row it resolved: deleting the row
-            and re-creating it (unarchive, snapshot regeneration, ...) generates a new id,
-            and a stale cache would then write into another study's rows. Every such path
-            builds a fresh DAO, which is the invariant this cache relies on.
-        """
-        if self._study_data_id is None:
-            stmt = select(STUDY_DATA_TABLE.c.study_data_id).where(STUDY_DATA_TABLE.c.study_id == self._study_id)
-            study_data_id = self._db_session.execute(stmt).scalar_one_or_none()
-            if study_data_id is None:
-                raise StudyNotFoundError(self._study_id)
-            self._study_data_id = study_data_id
-        return self._study_data_id
-
-    def set_study_data_id(self, study_data_id: int) -> None:
-        """
-        Prime the cache with the id of a freshly inserted `study_data` row, sparing a lookup.
-        """
-        self._study_data_id = study_data_id
-
-    @property
-    def session(self) -> Session:
-        """The SQLAlchemy session used for database operations."""
-        return self._db_session
+    study_id: str
+    study_data_id: int
+    session: Session
 
 
 class DatabaseDaoBase(ABC):

--- a/antarest/study/dao/database/database_area_dao.py
+++ b/antarest/study/dao/database/database_area_dao.py
@@ -62,7 +62,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         self, area_properties: AreaProperties, area_id: AreaId, area_name: AreaName
     ) -> dict[str, Any]:
         return {
-            "study_id": self._study_id,
+            "study_data_id": self._study_data_id,
             "area_id": area_id,
             "area_name": area_name,
             "energy_cost_unsupplied": area_properties.energy_cost_unsupplied,
@@ -82,10 +82,10 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         """
         Retrieve all physical areas of a study.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
-        stmt = select(AREA_TABLE.c.area_id).where(AREA_TABLE.c.study_id == study_id)
+        stmt = select(AREA_TABLE.c.area_id).where(AREA_TABLE.c.study_data_id == study_data_id)
         result = session.execute(stmt)
 
         return [row.area_id for row in result]
@@ -98,10 +98,10 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         Returns:
             The list of areas with their basic information.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
-        stmt = select(AREA_TABLE.c.area_id, AREA_TABLE.c.area_name).where(AREA_TABLE.c.study_id == study_id)
+        stmt = select(AREA_TABLE.c.area_id, AREA_TABLE.c.area_name).where(AREA_TABLE.c.study_data_id == study_data_id)
         result = session.execute(stmt)
 
         thermal_clusters = self.get_impl().get_all_thermals()
@@ -121,11 +121,11 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         Returns:
             A dictionary mapping area IDs to their UI data.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Single query to get all areas and their UI info
-        stmt = select(AREA_UI_TABLE).where(AREA_UI_TABLE.c.study_id == study_id)
+        stmt = select(AREA_UI_TABLE).where(AREA_UI_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt)
 
         # Group UI rows by area_id
@@ -180,14 +180,14 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         Raises:
             AreaNotFound: If the area does not exist.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Fetch both specified layer and default layer in one query
         layers_to_fetch = [layer, DEFAULT_LAYER_ID] if layer != DEFAULT_LAYER_ID else [DEFAULT_LAYER_ID]
 
         stmt = select(AREA_UI_TABLE).where(
-            (AREA_UI_TABLE.c.study_id == study_id)
+            (AREA_UI_TABLE.c.study_data_id == study_data_id)
             & (AREA_UI_TABLE.c.area_id == area_id)
             & (AREA_UI_TABLE.c.layer_id.in_(layers_to_fetch))
         )
@@ -195,7 +195,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
 
         # If no UI found, check if area exists (to raise proper error)
         if not rows:
-            validate_area_exists(session, study_id, area_id)
+            validate_area_exists(session, study_data_id, area_id)
             return AreaUI()
 
         # Prefer specified layer, fall back to default
@@ -236,13 +236,13 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         Raises:
             AreaNotFound: If the area does not exist.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
-        validate_area_exists(session, study_id, area_id)
+        validate_area_exists(session, study_data_id, area_id)
 
         # Remove area from districts that reference it
-        stmt = select(DISTRICT_TABLE).where(DISTRICT_TABLE.c.study_id == study_id)
+        stmt = select(DISTRICT_TABLE).where(DISTRICT_TABLE.c.study_data_id == study_data_id)
         district_rows = session.execute(stmt).fetchall()
 
         for row in district_rows:
@@ -255,7 +255,10 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
 
                 session.execute(
                     update(DISTRICT_TABLE)
-                    .where((DISTRICT_TABLE.c.study_id == study_id) & (DISTRICT_TABLE.c.district_id == row.district_id))
+                    .where(
+                        (DISTRICT_TABLE.c.study_data_id == study_data_id)
+                        & (DISTRICT_TABLE.c.district_id == row.district_id)
+                    )
                     .values(
                         add_areas=json.dumps(list(add_areas)),
                         subtract_areas=json.dumps(list(subtract_areas)),
@@ -263,13 +266,15 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
                 )
 
         # Delete area
-        delete_stmt = delete(AREA_TABLE).where((AREA_TABLE.c.study_id == study_id) & (AREA_TABLE.c.area_id == area_id))
+        delete_stmt = delete(AREA_TABLE).where(
+            (AREA_TABLE.c.study_data_id == study_data_id) & (AREA_TABLE.c.area_id == area_id)
+        )
         session.execute(delete_stmt)
         session.commit()
 
     @override
     def save_area_ui(self, data: AreaUiMapping) -> None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Set values
@@ -279,7 +284,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
                 r, g, b = area_ui.color_rgb
                 values.append(
                     {
-                        "study_id": study_id,
+                        "study_data_id": study_data_id,
                         "area_id": area_id,
                         "layer_id": layer,
                         "x": area_ui.x,
@@ -334,7 +339,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         if not self.get_impl().layer_exists(layer_id):
             raise LayerNotFound(layer_id)
 
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Get all areas and which ones already have this layer
@@ -347,11 +352,11 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
                 AREA_TABLE.outerjoin(
                     AREA_UI_TABLE,
                     (AREA_TABLE.c.area_id == AREA_UI_TABLE.c.area_id)
-                    & (AREA_UI_TABLE.c.study_id == study_id)
+                    & (AREA_UI_TABLE.c.study_data_id == study_data_id)
                     & (AREA_UI_TABLE.c.layer_id == layer_id),
                 )
             )
-            .where(AREA_TABLE.c.study_id == study_id)
+            .where(AREA_TABLE.c.study_data_id == study_data_id)
         )
 
         all_area_ids = set()
@@ -371,7 +376,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         to_remove = areas_with_layer - target_area_ids
         if to_remove:
             stmt_delete = delete(AREA_UI_TABLE).where(
-                (AREA_UI_TABLE.c.study_id == study_id)
+                (AREA_UI_TABLE.c.study_data_id == study_data_id)
                 & (AREA_UI_TABLE.c.area_id.in_(to_remove))
                 & (AREA_UI_TABLE.c.layer_id == layer_id)
             )
@@ -382,7 +387,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         if to_add:
             # Batch fetch all default UIs for areas to add
             stmt_defaults = select(AREA_UI_TABLE).where(
-                (AREA_UI_TABLE.c.study_id == study_id)
+                (AREA_UI_TABLE.c.study_data_id == study_data_id)
                 & (AREA_UI_TABLE.c.area_id.in_(to_add))
                 & (AREA_UI_TABLE.c.layer_id == DEFAULT_LAYER_ID)
             )
@@ -395,7 +400,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
                     ui = default_uis[aid]
                     insert_values.append(
                         {
-                            "study_id": study_id,
+                            "study_data_id": study_data_id,
                             "area_id": aid,
                             "layer_id": layer_id,
                             "x": ui.x,
@@ -414,7 +419,7 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
     def _create_new_ui(self, area_id: str, layer: str, area_ui: AreaUI) -> None:
         r, g, b = area_ui.color_rgb
         stmt_insert = insert(AREA_UI_TABLE).values(
-            study_id=self._study_id,
+            study_data_id=self._study_data_id,
             area_id=area_id,
             layer_id=layer,
             x=area_ui.x,
@@ -433,9 +438,9 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
         return str(row.matrix_id)
 
     def _get_matrix_row(self, area_id: str, table: Table) -> Row[Any] | None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(table).where((table.c.study_id == study_id) & (table.c.area_id == area_id))
+        stmt = select(table).where((table.c.study_data_id == study_data_id) & (table.c.area_id == area_id))
 
         return session.execute(stmt).fetchone()
 
@@ -466,23 +471,23 @@ class DatabaseAreaDao(AreaDao, DatabaseDaoBase):
 
     @override
     def get_all_load(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, LOAD_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, LOAD_TABLE)
 
     @override
     def get_all_misc_gen(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, MISC_GEN_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, MISC_GEN_TABLE)
 
     @override
     def get_all_reserves(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, RESERVES_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, RESERVES_TABLE)
 
     @override
     def get_all_solar(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, SOLAR_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, SOLAR_TABLE)
 
     @override
     def get_all_wind(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, WIND_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, WIND_TABLE)
 
     @override
     def save_load(self, series: AreaSeriesMapping) -> None:

--- a/antarest/study/dao/database/database_area_properties_dao.py
+++ b/antarest/study/dao/database/database_area_properties_dao.py
@@ -52,10 +52,12 @@ class DatabaseAreaPropertiesDao(AreaPropertiesDao, DatabaseDaoBase):
 
     @override
     def get_area_properties(self, area_id: str) -> AreaProperties:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
-        stmt = select(AREA_TABLE).where((AREA_TABLE.c.study_id == study_id) & (AREA_TABLE.c.area_id == area_id))
+        stmt = select(AREA_TABLE).where(
+            (AREA_TABLE.c.study_data_id == study_data_id) & (AREA_TABLE.c.area_id == area_id)
+        )
 
         row = session.execute(stmt).fetchone()
         if not row:
@@ -64,22 +66,22 @@ class DatabaseAreaPropertiesDao(AreaPropertiesDao, DatabaseDaoBase):
 
     @override
     def get_all_area_properties(self) -> dict[str, AreaProperties]:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Single query to get all areas and their properties
-        stmt = select(AREA_TABLE).where(AREA_TABLE.c.study_id == study_id)
+        stmt = select(AREA_TABLE).where(AREA_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt)
         return {row.area_id: _convert_db_properties_to_model(row) for row in rows}
 
     @override
     def save_area_properties(self, area_id: str, area_properties: AreaProperties) -> None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         stmt_update = (
             update(AREA_TABLE)
-            .where((AREA_TABLE.c.study_id == study_id) & (AREA_TABLE.c.area_id == area_id))
+            .where((AREA_TABLE.c.study_data_id == study_data_id) & (AREA_TABLE.c.area_id == area_id))
             .values(
                 energy_cost_unsupplied=area_properties.energy_cost_unsupplied,
                 energy_cost_spilled=area_properties.energy_cost_spilled,

--- a/antarest/study/dao/database/database_binding_constraint_dao.py
+++ b/antarest/study/dao/database/database_binding_constraint_dao.py
@@ -151,7 +151,7 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
         link_join = outerjoin(
             BC,
             LT,
-            (BC.c.study_id == LT.c.study_id) & (BC.c.constraint_id == LT.c.constraint_id),
+            (BC.c.study_data_id == LT.c.study_data_id) & (BC.c.constraint_id == LT.c.constraint_id),
         )
         q1 = (
             select(
@@ -170,7 +170,7 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
                 LT.c.offset.label("lt_offset"),
             )
             .select_from(link_join)
-            .where(BC.c.study_id == self._study_id)
+            .where(BC.c.study_data_id == self._study_data_id)
         )
         if constraint_ids:
             q1 = q1.where(BC.c.constraint_id.in_(constraint_ids))
@@ -194,7 +194,7 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
             return {}
 
         # Query 2: cluster terms only (BC already fetched above)
-        ct_filter = CT.c.study_id == self._study_id
+        ct_filter = CT.c.study_data_id == self._study_data_id
         if constraint_ids:
             ct_filter = ct_filter & (CT.c.constraint_id.in_(constraint_ids))
 
@@ -235,10 +235,12 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
         We want to avoid fetching terms as we do not need them.
         That's why we use a specific DB request
         """
-        join_query = BC.join(table, (BC.c.study_id == table.c.study_id) & (BC.c.constraint_id == table.c.constraint_id))
+        join_query = BC.join(
+            table, (BC.c.study_data_id == table.c.study_data_id) & (BC.c.constraint_id == table.c.constraint_id)
+        )
         q = (
             select(BC.c.time_step, table.c.matrix_id)
-            .where((BC.c.study_id == self._study_id) & (BC.c.constraint_id == constraint_id))
+            .where((BC.c.study_data_id == self._study_data_id) & (BC.c.constraint_id == constraint_id))
             .select_from(join_query)
         )
         row = self._db_session.execute(q).fetchone()
@@ -260,7 +262,10 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
         raise ValueError("One of the binding constraints table is not filled as it should") from exc
 
     def _save_bc_matrices(self, table: Table, series: BindingConstraintSeriesMapping) -> None:
-        rows = [{"study_id": self._study_id, "constraint_id": cid, "matrix_id": mid} for cid, mid in series.items()]
+        rows = [
+            {"study_data_id": self._study_data_id, "constraint_id": cid, "matrix_id": mid}
+            for cid, mid in series.items()
+        ]
 
         try:
             upsert_multiple(self._db_session, table, rows)
@@ -304,9 +309,9 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
         return self.get_all_bc_matrices(BINDING_CONSTRAINT_EQ_MATRIX_TABLE)
 
     def get_all_bc_matrices(self, table: Table) -> BindingConstraintSeriesMapping:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(table).where((table.c.study_id == study_id))
+        stmt = select(table).where((table.c.study_data_id == study_data_id))
         rows = session.execute(stmt).fetchall()
         return {row.constraint_id: row.matrix_id for row in rows}
 
@@ -327,19 +332,19 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
         upsert_multiple(
             self._db_session,
             BC,
-            [self._bc_to_row(self._study_id, bc) for bc in constraints],
+            [self._bc_to_row(self._study_data_id, bc) for bc in constraints],
         )
 
     def _save_cluster_terms(self, constraints: Sequence[BindingConstraint]) -> None:
         constraint_ids = [bc.id for bc in constraints]
         cluster_terms = [
-            self._cluster_term_to_row(self._study_id, bc.id, term)
+            self._cluster_term_to_row(self._study_data_id, bc.id, term)
             for bc in constraints
             for term in bc.terms
             if isinstance(term.data, ClusterTerm)
         ]
         self._db_session.execute(
-            delete(CT).where((CT.c.study_id == self._study_id) & (CT.c.constraint_id.in_(constraint_ids)))
+            delete(CT).where((CT.c.study_data_id == self._study_data_id) & (CT.c.constraint_id.in_(constraint_ids)))
         )
         if cluster_terms:
             upsert_multiple(self._db_session, CT, cluster_terms)
@@ -347,13 +352,13 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
     def _save_link_terms(self, constraints: Sequence[BindingConstraint]) -> None:
         constraint_ids = [bc.id for bc in constraints]
         link_terms = [
-            self._link_term_to_row(self._study_id, bc.id, term)
+            self._link_term_to_row(self._study_data_id, bc.id, term)
             for bc in constraints
             for term in bc.terms
             if isinstance(term.data, LinkTerm)
         ]
         self._db_session.execute(
-            delete(LT).where((LT.c.study_id == self._study_id) & (LT.c.constraint_id.in_(constraint_ids)))
+            delete(LT).where((LT.c.study_data_id == self._study_data_id) & (LT.c.constraint_id.in_(constraint_ids)))
         )
         if link_terms:
             upsert_multiple(self._db_session, LT, link_terms)
@@ -364,7 +369,7 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
         for matrix_type, table in _MATRIX_TYPE_TABLES.items():
             rows = self._db_session.execute(
                 select(table.c.constraint_id, table.c.matrix_id).where(
-                    (table.c.study_id == self._study_id) & (table.c.constraint_id.in_(constraint_ids))
+                    (table.c.study_data_id == self._study_data_id) & (table.c.constraint_id.in_(constraint_ids))
                 )
             ).fetchall()
             for row in rows:
@@ -565,7 +570,9 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
         for matrix_type, constraint_ids in deletions_by_type.items():
             table = _MATRIX_TYPE_TABLES[matrix_type]
             db.execute(
-                delete(table).where((table.c.study_id == self._study_id) & (table.c.constraint_id.in_(constraint_ids)))
+                delete(table).where(
+                    (table.c.study_data_id == self._study_data_id) & (table.c.constraint_id.in_(constraint_ids))
+                )
             )
 
         # Group insertions by type so we can issue one upsert batch per table.
@@ -578,7 +585,11 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
                 db,
                 _MATRIX_TYPE_TABLES[matrix_type],
                 [
-                    {"study_id": self._study_id, "constraint_id": ins.constraint_id, "matrix_id": ins.matrix_id}
+                    {
+                        "study_data_id": self._study_data_id,
+                        "constraint_id": ins.constraint_id,
+                        "matrix_id": ins.matrix_id,
+                    }
                     for ins in insertions
                 ],
             )
@@ -591,31 +602,35 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
         """
         if self.get_impl().get_version() < STUDY_VERSION_8_7:
             return
-        active_groups = select(BC.c.group).where(BC.c.study_id == self._study_id).distinct()
+        active_groups = select(BC.c.group).where(BC.c.study_data_id == self._study_data_id).distinct()
         self._db_session.execute(
             delete(SCENARIO_BINDING_CONSTRAINTS_TABLE).where(
-                (SCENARIO_BINDING_CONSTRAINTS_TABLE.c.study_id == self._study_id)
+                (SCENARIO_BINDING_CONSTRAINTS_TABLE.c.study_data_id == self._study_data_id)
                 & SCENARIO_BINDING_CONSTRAINTS_TABLE.c.bc_group_id.not_in(active_groups)
             )
         )
 
-    def _bc_to_row(self, study_id: str, bc: BindingConstraint) -> dict[str, Any]:
+    def _bc_to_row(self, study_data_id: int, bc: BindingConstraint) -> dict[str, Any]:
         data = bc.model_dump(exclude={"id", "terms"})
-        return {"study_id": study_id, "constraint_id": bc.id, **data}
+        return {"study_data_id": study_data_id, "constraint_id": bc.id, **data}
 
-    def _cluster_term_to_row(self, study_id: str, constraint_id: ConstraintId, term: ConstraintTerm) -> dict[str, Any]:
+    def _cluster_term_to_row(
+        self, study_data_id: int, constraint_id: ConstraintId, term: ConstraintTerm
+    ) -> dict[str, Any]:
         assert isinstance(term.data, ClusterTerm)
         return {
-            "study_id": study_id,
+            "study_data_id": study_data_id,
             "constraint_id": constraint_id,
             **term.model_dump(exclude={"data"}),
             **term.data.model_dump(),
         }
 
-    def _link_term_to_row(self, study_id: str, constraint_id: ConstraintId, term: ConstraintTerm) -> dict[str, Any]:
+    def _link_term_to_row(
+        self, study_data_id: int, constraint_id: ConstraintId, term: ConstraintTerm
+    ) -> dict[str, Any]:
         assert isinstance(term.data, LinkTerm)
         return {
-            "study_id": study_id,
+            "study_data_id": study_data_id,
             "constraint_id": constraint_id,
             **term.model_dump(exclude={"data"}),
             **term.data.model_dump(),
@@ -653,7 +668,9 @@ class DatabaseBindingConstraintDao(ConstraintDao, DatabaseDaoBase):
 
         # Order matters : delete BC rows first so the table reflects the final state,
         # then prune orphaned groups via a single subquery.
-        db.execute(delete(BC).where((BC.c.study_id == self._study_id) & (BC.c.constraint_id.in_(constraint_ids))))
+        db.execute(
+            delete(BC).where((BC.c.study_data_id == self._study_data_id) & (BC.c.constraint_id.in_(constraint_ids)))
+        )
         self._cleanup_scenario_builder_groups()
 
         db.commit()

--- a/antarest/study/dao/database/database_district_dao.py
+++ b/antarest/study/dao/database/database_district_dao.py
@@ -55,7 +55,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
 
         If the district already exists, it will be overwritten.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Validate that all areas exist
@@ -64,7 +64,7 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
             raise AreaNotFound(*invalid_areas)
 
         values = {
-            "study_id": study_id,
+            "study_data_id": study_data_id,
             "district_id": district.id,
             "name": district.name,
             "output": district.output,
@@ -81,18 +81,18 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         """
         Remove a district from a study.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         result = session.execute(
             delete(DISTRICT_TABLE).where(
-                (DISTRICT_TABLE.c.study_id == study_id) & (DISTRICT_TABLE.c.district_id == district_id)
+                (DISTRICT_TABLE.c.study_data_id == study_data_id) & (DISTRICT_TABLE.c.district_id == district_id)
             )
         )
         assert isinstance(result, CursorResult)
         if result.rowcount == 0:
             # Means the DELETE had no effect so the district did not exist
-            raise DistrictConfigNotFound(f"District '{district_id}' does not exist in study '{study_id}'")
+            raise DistrictConfigNotFound(f"District '{district_id}' does not exist in study '{self._study_id}'")
         session.commit()
 
     @override
@@ -100,10 +100,10 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         """
         Returns the list of districts in this study.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
-        stmt = select(DISTRICT_TABLE).where(DISTRICT_TABLE.c.study_id == study_id)
+        stmt = select(DISTRICT_TABLE).where(DISTRICT_TABLE.c.study_data_id == study_data_id)
         district_rows = session.execute(stmt).fetchall()
 
         return [_convert_db_row_to_district(row) for row in district_rows]
@@ -113,11 +113,11 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         """
         Get the district with the given id.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         stmt = select(DISTRICT_TABLE).where(
-            (DISTRICT_TABLE.c.study_id == study_id) & (DISTRICT_TABLE.c.district_id == district_id)
+            (DISTRICT_TABLE.c.study_data_id == study_data_id) & (DISTRICT_TABLE.c.district_id == district_id)
         )
         row = session.execute(stmt).fetchone()
         if not row:
@@ -130,10 +130,10 @@ class DatabaseDistrictDao(DistrictDao, DatabaseDaoBase):
         """
         Returns whether a district with the given id exists in the study.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         stmt = select(DISTRICT_TABLE.c.district_id).where(
-            (DISTRICT_TABLE.c.study_id == study_id) & (DISTRICT_TABLE.c.district_id == district_id)
+            (DISTRICT_TABLE.c.study_data_id == study_data_id) & (DISTRICT_TABLE.c.district_id == district_id)
         )
         return session.execute(stmt).fetchone() is not None

--- a/antarest/study/dao/database/database_hydro_dao.py
+++ b/antarest/study/dao/database/database_hydro_dao.py
@@ -78,7 +78,7 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
     default_water_values,
 )
 
-_MANAGEMENT_COLS = [c for c in HYDRO_MANAGEMENT_TABLE.c if c.name not in ("study_id", "area_id")]
+_MANAGEMENT_COLS = [c for c in HYDRO_MANAGEMENT_TABLE.c if c.name not in ("study_data_id", "area_id")]
 
 
 class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
@@ -110,16 +110,16 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             AreaNotFound: If the area does not exist.
             ValueError: If the area exists but has no hydro management configuration.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         stmt = select(HYDRO_MANAGEMENT_TABLE).where(
-            (HYDRO_MANAGEMENT_TABLE.c.study_id == study_id) & (HYDRO_MANAGEMENT_TABLE.c.area_id == area_id)
+            (HYDRO_MANAGEMENT_TABLE.c.study_data_id == study_data_id) & (HYDRO_MANAGEMENT_TABLE.c.area_id == area_id)
         )
         row = session.execute(stmt).fetchone()
 
         if not row:
-            validate_area_exists(session, study_id, area_id)
+            validate_area_exists(session, study_data_id, area_id)
             raise ValueError(f"Hydro management not found for area '{area_id}'")
 
         return self._convert_row_to_hydro_management(row)
@@ -145,12 +145,12 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         Raises:
             AreaNotFound: If the area does not exist.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         values = []
         for area_id, management in hydro_management.items():
-            values.append({"study_id": study_id, "area_id": area_id, **management.model_dump()})
+            values.append({"study_data_id": study_data_id, "area_id": area_id, **management.model_dump()})
 
         try:
             upsert_multiple(session, HYDRO_MANAGEMENT_TABLE, values)
@@ -175,16 +175,17 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             AreaNotFound: If the area does not exist.
             ValueError: If the area exists but has no inflow structure configuration.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         stmt = select(HYDRO_INFLOW_STRUCTURE_TABLE).where(
-            (HYDRO_INFLOW_STRUCTURE_TABLE.c.study_id == study_id) & (HYDRO_INFLOW_STRUCTURE_TABLE.c.area_id == area_id)
+            (HYDRO_INFLOW_STRUCTURE_TABLE.c.study_data_id == study_data_id)
+            & (HYDRO_INFLOW_STRUCTURE_TABLE.c.area_id == area_id)
         )
         row = session.execute(stmt).fetchone()
 
         if not row:
-            validate_area_exists(session, study_id, area_id)
+            validate_area_exists(session, study_data_id, area_id)
             raise ValueError(f"Inflow structure not found for area '{area_id}'")
 
         return self._convert_row_to_inflow_structure(row)
@@ -192,14 +193,14 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
     @override
     def save_inflow_structure(self, inflow_structure: dict[AreaId, InflowStructure]) -> None:
         """Save inflow structure configuration for several areas"""
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         values = []
         for area_id, inflow in inflow_structure.items():
             values.append(
                 {
-                    "study_id": study_id,
+                    "study_data_id": study_data_id,
                     "area_id": area_id,
                     "inter_monthly_correlation": inflow.inter_monthly_correlation,
                 }
@@ -221,7 +222,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         Returns:
             Dictionary mapping area_id to HydroProperties (management_options + inflow_structure).
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         stmt = (
@@ -232,15 +233,15 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             )
             .join(
                 HYDRO_MANAGEMENT_TABLE,
-                (AREA_TABLE.c.study_id == HYDRO_MANAGEMENT_TABLE.c.study_id)
+                (AREA_TABLE.c.study_data_id == HYDRO_MANAGEMENT_TABLE.c.study_data_id)
                 & (AREA_TABLE.c.area_id == HYDRO_MANAGEMENT_TABLE.c.area_id),
             )
             .join(
                 HYDRO_INFLOW_STRUCTURE_TABLE,
-                (AREA_TABLE.c.study_id == HYDRO_INFLOW_STRUCTURE_TABLE.c.study_id)
+                (AREA_TABLE.c.study_data_id == HYDRO_INFLOW_STRUCTURE_TABLE.c.study_data_id)
                 & (AREA_TABLE.c.area_id == HYDRO_INFLOW_STRUCTURE_TABLE.c.area_id),
             )
-            .where(AREA_TABLE.c.study_id == study_id)
+            .where(AREA_TABLE.c.study_data_id == study_data_id)
         )
         rows = session.execute(stmt).fetchall()
 
@@ -267,16 +268,17 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             AreaNotFound: If the area does not exist.
             ValueError: If the area exists but has no allocation data.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         stmt = select(HYDRO_ALLOCATION_TABLE).where(
-            (HYDRO_ALLOCATION_TABLE.c.study_id == study_id) & (HYDRO_ALLOCATION_TABLE.c.source_area_id == area_id)
+            (HYDRO_ALLOCATION_TABLE.c.study_data_id == study_data_id)
+            & (HYDRO_ALLOCATION_TABLE.c.source_area_id == area_id)
         )
         rows = session.execute(stmt).fetchall()
 
         if not rows:
-            validate_area_exists(session, study_id, area_id)
+            validate_area_exists(session, study_data_id, area_id)
             raise ValueError(f"Hydro allocation not found for area '{area_id}'")
 
         allocation_areas = [
@@ -295,14 +297,14 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         Raises:
             ValueError: If no hydro allocation data is found for the study.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
-        stmt = select(HYDRO_ALLOCATION_TABLE).where(HYDRO_ALLOCATION_TABLE.c.study_id == study_id)
+        stmt = select(HYDRO_ALLOCATION_TABLE).where(HYDRO_ALLOCATION_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
 
         if not rows:
-            raise ValueError(f"Hydro allocation not found for study '{study_id}'")
+            raise ValueError(f"Hydro allocation not found for study '{self._study_id}'")
 
         # Group by source area
         allocations_by_source: dict[str, list[HydroAllocationArea]] = {}
@@ -320,12 +322,12 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
 
         This will replace any existing allocation for the given areas.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Delete existing allocations for the source areas
         stmt_delete = delete(HYDRO_ALLOCATION_TABLE).where(
-            (HYDRO_ALLOCATION_TABLE.c.study_id == study_id)
+            (HYDRO_ALLOCATION_TABLE.c.study_data_id == study_data_id)
             & (HYDRO_ALLOCATION_TABLE.c.source_area_id.in_(set(allocation_dict)))
         )
         session.execute(stmt_delete)
@@ -336,7 +338,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             for alloc_area in allocation.allocation:
                 insert_values.append(
                     {
-                        "study_id": study_id,
+                        "study_data_id": study_data_id,
                         "source_area_id": area_id,
                         "target_area_id": alloc_area.area_id,
                         "coefficient": alloc_area.coefficient,
@@ -386,7 +388,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             HydroCorrelationMatrix with all area correlations.
             Returns identity matrix (self=1.0, rest=0.0) if no correlations stored.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Get all area IDs from the study
@@ -397,7 +399,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         array = np.identity(len(area_ids))
 
         # Get stored correlations and fill the matrix
-        stmt = select(HYDRO_CORRELATION_TABLE).where(HYDRO_CORRELATION_TABLE.c.study_id == study_id)
+        stmt = select(HYDRO_CORRELATION_TABLE).where(HYDRO_CORRELATION_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
 
         area_index = {area_id: i for i, area_id in enumerate(area_ids)}
@@ -416,7 +418,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
 
         This will replace any existing correlation for the given areas.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Validate self-correlation if provided
@@ -429,7 +431,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         # Delete existing correlations involving the given areas
         area_ids = set(correlation_dict)
         stmt_delete = delete(HYDRO_CORRELATION_TABLE).where(
-            (HYDRO_CORRELATION_TABLE.c.study_id == study_id)
+            (HYDRO_CORRELATION_TABLE.c.study_data_id == study_data_id)
             & ((HYDRO_CORRELATION_TABLE.c.area_from.in_(area_ids)) | (HYDRO_CORRELATION_TABLE.c.area_to.in_(area_ids)))
         )
         session.execute(stmt_delete)
@@ -451,7 +453,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
                     seen_area_pairs[pair] = coefficient
                     insert_values.append(
                         {
-                            "study_id": study_id,
+                            "study_data_id": study_data_id,
                             "area_from": a,
                             "area_to": b,
                             "coefficient": coefficient,
@@ -480,12 +482,12 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
     # ==================== Matrix Methods ====================
 
     def _get_hydro_matrix(self, area_id: str, table: Table) -> SeriesId:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(table).where((table.c.study_id == study_id) & (table.c.area_id == area_id))
+        stmt = select(table).where((table.c.study_data_id == study_data_id) & (table.c.area_id == area_id))
         row = session.execute(stmt).fetchone()
         if not row:
-            validate_area_exists(session, study_id, area_id)
+            validate_area_exists(session, study_data_id, area_id)
             raise ValueError(f"Hydro matrix not found for area '{area_id}' in table '{table.name}'")
         return str(row.matrix_id)
 
@@ -558,55 +560,55 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
 
     @override
     def get_all_hydro_maxpower(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_MAXPOWER_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_MAXPOWER_TABLE)
 
     @override
     def get_all_hydro_reservoir(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_RESERVOIR_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_RESERVOIR_TABLE)
 
     @override
     def get_all_hydro_energy(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_ENERGY_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_ENERGY_TABLE)
 
     @override
     def get_all_hydro_run_of_river(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_RUN_OF_RIVER_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_RUN_OF_RIVER_TABLE)
 
     @override
     def get_all_hydro_modulation(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_MODULATION_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_MODULATION_TABLE)
 
     @override
     def get_all_hydro_credit_modulations(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_CREDIT_MODULATIONS_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_CREDIT_MODULATIONS_TABLE)
 
     @override
     def get_all_hydro_inflow_pattern(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_INFLOW_PATTERN_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_INFLOW_PATTERN_TABLE)
 
     @override
     def get_all_hydro_water_values(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_WATER_VALUES_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_WATER_VALUES_TABLE)
 
     @override
     def get_all_hydro_mingen(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_MINGEN_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_MINGEN_TABLE)
 
     @override
     def get_all_hydro_max_hourly_gen_power(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_MAX_HOURLY_GEN_POWER_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_MAX_HOURLY_GEN_POWER_TABLE)
 
     @override
     def get_all_hydro_max_hourly_pump_power(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_MAX_HOURLY_PUMP_POWER_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_MAX_HOURLY_PUMP_POWER_TABLE)
 
     @override
     def get_all_hydro_max_daily_gen_energy(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_MAX_DAILY_GEN_ENERGY_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_MAX_DAILY_GEN_ENERGY_TABLE)
 
     @override
     def get_all_hydro_max_daily_pump_energy(self) -> AreaSeriesMapping:
-        return get_all_area_matrices(self._study_id, self._db_session, HYDRO_MAX_DAILY_PUMP_ENERGY_TABLE)
+        return get_all_area_matrices(self._study_data_id, self._db_session, HYDRO_MAX_DAILY_PUMP_ENERGY_TABLE)
 
     @override
     def save_hydro_maxpower(self, series: AreaSeriesMapping) -> None:
@@ -666,7 +668,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
         if compatibility_data.hydro_pmax == hydro_pmax:
             return
 
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         if hydro_pmax == HydroPmax.HOURLY:
@@ -676,10 +678,12 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
             daily_matrix_id = generator.matrix_service.create(create_polars_dataframe(np.full((365, 1), 24)))
 
             hourly_rows = [
-                {"study_id": study_id, "area_id": area_id, "matrix_id": hourly_matrix_id} for area_id in area_ids
+                {"study_data_id": study_data_id, "area_id": area_id, "matrix_id": hourly_matrix_id}
+                for area_id in area_ids
             ]
             daily_rows = [
-                {"study_id": study_id, "area_id": area_id, "matrix_id": daily_matrix_id} for area_id in area_ids
+                {"study_data_id": study_data_id, "area_id": area_id, "matrix_id": daily_matrix_id}
+                for area_id in area_ids
             ]
             try:
                 upsert_multiple(session, HYDRO_MAX_HOURLY_GEN_POWER_TABLE, hourly_rows)
@@ -698,7 +702,7 @@ class DatabaseHydroDao(HydroDao, DatabaseDaoBase):
                 HYDRO_MAX_DAILY_GEN_ENERGY_TABLE,
                 HYDRO_MAX_DAILY_PUMP_ENERGY_TABLE,
             ]:
-                session.execute(delete(table).where(table.c.study_id == study_id))
+                session.execute(delete(table).where(table.c.study_data_id == study_data_id))
             session.commit()
 
         compatibility_data.hydro_pmax = hydro_pmax

--- a/antarest/study/dao/database/database_layer_dao.py
+++ b/antarest/study/dao/database/database_layer_dao.py
@@ -45,17 +45,17 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
         The default layer (id="0") always contains all areas.
         Other layers contain the areas that have UI entries for that layer.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Get all layer names from LAYER_TABLE
-        stmt_layers = select(LAYER_TABLE).where(LAYER_TABLE.c.study_id == study_id)
+        stmt_layers = select(LAYER_TABLE).where(LAYER_TABLE.c.study_data_id == study_data_id)
         layer_rows = session.execute(stmt_layers).fetchall()
         layer_id_to_name = {row.layer_id: row.name for row in layer_rows}
 
         # Get all area-layer associations from AREA_UI_TABLE
         stmt_area_ui = select(AREA_UI_TABLE.c.layer_id, AREA_UI_TABLE.c.area_id).where(
-            AREA_UI_TABLE.c.study_id == study_id
+            AREA_UI_TABLE.c.study_data_id == study_data_id
         )
         area_ui_rows = session.execute(stmt_area_ui).fetchall()
 
@@ -83,10 +83,10 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
 
         Does not persist area associations, use save_layer_areas() for that.
         """
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
-        values = {"study_id": study_id, "layer_id": layer.id, "name": layer.name}
+        values = {"study_data_id": study_data_id, "layer_id": layer.id, "name": layer.name}
         upsert_one(session, LAYER_TABLE, values)
         session.commit()
 
@@ -101,11 +101,13 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
         if layer_id == DEFAULT_LAYER_ID:
             raise LayerNotAllowedToBeDeleted()
 
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         result = session.execute(
-            delete(LAYER_TABLE).where((LAYER_TABLE.c.study_id == study_id) & (LAYER_TABLE.c.layer_id == layer_id))
+            delete(LAYER_TABLE).where(
+                (LAYER_TABLE.c.study_data_id == study_data_id) & (LAYER_TABLE.c.layer_id == layer_id)
+            )
         )
         assert isinstance(result, CursorResult)
         if result.rowcount == 0:
@@ -125,11 +127,11 @@ class DatabaseLayerDao(LayerDao, DatabaseDaoBase):
         if layer_id == DEFAULT_LAYER_ID:
             return True
 
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         # Check if layer exists in LAYER_TABLE
         stmt = select(LAYER_TABLE.c.layer_id).where(
-            (LAYER_TABLE.c.study_id == study_id) & (LAYER_TABLE.c.layer_id == layer_id)
+            (LAYER_TABLE.c.study_data_id == study_data_id) & (LAYER_TABLE.c.layer_id == layer_id)
         )
         return session.execute(stmt).fetchone() is not None

--- a/antarest/study/dao/database/database_link_dao.py
+++ b/antarest/study/dao/database/database_link_dao.py
@@ -41,7 +41,7 @@ from antarest.study.storage.rawstudy.model.filesystem.matrix.simulator_default i
 
 def _convert_db_rows_to_model(db_row: Any) -> Link:
     data = get_row_representation_as_dict(db_row)
-    del data["study_id"]
+    del data["study_data_id"]
     return Link(**data)
 
 
@@ -78,7 +78,7 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
         session = self._db_session
         values = []
         for link in links:
-            values.append({"study_id": self._study_id, **link.model_dump()})
+            values.append({"study_data_id": self._study_data_id, **link.model_dump()})
 
         try:
             upsert_multiple(session, LINK_TABLE, values)
@@ -89,10 +89,10 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
 
     @override
     def delete_link(self, link: Link) -> None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
         stmt = delete(LINK_TABLE).where(
-            (LINK_TABLE.c.study_id == study_id)
+            (LINK_TABLE.c.study_data_id == study_data_id)
             & (LINK_TABLE.c.area1 == link.area1)
             & (LINK_TABLE.c.area2 == link.area2)
         )
@@ -105,9 +105,9 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
 
     @override
     def get_links(self) -> Sequence[Link]:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(LINK_TABLE).where(LINK_TABLE.c.study_id == study_id)
+        stmt = select(LINK_TABLE).where(LINK_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
         return [_convert_db_rows_to_model(row) for row in rows]
 
@@ -125,9 +125,11 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
 
     def _get_row(self, area1_id: str, area2_id: str, table: Table) -> Row[Any] | None:
         area1, area2 = sorted((area1_id, area2_id))
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(table).where((table.c.study_id == study_id) & (table.c.area1 == area1) & (table.c.area2 == area2))
+        stmt = select(table).where(
+            (table.c.study_data_id == study_data_id) & (table.c.area1 == area1) & (table.c.area2 == area2)
+        )
         return session.execute(stmt).fetchone()
 
     def _get_link_matrix(self, area_from_id: str, area_to_id: str, table: Table) -> SeriesId:
@@ -138,12 +140,12 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
 
     def _save_link_matrices(self, series: LinkSeriesMapping, table: Table) -> None:
         session = self._db_session
-        study_id = self._study_id
+        study_data_id = self._study_data_id
 
         values = []
         for key, series_id in series.items():
             area1, area2 = sorted(key)
-            values.append({"study_id": study_id, "area1": area1, "area2": area2, "matrix_id": series_id})
+            values.append({"study_data_id": study_data_id, "area1": area1, "area2": area2, "matrix_id": series_id})
         try:
             upsert_multiple(session, table, values)
         except IntegrityError as e:
@@ -181,9 +183,9 @@ class DatabaseLinkDao(LinkDao, DatabaseDaoBase):
         return self.get_impl().get_matrix(matrix_id, default_empty_supplier=default_empty)
 
     def _get_link_matrices(self, table: Table) -> LinkSeriesMapping:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(table).where(table.c.study_id == study_id)
+        stmt = select(table).where(table.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
         result: LinkSeriesMapping = {}
         for row in rows:

--- a/antarest/study/dao/database/database_renewable_dao.py
+++ b/antarest/study/dao/database/database_renewable_dao.py
@@ -46,7 +46,7 @@ class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
 
     def _convert_db_row_to_renewable(self, row: Any) -> RenewableCluster:
         data = get_row_representation_as_dict(row)
-        del data["study_id"]
+        del data["study_data_id"]
         del data["area_id"]
         data["id"] = data.pop("renewable_id")
         cluster = RenewableCluster(**data)
@@ -55,7 +55,7 @@ class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
         return cluster
 
     def _convert_renewable_cluster_to_row(self, area_id: str, cluster: RenewableCluster) -> dict[str, Any]:
-        values = dict(study_id=self._study_id, area_id=area_id, **cluster.model_dump())
+        values = dict(study_data_id=self._study_data_id, area_id=area_id, **cluster.model_dump())
         values["renewable_id"] = values.pop("id").lower()
         return values
 
@@ -119,7 +119,7 @@ class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
 
     @override
     def save_renewable_series(self, series: RenewableSeriesMapping) -> None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         try:
@@ -127,7 +127,7 @@ class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
             for area_id, value in series.items():
                 for renewable_id, matrix_id in value.items():
                     data = {
-                        "study_id": study_id,
+                        "study_data_id": study_data_id,
                         "area_id": area_id,
                         "renewable_id": renewable_id,
                         "matrix_id": matrix_id,
@@ -142,13 +142,13 @@ class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
 
     @override
     def delete_renewable(self, area_id: str, renewable: RenewableCluster) -> None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
         renewable_id = renewable.id.lower()
 
         result = session.execute(
             delete(RENEWABLE_CLUSTER_TABLE).where(
-                (RENEWABLE_CLUSTER_TABLE.c.study_id == study_id)
+                (RENEWABLE_CLUSTER_TABLE.c.study_data_id == study_data_id)
                 & (RENEWABLE_CLUSTER_TABLE.c.area_id == area_id)
                 & (RENEWABLE_CLUSTER_TABLE.c.renewable_id == renewable_id)
             )
@@ -162,10 +162,10 @@ class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
 
     @override
     def get_all_renewables(self) -> dict[str, dict[str, RenewableCluster]]:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
-        stmt = select(RENEWABLE_CLUSTER_TABLE).where(RENEWABLE_CLUSTER_TABLE.c.study_id == study_id)
+        stmt = select(RENEWABLE_CLUSTER_TABLE).where(RENEWABLE_CLUSTER_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
 
         renewables_by_areas: dict[str, dict[str, RenewableCluster]] = {}
@@ -176,20 +176,20 @@ class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
 
     @override
     def get_all_renewables_for_area(self, area_id: str) -> Sequence[RenewableCluster]:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        validate_area_exists(session, study_id, area_id)
+        validate_area_exists(session, study_data_id, area_id)
 
         stmt = select(RENEWABLE_CLUSTER_TABLE).where(
-            (RENEWABLE_CLUSTER_TABLE.c.study_id == study_id) & (RENEWABLE_CLUSTER_TABLE.c.area_id == area_id)
+            (RENEWABLE_CLUSTER_TABLE.c.study_data_id == study_data_id) & (RENEWABLE_CLUSTER_TABLE.c.area_id == area_id)
         )
         rows = session.execute(stmt).fetchall()
         return [self._convert_db_row_to_renewable(row) for row in rows]
 
     def _select_renewable_cluster(self, area_id: str, renewable_id: str) -> Select[Any]:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         return select(RENEWABLE_CLUSTER_TABLE).where(
-            (RENEWABLE_CLUSTER_TABLE.c.study_id == study_id)
+            (RENEWABLE_CLUSTER_TABLE.c.study_data_id == study_data_id)
             & (RENEWABLE_CLUSTER_TABLE.c.area_id == area_id)
             & (RENEWABLE_CLUSTER_TABLE.c.renewable_id == renewable_id)
         )
@@ -212,10 +212,10 @@ class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
 
     @override
     def get_renewable_series(self, area_id: str, renewable_id: str) -> pl.DataFrame:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
         stmt = select(RENEWABLE_SERIES_TABLE).where(
-            (RENEWABLE_SERIES_TABLE.c.study_id == study_id)
+            (RENEWABLE_SERIES_TABLE.c.study_data_id == study_data_id)
             & (RENEWABLE_SERIES_TABLE.c.area_id == area_id)
             & (RENEWABLE_SERIES_TABLE.c.renewable_id == renewable_id)
         )
@@ -227,9 +227,9 @@ class DatabaseRenewableDao(RenewableDao, DatabaseDaoBase):
 
     @override
     def get_all_renewables_series(self) -> RenewableSeriesMapping:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(RENEWABLE_SERIES_TABLE).where(RENEWABLE_SERIES_TABLE.c.study_id == study_id)
+        stmt = select(RENEWABLE_SERIES_TABLE).where(RENEWABLE_SERIES_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
         result: RenewableSeriesMapping = {}
         for row in rows:

--- a/antarest/study/dao/database/database_reserve_certification_dao.py
+++ b/antarest/study/dao/database/database_reserve_certification_dao.py
@@ -35,17 +35,17 @@ _THERMAL_TABLE = THERMAL_RESERVE_CERTIFICATION_TABLE
 
 def _convert_row_to_model(row: Row[Any]) -> ThermalReserveCertification:
     data = get_row_representation_as_dict(row)
-    for key in ("study_id", "area_id", "thermal_id", "reserve_id"):
+    for key in ("study_data_id", "area_id", "thermal_id", "reserve_id"):
         del data[key]
     return ThermalReserveCertification.model_validate(data)
 
 
 def _convert_model_to_row(
-    study_id: str, area_id: str, thermal_id: str, reserve_id: str, certification: ThermalReserveCertification
+    study_data_id: int, area_id: str, thermal_id: str, reserve_id: str, certification: ThermalReserveCertification
 ) -> dict[str, Any]:
     values = certification.model_dump()
     values["reserve_id"] = reserve_id
-    values["study_id"] = study_id
+    values["study_data_id"] = study_data_id
     values["area_id"] = area_id
     values["thermal_id"] = thermal_id
     return values
@@ -56,7 +56,7 @@ class DatabaseReserveCertificationDao(ReserveCertificationDao, DatabaseDaoBase):
 
     def _select_one(self, area_id: str, thermal_id: str, reserve_id: str) -> Select[Any]:
         return select(_THERMAL_TABLE).where(
-            (_THERMAL_TABLE.c.study_id == self._study_id)
+            (_THERMAL_TABLE.c.study_data_id == self._study_data_id)
             & (_THERMAL_TABLE.c.area_id == area_id)
             & (_THERMAL_TABLE.c.thermal_id == thermal_id)
             & (_THERMAL_TABLE.c.reserve_id == reserve_id)
@@ -64,7 +64,7 @@ class DatabaseReserveCertificationDao(ReserveCertificationDao, DatabaseDaoBase):
 
     @override
     def get_all_thermal_reserve_certifications(self) -> dict[AreaId, ThermalReserveCertificationMapping]:
-        stmt = select(_THERMAL_TABLE).where(_THERMAL_TABLE.c.study_id == self._study_id)
+        stmt = select(_THERMAL_TABLE).where(_THERMAL_TABLE.c.study_data_id == self._study_data_id)
         rows = self._db_session.execute(stmt).fetchall()
         result: dict[AreaId, ThermalReserveCertificationMapping] = {}
         for row in rows:
@@ -75,7 +75,7 @@ class DatabaseReserveCertificationDao(ReserveCertificationDao, DatabaseDaoBase):
     @override
     def get_thermal_reserve_certifications(self, area_id: AreaId) -> ThermalReserveCertificationMapping:
         stmt = select(_THERMAL_TABLE).where(
-            (_THERMAL_TABLE.c.study_id == self._study_id) & (_THERMAL_TABLE.c.area_id == area_id)
+            (_THERMAL_TABLE.c.study_data_id == self._study_data_id) & (_THERMAL_TABLE.c.area_id == area_id)
         )
         rows = self._db_session.execute(stmt).fetchall()
         result: ThermalReserveCertificationMapping = {}
@@ -91,12 +91,14 @@ class DatabaseReserveCertificationDao(ReserveCertificationDao, DatabaseDaoBase):
         for area_id, reserves_dict in data.items():
             for reserve_id, thermal_dict in reserves_dict.items():
                 for thermal_id, certification in thermal_dict.items():
-                    values.append(_convert_model_to_row(self._study_id, area_id, thermal_id, reserve_id, certification))
+                    values.append(
+                        _convert_model_to_row(self._study_data_id, area_id, thermal_id, reserve_id, certification)
+                    )
         try:
             # First, clean the DB
             area_ids = set(data)
             stmt = delete(_THERMAL_TABLE).where(
-                (_THERMAL_TABLE.c.study_id == self._study_id) & (_THERMAL_TABLE.c.area_id.in_(area_ids))
+                (_THERMAL_TABLE.c.study_data_id == self._study_data_id) & (_THERMAL_TABLE.c.area_id.in_(area_ids))
             )
             self._db_session.execute(stmt)
             # Then, insert the new values

--- a/antarest/study/dao/database/database_reserve_definition_dao.py
+++ b/antarest/study/dao/database/database_reserve_definition_dao.py
@@ -37,16 +37,16 @@ _NEED_TABLE = RESERVE_NEED_MATRIX_TABLE
 
 def _convert_row_to_model(row: Row[Any]) -> ReserveDefinition:
     data = get_row_representation_as_dict(row)
-    del data["study_id"]
+    del data["study_data_id"]
     del data["area_id"]
     data["id"] = data.pop("reserve_id")
     return ReserveDefinition.model_validate(data)
 
 
-def _convert_model_to_row(study_id: str, area_id: str, reserve: ReserveDefinition) -> dict[str, Any]:
+def _convert_model_to_row(study_data_id: int, area_id: str, reserve: ReserveDefinition) -> dict[str, Any]:
     values = reserve.model_dump()
     values["reserve_id"] = values.pop("id")
-    values["study_id"] = study_id
+    values["study_data_id"] = study_data_id
     values["area_id"] = area_id
     return values
 
@@ -56,12 +56,14 @@ class DatabaseReserveDefinitionDao(ReserveDefinitionDao, DatabaseDaoBase):
 
     def _select_reserve(self, area_id: str, reserve_id: str) -> Select[Any]:
         return select(_TABLE).where(
-            (_TABLE.c.study_id == self._study_id) & (_TABLE.c.area_id == area_id) & (_TABLE.c.reserve_id == reserve_id)
+            (_TABLE.c.study_data_id == self._study_data_id)
+            & (_TABLE.c.area_id == area_id)
+            & (_TABLE.c.reserve_id == reserve_id)
         )
 
     @override
     def get_all_reserve_definitions(self) -> ReserveDefinitionsMapping:
-        stmt = select(_TABLE).where(_TABLE.c.study_id == self._study_id)
+        stmt = select(_TABLE).where(_TABLE.c.study_data_id == self._study_data_id)
         rows = self._db_session.execute(stmt).fetchall()
         result: ReserveDefinitionsMapping = {}
         for row in rows:
@@ -73,18 +75,18 @@ class DatabaseReserveDefinitionDao(ReserveDefinitionDao, DatabaseDaoBase):
     def get_all_reserve_definitions_for_area(self, area_id: str) -> Sequence[ReserveDefinition]:
         rows = self._get_all_reserve_definitions_for_area(area_id)
         if not rows:
-            validate_area_exists(self._db_session, self._study_id, area_id)
+            validate_area_exists(self._db_session, self._study_data_id, area_id)
         return [_convert_row_to_model(row) for row in rows]
 
     def _get_all_reserve_definitions_for_area(self, area_id: str) -> Sequence[Row[Any]]:
-        stmt = select(_TABLE).where((_TABLE.c.study_id == self._study_id) & (_TABLE.c.area_id == area_id))
+        stmt = select(_TABLE).where((_TABLE.c.study_data_id == self._study_data_id) & (_TABLE.c.area_id == area_id))
         return self._db_session.execute(stmt).fetchall()
 
     @override
     def get_reserve_definition(self, area_id: str, reserve_id: str) -> ReserveDefinition:
         row = self._db_session.execute(self._select_reserve(area_id, reserve_id)).fetchone()
         if not row:
-            validate_area_exists(self._db_session, self._study_id, area_id)
+            validate_area_exists(self._db_session, self._study_data_id, area_id)
             raise ReserveDefinitionNotFound(area_id, reserve_id)
         return _convert_row_to_model(row)
 
@@ -100,12 +102,12 @@ class DatabaseReserveDefinitionDao(ReserveDefinitionDao, DatabaseDaoBase):
         values = []
         for area_id, reserves in data.items():
             for reserve in reserves:
-                values.append(_convert_model_to_row(self._study_id, area_id, reserve))
+                values.append(_convert_model_to_row(self._study_data_id, area_id, reserve))
         try:
             upsert_multiple(session=self._db_session, table=_TABLE, values=values)
         except IntegrityError as e:
             for area_id in data:
-                if not area_exists(self._db_session, self._study_id, area_id):
+                if not area_exists(self._db_session, self._study_data_id, area_id):
                     raise AreaNotFound(area_id) from e
             raise
         self._db_session.commit()
@@ -116,7 +118,7 @@ class DatabaseReserveDefinitionDao(ReserveDefinitionDao, DatabaseDaoBase):
             return
         result = self._db_session.execute(
             delete(_TABLE).where(
-                (_TABLE.c.study_id == self._study_id)
+                (_TABLE.c.study_data_id == self._study_data_id)
                 & (_TABLE.c.area_id == area_id)
                 & (_TABLE.c.reserve_id.in_(reserve_ids))
             )
@@ -138,7 +140,7 @@ class DatabaseReserveDefinitionDao(ReserveDefinitionDao, DatabaseDaoBase):
     @override
     def get_reserve_need(self, area_id: str, reserve_id: str) -> pl.DataFrame:
         stmt = select(_NEED_TABLE).where(
-            (_NEED_TABLE.c.study_id == self._study_id)
+            (_NEED_TABLE.c.study_data_id == self._study_data_id)
             & (_NEED_TABLE.c.area_id == area_id)
             & (_NEED_TABLE.c.reserve_id == reserve_id)
         )
@@ -149,7 +151,7 @@ class DatabaseReserveDefinitionDao(ReserveDefinitionDao, DatabaseDaoBase):
 
     @override
     def get_all_reserve_needs(self) -> ReserveNeedsMapping:
-        stmt = select(_NEED_TABLE).where(_NEED_TABLE.c.study_id == self._study_id)
+        stmt = select(_NEED_TABLE).where(_NEED_TABLE.c.study_data_id == self._study_data_id)
         rows = self._db_session.execute(stmt).fetchall()
         result: ReserveNeedsMapping = {}
         for row in rows:
@@ -165,7 +167,7 @@ class DatabaseReserveDefinitionDao(ReserveDefinitionDao, DatabaseDaoBase):
             for reserve_id, matrix_id in per_reserve.items():
                 values.append(
                     {
-                        "study_id": self._study_id,
+                        "study_data_id": self._study_data_id,
                         "area_id": area_id,
                         "reserve_id": reserve_id,
                         "matrix_id": matrix_id,
@@ -175,7 +177,7 @@ class DatabaseReserveDefinitionDao(ReserveDefinitionDao, DatabaseDaoBase):
             upsert_multiple(session=self._db_session, table=_NEED_TABLE, values=values)
         except IntegrityError as e:
             for area_id in mapping:
-                if not area_exists(self._db_session, self._study_id, area_id):
+                if not area_exists(self._db_session, self._study_data_id, area_id):
                     raise AreaNotFound(area_id) from e
             for area_id, per_reserve in mapping.items():
                 for reserve_id in per_reserve:

--- a/antarest/study/dao/database/database_reserve_symmetries_dao.py
+++ b/antarest/study/dao/database/database_reserve_symmetries_dao.py
@@ -37,9 +37,14 @@ def _convert_row_to_model(row: Row[Any]) -> ReserveSymmetries:
 
 
 def _convert_model_to_row(
-    study_id: str, area_id: str, thermal_id: str, symmetries: ReserveSymmetries
+    study_data_id: int, area_id: str, thermal_id: str, symmetries: ReserveSymmetries
 ) -> dict[str, Any]:
-    values = {"study_id": study_id, "area_id": area_id, "thermal_id": thermal_id, "symmetries": json.dumps(symmetries)}
+    values = {
+        "study_data_id": study_data_id,
+        "area_id": area_id,
+        "thermal_id": thermal_id,
+        "symmetries": json.dumps(symmetries),
+    }
     return values
 
 
@@ -65,7 +70,7 @@ class DatabaseReserveSymmetriesDao(ReserveSymmetriesDao, DatabaseDaoBase):
 
     @override
     def get_all_thermal_reserve_symmetries(self) -> ThermalReserveSymmetriesMapping:
-        stmt = select(_THERMAL_TABLE).where(_THERMAL_TABLE.c.study_id == self._study_id)
+        stmt = select(_THERMAL_TABLE).where(_THERMAL_TABLE.c.study_data_id == self._study_data_id)
         rows = self._db_session.execute(stmt).fetchall()
         result: ThermalReserveSymmetriesMapping = {}
         for row in rows:
@@ -75,7 +80,7 @@ class DatabaseReserveSymmetriesDao(ReserveSymmetriesDao, DatabaseDaoBase):
     @override
     def get_thermal_reserve_symmetries(self, area_id: AreaId) -> dict[ThermalId, ReserveSymmetries]:
         stmt = select(_THERMAL_TABLE).where(
-            (_THERMAL_TABLE.c.study_id == self._study_id) & (_THERMAL_TABLE.c.area_id == area_id)
+            (_THERMAL_TABLE.c.study_data_id == self._study_data_id) & (_THERMAL_TABLE.c.area_id == area_id)
         )
         rows = self._db_session.execute(stmt).fetchall()
         result = {}
@@ -110,12 +115,12 @@ class DatabaseReserveSymmetriesDao(ReserveSymmetriesDao, DatabaseDaoBase):
             for thermal_id, symmetries in thermal_dict.items():
                 if symmetries == [[]]:
                     continue
-                values.append(_convert_model_to_row(self._study_id, area_id, thermal_id, symmetries))
+                values.append(_convert_model_to_row(self._study_data_id, area_id, thermal_id, symmetries))
         try:
             # First, clean the DB
             area_ids = set(data)
             stmt = delete(_THERMAL_TABLE).where(
-                (_THERMAL_TABLE.c.study_id == self._study_id) & (_THERMAL_TABLE.c.area_id.in_(area_ids))
+                (_THERMAL_TABLE.c.study_data_id == self._study_data_id) & (_THERMAL_TABLE.c.area_id.in_(area_ids))
             )
             self._db_session.execute(stmt)
             # Then, insert the new values

--- a/antarest/study/dao/database/database_reserves_global_parameters_dao.py
+++ b/antarest/study/dao/database/database_reserves_global_parameters_dao.py
@@ -82,6 +82,6 @@ class DatabaseReservesGlobalParametersDao(ReservesGlobalParametersDao, DatabaseD
         except IntegrityError:
             session.rollback()
             for area_id in mapping:
-                validate_area_exists(session, study_id, area_id)
+                validate_area_exists(session, study_data_id, area_id)
             raise
         session.commit()

--- a/antarest/study/dao/database/database_reserves_global_parameters_dao.py
+++ b/antarest/study/dao/database/database_reserves_global_parameters_dao.py
@@ -45,30 +45,30 @@ class DatabaseReservesGlobalParametersDao(ReservesGlobalParametersDao, DatabaseD
 
     @override
     def get_reserves_global_parameters(self, area_id: str) -> ReservesGlobalParameters:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(_TABLE).where((_TABLE.c.study_id == study_id) & (_TABLE.c.area_id == area_id))
+        stmt = select(_TABLE).where((_TABLE.c.study_data_id == study_data_id) & (_TABLE.c.area_id == area_id))
         row = session.execute(stmt).fetchone()
         if not row:
-            validate_area_exists(session, study_id, area_id)
+            validate_area_exists(session, study_data_id, area_id)
             raise ValueError(f"Reserves global parameters not found for area '{area_id}'")
         return _convert_row_to_model(row)
 
     @override
     def get_all_reserves_global_parameters(self) -> ReservesGlobalParametersMapping:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(_TABLE).where(_TABLE.c.study_id == study_id)
+        stmt = select(_TABLE).where(_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt)
         return {row.area_id: _convert_row_to_model(row) for row in rows}
 
     @override
     def save_reserves_global_parameters(self, mapping: ReservesGlobalParametersMapping) -> None:
         session = self._db_session
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         values = [
             {
-                "study_id": study_id,
+                "study_data_id": study_data_id,
                 "area_id": area_id,
                 "reference_activation_duration_up": params.reference_activation_duration_up,
                 "energy_activation_ratio_up": params.energy_activation_ratio_up,

--- a/antarest/study/dao/database/database_scenario_builder_dao.py
+++ b/antarest/study/dao/database/database_scenario_builder_dao.py
@@ -69,7 +69,7 @@ class DatabaseScenarioBuilderDao(ScenarioBuilderDao, DatabaseDaoBase):
 
     @override
     def save_scenario_builder(self, ruleset: Ruleset) -> None:
-        study_id, session = self._study_id, self._db_session
+        study_data_id, session = self._study_data_id, self._db_session
 
         # Delete all existing scenario data for the study
         all_tables = [
@@ -80,9 +80,9 @@ class DatabaseScenarioBuilderDao(ScenarioBuilderDao, DatabaseDaoBase):
             SCENARIO_STORAGE_CONSTRAINTS_TABLE,
         ]
         for table in all_tables:
-            session.execute(delete(table).where(table.c.study_id == study_id))
+            session.execute(delete(table).where(table.c.study_data_id == study_data_id))
 
-        base = {"study_id": study_id}
+        base = {"study_data_id": study_data_id}
 
         for field_name, table in _AREA_FIELD_TO_TABLE.items():
             scenarios: dict[str, Any] = getattr(ruleset, field_name)
@@ -143,29 +143,29 @@ class DatabaseScenarioBuilderDao(ScenarioBuilderDao, DatabaseDaoBase):
 
     @override
     def get_ruleset(self) -> Ruleset:
-        study_id, session = self._study_id, self._db_session
+        study_data_id, session = self._study_data_id, self._db_session
         ruleset = Ruleset()
 
         for field_name, table in _AREA_FIELD_TO_TABLE.items():
-            stmt = select(table).where(table.c.study_id == study_id)
+            stmt = select(table).where(table.c.study_data_id == study_data_id)
             scenarios = {row.area_id: row.value for row in session.execute(stmt)}
             if scenarios:
                 setattr(ruleset, field_name, scenarios)
 
-        stmt = select(SCENARIO_NTC_TABLE).where(SCENARIO_NTC_TABLE.c.study_id == study_id)
+        stmt = select(SCENARIO_NTC_TABLE).where(SCENARIO_NTC_TABLE.c.study_data_id == study_data_id)
         ntc = {f"{row.area1}{_LINK_SEPARATOR}{row.area2}": row.value for row in session.execute(stmt)}
         if ntc:
             ruleset.ntc = ntc
 
         stmt = select(SCENARIO_BINDING_CONSTRAINTS_TABLE).where(
-            SCENARIO_BINDING_CONSTRAINTS_TABLE.c.study_id == study_id
+            SCENARIO_BINDING_CONSTRAINTS_TABLE.c.study_data_id == study_data_id
         )
         bc = {row.bc_group_id: row.value for row in session.execute(stmt)}
         if bc:
             ruleset.binding_constraints = bc
 
         for scenario_type, (table, id_col) in _AREA_ITEM_TABLE_MAP.items():
-            stmt = select(table).where(table.c.study_id == study_id)
+            stmt = select(table).where(table.c.study_data_id == study_data_id)
             result: dict[str, dict[str, Any]] = {}
             for row in session.execute(stmt):
                 result.setdefault(row.area_id, {})[getattr(row, id_col)] = row.value
@@ -173,7 +173,7 @@ class DatabaseScenarioBuilderDao(ScenarioBuilderDao, DatabaseDaoBase):
                 ruleset.set(scenario_type, result)
 
         stmt = select(SCENARIO_STORAGE_CONSTRAINTS_TABLE).where(
-            SCENARIO_STORAGE_CONSTRAINTS_TABLE.c.study_id == study_id
+            SCENARIO_STORAGE_CONSTRAINTS_TABLE.c.study_data_id == study_data_id
         )
         storage_constraints: dict[str, dict[str, dict[str, Any]]] = {}
         for row in session.execute(stmt):

--- a/antarest/study/dao/database/database_st_storage_dao.py
+++ b/antarest/study/dao/database/database_st_storage_dao.py
@@ -75,13 +75,13 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
     """
 
     def _convert_st_storage_to_row(self, area_id: str, st_storage: STStorage) -> dict[str, Any]:
-        values = dict(study_id=self._study_id, area_id=area_id, **st_storage.model_dump())
+        values = dict(study_data_id=self._study_data_id, area_id=area_id, **st_storage.model_dump())
         values["st_storage_id"] = values.pop("id")
         return values
 
     def _convert_db_row_to_st_storage(self, row: Row[Any]) -> STStorage:
         data = get_row_representation_as_dict(row)
-        del data["study_id"]
+        del data["study_data_id"]
         del data["area_id"]
         data["id"] = data.pop("st_storage_id")
         storage = STStorage(**data)
@@ -92,13 +92,15 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
     def _convert_constraint_to_row(
         self, area_id: str, storage_id: str, constraint: STStorageAdditionalConstraint
     ) -> dict[str, Any]:
-        values = dict(study_id=self._study_id, area_id=area_id, st_storage_id=storage_id, **constraint.model_dump())
+        values = dict(
+            study_data_id=self._study_data_id, area_id=area_id, st_storage_id=storage_id, **constraint.model_dump()
+        )
         values["constraint_id"] = values.pop("id")
         return values
 
     def _convert_db_row_to_constraint(self, row: Row[Any]) -> STStorageAdditionalConstraint:
         data = get_row_representation_as_dict(row)
-        del data["study_id"]
+        del data["study_data_id"]
         del data["area_id"]
         del data["st_storage_id"]
         data["id"] = data.pop("constraint_id")
@@ -175,9 +177,9 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
 
     @override
     def get_all_st_storages(self) -> dict[str, dict[str, STStorage]]:
-        session, study_id = self._db_session, self._study_id
+        session, study_data_id = self._db_session, self._study_data_id
 
-        stmt = select(ST_STORAGE_TABLE).where(ST_STORAGE_TABLE.c.study_id == study_id)
+        stmt = select(ST_STORAGE_TABLE).where(ST_STORAGE_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
 
         st_storages_by_areas: dict[str, dict[str, STStorage]] = {}
@@ -188,25 +190,25 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
 
     @override
     def get_all_st_storages_for_area(self, area_id: str) -> Sequence[STStorage]:
-        session, study_id = self._db_session, self._study_id
+        session, study_data_id = self._db_session, self._study_data_id
 
         stmt = select(ST_STORAGE_TABLE).where(
-            (ST_STORAGE_TABLE.c.study_id == study_id) & (ST_STORAGE_TABLE.c.area_id == area_id)
+            (ST_STORAGE_TABLE.c.study_data_id == study_data_id) & (ST_STORAGE_TABLE.c.area_id == area_id)
         )
 
         rows = session.execute(stmt).fetchall()
 
         if not rows:
-            validate_area_exists(session, study_id, area_id)
+            validate_area_exists(session, study_data_id, area_id)
 
         return [self._convert_db_row_to_st_storage(row) for row in rows]
 
     @override
     def get_st_storage(self, area_id: str, storage_id: str) -> STStorage:
-        session, study_id = self._db_session, self._study_id
+        session, study_data_id = self._db_session, self._study_data_id
 
         stmt = select(ST_STORAGE_TABLE).where(
-            (ST_STORAGE_TABLE.c.study_id == study_id)
+            (ST_STORAGE_TABLE.c.study_data_id == study_data_id)
             & (ST_STORAGE_TABLE.c.area_id == area_id)
             & (ST_STORAGE_TABLE.c.st_storage_id == storage_id)
         )
@@ -220,10 +222,10 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
 
     @override
     def st_storage_exists(self, area_id: str, storage_id: str) -> bool:
-        session, study_id = self._db_session, self._study_id
+        session, study_data_id = self._db_session, self._study_data_id
 
         stmt = select(ST_STORAGE_TABLE).where(
-            (ST_STORAGE_TABLE.c.study_id == study_id)
+            (ST_STORAGE_TABLE.c.study_data_id == study_data_id)
             & (ST_STORAGE_TABLE.c.area_id == area_id)
             & (ST_STORAGE_TABLE.c.st_storage_id == storage_id)
         )
@@ -236,7 +238,7 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
 
         result = session.execute(
             ST_STORAGE_TABLE.delete().where(
-                (ST_STORAGE_TABLE.c.study_id == self._study_id)
+                (ST_STORAGE_TABLE.c.study_data_id == self._study_data_id)
                 & (ST_STORAGE_TABLE.c.area_id == area_id)
                 & (ST_STORAGE_TABLE.c.st_storage_id == storage.id)
             )
@@ -273,10 +275,10 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
 
     @override
     def get_all_st_storage_additional_constraints(self) -> STStorageAdditionalConstraintsMap:
-        session, study_id = self._db_session, self._study_id
+        session, study_data_id = self._db_session, self._study_data_id
 
         stmt = select(ST_STORAGE_ADDITIONAL_CONSTRAINT_TABLE).where(
-            ST_STORAGE_ADDITIONAL_CONSTRAINT_TABLE.c.study_id == study_id
+            ST_STORAGE_ADDITIONAL_CONSTRAINT_TABLE.c.study_data_id == study_data_id
         )
         rows = session.execute(stmt).fetchall()
 
@@ -290,11 +292,13 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
     def get_st_storage_additional_constraints(
         self, area_id: str, storage_id: str
     ) -> list[STStorageAdditionalConstraint]:
-        session, study_id = self._db_session, self._study_id
+        session, study_data_id = self._db_session, self._study_data_id
 
         table = ST_STORAGE_ADDITIONAL_CONSTRAINT_TABLE
         stmt = select(table).where(
-            (table.c.study_id == study_id) & (table.c.area_id == area_id) & (table.c.st_storage_id == storage_id)
+            (table.c.study_data_id == study_data_id)
+            & (table.c.area_id == area_id)
+            & (table.c.st_storage_id == storage_id)
         )
         rows = session.execute(stmt).fetchall()
 
@@ -307,7 +311,7 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
 
         result = session.execute(
             table.delete().where(
-                (table.c.study_id == self._study_id)
+                (table.c.study_data_id == self._study_data_id)
                 & (table.c.area_id == area_id)
                 & (table.c.st_storage_id == storage_id)
                 & (table.c.constraint_id.in_(constraints))
@@ -321,14 +325,19 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
         session.commit()
 
     def _save_st_storage_matrix(self, series: StStorageSeriesMapping, table: Table) -> None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         try:
             values = []
             for area_id, value in series.items():
                 for sts_id, matrix_id in value.items():
-                    data = {"study_id": study_id, "area_id": area_id, "st_storage_id": sts_id, "matrix_id": matrix_id}
+                    data = {
+                        "study_data_id": study_data_id,
+                        "area_id": area_id,
+                        "st_storage_id": sts_id,
+                        "matrix_id": matrix_id,
+                    }
                     values.append(data)
             upsert_multiple(session, table, values)
         except IntegrityError as e:
@@ -428,9 +437,9 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
         return self.get_impl().get_matrix(matrix_id, default_empty_supplier=default_scenario_hourly)
 
     def _get_all_sts_matrix(self, table: Table) -> StStorageSeriesMapping:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(table).where(table.c.study_id == study_id)
+        stmt = select(table).where(table.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
         result: StStorageSeriesMapping = {}
         for row in rows:
@@ -483,7 +492,7 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
     ) -> pl.DataFrame:
         table = ST_STORAGE_ADDITIONAL_CONSTRAINT_MATRIX_TABLE
         stmt = select(table).where(
-            (table.c.study_id == self._study_id)
+            (table.c.study_data_id == self._study_data_id)
             & (table.c.area_id == area_id)
             & (table.c.st_storage_id == storage_id)
             & (table.c.constraint_id == constraint_id)
@@ -497,7 +506,7 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
     def get_all_st_storage_additional_constraint_matrices(self) -> StStorageConstraintSeriesMapping:
         result: StStorageConstraintSeriesMapping = {}
         table = ST_STORAGE_ADDITIONAL_CONSTRAINT_MATRIX_TABLE
-        stmt = select(table).where(table.c.study_id == self._study_id)
+        stmt = select(table).where(table.c.study_data_id == self._study_data_id)
         rows = self._db_session.execute(stmt).fetchall()
         for row in rows:
             result.setdefault(row.area_id, {}).setdefault(row.st_storage_id, {})[row.constraint_id] = row.matrix_id
@@ -505,7 +514,7 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
 
     @override
     def save_st_storage_constraint_matrices(self, series: StStorageConstraintSeriesMapping) -> None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         values = []
@@ -513,7 +522,7 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
             for sts_id, v in value.items():
                 for constraint_id, matrix_id in v.items():
                     data = {
-                        "study_id": study_id,
+                        "study_data_id": study_data_id,
                         "area_id": area_id,
                         "st_storage_id": sts_id,
                         "constraint_id": constraint_id,
@@ -534,7 +543,9 @@ class DatabaseStStorageDao(STStorageDao, DatabaseDaoBase):
 
     def _get_st_storage_matrix_row(self, area_id: str, storage_id: str, table: Table) -> Row[Any] | None:
         stmt = select(table).where(
-            (table.c.study_id == self._study_id) & (table.c.area_id == area_id) & (table.c.st_storage_id == storage_id)
+            (table.c.study_data_id == self._study_data_id)
+            & (table.c.area_id == area_id)
+            & (table.c.st_storage_id == storage_id)
         )
         return self._db_session.execute(stmt).fetchone()
 

--- a/antarest/study/dao/database/database_study_dao.py
+++ b/antarest/study/dao/database/database_study_dao.py
@@ -126,6 +126,13 @@ class DatabaseStudyDao(
     def generator_matrix_constants(self) -> GeneratorMatrixConstants:
         return self._generator_matrix_constants
 
+    def set_study_data_id(self, study_data_id: int) -> None:
+        """
+        Prime this DAO with the id of the `study_data` row that was just created for its study,
+        sparing the lookup the first query would otherwise trigger.
+        """
+        self._context.set_study_data_id(study_data_id)
+
     # Implementation of abstract methods required by StudyDao
     @override
     def get_study_id(self) -> str:
@@ -201,13 +208,13 @@ class DatabaseStudyDao(
 
     @override
     def get_comments(self) -> str:
-        stmt = select(COMMENTS_TABLE.c.comments).where(COMMENTS_TABLE.c.study_id == self._study_id)
+        stmt = select(COMMENTS_TABLE.c.comments).where(COMMENTS_TABLE.c.study_data_id == self._study_data_id)
         comments = self._db_session.execute(stmt).scalar_one_or_none()
         return comments if comments is not None else ""
 
     @override
     def save_comments(self, comments: str) -> None:
-        upsert_one(self._db_session, COMMENTS_TABLE, {"study_id": self._study_id, "comments": comments})
+        upsert_one(self._db_session, COMMENTS_TABLE, {"study_data_id": self._study_data_id, "comments": comments})
         self._db_session.commit()
 
     @override

--- a/antarest/study/dao/database/database_study_dao.py
+++ b/antarest/study/dao/database/database_study_dao.py
@@ -91,6 +91,7 @@ class DatabaseStudyDao(
     def __init__(
         self,
         study_id: str,
+        study_data_id: int,
         db_session: Session,
         matrix_service: ISimpleMatrixService,
         blob_service: IBlobService,
@@ -106,7 +107,7 @@ class DatabaseStudyDao(
             blob_service: Blobs storage service
             generator_matrix_constants: Predefined matrix constants generator
         """
-        DatabaseDaoBase.__init__(self, StudyDaoContext(study_id, db_session))
+        DatabaseDaoBase.__init__(self, StudyDaoContext(study_id, study_data_id, db_session))
         self._matrix_service = matrix_service
         self._blob_service = blob_service
         self._generator_matrix_constants = generator_matrix_constants
@@ -125,13 +126,6 @@ class DatabaseStudyDao(
     @property
     def generator_matrix_constants(self) -> GeneratorMatrixConstants:
         return self._generator_matrix_constants
-
-    def set_study_data_id(self, study_data_id: int) -> None:
-        """
-        Prime this DAO with the id of the `study_data` row that was just created for its study,
-        sparing the lookup the first query would otherwise trigger.
-        """
-        self._context.set_study_data_id(study_data_id)
 
     # Implementation of abstract methods required by StudyDao
     @override

--- a/antarest/study/dao/database/database_study_factory_dao.py
+++ b/antarest/study/dao/database/database_study_factory_dao.py
@@ -10,11 +10,12 @@
 #
 # This file is part of the Antares project.
 from antares.study.version import StudyVersion
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from antarest.blobstore.service import IBlobService
-from antarest.core.exceptions import UnsupportedStudyVersion
+from antarest.core.exceptions import StudyNotFoundError, UnsupportedStudyVersion
 from antarest.core.utils.fastapi_sqlalchemy import db
 from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.area_model import DEFAULT_LAYER_ID, DEFAULT_LAYER_NAME
@@ -138,8 +139,16 @@ class DatabaseStudyDaoFactory(StudyFactoryDao):
             raise UnsupportedStudyVersion(
                 f"{version} is not a supported version, supported versions are: {STUDY_REFERENCE_TEMPLATES}"
             )
-        dao = self.get_study_dao(metadata.id, metadata.managed)
-        dao.set_study_data_id(self._initialize_study_data_table(dao.get_study_id()))
+        study_data_id = self._initialize_study_data_table(metadata.id)
+        dao = DatabaseStudyDao(
+            metadata.id,
+            study_data_id,
+            self.session,
+            self._matrix_service,
+            self._blob_service,
+            self._generator_matrix_constants,
+        )
+
         dao.save_layer(Layer(id=DEFAULT_LAYER_ID, name=DEFAULT_LAYER_NAME))
         dao.save_district(
             District(
@@ -155,6 +164,15 @@ class DatabaseStudyDaoFactory(StudyFactoryDao):
 
     @override
     def get_study_dao(self, study_id: str, is_study_managed: bool) -> DatabaseStudyDao:
+        stmt = select(STUDY_DATA_TABLE.c.study_data_id).where(STUDY_DATA_TABLE.c.study_id == study_id)
+        study_data_id: int | None = self.session.execute(stmt).scalar_one_or_none()
+        if study_data_id is None:
+            raise StudyNotFoundError(study_id)
         return DatabaseStudyDao(
-            study_id, self.session, self._matrix_service, self._blob_service, self._generator_matrix_constants
+            study_id,
+            study_data_id,
+            self.session,
+            self._matrix_service,
+            self._blob_service,
+            self._generator_matrix_constants,
         )

--- a/antarest/study/dao/database/database_study_factory_dao.py
+++ b/antarest/study/dao/database/database_study_factory_dao.py
@@ -118,13 +118,18 @@ class DatabaseStudyDaoFactory(StudyFactoryDao):
             return db.session
         return self._session
 
-    def _initialize_study_data_table(self, study_id: str) -> None:
+    def _initialize_study_data_table(self, study_id: str) -> int:
         """
         Initialize the study data table as every DB DAO table is linked to it via foreign keys.
+
+        Returns:
+            The generated `study_data_id`, the key all study data tables are keyed by.
         """
         session = self.session
-        session.execute(STUDY_DATA_TABLE.insert().values({"study_id": study_id}))
+        stmt = STUDY_DATA_TABLE.insert().values({"study_id": study_id}).returning(STUDY_DATA_TABLE.c.study_data_id)
+        study_data_id: int = session.execute(stmt).scalar_one()
         session.commit()
+        return study_data_id
 
     @override
     def create_study_dao(self, metadata: StudyMetadataCreation) -> DatabaseStudyDao:
@@ -134,7 +139,7 @@ class DatabaseStudyDaoFactory(StudyFactoryDao):
                 f"{version} is not a supported version, supported versions are: {STUDY_REFERENCE_TEMPLATES}"
             )
         dao = self.get_study_dao(metadata.id, metadata.managed)
-        self._initialize_study_data_table(dao.get_study_id())
+        dao.set_study_data_id(self._initialize_study_data_table(dao.get_study_id()))
         dao.save_layer(Layer(id=DEFAULT_LAYER_ID, name=DEFAULT_LAYER_NAME))
         dao.save_district(
             District(

--- a/antarest/study/dao/database/database_study_settings_dao.py
+++ b/antarest/study/dao/database/database_study_settings_dao.py
@@ -206,7 +206,7 @@ class DatabaseStudySettingsDao(
             logger.warning(
                 "Dropping playlist entries for years outside [1, %d] on study %s: %s",
                 nb_years,
-                self._study_data_id,
+                self._study_id,
                 sorted(out_of_range),
             )
         years = {y: v for y, v in playlist.years.items() if 1 <= y <= nb_years}

--- a/antarest/study/dao/database/database_study_settings_dao.py
+++ b/antarest/study/dao/database/database_study_settings_dao.py
@@ -70,25 +70,25 @@ class DatabaseStudySettingsDao(
 
     @override
     def save_general_config(self, config: GeneralConfig) -> None:
-        values = dict(study_id=self._study_id, **config.model_dump())
+        values = dict(study_data_id=self._study_data_id, **config.model_dump())
         session = self._db_session
         upsert_one(session, GENERAL_CONFIG_TABLE, values)
         session.commit()
 
     @override
     def get_general_config(self) -> GeneralConfig:
-        study_id = self._study_id
-        stmt = select(GENERAL_CONFIG_TABLE).where(GENERAL_CONFIG_TABLE.c.study_id == study_id)
+        study_data_id = self._study_data_id
+        stmt = select(GENERAL_CONFIG_TABLE).where(GENERAL_CONFIG_TABLE.c.study_data_id == study_data_id)
         row = self._db_session.execute(stmt).fetchone()
         if not row:
-            raise StudyNotFoundError(study_id)
+            raise StudyNotFoundError(self._study_id)
         data = get_row_representation_as_dict(row)
-        del data["study_id"]
+        del data["study_data_id"]
         return GeneralConfig(**data)
 
     @override
     def save_optimization_preferences(self, config: OptimizationPreferences) -> None:
-        values = dict(study_id=self._study_id, **config.model_dump(exclude={"export_mps"}))
+        values = dict(study_data_id=self._study_data_id, **config.model_dump(exclude={"export_mps"}))
         # Handle `export_mps` differently as it can either be a string or a boolean but will be stored as String in DB.
         if isinstance(config.export_mps, bool):
             mps = str(config.export_mps)
@@ -102,14 +102,16 @@ class DatabaseStudySettingsDao(
 
     @override
     def get_optimization_preferences(self) -> OptimizationPreferences:
-        study_id = self._study_id
-        stmt = select(OPTIMIZATION_PREFERENCES_TABLE).where(OPTIMIZATION_PREFERENCES_TABLE.c.study_id == study_id)
+        study_data_id = self._study_data_id
+        stmt = select(OPTIMIZATION_PREFERENCES_TABLE).where(
+            OPTIMIZATION_PREFERENCES_TABLE.c.study_data_id == study_data_id
+        )
         row = self._db_session.execute(stmt).fetchone()
         if not row:
-            raise StudyNotFoundError(study_id)
+            raise StudyNotFoundError(self._study_id)
 
         data = get_row_representation_as_dict(row)
-        del data["study_id"]
+        del data["study_data_id"]
         # Handle `export_mps` differently as it is stored as String in DB, but it can either be a string or a boolean.
         mps: bool | str
         if row.export_mps.lower() == "true":
@@ -124,72 +126,76 @@ class DatabaseStudySettingsDao(
 
     @override
     def save_advanced_parameters(self, parameters: AdvancedParameters) -> None:
-        values = dict(study_id=self._study_id, **parameters.model_dump())
+        values = dict(study_data_id=self._study_data_id, **parameters.model_dump())
         session = self._db_session
         upsert_one(session, ADVANCED_PARAMETERS_TABLE, values)
         session.commit()
 
     @override
     def get_advanced_parameters(self) -> AdvancedParameters:
-        study_id = self._study_id
-        stmt = select(ADVANCED_PARAMETERS_TABLE).where(ADVANCED_PARAMETERS_TABLE.c.study_id == study_id)
+        study_data_id = self._study_data_id
+        stmt = select(ADVANCED_PARAMETERS_TABLE).where(ADVANCED_PARAMETERS_TABLE.c.study_data_id == study_data_id)
         row = self._db_session.execute(stmt).fetchone()
         if not row:
-            raise StudyNotFoundError(study_id)
+            raise StudyNotFoundError(self._study_id)
 
         data = get_row_representation_as_dict(row)
-        del data["study_id"]
+        del data["study_data_id"]
         return AdvancedParameters(**data)
 
     @override
     def get_compatibility_parameters(self) -> CompatibilityParameters:
-        study_id = self._study_id
-        stmt = select(COMPATIBILITY_PARAMETERS_TABLE).where(COMPATIBILITY_PARAMETERS_TABLE.c.study_id == study_id)
+        study_data_id = self._study_data_id
+        stmt = select(COMPATIBILITY_PARAMETERS_TABLE).where(
+            COMPATIBILITY_PARAMETERS_TABLE.c.study_data_id == study_data_id
+        )
         row = self._db_session.execute(stmt).fetchone()
         if not row:
-            raise StudyNotFoundError(study_id)
+            raise StudyNotFoundError(self._study_id)
         return CompatibilityParameters(hydro_pmax=row.hydro_pmax)
 
     @override
     def save_compatibility_parameters(self, parameters: CompatibilityParameters) -> None:
-        values = dict(study_id=self._study_id, hydro_pmax=parameters.hydro_pmax)
+        values = dict(study_data_id=self._study_data_id, hydro_pmax=parameters.hydro_pmax)
         session = self._db_session
         upsert_one(session, COMPATIBILITY_PARAMETERS_TABLE, values)
         session.commit()
 
     @override
     def save_adequacy_patch_parameters(self, parameters: AdequacyPatchParameters) -> None:
-        values = dict(study_id=self._study_id, **parameters.model_dump())
+        values = dict(study_data_id=self._study_data_id, **parameters.model_dump())
         session = self._db_session
         upsert_one(session, ADEQUACY_PATCH_PARAMETERS_TABLE, values)
         session.commit()
 
     @override
     def get_adequacy_patch_parameters(self) -> AdequacyPatchParameters:
-        study_id = self._study_id
-        stmt = select(ADEQUACY_PATCH_PARAMETERS_TABLE).where(ADEQUACY_PATCH_PARAMETERS_TABLE.c.study_id == study_id)
+        study_data_id = self._study_data_id
+        stmt = select(ADEQUACY_PATCH_PARAMETERS_TABLE).where(
+            ADEQUACY_PATCH_PARAMETERS_TABLE.c.study_data_id == study_data_id
+        )
         row = self._db_session.execute(stmt).fetchone()
         if not row:
-            raise StudyNotFoundError(study_id)
+            raise StudyNotFoundError(self._study_id)
 
         data = get_row_representation_as_dict(row)
-        del data["study_id"]
+        del data["study_data_id"]
         return AdequacyPatchParameters(**data)
 
     @override
     def save_timeseries_config(self, config: TimeSeriesConfiguration) -> None:
-        values = dict(study_id=self._study_id, thermal_number=config.thermal.number)
+        values = dict(study_data_id=self._study_data_id, thermal_number=config.thermal.number)
         session = self._db_session
         upsert_one(session, TIMESERIES_CONFIG_TABLE, values)
         session.commit()
 
     @override
     def get_timeseries_config(self) -> TimeSeriesConfiguration:
-        study_id = self._study_id
-        stmt = select(TIMESERIES_CONFIG_TABLE).where(TIMESERIES_CONFIG_TABLE.c.study_id == study_id)
+        study_data_id = self._study_data_id
+        stmt = select(TIMESERIES_CONFIG_TABLE).where(TIMESERIES_CONFIG_TABLE.c.study_data_id == study_data_id)
         row = self._db_session.execute(stmt).fetchone()
         if not row:
-            raise StudyNotFoundError(study_id)
+            raise StudyNotFoundError(self._study_id)
         return TimeSeriesConfiguration(thermal=TimeSeriesType(number=row.thermal_number))
 
     @override
@@ -200,22 +206,22 @@ class DatabaseStudySettingsDao(
             logger.warning(
                 "Dropping playlist entries for years outside [1, %d] on study %s: %s",
                 nb_years,
-                self._study_id,
+                self._study_data_id,
                 sorted(out_of_range),
             )
         years = {y: v for y, v in playlist.years.items() if 1 <= y <= nb_years}
-        values = dict(study_id=self._study_id, years=to_json_string(years))
+        values = dict(study_data_id=self._study_data_id, years=to_json_string(years))
         session = self._db_session
         upsert_one(session, PLAYLIST_TABLE, values)
         session.commit()
 
     @override
     def get_playlist_config(self) -> Playlist:
-        study_id = self._study_id
-        stmt = select(PLAYLIST_TABLE).where(PLAYLIST_TABLE.c.study_id == study_id)
+        study_data_id = self._study_data_id
+        stmt = select(PLAYLIST_TABLE).where(PLAYLIST_TABLE.c.study_data_id == study_data_id)
         row = self._db_session.execute(stmt).fetchone()
         if not row:
-            raise StudyNotFoundError(study_id)
+            raise StudyNotFoundError(self._study_id)
         sparse = Playlist(years=from_json(row.years))
         nb_years = self.get_general_config().nb_years
         return _expand_playlist(sparse, nb_years)

--- a/antarest/study/dao/database/database_thematic_trimming_dao.py
+++ b/antarest/study/dao/database/database_thematic_trimming_dao.py
@@ -31,26 +31,26 @@ class DatabaseThematicTrimmingDao(ThematicTrimmingDao, DatabaseDaoBase):
 
     @override
     def get_thematic_trimming(self) -> ThematicTrimming:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
 
-        stmt = select(THEMATIC_TRIMMING_TABLE).where(THEMATIC_TRIMMING_TABLE.c.study_id == study_id)
+        stmt = select(THEMATIC_TRIMMING_TABLE).where(THEMATIC_TRIMMING_TABLE.c.study_data_id == study_data_id)
 
         row = self._db_session.execute(stmt).fetchone()
         if not row:
-            raise StudyNotFoundError(study_id)
+            raise StudyNotFoundError(self._study_id)
         return ThematicTrimming.model_validate(row.thematic_trimming)
 
     @override
     def save_thematic_trimming(self, trimming: ThematicTrimming) -> None:
         check_thematic_trimming_complete(trimming, self.get_impl().get_version())
         session = self._db_session
-        study_id = self._study_id
-        values = {"study_id": study_id, "thematic_trimming": trimming.model_dump(exclude_none=True)}
+        study_data_id = self._study_data_id
+        values = {"study_data_id": study_data_id, "thematic_trimming": trimming.model_dump(exclude_none=True)}
 
         try:
             upsert_one(session, THEMATIC_TRIMMING_TABLE, values)
         except IntegrityError as e:
             # Happens if the study does not exist -> ForeignKey constraint fails
-            raise StudyNotFoundError(study_id) from e
+            raise StudyNotFoundError(self._study_id) from e
 
         session.commit()

--- a/antarest/study/dao/database/database_thermal_dao.py
+++ b/antarest/study/dao/database/database_thermal_dao.py
@@ -59,7 +59,7 @@ class DatabaseThermalDao(ThermalDao, DatabaseDaoBase):
 
     def _convert_db_row_to_thermal(self, row: Any) -> ThermalCluster:
         data = get_row_representation_as_dict(row)
-        del data["study_id"]
+        del data["study_data_id"]
         del data["area_id"]
         data["id"] = data.pop("thermal_id")
         cluster = ThermalCluster(**data)
@@ -68,15 +68,15 @@ class DatabaseThermalDao(ThermalDao, DatabaseDaoBase):
         return cluster
 
     def _convert_thermal_cluster_to_row(self, area_id: str, cluster: ThermalCluster) -> dict[str, Any]:
-        values = dict(study_id=self._study_id, area_id=area_id, **cluster.model_dump())
+        values = dict(study_data_id=self._study_data_id, area_id=area_id, **cluster.model_dump())
         values["thermal_id"] = values.pop("id").lower()
         return values
 
     def _get_thermal_matrix_row(self, area_id: str, thermal_id: str, table: Table) -> Row[Any] | None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
         stmt = select(table).where(
-            (table.c.study_id == study_id) & (table.c.area_id == area_id) & (table.c.thermal_id == thermal_id)
+            (table.c.study_data_id == study_data_id) & (table.c.area_id == area_id) & (table.c.thermal_id == thermal_id)
         )
         return session.execute(stmt).fetchone()
 
@@ -87,14 +87,19 @@ class DatabaseThermalDao(ThermalDao, DatabaseDaoBase):
         return str(row.matrix_id)
 
     def _save_thermal_matrix(self, series: ThermalSeriesMapping, table: Table) -> None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         try:
             values = []
             for area_id, value in series.items():
                 for thermal_id, matrix_id in value.items():
-                    data = {"study_id": study_id, "area_id": area_id, "thermal_id": thermal_id, "matrix_id": matrix_id}
+                    data = {
+                        "study_data_id": study_data_id,
+                        "area_id": area_id,
+                        "thermal_id": thermal_id,
+                        "matrix_id": matrix_id,
+                    }
                     values.append(data)
             upsert_multiple(session, table, values)
         except IntegrityError as e:
@@ -173,12 +178,12 @@ class DatabaseThermalDao(ThermalDao, DatabaseDaoBase):
 
     @override
     def delete_thermal(self, area_id: str, thermal_id: str) -> None:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         result = session.execute(
             delete(THERMAL_CLUSTER_TABLE).where(
-                (THERMAL_CLUSTER_TABLE.c.study_id == study_id)
+                (THERMAL_CLUSTER_TABLE.c.study_data_id == study_data_id)
                 & (THERMAL_CLUSTER_TABLE.c.area_id == area_id)
                 & (THERMAL_CLUSTER_TABLE.c.thermal_id == thermal_id)
             )
@@ -192,10 +197,10 @@ class DatabaseThermalDao(ThermalDao, DatabaseDaoBase):
 
     @override
     def get_all_thermals(self) -> dict[str, dict[str, ThermalCluster]]:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
-        stmt = select(THERMAL_CLUSTER_TABLE).where(THERMAL_CLUSTER_TABLE.c.study_id == study_id)
+        stmt = select(THERMAL_CLUSTER_TABLE).where(THERMAL_CLUSTER_TABLE.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
 
         thermals_by_areas: dict[str, dict[str, ThermalCluster]] = {}
@@ -206,24 +211,24 @@ class DatabaseThermalDao(ThermalDao, DatabaseDaoBase):
 
     @override
     def get_all_thermals_for_area(self, area_id: str) -> Sequence[ThermalCluster]:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
 
         stmt = select(THERMAL_CLUSTER_TABLE).where(
-            (THERMAL_CLUSTER_TABLE.c.study_id == study_id) & (THERMAL_CLUSTER_TABLE.c.area_id == area_id)
+            (THERMAL_CLUSTER_TABLE.c.study_data_id == study_data_id) & (THERMAL_CLUSTER_TABLE.c.area_id == area_id)
         )
         rows = session.execute(stmt).fetchall()
 
         if not rows:
             # Ensures the area exists
-            validate_area_exists(session, study_id, area_id)
+            validate_area_exists(session, study_data_id, area_id)
 
         return [self._convert_db_row_to_thermal(row) for row in rows]
 
     def _select_thermal_cluster(self, area_id: str, thermal_id: str) -> Select[Any]:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         return select(THERMAL_CLUSTER_TABLE).where(
-            (THERMAL_CLUSTER_TABLE.c.study_id == study_id)
+            (THERMAL_CLUSTER_TABLE.c.study_data_id == study_data_id)
             & (THERMAL_CLUSTER_TABLE.c.area_id == area_id)
             & (THERMAL_CLUSTER_TABLE.c.thermal_id == thermal_id)
         )
@@ -270,9 +275,9 @@ class DatabaseThermalDao(ThermalDao, DatabaseDaoBase):
         return self.get_impl().get_matrix(matrix_id, default_empty_supplier=default_scenario_hourly)
 
     def _get_all_thermal_matrix(self, table: Table) -> ThermalSeriesMapping:
-        study_id = self._study_id
+        study_data_id = self._study_data_id
         session = self._db_session
-        stmt = select(table).where(table.c.study_id == study_id)
+        stmt = select(table).where(table.c.study_data_id == study_data_id)
         rows = session.execute(stmt).fetchall()
         result: ThermalSeriesMapping = {}
         for row in rows:

--- a/antarest/study/dao/database/database_user_resources.py
+++ b/antarest/study/dao/database/database_user_resources.py
@@ -101,7 +101,7 @@ class DatabaseUserResourcesDao(UserResourcesDao, DatabaseDaoBase):
                 is_last_part = k == len(parts) - 1
 
                 value = {
-                    "study_id": self._study_id,
+                    "study_data_id": self._study_data_id,
                     "id": resource_id,
                     "name": part,
                     "parent_id": parent_id,
@@ -141,7 +141,9 @@ class DatabaseUserResourcesDao(UserResourcesDao, DatabaseDaoBase):
                 relative_path_parts_length = len(resource.relative_to(resource_path).parts)
                 id_to_remove = data.ids[-1 - relative_path_parts_length]
 
-                stmt = delete(_TABLE).where((_TABLE.c.study_id == self._study_id) & (_TABLE.c.id == id_to_remove))
+                stmt = delete(_TABLE).where(
+                    (_TABLE.c.study_data_id == self._study_data_id) & (_TABLE.c.id == id_to_remove)
+                )
                 self._db_session.execute(stmt)
                 self._db_session.commit()
                 return
@@ -171,7 +173,7 @@ class DatabaseUserResourcesDao(UserResourcesDao, DatabaseDaoBase):
         return self.blob_service.get(data.blob_id)
 
     def _build_resources_tree(self) -> dict[PurePosixPath, UserResourcesDatabaseData]:
-        stmt = select(_TABLE).where(_TABLE.c.study_id == self._study_id)
+        stmt = select(_TABLE).where(_TABLE.c.study_data_id == self._study_data_id)
 
         rows = self._db_session.execute(stmt).fetchall()
 

--- a/antarest/study/dao/database/database_xpansion_dao.py
+++ b/antarest/study/dao/database/database_xpansion_dao.py
@@ -63,14 +63,16 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     """Database implementation of XpansionDao."""
 
     def _settings_row_exists(self) -> bool:
-        stmt = select(XPANSION_SETTINGS_TABLE.c.study_id).where(XPANSION_SETTINGS_TABLE.c.study_id == self._study_id)
+        stmt = select(XPANSION_SETTINGS_TABLE.c.study_data_id).where(
+            XPANSION_SETTINGS_TABLE.c.study_data_id == self._study_data_id
+        )
         return self._db_session.execute(stmt).fetchone() is not None
 
     def _candidate_to_row(self, candidate: XpansionCandidate) -> dict[str, Any]:
         data = candidate.model_dump()
         data.pop("link")
         return {
-            "study_id": self._study_id,
+            "study_data_id": self._study_data_id,
             "link_area_from": candidate.link.area_from,
             "link_area_to": candidate.link.area_to,
             **data,
@@ -80,7 +82,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
         data = get_row_representation_as_dict(row)
         area_from = data.pop("link_area_from")
         area_to = data.pop("link_area_to")
-        del data["study_id"]
+        del data["study_data_id"]
         data["link"] = XpansionLink(area_from=area_from, area_to=area_to).serialize()
         return XpansionCandidate.model_validate(data)
 
@@ -99,7 +101,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     @override
     def delete_xpansion_configuration(self) -> None:
         result = self._db_session.execute(
-            delete(XPANSION_SETTINGS_TABLE).where(XPANSION_SETTINGS_TABLE.c.study_id == self._study_id)
+            delete(XPANSION_SETTINGS_TABLE).where(XPANSION_SETTINGS_TABLE.c.study_data_id == self._study_data_id)
         )
         assert isinstance(result, CursorResult)
         if result.rowcount == 0:
@@ -117,16 +119,16 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
             select(XPANSION_SETTINGS_TABLE, XPANSION_SENSITIVITY_PROJECTION_TABLE.c.candidate_name)
             .outerjoin(
                 XPANSION_SENSITIVITY_PROJECTION_TABLE,
-                XPANSION_SETTINGS_TABLE.c.study_id == XPANSION_SENSITIVITY_PROJECTION_TABLE.c.study_id,
+                XPANSION_SETTINGS_TABLE.c.study_data_id == XPANSION_SENSITIVITY_PROJECTION_TABLE.c.study_data_id,
             )
-            .where(XPANSION_SETTINGS_TABLE.c.study_id == self._study_id)
+            .where(XPANSION_SETTINGS_TABLE.c.study_data_id == self._study_data_id)
         )
         rows = self._db_session.execute(stmt).fetchall()
         if not rows:
             raise XpansionConfigurationDoesNotExist(self._study_id)
 
         data = get_row_representation_as_dict(rows[0])
-        del data["study_id"]
+        del data["study_data_id"]
         del data["candidate_name"]
         sensitivity_config = XpansionSensitivitySettings(
             epsilon=data.pop("sensitivity_epsilon"),
@@ -140,7 +142,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
         data = settings.model_dump()
         sensitivity = data.pop("sensitivity_config")
         values: dict[str, Any] = {
-            "study_id": self._study_id,
+            "study_data_id": self._study_data_id,
             **data,
             "sensitivity_epsilon": sensitivity["epsilon"],
             "sensitivity_capex": sensitivity["capex"],
@@ -149,14 +151,17 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
         # Replace projection rows: delete existing, then insert the new list.
         self._db_session.execute(
             delete(XPANSION_SENSITIVITY_PROJECTION_TABLE).where(
-                XPANSION_SENSITIVITY_PROJECTION_TABLE.c.study_id == self._study_id
+                XPANSION_SENSITIVITY_PROJECTION_TABLE.c.study_data_id == self._study_data_id
             )
         )
         if sensitivity["projection"]:
             try:
                 self._db_session.execute(
                     insert(XPANSION_SENSITIVITY_PROJECTION_TABLE),
-                    [{"study_id": self._study_id, "candidate_name": name} for name in sensitivity["projection"]],
+                    [
+                        {"study_data_id": self._study_data_id, "candidate_name": name}
+                        for name in sensitivity["projection"]
+                    ],
                 )
             except IntegrityError:
                 self._db_session.rollback()
@@ -172,7 +177,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
             if filename:
                 row = self._db_session.execute(
                     select(table.c.filename).where(
-                        (table.c.study_id == self._study_id) & (table.c.filename == filename)
+                        (table.c.study_data_id == self._study_data_id) & (table.c.filename == filename)
                     )
                 ).fetchone()
                 if row is None:
@@ -184,14 +189,15 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
 
     @override
     def get_all_xpansion_candidates(self) -> list[XpansionCandidate]:
-        stmt = select(XPANSION_CANDIDATE_TABLE).where(XPANSION_CANDIDATE_TABLE.c.study_id == self._study_id)
+        stmt = select(XPANSION_CANDIDATE_TABLE).where(XPANSION_CANDIDATE_TABLE.c.study_data_id == self._study_data_id)
         rows = self._db_session.execute(stmt).fetchall()
         return [self._row_to_candidate(row) for row in rows]
 
     @override
     def get_xpansion_candidate(self, candidate_id: str) -> XpansionCandidate:
         stmt = select(XPANSION_CANDIDATE_TABLE).where(
-            (XPANSION_CANDIDATE_TABLE.c.study_id == self._study_id) & (XPANSION_CANDIDATE_TABLE.c.name == candidate_id)
+            (XPANSION_CANDIDATE_TABLE.c.study_data_id == self._study_data_id)
+            & (XPANSION_CANDIDATE_TABLE.c.name == candidate_id)
         )
         row = self._db_session.execute(stmt).fetchone()
         if not row:
@@ -216,14 +222,14 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
         if old_id and old_id != candidate.name:
             self._db_session.execute(
                 delete(XPANSION_CANDIDATE_TABLE).where(
-                    (XPANSION_CANDIDATE_TABLE.c.study_id == self._study_id)
+                    (XPANSION_CANDIDATE_TABLE.c.study_data_id == self._study_data_id)
                     & (XPANSION_CANDIDATE_TABLE.c.name == candidate.name)
                 )
             )
             result = self._db_session.execute(
                 update(XPANSION_CANDIDATE_TABLE)
                 .where(
-                    (XPANSION_CANDIDATE_TABLE.c.study_id == self._study_id)
+                    (XPANSION_CANDIDATE_TABLE.c.study_data_id == self._study_data_id)
                     & (XPANSION_CANDIDATE_TABLE.c.name == old_id)
                 )
                 .values(self._candidate_to_row(candidate))
@@ -245,7 +251,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     def delete_xpansion_candidate(self, candidate_name: str) -> None:
         result = self._db_session.execute(
             delete(XPANSION_CANDIDATE_TABLE).where(
-                (XPANSION_CANDIDATE_TABLE.c.study_id == self._study_id)
+                (XPANSION_CANDIDATE_TABLE.c.study_data_id == self._study_data_id)
                 & (XPANSION_CANDIDATE_TABLE.c.name == candidate_name)
             )
         )
@@ -274,7 +280,9 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
         existing = {
             row.filename
             for row in self._db_session.execute(
-                select(XPANSION_CAPACITY_TABLE.c.filename).where(XPANSION_CAPACITY_TABLE.c.study_id == self._study_id)
+                select(XPANSION_CAPACITY_TABLE.c.filename).where(
+                    XPANSION_CAPACITY_TABLE.c.study_data_id == self._study_data_id
+                )
             ).fetchall()
         }
         for attr in [
@@ -292,7 +300,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     @override
     def checks_xpansion_candidate_can_be_deleted(self, candidate_name: str) -> None:
         stmt = select(XPANSION_SENSITIVITY_PROJECTION_TABLE.c.candidate_name).where(
-            (XPANSION_SENSITIVITY_PROJECTION_TABLE.c.study_id == self._study_id)
+            (XPANSION_SENSITIVITY_PROJECTION_TABLE.c.study_data_id == self._study_data_id)
             & (XPANSION_SENSITIVITY_PROJECTION_TABLE.c.candidate_name == candidate_name)
         )
         if self._db_session.execute(stmt).fetchone() is not None:
@@ -312,9 +320,9 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
             )
             .outerjoin(
                 XPANSION_ADEQUACY_PATTERN_TABLE,
-                XPANSION_ADEQUACY_CRITERION_TABLE.c.study_id == XPANSION_ADEQUACY_PATTERN_TABLE.c.study_id,
+                XPANSION_ADEQUACY_CRITERION_TABLE.c.study_data_id == XPANSION_ADEQUACY_PATTERN_TABLE.c.study_data_id,
             )
-            .where(XPANSION_ADEQUACY_CRITERION_TABLE.c.study_id == self._study_id)
+            .where(XPANSION_ADEQUACY_CRITERION_TABLE.c.study_data_id == self._study_data_id)
         )
         rows = self._db_session.execute(stmt).fetchall()
         if not rows:
@@ -338,19 +346,24 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
             self._db_session,
             XPANSION_ADEQUACY_CRITERION_TABLE,
             {
-                "study_id": self._study_id,
+                "study_data_id": self._study_data_id,
                 "stopping_threshold": criterion.stopping_threshold,
                 "criterion_count_threshold": criterion.criterion_count_threshold,
             },
         )
         # Replace all patterns: delete existing rows then insert the new ones.
         self._db_session.execute(
-            delete(XPANSION_ADEQUACY_PATTERN_TABLE).where(XPANSION_ADEQUACY_PATTERN_TABLE.c.study_id == self._study_id)
+            delete(XPANSION_ADEQUACY_PATTERN_TABLE).where(
+                XPANSION_ADEQUACY_PATTERN_TABLE.c.study_data_id == self._study_data_id
+            )
         )
         if criterion.patterns:
             self._db_session.execute(
                 insert(XPANSION_ADEQUACY_PATTERN_TABLE),
-                [{"study_id": self._study_id, "area": p.area, "criterion": p.criterion} for p in criterion.patterns],
+                [
+                    {"study_data_id": self._study_data_id, "area": p.area, "criterion": p.criterion}
+                    for p in criterion.patterns
+                ],
             )
         self._db_session.commit()
 
@@ -369,7 +382,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     def get_all_xpansion_weights(self) -> XpansionWeightsMapping:
         rows = self._db_session.execute(
             select(XPANSION_WEIGHT_TABLE.c.matrix_id, XPANSION_WEIGHT_TABLE.c.filename).where(
-                XPANSION_WEIGHT_TABLE.c.study_id == self._study_id
+                XPANSION_WEIGHT_TABLE.c.study_data_id == self._study_data_id
             )
         ).fetchall()
         return {row.filename: row.matrix_id for row in rows}
@@ -378,7 +391,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     def get_all_xpansion_capacities(self) -> XpansionCapacitiesMapping:
         rows = self._db_session.execute(
             select(XPANSION_CAPACITY_TABLE.c.matrix_id, XPANSION_CAPACITY_TABLE.c.filename).where(
-                XPANSION_CAPACITY_TABLE.c.study_id == self._study_id
+                XPANSION_CAPACITY_TABLE.c.study_data_id == self._study_data_id
             )
         ).fetchall()
         return {row.filename: row.matrix_id for row in rows}
@@ -387,7 +400,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     def get_all_xpansion_constraints(self) -> XpansionConstraintsMapping:
         rows = self._db_session.execute(
             select(XPANSION_CONSTRAINT_TABLE.c.content, XPANSION_CONSTRAINT_TABLE.c.filename).where(
-                XPANSION_CONSTRAINT_TABLE.c.study_id == self._study_id
+                XPANSION_CONSTRAINT_TABLE.c.study_data_id == self._study_data_id
             )
         ).fetchall()
         return {row.filename: row.content for row in rows}
@@ -397,7 +410,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
         if resource_type == XpansionResourceFileType.CONSTRAINTS:
             row = self._db_session.execute(
                 select(XPANSION_CONSTRAINT_TABLE.c.content).where(
-                    (XPANSION_CONSTRAINT_TABLE.c.study_id == self._study_id)
+                    (XPANSION_CONSTRAINT_TABLE.c.study_data_id == self._study_data_id)
                     & (XPANSION_CONSTRAINT_TABLE.c.filename == filename)
                 )
             ).fetchone()
@@ -406,7 +419,9 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
             return bytes(row.content)
         table = self._get_resource_table(resource_type)
         row = self._db_session.execute(
-            select(table.c.matrix_id).where((table.c.study_id == self._study_id) & (table.c.filename == filename))
+            select(table.c.matrix_id).where(
+                (table.c.study_data_id == self._study_data_id) & (table.c.filename == filename)
+            )
         ).fetchone()
         if row is None:
             raise XpansionFileNotFoundError(f"Resource '{filename}' not found")
@@ -416,7 +431,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     def get_xpansion_resources(self, resource_type: XpansionResourceFileType) -> list[str]:
         table = self._get_resource_table(resource_type)
         rows = self._db_session.execute(
-            select(table.c.filename).where(table.c.study_id == self._study_id).order_by(asc(table.c.filename))
+            select(table.c.filename).where(table.c.study_data_id == self._study_data_id).order_by(asc(table.c.filename))
         ).fetchall()
         return [row.filename for row in rows]
 
@@ -441,7 +456,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
             ]
             row = self._db_session.execute(
                 select(XPANSION_CANDIDATE_TABLE.c.name).where(
-                    (XPANSION_CANDIDATE_TABLE.c.study_id == self._study_id)
+                    (XPANSION_CANDIDATE_TABLE.c.study_data_id == self._study_data_id)
                     & or_(*[col == filename for col in profile_cols])
                 )
             ).fetchone()
@@ -452,8 +467,8 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
         self, col: ColumnElement[str], resource_type: XpansionResourceFileType, filename: str
     ) -> None:
         row = self._db_session.execute(
-            select(XPANSION_SETTINGS_TABLE.c.study_id).where(
-                (XPANSION_SETTINGS_TABLE.c.study_id == self._study_id) & (col == filename)
+            select(XPANSION_SETTINGS_TABLE.c.study_data_id).where(
+                (XPANSION_SETTINGS_TABLE.c.study_data_id == self._study_data_id) & (col == filename)
             )
         ).fetchone()
         if row:
@@ -463,7 +478,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     def delete_xpansion_resource(self, resource_type: XpansionResourceFileType, filename: str) -> None:
         table = self._get_resource_table(resource_type)
         result = self._db_session.execute(
-            delete(table).where((table.c.study_id == self._study_id) & (table.c.filename == filename))
+            delete(table).where((table.c.study_data_id == self._study_data_id) & (table.c.filename == filename))
         )
         assert isinstance(result, CursorResult)
         if result.rowcount == 0:
@@ -474,7 +489,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     def save_xpansion_constraint(self, data: XpansionConstraintsMapping) -> None:
         values = []
         for filename, content in data.items():
-            values.append({"study_id": self._study_id, "filename": filename, "content": content})
+            values.append({"study_data_id": self._study_data_id, "filename": filename, "content": content})
 
         upsert_multiple(self._db_session, XPANSION_CONSTRAINT_TABLE, values)
         self._db_session.commit()
@@ -483,7 +498,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     def save_xpansion_capacity(self, data: XpansionCapacitiesMapping) -> None:
         values = []
         for filename, series_id in data.items():
-            values.append({"study_id": self._study_id, "filename": filename, "matrix_id": series_id})
+            values.append({"study_data_id": self._study_data_id, "filename": filename, "matrix_id": series_id})
 
         upsert_multiple(self._db_session, XPANSION_CAPACITY_TABLE, values)
         self._db_session.commit()
@@ -492,7 +507,7 @@ class DatabaseXpansionDao(XpansionDao, DatabaseDaoBase):
     def save_xpansion_weight(self, data: XpansionWeightsMapping) -> None:
         values = []
         for filename, series_id in data.items():
-            values.append({"study_id": self._study_id, "filename": filename, "matrix_id": series_id})
+            values.append({"study_data_id": self._study_data_id, "filename": filename, "matrix_id": series_id})
 
         upsert_multiple(self._db_session, XPANSION_WEIGHT_TABLE, values)
         self._db_session.commit()

--- a/antarest/study/dao/database/models/__init__.py
+++ b/antarest/study/dao/database/models/__init__.py
@@ -9,14 +9,30 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # This file is part of the Antares project.
-from sqlalchemy import Column, ForeignKey, String, Table
+from sqlalchemy import BigInteger, Column, ForeignKey, Integer, String, Table
 
 from antarest.dbmodel import Base
 
 metadata = Base.metadata
 
+# `BigInteger` alone does not autoincrement on SQLite: only `INTEGER PRIMARY KEY` aliases the
+# rowid. The `Integer` variant makes the column an autoincrementing rowid alias there, while
+# keeping a real 64 bits column on PostgreSQL.
+STUDY_DATA_ID_TYPE = BigInteger().with_variant(Integer, "sqlite")
+
 STUDY_DATA_TABLE = Table(
     "study_data",
     metadata,
-    Column("study_id", String(36), ForeignKey("study.id", ondelete="CASCADE"), nullable=False, primary_key=True),
+    Column("study_data_id", STUDY_DATA_ID_TYPE, primary_key=True, autoincrement=True),
+    Column("study_id", String(36), ForeignKey("study.id", ondelete="CASCADE"), nullable=False, unique=True),
 )
+
+
+def study_data_id_col(*, primary_key: bool = True) -> Column[int]:
+    """
+    The surrogate study key carried by every study data table.
+
+    It replaces the 36 chars `study_id` as the leading column of the composite primary keys,
+    and ultimately references `study_data.study_data_id`.
+    """
+    return Column("study_data_id", STUDY_DATA_ID_TYPE, nullable=False, primary_key=primary_key)

--- a/antarest/study/dao/database/models/area.py
+++ b/antarest/study/dao/database/models/area.py
@@ -17,24 +17,19 @@ This module defines the database tables used when a study has storage_mode=DATAB
 These tables store study data (areas, UI positions, etc.) in the database instead of the filesystem.
 """
 
-from sqlalchemy import Boolean, Column, Float, ForeignKey, ForeignKeyConstraint, Integer, String, Table
+from sqlalchemy import Boolean, Column, Float, ForeignKeyConstraint, Integer, String, Table
 
 from antarest.core.utils.sql_utils import enum_col
 from antarest.dbmodel import Base
 from antarest.study.business.model.area_properties_model import AdequacyPatchMode
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 AREA_TABLE = Table(
     "area",
     metadata,
-    Column(
-        "study_id",
-        String(36),
-        ForeignKey("study_data.study_id", ondelete="CASCADE"),
-        nullable=False,
-        primary_key=True,
-    ),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("area_name", String(255), nullable=False),
     Column("energy_cost_unsupplied", Float, nullable=False),
@@ -47,13 +42,14 @@ AREA_TABLE = Table(
     Column("filter_synthesis", String(), nullable=False),
     Column("filter_by_year", String(), nullable=False),
     Column("adequacy_patch_mode", enum_col(AdequacyPatchMode), nullable=True),  # Since v8.3
+    ForeignKeyConstraint(["study_data_id"], ["study_data.study_data_id"], ondelete="CASCADE"),
 )
 
 # Relation: One area can have multiple UI configurations (one per layer)
 AREA_UI_TABLE = Table(
     "area_ui",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("layer_id", String(10), nullable=False, primary_key=True),
     Column("x", Integer, nullable=False),
@@ -62,13 +58,13 @@ AREA_UI_TABLE = Table(
     Column("color_g", Integer, nullable=False),
     Column("color_b", Integer, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id"],
-        ["area.study_id", "area.area_id"],
+        ["study_data_id", "area_id"],
+        ["area.study_data_id", "area.area_id"],
         ondelete="CASCADE",
     ),
     ForeignKeyConstraint(
-        ["study_id", "layer_id"],
-        ["layer.study_id", "layer.layer_id"],
+        ["study_data_id", "layer_id"],
+        ["layer.study_data_id", "layer.layer_id"],
         ondelete="CASCADE",
     ),
 )
@@ -78,10 +74,10 @@ def _create_matrix_table(name: str) -> Table:
     return Table(
         name,
         metadata,
-        Column("study_id", String(36), nullable=False, primary_key=True),
+        study_data_id_col(),
         Column("area_id", String(255), nullable=False, primary_key=True),
         Column("matrix_id", String(64), nullable=False),
-        ForeignKeyConstraint(["study_id", "area_id"], ["area.study_id", "area.area_id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(["study_data_id", "area_id"], ["area.study_data_id", "area.area_id"], ondelete="CASCADE"),
     )
 
 
@@ -95,11 +91,11 @@ MISC_GEN_TABLE = _create_matrix_table("misc_gen")
 RESERVES_GLOBAL_PARAMETERS_TABLE = Table(
     "reserves_global_parameters",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("reference_activation_duration_up", Integer, nullable=False),
     Column("energy_activation_ratio_up", Float, nullable=False),
     Column("reference_activation_duration_down", Integer, nullable=False),
     Column("energy_activation_ratio_down", Float, nullable=False),
-    ForeignKeyConstraint(["study_id", "area_id"], ["area.study_id", "area.area_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id", "area_id"], ["area.study_data_id", "area.area_id"], ondelete="CASCADE"),
 )

--- a/antarest/study/dao/database/models/binding_constraint.py
+++ b/antarest/study/dao/database/models/binding_constraint.py
@@ -22,13 +22,14 @@ from sqlalchemy import Boolean, Column, Float, ForeignKeyConstraint, Integer, St
 from antarest.core.utils.sql_utils import enum_col
 from antarest.dbmodel import Base
 from antarest.study.business.model.binding_constraint_model import BindingConstraintFrequency, BindingConstraintOperator
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 BINDING_CONSTRAINT_TABLE = Table(
     "binding_constraint",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("constraint_id", String(255), nullable=False, primary_key=True),
     Column("name", String(255), nullable=False),
     Column("enabled", Boolean, nullable=False),
@@ -41,9 +42,9 @@ BINDING_CONSTRAINT_TABLE = Table(
     # Nullable: only present for study versions >= 8.7
     Column("group", String(255), nullable=True),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["study_data.study_id"],
-        name="fk_binding_constraint_study_id",
+        ["study_data_id"],
+        ["study_data.study_data_id"],
+        name="fk_binding_constraint_study_data_id",
         ondelete="CASCADE",
     ),
 )
@@ -51,15 +52,15 @@ BINDING_CONSTRAINT_TABLE = Table(
 BINDING_CONSTRAINT_LINK_TERM_TABLE = Table(
     "binding_constraint_link_term",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("constraint_id", String(255), nullable=False, primary_key=True),
     Column("area1", String(255), nullable=False, primary_key=True),
     Column("area2", String(255), nullable=False, primary_key=True),
     Column("weight", Float, nullable=False),
     Column("offset", Integer, nullable=True),
     ForeignKeyConstraint(
-        ["study_id", "constraint_id"],
-        ["binding_constraint.study_id", "binding_constraint.constraint_id"],
+        ["study_data_id", "constraint_id"],
+        ["binding_constraint.study_data_id", "binding_constraint.constraint_id"],
         name="fk_bc_link_term_constraint",
         ondelete="CASCADE",
     ),
@@ -68,15 +69,15 @@ BINDING_CONSTRAINT_LINK_TERM_TABLE = Table(
 BINDING_CONSTRAINT_CLUSTER_TERM_TABLE = Table(
     "binding_constraint_cluster_term",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("constraint_id", String(255), nullable=False, primary_key=True),
     Column("area", String(255), nullable=False, primary_key=True),
     Column("cluster", String(255), nullable=False, primary_key=True),
     Column("weight", Float, nullable=False),
     Column("offset", Integer, nullable=True),
     ForeignKeyConstraint(
-        ["study_id", "constraint_id"],
-        ["binding_constraint.study_id", "binding_constraint.constraint_id"],
+        ["study_data_id", "constraint_id"],
+        ["binding_constraint.study_data_id", "binding_constraint.constraint_id"],
         name="fk_bc_cluster_term_constraint",
         ondelete="CASCADE",
     ),
@@ -87,12 +88,12 @@ def _create_bc_matrix_table(name: str) -> Table:
     return Table(
         name,
         metadata,
-        Column("study_id", String(36), nullable=False, primary_key=True),
+        study_data_id_col(),
         Column("constraint_id", String(255), nullable=False, primary_key=True),
         Column("matrix_id", String(64), nullable=False),
         ForeignKeyConstraint(
-            ["study_id", "constraint_id"],
-            ["binding_constraint.study_id", "binding_constraint.constraint_id"],
+            ["study_data_id", "constraint_id"],
+            ["binding_constraint.study_data_id", "binding_constraint.constraint_id"],
             name=f"fk_{name}_constraint",
             ondelete="CASCADE",
         ),

--- a/antarest/study/dao/database/models/comments.py
+++ b/antarest/study/dao/database/models/comments.py
@@ -14,16 +14,17 @@
 SQLAlchemy Core table definitions for study comments storage.
 """
 
-from sqlalchemy import Column, ForeignKeyConstraint, String, Table, Text
+from sqlalchemy import Column, ForeignKeyConstraint, Table, Text
 
 from antarest.dbmodel import Base
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 COMMENTS_TABLE = Table(
     "comments",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("comments", Text(), nullable=False, server_default=""),
-    ForeignKeyConstraint(["study_id"], ["study_data.study_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id"], ["study_data.study_data_id"], ondelete="CASCADE"),
 )

--- a/antarest/study/dao/database/models/district.py
+++ b/antarest/study/dao/database/models/district.py
@@ -19,13 +19,14 @@ from sqlalchemy import Boolean, Column, ForeignKeyConstraint, String, Table
 from antarest.core.utils.sql_utils import enum_col
 from antarest.dbmodel import Base
 from antarest.study.business.model.district_model import DistrictApplyFilter
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 DISTRICT_TABLE = Table(
     "district",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("district_id", String(255), nullable=False, primary_key=True),
     Column("name", String(255), nullable=False),
     Column("output", Boolean, nullable=False),
@@ -33,5 +34,5 @@ DISTRICT_TABLE = Table(
     Column("apply_filter", enum_col(DistrictApplyFilter), nullable=False),
     Column("add_areas", String, nullable=False),
     Column("subtract_areas", String, nullable=False),
-    ForeignKeyConstraint(["study_id"], ["study_data.study_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id"], ["study_data.study_data_id"], ondelete="CASCADE"),
 )

--- a/antarest/study/dao/database/models/hydro.py
+++ b/antarest/study/dao/database/models/hydro.py
@@ -20,13 +20,14 @@ when a study has storage_mode=DATABASE.
 from sqlalchemy import Boolean, Column, Float, ForeignKeyConstraint, Integer, String, Table
 
 from antarest.dbmodel import Base
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 HYDRO_MANAGEMENT_TABLE = Table(
     "hydro_management",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     # Hydro management configuration fields
     Column("inter_daily_breakdown", Float, nullable=False),
@@ -47,9 +48,9 @@ HYDRO_MANAGEMENT_TABLE = Table(
     # v9.2+ field - nullable for older study versions
     Column("overflow_spilled_cost_difference", Float, nullable=True),
     ForeignKeyConstraint(
-        ["study_id", "area_id"],
-        ["area.study_id", "area.area_id"],
-        name="fk_hydro_management_study_id_area_id_area",
+        ["study_data_id", "area_id"],
+        ["area.study_data_id", "area.area_id"],
+        name="fk_hydro_management_study_data_id_area_id_area",
         ondelete="CASCADE",
     ),
 )
@@ -57,13 +58,13 @@ HYDRO_MANAGEMENT_TABLE = Table(
 HYDRO_INFLOW_STRUCTURE_TABLE = Table(
     "hydro_inflow_structure",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("inter_monthly_correlation", Float, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id"],
-        ["area.study_id", "area.area_id"],
-        name="fk_hydro_inflow_structure_study_id_area_id_area",
+        ["study_data_id", "area_id"],
+        ["area.study_data_id", "area.area_id"],
+        name="fk_hydro_inflow_structure_study_data_id_area_id_area",
         ondelete="CASCADE",
     ),
 )
@@ -71,20 +72,20 @@ HYDRO_INFLOW_STRUCTURE_TABLE = Table(
 HYDRO_ALLOCATION_TABLE = Table(
     "hydro_allocation",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("source_area_id", String(255), nullable=False, primary_key=True),
     Column("target_area_id", String(255), nullable=False, primary_key=True),
     Column("coefficient", Float, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "source_area_id"],
-        ["area.study_id", "area.area_id"],
-        name="fk_hydro_allocation_study_id_source_area_id_area",
+        ["study_data_id", "source_area_id"],
+        ["area.study_data_id", "area.area_id"],
+        name="fk_hydro_allocation_study_data_id_source_area_id_area",
         ondelete="CASCADE",
     ),
     ForeignKeyConstraint(
-        ["study_id", "target_area_id"],
-        ["area.study_id", "area.area_id"],
-        name="fk_hydro_allocation_study_id_target_area_id_area",
+        ["study_data_id", "target_area_id"],
+        ["area.study_data_id", "area.area_id"],
+        name="fk_hydro_allocation_study_data_id_target_area_id_area",
         ondelete="CASCADE",
     ),
 )
@@ -92,21 +93,21 @@ HYDRO_ALLOCATION_TABLE = Table(
 HYDRO_CORRELATION_TABLE = Table(
     "hydro_correlation",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_from", String(255), nullable=False, primary_key=True),
     Column("area_to", String(255), nullable=False, primary_key=True),
     # Stored as -1 to 1
     Column("coefficient", Float, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_from"],
-        ["area.study_id", "area.area_id"],
-        name="fk_hydro_correlation_study_id_area_from_area",
+        ["study_data_id", "area_from"],
+        ["area.study_data_id", "area.area_id"],
+        name="fk_hydro_correlation_study_data_id_area_from_area",
         ondelete="CASCADE",
     ),
     ForeignKeyConstraint(
-        ["study_id", "area_to"],
-        ["area.study_id", "area.area_id"],
-        name="fk_hydro_correlation_study_id_area_to_area",
+        ["study_data_id", "area_to"],
+        ["area.study_data_id", "area.area_id"],
+        name="fk_hydro_correlation_study_data_id_area_to_area",
         ondelete="CASCADE",
     ),
 )
@@ -116,10 +117,10 @@ def _create_hydro_matrix_table(name: str) -> Table:
     return Table(
         name,
         metadata,
-        Column("study_id", String(36), nullable=False, primary_key=True),
+        study_data_id_col(),
         Column("area_id", String(255), nullable=False, primary_key=True),
         Column("matrix_id", String(64), nullable=False),
-        ForeignKeyConstraint(["study_id", "area_id"], ["area.study_id", "area.area_id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(["study_data_id", "area_id"], ["area.study_data_id", "area.area_id"], ondelete="CASCADE"),
     )
 
 

--- a/antarest/study/dao/database/models/layer.py
+++ b/antarest/study/dao/database/models/layer.py
@@ -17,14 +17,15 @@ SQLAlchemy Core table definitions for layer storage.
 from sqlalchemy import Column, ForeignKeyConstraint, String, Table
 
 from antarest.dbmodel import Base
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 LAYER_TABLE = Table(
     "layer",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("layer_id", String(10), nullable=False, primary_key=True),
     Column("name", String(255), nullable=False),
-    ForeignKeyConstraint(["study_id"], ["study_data.study_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id"], ["study_data.study_data_id"], ondelete="CASCADE"),
 )

--- a/antarest/study/dao/database/models/link.py
+++ b/antarest/study/dao/database/models/link.py
@@ -15,6 +15,7 @@ from sqlalchemy import Boolean, Column, Float, ForeignKeyConstraint, Integer, St
 from antarest.core.utils.sql_utils import enum_col
 from antarest.dbmodel import Base
 from antarest.study.business.model.link_model import AssetType, LinkStyle, TransmissionCapacity
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
@@ -22,7 +23,7 @@ metadata = Base.metadata
 LINK_TABLE = Table(
     "link",
     metadata,
-    Column("study_id", String(length=36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area1", String(length=255), nullable=False, primary_key=True),
     Column("area2", String(length=255), nullable=False, primary_key=True),
     Column("hurdles_cost", Boolean(), nullable=False),
@@ -40,15 +41,15 @@ LINK_TABLE = Table(
     Column("filter_synthesis", String(), nullable=False),
     Column("filter_year_by_year", String(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area1"],
-        ["area.study_id", "area.area_id"],
-        name="fk_link_study_id_area_id_1",
+        ["study_data_id", "area1"],
+        ["area.study_data_id", "area.area_id"],
+        name="fk_link_study_data_id_area_id_1",
         ondelete="CASCADE",
     ),
     ForeignKeyConstraint(
-        ["study_id", "area2"],
-        ["area.study_id", "area.area_id"],
-        name="fk_link_study_id_area_id_2",
+        ["study_data_id", "area2"],
+        ["area.study_data_id", "area.area_id"],
+        name="fk_link_study_data_id_area_id_2",
         ondelete="CASCADE",
     ),
 )
@@ -58,12 +59,12 @@ def _create_matrix_table(name: str) -> Table:
     return Table(
         name,
         metadata,
-        Column("study_id", String(36), nullable=False, primary_key=True),
+        study_data_id_col(),
         Column("area1", String(255), nullable=False, primary_key=True),
         Column("area2", String(255), nullable=False, primary_key=True),
         Column("matrix_id", String(64), nullable=False),
         ForeignKeyConstraint(
-            ["study_id", "area1", "area2"], ["link.study_id", "link.area1", "link.area2"], ondelete="CASCADE"
+            ["study_data_id", "area1", "area2"], ["link.study_data_id", "link.area1", "link.area2"], ondelete="CASCADE"
         ),
     )
 

--- a/antarest/study/dao/database/models/renewable.py
+++ b/antarest/study/dao/database/models/renewable.py
@@ -19,6 +19,7 @@ from sqlalchemy import Boolean, Column, Float, ForeignKeyConstraint, Integer, St
 from antarest.core.utils.sql_utils import enum_col
 from antarest.dbmodel import Base
 from antarest.study.business.model.renewable_cluster_model import TimeSeriesInterpretation
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
@@ -27,7 +28,7 @@ _TS_INTERPRETATION_ENUM = enum_col(TimeSeriesInterpretation, name="renewabletsin
 RENEWABLE_CLUSTER_TABLE = Table(
     "renewable_cluster",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("renewable_id", String(255), nullable=False, primary_key=True),
     Column("name", String(255), nullable=False),
@@ -36,19 +37,19 @@ RENEWABLE_CLUSTER_TABLE = Table(
     Column("enabled", Boolean, nullable=False),
     Column("group", String(255), nullable=False),
     Column("ts_interpretation", _TS_INTERPRETATION_ENUM, nullable=False),
-    ForeignKeyConstraint(["study_id", "area_id"], ["area.study_id", "area.area_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id", "area_id"], ["area.study_data_id", "area.area_id"], ondelete="CASCADE"),
 )
 
 RENEWABLE_SERIES_TABLE = Table(
     "renewable_series",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("renewable_id", String(255), nullable=False, primary_key=True),
     Column("matrix_id", String(64), nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "renewable_id"],
-        ["renewable_cluster.study_id", "renewable_cluster.area_id", "renewable_cluster.renewable_id"],
+        ["study_data_id", "area_id", "renewable_id"],
+        ["renewable_cluster.study_data_id", "renewable_cluster.area_id", "renewable_cluster.renewable_id"],
         ondelete="CASCADE",
     ),
 )

--- a/antarest/study/dao/database/models/reserve_definition.py
+++ b/antarest/study/dao/database/models/reserve_definition.py
@@ -15,13 +15,14 @@ from sqlalchemy import Column, Float, ForeignKeyConstraint, Integer, String, Tab
 from antarest.core.utils.sql_utils import enum_col
 from antarest.dbmodel import Base
 from antarest.study.business.model.reserve_definition_model import ReserveType
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 RESERVE_DEFINITION_TABLE = Table(
     "reserve_definition",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("reserve_id", String(255), nullable=False, primary_key=True),
     Column("name", String(255), nullable=False),
@@ -31,5 +32,5 @@ RESERVE_DEFINITION_TABLE = Table(
     Column("reference_activation_duration", Integer, nullable=False),
     Column("power_activation_ratio", Float, nullable=False),
     Column("energy_activation_ratio", Float, nullable=False),
-    ForeignKeyConstraint(["study_id", "area_id"], ["area.study_id", "area.area_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id", "area_id"], ["area.study_data_id", "area.area_id"], ondelete="CASCADE"),
 )

--- a/antarest/study/dao/database/models/reserve_need.py
+++ b/antarest/study/dao/database/models/reserve_need.py
@@ -13,19 +13,20 @@
 from sqlalchemy import Column, ForeignKeyConstraint, String, Table
 
 from antarest.dbmodel import Base
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 RESERVE_NEED_MATRIX_TABLE = Table(
     "reserve_need_matrix",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("reserve_id", String(255), nullable=False, primary_key=True),
     Column("matrix_id", String(64), nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "reserve_id"],
-        ["reserve_definition.study_id", "reserve_definition.area_id", "reserve_definition.reserve_id"],
+        ["study_data_id", "area_id", "reserve_id"],
+        ["reserve_definition.study_data_id", "reserve_definition.area_id", "reserve_definition.reserve_id"],
         ondelete="CASCADE",
     ),
 )

--- a/antarest/study/dao/database/models/ruleset.py
+++ b/antarest/study/dao/database/models/ruleset.py
@@ -17,6 +17,7 @@ SQLAlchemy Core table definitions for scenario builder (ruleset).
 from sqlalchemy import JSON, Column, ForeignKeyConstraint, String, Table
 
 from antarest.dbmodel import Base
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
@@ -25,10 +26,10 @@ def _create_area_scenario_table(name: str) -> Table:
     return Table(
         name,
         metadata,
-        Column("study_id", String(36), nullable=False, primary_key=True),
+        study_data_id_col(),
         Column("area_id", String(255), nullable=False, primary_key=True),
         Column("value", JSON, nullable=False),
-        ForeignKeyConstraint(("study_id", "area_id"), ["area.study_id", "area.area_id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(("study_data_id", "area_id"), ["area.study_data_id", "area.area_id"], ondelete="CASCADE"),
     )
 
 
@@ -43,13 +44,13 @@ SCENARIO_HYDRO_GENERATION_POWER_TABLE = _create_area_scenario_table("scenario_hy
 SCENARIO_NTC_TABLE = Table(
     "scenario_ntc",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area1", String(255), nullable=False, primary_key=True),
     Column("area2", String(255), nullable=False, primary_key=True),
     Column("value", JSON, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area1", "area2"],
-        ["link.study_id", "link.area1", "link.area2"],
+        ["study_data_id", "area1", "area2"],
+        ["link.study_data_id", "link.area1", "link.area2"],
         ondelete="CASCADE",
     ),
 )
@@ -57,22 +58,22 @@ SCENARIO_NTC_TABLE = Table(
 SCENARIO_BINDING_CONSTRAINTS_TABLE = Table(
     "scenario_binding_constraints",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("bc_group_id", String(255), nullable=False, primary_key=True),
     Column("value", JSON, nullable=False),
-    ForeignKeyConstraint(["study_id"], ["study_data.study_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id"], ["study_data.study_data_id"], ondelete="CASCADE"),
 )
 
 SCENARIO_THERMAL_TABLE = Table(
     "scenario_thermal",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("thermal_id", String(255), nullable=False, primary_key=True),
     Column("value", JSON, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "thermal_id"],
-        ["thermal_cluster.study_id", "thermal_cluster.area_id", "thermal_cluster.thermal_id"],
+        ["study_data_id", "area_id", "thermal_id"],
+        ["thermal_cluster.study_data_id", "thermal_cluster.area_id", "thermal_cluster.thermal_id"],
         ondelete="CASCADE",
     ),
 )
@@ -80,13 +81,13 @@ SCENARIO_THERMAL_TABLE = Table(
 SCENARIO_RENEWABLE_TABLE = Table(
     "scenario_renewable",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("renewable_id", String(255), nullable=False, primary_key=True),
     Column("value", JSON, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "renewable_id"],
-        ["renewable_cluster.study_id", "renewable_cluster.area_id", "renewable_cluster.renewable_id"],
+        ["study_data_id", "area_id", "renewable_id"],
+        ["renewable_cluster.study_data_id", "renewable_cluster.area_id", "renewable_cluster.renewable_id"],
         ondelete="CASCADE",
     ),
 )
@@ -94,13 +95,13 @@ SCENARIO_RENEWABLE_TABLE = Table(
 SCENARIO_STORAGE_INFLOWS_TABLE = Table(
     "scenario_storage_inflows",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("st_storage_id", String(255), nullable=False, primary_key=True),
     Column("value", JSON, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "st_storage_id"],
-        ["st_storage.study_id", "st_storage.area_id", "st_storage.st_storage_id"],
+        ["study_data_id", "area_id", "st_storage_id"],
+        ["st_storage.study_data_id", "st_storage.area_id", "st_storage.st_storage_id"],
         ondelete="CASCADE",
     ),
 )
@@ -108,15 +109,15 @@ SCENARIO_STORAGE_INFLOWS_TABLE = Table(
 SCENARIO_STORAGE_CONSTRAINTS_TABLE = Table(
     "scenario_storage_constraints",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("st_storage_id", String(255), nullable=False, primary_key=True),
     Column("constraint_id", String(255), nullable=False, primary_key=True),
     Column("value", JSON, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "st_storage_id", "constraint_id"],
+        ["study_data_id", "area_id", "st_storage_id", "constraint_id"],
         [
-            "st_storage_additional_constraint.study_id",
+            "st_storage_additional_constraint.study_data_id",
             "st_storage_additional_constraint.area_id",
             "st_storage_additional_constraint.st_storage_id",
             "st_storage_additional_constraint.constraint_id",

--- a/antarest/study/dao/database/models/settings.py
+++ b/antarest/study/dao/database/models/settings.py
@@ -32,20 +32,16 @@ from antarest.study.business.model.config.optimization_config_model import (
     SimplexOptimizationRange,
     UnfeasibleProblemBehavior,
 )
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 # Relations: One to one with `Study`
 
-
-def get_study_id_col() -> Column[str]:
-    return Column("study_id", String(length=36), nullable=False, primary_key=True)
-
-
 GENERAL_CONFIG_TABLE = Table(
     "general_config",
     metadata,
-    get_study_id_col(),
+    study_data_id_col(),
     Column("mode", enum_col(Mode), nullable=False),
     Column("first_day", Integer(), nullable=False),
     Column("last_day", Integer(), nullable=False),
@@ -63,13 +59,15 @@ GENERAL_CONFIG_TABLE = Table(
     Column("filtering", Boolean(), nullable=True),
     Column("geographic_trimming", Boolean(), nullable=True),
     Column("thematic_trimming", Boolean(), nullable=True),
-    ForeignKeyConstraint(["study_id"], ["study_data.study_id"], name="fk_general_config_study_id", ondelete="CASCADE"),
+    ForeignKeyConstraint(
+        ["study_data_id"], ["study_data.study_data_id"], name="fk_general_config_study_data_id", ondelete="CASCADE"
+    ),
 )
 
 ADVANCED_PARAMETERS_TABLE = Table(
     "advanced_parameters",
     metadata,
-    get_study_id_col(),
+    study_data_id_col(),
     Column("accuracy_on_correlation", String(), nullable=False),
     Column("power_fluctuations", enum_col(PowerFluctuation), nullable=False),
     Column("shedding_policy", enum_col(SheddingPolicy), nullable=False),
@@ -93,14 +91,14 @@ ADVANCED_PARAMETERS_TABLE = Table(
     Column("initial_reservoir_levels", enum_col(InitialReservoirLevel), nullable=True),
     Column("accurate_shave_peaks_include_short_term_storage", Boolean(), nullable=True),
     ForeignKeyConstraint(
-        ["study_id"], ["study_data.study_id"], name="fk_advanced_parameters_study_id", ondelete="CASCADE"
+        ["study_data_id"], ["study_data.study_data_id"], name="fk_advanced_parameters_study_data_id", ondelete="CASCADE"
     ),
 )
 
 ADEQUACY_PATCH_PARAMETERS_TABLE = Table(
     "adequacy_patch_parameters",
     metadata,
-    get_study_id_col(),
+    study_data_id_col(),
     Column("enable_adequacy_patch", Boolean(), nullable=False),
     Column("ntc_from_physical_areas_out_to_physical_areas_in_adequacy_patch", Boolean(), nullable=False),
     Column("price_taking_order", enum_col(PriceTakingOrder), nullable=True),
@@ -112,9 +110,9 @@ ADEQUACY_PATCH_PARAMETERS_TABLE = Table(
     Column("ntc_between_physical_areas_out_adequacy_patch", Boolean(), nullable=True),
     Column("redispatch", Boolean(), nullable=True),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["study_data.study_id"],
-        name="fk_adequacy_patch_parameters_study_id",
+        ["study_data_id"],
+        ["study_data.study_data_id"],
+        name="fk_adequacy_patch_parameters_study_data_id",
         ondelete="CASCADE",
     ),
 )
@@ -123,12 +121,12 @@ ADEQUACY_PATCH_PARAMETERS_TABLE = Table(
 COMPATIBILITY_PARAMETERS_TABLE = Table(
     "compatibility_parameters",
     metadata,
-    get_study_id_col(),
+    study_data_id_col(),
     Column("hydro_pmax", enum_col(HydroPmax), nullable=True),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["study_data.study_id"],
-        name="fk_compatibility_parameters_study_id",
+        ["study_data_id"],
+        ["study_data.study_data_id"],
+        name="fk_compatibility_parameters_study_data_id",
         ondelete="CASCADE",
     ),
 )
@@ -136,7 +134,7 @@ COMPATIBILITY_PARAMETERS_TABLE = Table(
 OPTIMIZATION_PREFERENCES_TABLE = Table(
     "optimization_preferences",
     metadata,
-    get_study_id_col(),
+    study_data_id_col(),
     Column("binding_constraints", Boolean(), nullable=False),
     Column("hurdle_costs", Boolean(), nullable=False),
     Column("transmission_capacities", String(), nullable=False),
@@ -151,9 +149,9 @@ OPTIMIZATION_PREFERENCES_TABLE = Table(
     Column("simplex_optimization_range", enum_col(SimplexOptimizationRange), nullable=False),
     Column("include_reserves", Boolean(), nullable=True),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["study_data.study_id"],
-        name="fk_optimization_preferences_study_id",
+        ["study_data_id"],
+        ["study_data.study_data_id"],
+        name="fk_optimization_preferences_study_data_id",
         ondelete="CASCADE",
     ),
 )
@@ -161,17 +159,19 @@ OPTIMIZATION_PREFERENCES_TABLE = Table(
 TIMESERIES_CONFIG_TABLE = Table(
     "timeseries_config",
     metadata,
-    get_study_id_col(),
+    study_data_id_col(),
     Column("thermal_number", Integer(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id"], ["study_data.study_id"], name="fk_timeseries_config_study_id", ondelete="CASCADE"
+        ["study_data_id"], ["study_data.study_data_id"], name="fk_timeseries_config_study_data_id", ondelete="CASCADE"
     ),
 )
 
 PLAYLIST_TABLE = Table(
     "playlist",
     metadata,
-    get_study_id_col(),
+    study_data_id_col(),
     Column("years", String(), nullable=False),
-    ForeignKeyConstraint(["study_id"], ["study_data.study_id"], name="fk_playlist_study_id", ondelete="CASCADE"),
+    ForeignKeyConstraint(
+        ["study_data_id"], ["study_data.study_data_id"], name="fk_playlist_study_data_id", ondelete="CASCADE"
+    ),
 )

--- a/antarest/study/dao/database/models/st_storage.py
+++ b/antarest/study/dao/database/models/st_storage.py
@@ -22,6 +22,7 @@ from antarest.study.business.model.sts_model import (
     AdditionalConstraintOperator,
     AdditionalConstraintVariable,
 )
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
@@ -32,7 +33,7 @@ _OPERATOR_ENUM = enum_col(AdditionalConstraintOperator, name="additionalconstrai
 ST_STORAGE_TABLE = Table(
     "st_storage",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("st_storage_id", String(255), nullable=False, primary_key=True),
     Column("name", String(255), nullable=False),
@@ -48,7 +49,7 @@ ST_STORAGE_TABLE = Table(
     Column("penalize_variation_injection", Boolean, nullable=True),
     Column("penalize_variation_withdrawal", Boolean, nullable=True),
     Column("allow_overflow", Boolean, nullable=True),
-    ForeignKeyConstraint(["study_id", "area_id"], ["area.study_id", "area.area_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id", "area_id"], ["area.study_data_id", "area.area_id"], ondelete="CASCADE"),
 )
 
 
@@ -56,13 +57,13 @@ def _create_st_storage_matrix_table(name: str) -> Table:
     return Table(
         name,
         metadata,
-        Column("study_id", String(36), nullable=False, primary_key=True),
+        study_data_id_col(),
         Column("area_id", String(255), nullable=False, primary_key=True),
         Column("st_storage_id", String(255), nullable=False, primary_key=True),
         Column("matrix_id", String(64), nullable=False),
         ForeignKeyConstraint(
-            ["study_id", "area_id", "st_storage_id"],
-            ["st_storage.study_id", "st_storage.area_id", "st_storage.st_storage_id"],
+            ["study_data_id", "area_id", "st_storage_id"],
+            ["st_storage.study_data_id", "st_storage.area_id", "st_storage.st_storage_id"],
             ondelete="CASCADE",
         ),
     )
@@ -83,7 +84,7 @@ COST_VARIATION_WITHDRAWAL_TABLE = _create_st_storage_matrix_table("st_storage_co
 ST_STORAGE_ADDITIONAL_CONSTRAINT_TABLE = Table(
     "st_storage_additional_constraint",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("st_storage_id", String(255), nullable=False, primary_key=True),
     Column("constraint_id", String(255), nullable=False, primary_key=True),
@@ -93,8 +94,8 @@ ST_STORAGE_ADDITIONAL_CONSTRAINT_TABLE = Table(
     Column("occurrences", JSON, nullable=False),
     Column("enabled", Boolean, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "st_storage_id"],
-        ["st_storage.study_id", "st_storage.area_id", "st_storage.st_storage_id"],
+        ["study_data_id", "area_id", "st_storage_id"],
+        ["st_storage.study_data_id", "st_storage.area_id", "st_storage.st_storage_id"],
         ondelete="CASCADE",
     ),
 )
@@ -102,15 +103,15 @@ ST_STORAGE_ADDITIONAL_CONSTRAINT_TABLE = Table(
 ST_STORAGE_ADDITIONAL_CONSTRAINT_MATRIX_TABLE = Table(
     "st_storage_additional_constraint_matrix",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("st_storage_id", String(255), nullable=False, primary_key=True),
     Column("constraint_id", String(255), nullable=False, primary_key=True),
     Column("matrix_id", String(64), nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "st_storage_id", "constraint_id"],
+        ["study_data_id", "area_id", "st_storage_id", "constraint_id"],
         [
-            "st_storage_additional_constraint.study_id",
+            "st_storage_additional_constraint.study_data_id",
             "st_storage_additional_constraint.area_id",
             "st_storage_additional_constraint.st_storage_id",
             "st_storage_additional_constraint.constraint_id",

--- a/antarest/study/dao/database/models/thematic_trimming.py
+++ b/antarest/study/dao/database/models/thematic_trimming.py
@@ -10,9 +10,10 @@
 #
 # This file is part of the Antares project.
 
-from sqlalchemy import JSON, Column, ForeignKeyConstraint, String, Table
+from sqlalchemy import JSON, Column, ForeignKeyConstraint, Table
 
 from antarest.dbmodel import Base
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
@@ -21,12 +22,12 @@ metadata = Base.metadata
 THEMATIC_TRIMMING_TABLE = Table(
     "thematic_trimming",
     metadata,
-    Column("study_id", String(length=36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("thematic_trimming", JSON(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["study_data.study_id"],
-        name="fk_thematic_trimming_study_id_study",
+        ["study_data_id"],
+        ["study_data.study_data_id"],
+        name="fk_thematic_trimming_study_data_id_study",
         ondelete="CASCADE",
     ),
 )

--- a/antarest/study/dao/database/models/thermal.py
+++ b/antarest/study/dao/database/models/thermal.py
@@ -23,6 +23,7 @@ from antarest.study.business.model.thermal_cluster_model import (
     LocalTSGenerationBehavior,
     ThermalCostGeneration,
 )
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
@@ -33,7 +34,7 @@ _COST_GEN_ENUM = enum_col(ThermalCostGeneration, name="thermalcostgeneration")
 THERMAL_CLUSTER_TABLE = Table(
     "thermal_cluster",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("thermal_id", String(255), nullable=False, primary_key=True),
     Column("name", String(255), nullable=False),
@@ -72,7 +73,7 @@ THERMAL_CLUSTER_TABLE = Table(
     Column("cost_generation", _COST_GEN_ENUM, nullable=True),
     Column("efficiency", Float, nullable=True),
     Column("variable_o_m_cost", Float, nullable=True),
-    ForeignKeyConstraint(["study_id", "area_id"], ["area.study_id", "area.area_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id", "area_id"], ["area.study_data_id", "area.area_id"], ondelete="CASCADE"),
 )
 
 
@@ -80,13 +81,13 @@ def _create_thermal_matrix_table(name: str) -> Table:
     return Table(
         name,
         metadata,
-        Column("study_id", String(36), nullable=False, primary_key=True),
+        study_data_id_col(),
         Column("area_id", String(255), nullable=False, primary_key=True),
         Column("thermal_id", String(255), nullable=False, primary_key=True),
         Column("matrix_id", String(64), nullable=False),
         ForeignKeyConstraint(
-            ["study_id", "area_id", "thermal_id"],
-            ["thermal_cluster.study_id", "thermal_cluster.area_id", "thermal_cluster.thermal_id"],
+            ["study_data_id", "area_id", "thermal_id"],
+            ["thermal_cluster.study_data_id", "thermal_cluster.area_id", "thermal_cluster.thermal_id"],
             ondelete="CASCADE",
         ),
     )

--- a/antarest/study/dao/database/models/thermal_reserve_certification.py
+++ b/antarest/study/dao/database/models/thermal_reserve_certification.py
@@ -13,13 +13,14 @@
 from sqlalchemy import Column, Float, ForeignKeyConstraint, String, Table
 
 from antarest.dbmodel import Base
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 THERMAL_RESERVE_CERTIFICATION_TABLE = Table(
     "thermal_reserve_certifications",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("thermal_id", String(255), nullable=False, primary_key=True),
     Column("reserve_id", String(255), nullable=False, primary_key=True),
@@ -28,13 +29,13 @@ THERMAL_RESERVE_CERTIFICATION_TABLE = Table(
     Column("participation_cost", Float, nullable=False),
     Column("participation_cost_off", Float, nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "thermal_id"],
-        ["thermal_cluster.study_id", "thermal_cluster.area_id", "thermal_cluster.thermal_id"],
+        ["study_data_id", "area_id", "thermal_id"],
+        ["thermal_cluster.study_data_id", "thermal_cluster.area_id", "thermal_cluster.thermal_id"],
         ondelete="CASCADE",
     ),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "reserve_id"],
-        ["reserve_definition.study_id", "reserve_definition.area_id", "reserve_definition.reserve_id"],
+        ["study_data_id", "area_id", "reserve_id"],
+        ["reserve_definition.study_data_id", "reserve_definition.area_id", "reserve_definition.reserve_id"],
         ondelete="CASCADE",
     ),
 )

--- a/antarest/study/dao/database/models/thermal_reserve_symmetries.py
+++ b/antarest/study/dao/database/models/thermal_reserve_symmetries.py
@@ -13,19 +13,20 @@
 from sqlalchemy import Column, ForeignKeyConstraint, String, Table
 
 from antarest.dbmodel import Base
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 THERMAL_RESERVE_SYMMETRIES_TABLE = Table(
     "thermal_reserve_symmetries",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area_id", String(255), nullable=False, primary_key=True),
     Column("thermal_id", String(255), nullable=False, primary_key=True),
     Column("symmetries", String(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id", "area_id", "thermal_id"],
-        ["thermal_cluster.study_id", "thermal_cluster.area_id", "thermal_cluster.thermal_id"],
+        ["study_data_id", "area_id", "thermal_id"],
+        ["thermal_cluster.study_data_id", "thermal_cluster.area_id", "thermal_cluster.thermal_id"],
         ondelete="CASCADE",
     ),
 )

--- a/antarest/study/dao/database/models/user_resources.py
+++ b/antarest/study/dao/database/models/user_resources.py
@@ -14,11 +14,12 @@
 SQLAlchemy Core table definitions for user resources storage.
 """
 
-from sqlalchemy import Column, ForeignKeyConstraint, String, Table
+from sqlalchemy import Column, ForeignKeyConstraint, Index, String, Table
 
 from antarest.core.utils.sql_utils import enum_col
 from antarest.dbmodel import Base
 from antarest.study.business.model.user_model import ResourceType
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
@@ -27,12 +28,15 @@ _RESOURCE_TYPE_ENUM = enum_col(ResourceType, name="resourcetype")
 USER_RESOURCES_TABLE = Table(
     "user_resources",
     metadata,
-    Column("study_id", String(36), nullable=False),
+    study_data_id_col(primary_key=False),
     Column("id", String(36), nullable=False, primary_key=True),
     Column("name", String(255), nullable=False),
     Column("parent_id", String(36), nullable=True),
     Column("resource_type", _RESOURCE_TYPE_ENUM, nullable=False),
     Column("blob_id", String(64), nullable=True),
-    ForeignKeyConstraint(["study_id"], ["study_data.study_id"], ondelete="CASCADE"),
+    ForeignKeyConstraint(["study_data_id"], ["study_data.study_data_id"], ondelete="CASCADE"),
     ForeignKeyConstraint(["parent_id"], ["user_resources.id"], ondelete="CASCADE"),
+    # This is the only data table whose study key is not the leading column of the primary key,
+    # so it needs an explicit index: neither PostgreSQL nor SQLite indexes foreign keys.
+    Index("ix_user_resources_study_data_id", "study_data_id"),
 )

--- a/antarest/study/dao/database/models/xpansion.py
+++ b/antarest/study/dao/database/models/xpansion.py
@@ -14,13 +14,14 @@ from sqlalchemy import Boolean, Column, Float, ForeignKeyConstraint, Integer, La
 from antarest.core.utils.sql_utils import enum_col
 from antarest.dbmodel import Base
 from antarest.study.business.model.xpansion_model import Master, Solver, UcType
+from antarest.study.dao.database.models import study_data_id_col
 
 metadata = Base.metadata
 
 XPANSION_SETTINGS_TABLE = Table(
     "xpansion_settings",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     # --- XpansionSettings scalars ---
     Column("master", enum_col(Master, name="xpansion_master"), nullable=False),
     Column("uc_type", enum_col(UcType, name="xpansion_uc_type"), nullable=False),
@@ -41,9 +42,9 @@ XPANSION_SETTINGS_TABLE = Table(
     Column("sensitivity_epsilon", Float(), nullable=False),
     Column("sensitivity_capex", Boolean(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["study_data.study_id"],
-        name="fk_xpansion_settings_study_id",
+        ["study_data_id"],
+        ["study_data.study_data_id"],
+        name="fk_xpansion_settings_study_data_id",
         ondelete="CASCADE",
     ),
 )
@@ -51,7 +52,7 @@ XPANSION_SETTINGS_TABLE = Table(
 XPANSION_CANDIDATE_TABLE = Table(
     "xpansion_candidate",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("name", String(255), nullable=False, primary_key=True),
     Column("link_area_from", String(255), nullable=False),
     Column("link_area_to", String(255), nullable=False),
@@ -67,14 +68,14 @@ XPANSION_CANDIDATE_TABLE = Table(
     Column("already_installed_direct_link_profile", String(255), nullable=True),
     Column("already_installed_indirect_link_profile", String(255), nullable=True),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["xpansion_settings.study_id"],
+        ["study_data_id"],
+        ["xpansion_settings.study_data_id"],
         name="fk_xpansion_candidate_settings",
         ondelete="CASCADE",
     ),
     ForeignKeyConstraint(
-        ["study_id", "link_area_from", "link_area_to"],
-        ["link.study_id", "link.area1", "link.area2"],
+        ["study_data_id", "link_area_from", "link_area_to"],
+        ["link.study_data_id", "link.area1", "link.area2"],
         name="fk_xpansion_candidate_link",
         ondelete="CASCADE",
     ),
@@ -83,11 +84,11 @@ XPANSION_CANDIDATE_TABLE = Table(
 XPANSION_SENSITIVITY_PROJECTION_TABLE = Table(
     "xpansion_sensitivity_projection",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("candidate_name", String(255), nullable=False, primary_key=True),
     ForeignKeyConstraint(
-        ["study_id", "candidate_name"],
-        ["xpansion_candidate.study_id", "xpansion_candidate.name"],
+        ["study_data_id", "candidate_name"],
+        ["xpansion_candidate.study_data_id", "xpansion_candidate.name"],
         name="fk_xpansion_sensitivity_projection_candidate",
         ondelete="CASCADE",
         onupdate="CASCADE",
@@ -97,12 +98,12 @@ XPANSION_SENSITIVITY_PROJECTION_TABLE = Table(
 XPANSION_ADEQUACY_CRITERION_TABLE = Table(
     "xpansion_adequacy_criterion",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("stopping_threshold", Float(), nullable=False),
     Column("criterion_count_threshold", Float(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["xpansion_settings.study_id"],
+        ["study_data_id"],
+        ["xpansion_settings.study_data_id"],
         name="fk_xpansion_adequacy_criterion_settings",
         ondelete="CASCADE",
     ),
@@ -111,19 +112,19 @@ XPANSION_ADEQUACY_CRITERION_TABLE = Table(
 XPANSION_ADEQUACY_PATTERN_TABLE = Table(
     "xpansion_adequacy_pattern",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("area", String(255), nullable=False, primary_key=True),
     Column("criterion", Float(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["xpansion_adequacy_criterion.study_id"],
+        ["study_data_id"],
+        ["xpansion_adequacy_criterion.study_data_id"],
         name="fk_xpansion_adequacy_pattern_criterion",
         ondelete="CASCADE",
     ),
     ForeignKeyConstraint(
-        ["study_id", "area"],
-        ["area.study_id", "area.area_id"],
-        name="fk_xpansion_adequacy_pattern_study_id_area_area",
+        ["study_data_id", "area"],
+        ["area.study_data_id", "area.area_id"],
+        name="fk_xpansion_adequacy_pattern_study_data_id_area_area",
         ondelete="CASCADE",
     ),
 )
@@ -131,12 +132,12 @@ XPANSION_ADEQUACY_PATTERN_TABLE = Table(
 XPANSION_CONSTRAINT_TABLE = Table(
     "xpansion_constraint",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("filename", String(255), nullable=False, primary_key=True),
     Column("content", LargeBinary(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["xpansion_settings.study_id"],
+        ["study_data_id"],
+        ["xpansion_settings.study_data_id"],
         name="fk_xpansion_constraint_settings",
         ondelete="CASCADE",
     ),
@@ -145,12 +146,12 @@ XPANSION_CONSTRAINT_TABLE = Table(
 XPANSION_CAPACITY_TABLE = Table(
     "xpansion_capacity",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("filename", String(255), nullable=False, primary_key=True),
     Column("matrix_id", String(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["xpansion_settings.study_id"],
+        ["study_data_id"],
+        ["xpansion_settings.study_data_id"],
         name="fk_xpansion_capacity_settings",
         ondelete="CASCADE",
     ),
@@ -159,12 +160,12 @@ XPANSION_CAPACITY_TABLE = Table(
 XPANSION_WEIGHT_TABLE = Table(
     "xpansion_weight",
     metadata,
-    Column("study_id", String(36), nullable=False, primary_key=True),
+    study_data_id_col(),
     Column("filename", String(255), nullable=False, primary_key=True),
     Column("matrix_id", String(), nullable=False),
     ForeignKeyConstraint(
-        ["study_id"],
-        ["xpansion_settings.study_id"],
+        ["study_data_id"],
+        ["xpansion_settings.study_data_id"],
         name="fk_xpansion_weight_settings",
         ondelete="CASCADE",
     ),

--- a/antarest/study/dao/database/study_data_queries.py
+++ b/antarest/study/dao/database/study_data_queries.py
@@ -23,6 +23,7 @@ from collections.abc import Iterator, Sequence
 from sqlalchemy import ColumnElement, Table, select
 from sqlalchemy.orm import Session
 
+from antarest.study.dao.database.models import STUDY_DATA_TABLE
 from antarest.study.dao.database.models.user_resources import USER_RESOURCES_TABLE
 
 
@@ -33,8 +34,14 @@ def belongs_to_study(table: Table, study_id: str) -> ColumnElement[bool]:
     Args:
         table: Any study data table, i.e. any table keyed by a study.
         study_id: The study ID, as found in `study.id`.
+
+    Note:
+        Study data tables are keyed by `study_data_id`, not by the study ID, hence the
+        subquery. A study with no `study_data` row matches nothing, which is correct:
+        its data rows were cascade-deleted along with it.
     """
-    return table.c.study_id == study_id
+    study_data_ids = select(STUDY_DATA_TABLE.c.study_data_id).where(STUDY_DATA_TABLE.c.study_id == study_id)
+    return table.c.study_data_id.in_(study_data_ids)
 
 
 def yield_matrix_ids(session: Session, tables: Sequence[Table], study_id: str) -> Iterator[tuple[Table, str]]:
@@ -56,7 +63,16 @@ def yield_used_blobs(session: Session) -> Iterator[tuple[str, str]]:
 
     Used by the blob garbage collector: a blob missing from this listing is considered
     unused and becomes eligible for deletion.
+
+    Note:
+        The join back to `study_data` only recovers the study ID for the usage description.
+        It cannot hide a used blob: `user_resources.study_data_id` is `NOT NULL` and carries
+        a foreign key onto `study_data`, so every row has exactly one match.
     """
-    stmt = select(USER_RESOURCES_TABLE).where(USER_RESOURCES_TABLE.c.blob_id.isnot(None))
+    stmt = (
+        select(USER_RESOURCES_TABLE.c.blob_id, STUDY_DATA_TABLE.c.study_id)
+        .join(STUDY_DATA_TABLE, USER_RESOURCES_TABLE.c.study_data_id == STUDY_DATA_TABLE.c.study_data_id)
+        .where(USER_RESOURCES_TABLE.c.blob_id.isnot(None))
+    )
     for row in session.execute(stmt).fetchall():
         yield row.blob_id, row.study_id

--- a/tests/core/test_study_data_key_migration.py
+++ b/tests/core/test_study_data_key_migration.py
@@ -1,0 +1,384 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Data-bearing tests of the `1f0c9b2e7a34` migration, which replaces the `study_id` carried by
+every study data table with the `study_data.study_data_id` surrogate key.
+
+`tests/core/test_alembic_migration.py` runs the migrations on an empty database: it proves they
+execute, not that they carry the data over. These tests seed two studies at the previous revision
+and check, after the upgrade, that every row is still there and still attached to the study it
+was seeded for.
+"""
+
+import os
+from datetime import datetime
+from io import StringIO
+from pathlib import Path
+from typing import Any, Dict, Iterator, List
+
+import pytest
+import sqlalchemy as sa
+import yaml
+from alembic.config import Config
+from sqlalchemy.engine import Engine
+
+from alembic import command
+from antarest.core.utils.utils import get_local_path
+from antarest.dbmodel import Base
+from antarest.study.business.model.user_model import ResourceType
+from antarest.study.dao.database.models.area import AREA_TABLE, AREA_UI_TABLE, LOAD_TABLE  # noqa: F401
+from antarest.study.dao.database.models.layer import LAYER_TABLE  # noqa: F401
+from antarest.study.dao.database.models.thermal import THERMAL_CLUSTER_TABLE, THERMAL_SERIES_TABLE  # noqa: F401
+from antarest.study.dao.database.models.user_resources import USER_RESOURCES_TABLE  # noqa: F401
+from antarest.study.model import Study  # noqa: F401
+from tests.integration.conftest import RUN_ON_WINDOWS
+
+REVISION = "1f0c9b2e7a34"
+PREVIOUS_REVISION = "6012b0407e38"
+
+REFERENCE_TABLE = "study_data"
+STRING_KEY = "study_id"
+SURROGATE_KEY = "study_data_id"
+
+# One representative table per shape the migration has to handle: a direct child of `study_data`,
+# a child reached through a two-column composite key, one reached through a three-column one, a
+# matrix table (what the matrix garbage collector walks), and the only table whose study key is
+# not part of its primary key. Parents come before children: they are inserted in this order.
+SEEDED_TABLES = ["layer", "area", "area_ui", "load", "thermal_cluster", "thermal_series", "user_resources"]
+
+
+def _seeded_rows(tag: str) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    The identifying columns of the rows seeded for one study. Every other column is filled in by
+    `_row`, so that adding a column to a model does not break this test.
+    """
+    return {
+        "layer": [{"layer_id": "0"}, {"layer_id": "1"}],
+        "area": [{"area_id": "fr"}, {"area_id": "de"}],
+        "area_ui": [{"area_id": "fr", "layer_id": "0"}, {"area_id": "de", "layer_id": "1"}],
+        "load": [{"area_id": "fr", "matrix_id": f"load_matrix_{tag}"}],
+        "thermal_cluster": [{"area_id": "fr", "thermal_id": "gas"}],
+        "thermal_series": [{"area_id": "fr", "thermal_id": "gas", "matrix_id": f"series_matrix_{tag}"}],
+        "user_resources": [
+            {
+                "id": f"resource_{tag}",
+                "name": "file.txt",
+                "resource_type": ResourceType.FILE.value,
+                "blob_id": f"blob_{tag}",
+            },
+            {
+                "id": f"folder_{tag}",
+                "name": "my_folder",
+                "resource_type": ResourceType.FOLDER.value,
+                "blob_id": None,
+            },
+        ],
+    }
+
+
+#
+# Alembic driving
+#
+
+
+def _alembic_config(tmp_path: Path, db_url: str) -> Config:
+    config_file = tmp_path / "config.yaml"
+    with open(config_file, "w") as f:
+        yaml.safe_dump({"db": {"url": db_url}}, f)
+    os.environ["ANTAREST_CONF"] = str(config_file)
+
+    alembic_cfg = Config(str(get_local_path() / "alembic.ini"))
+    alembic_cfg.stdout = StringIO()
+    alembic_cfg.set_main_option("script_location", str(get_local_path() / "alembic"))
+    return alembic_cfg
+
+
+#
+# Seeding
+#
+
+
+def _placeholder(column: "sa.Column[Any]", tag: str) -> Any:
+    """
+    A value of the right type for a column the test does not care about, distinct between studies
+    so that a row leaking from one study to the other cannot go unnoticed.
+    """
+    column_type = column.type
+    # `Enum` derives from `String`, so it has to be matched first.
+    if isinstance(column_type, sa.Enum):
+        return column_type.enums[0]
+    if isinstance(column_type, sa.Boolean):
+        return False
+    if isinstance(column_type, sa.String):
+        value = f"{column.name}_{tag}"
+        return value[: column_type.length] if column_type.length else value
+    if isinstance(column_type, sa.Float):
+        return 1.5
+    if isinstance(column_type, sa.Integer):
+        return 1
+    if isinstance(column_type, sa.DateTime):
+        return datetime(2026, 1, 1)
+    raise NotImplementedError(f"No placeholder for {column.name} of type {column_type}")
+
+
+def _row(table_name: str, tag: str, **values: Any) -> Dict[str, Any]:
+    """
+    Complete `values` into a full row of `table_name`, reading the column definitions from the
+    models rather than from the database: at the previous revision the study key columns are
+    reflected as plain strings, which loses the enum values the check constraints require.
+
+    Every column is given a value, nullable ones included, so that the row read back after the
+    migration can be compared to this one field by field.
+    """
+    row = dict(values)
+    for column in Base.metadata.tables[table_name].columns:
+        if column.name in row or column.name == SURROGATE_KEY or column.autoincrement is True:
+            continue
+        row[column.name] = None if column.nullable else _placeholder(column, tag)
+    return row
+
+
+def _seed_study(engine: Engine, study_id: str, tag: str) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Insert a study and its data rows at the previous revision. Returns the seeded rows, keyed by
+    table, as they are expected to be found after the upgrade.
+    """
+    metadata = sa.MetaData()
+    metadata.reflect(bind=engine, only=["study", REFERENCE_TABLE, *SEEDED_TABLES])
+
+    seeded = {
+        table: [_row(table, tag, study_id=study_id, **row) for row in rows] for table, rows in _seeded_rows(tag).items()
+    }
+
+    with engine.begin() as connection:
+        connection.execute(metadata.tables["study"].insert().values(_row("study", tag, id=study_id)))
+        connection.execute(metadata.tables[REFERENCE_TABLE].insert().values({STRING_KEY: study_id}))
+        for table in SEEDED_TABLES:
+            connection.execute(metadata.tables[table].insert(), seeded[table])
+    return seeded
+
+
+def _study_data_id(engine: Engine, study_id: str) -> int:
+    with engine.connect() as connection:
+        stmt = sa.text(f"SELECT {SURROGATE_KEY} FROM {REFERENCE_TABLE} WHERE {STRING_KEY} = :study_id")
+        study_data_id: int = connection.execute(stmt, {"study_id": study_id}).scalar_one()
+    return study_data_id
+
+
+def _fetch(engine: Engine, table_name: str, study_data_id: int) -> List[Dict[str, Any]]:
+    """
+    The rows of `table_name` belonging to a study, keyed by the surrogate key instead of the
+    study id, so that they can be compared to what was seeded.
+    """
+    metadata = sa.MetaData()
+    table = sa.Table(table_name, metadata, autoload_with=engine)
+    with engine.connect() as connection:
+        rows = connection.execute(sa.select(table).where(table.c[SURROGATE_KEY] == study_data_id)).fetchall()
+    return [{key: value for key, value in row._mapping.items() if key != SURROGATE_KEY} for row in rows]
+
+
+def _sorted(rows: List[Dict[str, Any]]) -> List[List[Any]]:
+    return sorted([sorted((key, str(value)) for key, value in row.items()) for row in rows])
+
+
+def _assert_rows_migrated(engine: Engine, study_id: str, seeded: Dict[str, List[Dict[str, Any]]]) -> None:
+    study_data_id = _study_data_id(engine, study_id)
+    for table in SEEDED_TABLES:
+        expected = [{key: value for key, value in row.items() if key != STRING_KEY} for row in seeded[table]]
+        assert _sorted(_fetch(engine, table, study_data_id)) == _sorted(expected), (
+            f"Table {table} was not migrated as expected for study {study_id}"
+        )
+
+
+#
+# Fixtures
+#
+
+
+@pytest.fixture(scope="module")
+def postgresql_url() -> Iterator[str]:
+    if RUN_ON_WINDOWS:
+        pytest.skip("Docker fails on Windows")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:14") as postgres:
+        yield postgres.get_connection_url()
+
+
+@pytest.fixture(params=["sqlite", "postgresql"])
+def engine(request: Any, tmp_path: Path) -> Iterator[Engine]:
+    """
+    An empty database, migrated up to the revision preceding the one under test.
+
+    The PostgreSQL container is shared by the whole module — starting one per test is slow — so
+    its schema is dropped between tests.
+    """
+    if request.param == "sqlite":
+        db_url = f"sqlite:///{tmp_path / 'db.sqlite'}"
+    else:
+        db_url = request.getfixturevalue("postgresql_url")
+        with sa.create_engine(db_url).begin() as connection:
+            connection.execute(sa.text("DROP SCHEMA public CASCADE"))
+            connection.execute(sa.text("CREATE SCHEMA public"))
+
+    engine = sa.create_engine(db_url)
+    if request.param == "sqlite":
+        # SQLite ignores foreign keys unless they are explicitly turned on, and the test relies
+        # on the cascade from `study_data`.
+        sa.event.listen(
+            engine, "connect", lambda dbapi_connection, _: dbapi_connection.execute("PRAGMA foreign_keys=ON")
+        )
+
+    command.upgrade(_alembic_config(tmp_path, db_url), PREVIOUS_REVISION)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def alembic_cfg(engine: Engine, tmp_path: Path) -> Config:
+    return _alembic_config(tmp_path, str(engine.url.render_as_string(hide_password=False)))
+
+
+#
+# Tests
+#
+
+
+def test_upgrade_carries_study_data_over(engine: Engine, alembic_cfg: Config) -> None:
+    """
+    Two studies are seeded so that a backfill joining on the wrong row shows up as data of one
+    study landing on the other.
+    """
+    first_seeded = _seed_study(engine, "study-one", "one")
+    second_seeded = _seed_study(engine, "study-two", "two")
+
+    command.upgrade(alembic_cfg, REVISION)
+
+    _assert_rows_migrated(engine, "study-one", first_seeded)
+    _assert_rows_migrated(engine, "study-two", second_seeded)
+    assert _study_data_id(engine, "study-one") != _study_data_id(engine, "study-two")
+
+
+def test_upgrade_replaces_the_study_key(engine: Engine, alembic_cfg: Config) -> None:
+    _seed_study(engine, "study-one", "one")
+
+    command.upgrade(alembic_cfg, REVISION)
+
+    inspector = sa.inspect(engine)
+    for table in SEEDED_TABLES:
+        columns = {column["name"] for column in inspector.get_columns(table)}
+        assert STRING_KEY not in columns, f"Table {table} still carries {STRING_KEY}"
+        assert SURROGATE_KEY in columns
+
+        model_columns = {column.name for column in Base.metadata.tables[table].columns}
+        assert columns == model_columns, f"Table {table} does not match its model"
+
+        primary_key = inspector.get_pk_constraint(table)["constrained_columns"]
+        model_primary_key = [column.name for column in Base.metadata.tables[table].primary_key]
+        assert primary_key == model_primary_key, f"Primary key of {table} does not match its model"
+
+    # `user_resources` is the one table whose study key is not covered by its primary key.
+    assert any(index["column_names"] == [SURROGATE_KEY] for index in inspector.get_indexes("user_resources")), (
+        "The foreign key of user_resources is left unindexed"
+    )
+
+    reference_columns = {column["name"] for column in inspector.get_columns(REFERENCE_TABLE)}
+    assert reference_columns == {STRING_KEY, SURROGATE_KEY}
+    assert inspector.get_pk_constraint(REFERENCE_TABLE)["constrained_columns"] == [SURROGATE_KEY]
+
+
+def test_upgrade_preserves_the_cascade_from_study(engine: Engine, alembic_cfg: Config) -> None:
+    """
+    Clearing a study's data is a single `DELETE` on `study_data`, which is the reason that table
+    exists. Re-pointing every foreign key must not break it.
+    """
+    _seed_study(engine, "study-one", "one")
+    second_seeded = _seed_study(engine, "study-two", "two")
+
+    command.upgrade(alembic_cfg, REVISION)
+    first_id = _study_data_id(engine, "study-one")
+
+    with engine.begin() as connection:
+        connection.execute(sa.text(f"DELETE FROM {REFERENCE_TABLE} WHERE {STRING_KEY} = 'study-one'"))
+
+    with engine.connect() as connection:
+        for table in SEEDED_TABLES:
+            remaining = connection.execute(sa.text(f'SELECT COUNT(*) FROM "{table}"')).scalar_one()
+            assert remaining == len(second_seeded[table]), f"Deleting a study did not clear {table}"
+            assert _fetch(engine, table, first_id) == []
+    _assert_rows_migrated(engine, "study-two", second_seeded)
+
+
+def test_downgrade_restores_the_schema(engine: Engine, alembic_cfg: Config) -> None:
+    """
+    The downgrade is schema-only by design: it rebuilds the data tables empty. What it must
+    restore exactly is the schema, so that a subsequent upgrade finds what it expects.
+    """
+    _seed_study(engine, "study-one", "one")
+    before = _schema(engine)
+    # Guards against comparing two snapshots that describe nothing.
+    assert before[REFERENCE_TABLE]["primary_key"] == [STRING_KEY]
+    assert STRING_KEY in before["area"]["columns"]
+
+    command.upgrade(alembic_cfg, REVISION)
+    command.downgrade(alembic_cfg, PREVIOUS_REVISION)
+
+    assert _schema(engine) == before
+
+    with engine.connect() as connection:
+        # Data loss is expected — but only of the study data, not of the studies themselves.
+        for table in SEEDED_TABLES:
+            assert connection.execute(sa.text(f'SELECT COUNT(*) FROM "{table}"')).scalar_one() == 0
+        assert connection.execute(sa.text(f"SELECT {STRING_KEY} FROM {REFERENCE_TABLE}")).scalars().all() == [
+            "study-one"
+        ]
+        assert connection.execute(sa.text("SELECT id FROM study")).scalars().all() == ["study-one"]
+
+    # The rebuilt schema is the one the upgrade was written against.
+    command.upgrade(alembic_cfg, REVISION)
+    assert _study_data_id(engine, "study-one") is not None
+
+
+def _schema(engine: Engine) -> Dict[str, Any]:
+    """
+    The parts of the schema the migration rewrites, in a form that can be compared across the
+    upgrade/downgrade round trip.
+
+    Constraint and index names are dropped: PostgreSQL and SQLite name them differently, and the
+    migration renames some on the way. Column order is dropped too: PostgreSQL cannot insert a
+    column in the middle of a table, so the downgrade appends the restored `study_id`.
+    """
+    inspector = sa.inspect(engine)
+    schema = {}
+    for table in sorted(inspector.get_table_names()):
+        schema[table] = {
+            "columns": {
+                column["name"]: (str(column["type"]), column["nullable"]) for column in inspector.get_columns(table)
+            },
+            "primary_key": inspector.get_pk_constraint(table)["constrained_columns"],
+            "foreign_keys": sorted(
+                (
+                    tuple(fk["constrained_columns"]),
+                    fk["referred_table"],
+                    tuple(fk["referred_columns"]),
+                    fk["options"].get("ondelete"),
+                )
+                for fk in inspector.get_foreign_keys(table)
+            ),
+            "indexes": sorted(
+                (tuple(index["column_names"]), bool(index["unique"])) for index in inspector.get_indexes(table)
+            ),
+        }
+    return schema

--- a/tests/core/test_study_data_key_migration.py
+++ b/tests/core/test_study_data_key_migration.py
@@ -289,10 +289,14 @@ def test_upgrade_replaces_the_study_key(engine: Engine, alembic_cfg: Config) -> 
         model_primary_key = [column.name for column in Base.metadata.tables[table].primary_key]
         assert primary_key == model_primary_key, f"Primary key of {table} does not match its model"
 
-    # `user_resources` is the one table whose study key is not covered by its primary key.
-    assert any(index["column_names"] == [SURROGATE_KEY] for index in inspector.get_indexes("user_resources")), (
-        "The foreign key of user_resources is left unindexed"
-    )
+    # `user_resources` is the one table whose study key is not covered by its primary key: it is
+    # the only one to need an explicit index, the others would only duplicate their primary key.
+    for table in SEEDED_TABLES:
+        indexed = any(index["column_names"] == [SURROGATE_KEY] for index in inspector.get_indexes(table))
+        if table == "user_resources":
+            assert indexed, "The foreign key of user_resources is left unindexed"
+        else:
+            assert not indexed, f"Table {table} carries an index duplicating its primary key"
 
     reference_columns = {column["name"] for column in inspector.get_columns(REFERENCE_TABLE)}
     assert reference_columns == {STRING_KEY, SURROGATE_KEY}

--- a/tests/integration/maintenance_blueprint/test_gc_blob.py
+++ b/tests/integration/maintenance_blueprint/test_gc_blob.py
@@ -122,10 +122,12 @@ class TestCleanBlobsIntegration:
         with db():
             db.session.add(create_study(id=study_id, name="Test Study", version="880"))
             db.session.flush()
-            db.session.execute(STUDY_DATA_TABLE.insert().values({"study_id": study_id}))
+            study_data_id = db.session.execute(
+                STUDY_DATA_TABLE.insert().values({"study_id": study_id}).returning(STUDY_DATA_TABLE.c.study_data_id)
+            ).scalar_one()
             db.session.execute(
                 USER_RESOURCES_TABLE.insert().values(
-                    study_id=study_id,
+                    study_data_id=study_data_id,
                     id=str(uuid.uuid4()),
                     parent_id=None,
                     name="my_file.txt",

--- a/tests/study/dao/test_binding_constraint_dao.py
+++ b/tests/study/dao/test_binding_constraint_dao.py
@@ -42,6 +42,7 @@ from antarest.study.dao.database.models.binding_constraint import (
     BINDING_CONSTRAINT_TABLE,
     BINDING_CONSTRAINT_VALUES_MATRIX_TABLE,
 )
+from antarest.study.dao.database.study_data_queries import belongs_to_study
 from antarest.study.model import STUDY_VERSION_8_8, Study
 from tests.study.dao.conftest import build_db_dao
 
@@ -726,7 +727,7 @@ def test_mixed_matrix_changes_in_one_call(dao: StudyDao) -> None:
 
 def _assert_tables_empty(db_session: Session, tables: list[Table], study_id: str) -> None:
     for table in tables:
-        rows = db_session.execute(select(table).where(table.c.study_id == study_id)).fetchall()
+        rows = db_session.execute(select(table).where(belongs_to_study(table, study_id))).fetchall()
         assert rows == [], f"{table.name}: expected no rows for study {study_id}, found {len(rows)}"
 
 

--- a/tests/study/dao/test_database_blob_usage_provider.py
+++ b/tests/study/dao/test_database_blob_usage_provider.py
@@ -11,10 +11,15 @@
 # This file is part of the Antares project.
 from pathlib import PurePosixPath
 
+from sqlalchemy.orm import Session
+
 from antarest.blobstore.model import BlobReference
+from antarest.matrixstore.service import ISimpleMatrixService
 from antarest.study.business.model.user_model import ResourceType, UserResourceDataCreation
 from antarest.study.dao.database.database_blob_usage_provider import DatabaseBlobUsageProvider
 from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+from antarest.study.model import STUDY_VERSION_8_8
+from tests.conftest import build_db_dao
 
 
 def test_blob_usage_provider_returns_blob_ids(db_dao: DatabaseStudyDao) -> None:
@@ -55,6 +60,30 @@ def test_blob_usage_provider_ignores_folders(db_dao: DatabaseStudyDao) -> None:
 
     assert len(used_blobs) == 1
     assert used_blobs[0].blob_id == "blob_aaa"
+
+
+def test_blob_usage_provider_reports_every_study(
+    db_dao: DatabaseStudyDao, db_session: Session, matrix_service: ISimpleMatrixService
+) -> None:
+    """
+    The provider walks all studies at once. Since `user_resources` is keyed by `study_data_id`,
+    the study each blob is used by is recovered by a join, which must not lose or mix up rows.
+    """
+    other_dao = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    db_dao.save_user_resources(
+        [UserResourceDataCreation(path=PurePosixPath("a.txt"), resource_type=ResourceType.FILE, blob_id="blob_aaa")]
+    )
+    other_dao.save_user_resources(
+        [UserResourceDataCreation(path=PurePosixPath("b.txt"), resource_type=ResourceType.FILE, blob_id="blob_bbb")]
+    )
+
+    provider = DatabaseBlobUsageProvider()
+    usage = {b.blob_id: b.use_description for b in provider.get_blob_usage()}
+
+    assert usage == {
+        "blob_aaa": f"Used by study {db_dao.get_study_id()}",
+        "blob_bbb": f"Used by study {other_dao.get_study_id()}",
+    }
 
 
 def test_blob_usage_provider_empty() -> None:

--- a/tests/study/dao/test_database_hydro_dao.py
+++ b/tests/study/dao/test_database_hydro_dao.py
@@ -47,6 +47,7 @@ from antarest.study.dao.database.models.hydro import (
     HYDRO_RUN_OF_RIVER_TABLE,
     HYDRO_WATER_VALUES_TABLE,
 )
+from antarest.study.dao.database.study_data_queries import belongs_to_study
 from tests.study.dao.utils import save_area
 
 
@@ -430,7 +431,7 @@ class TestCascadeDelete:
         # Verify hydro management is also deleted
         with db_session:
             stmt = select(HYDRO_MANAGEMENT_TABLE).where(
-                (HYDRO_MANAGEMENT_TABLE.c.study_id == dao.get_study_id())
+                (belongs_to_study(HYDRO_MANAGEMENT_TABLE, dao.get_study_id()))
                 & (HYDRO_MANAGEMENT_TABLE.c.area_id == "paris")
             )
             row = db_session.execute(stmt).fetchone()
@@ -447,7 +448,7 @@ class TestCascadeDelete:
         # Verify inflow structure is also deleted
         with db_session:
             stmt = select(HYDRO_INFLOW_STRUCTURE_TABLE).where(
-                (HYDRO_INFLOW_STRUCTURE_TABLE.c.study_id == dao.get_study_id())
+                (belongs_to_study(HYDRO_INFLOW_STRUCTURE_TABLE, dao.get_study_id()))
                 & (HYDRO_INFLOW_STRUCTURE_TABLE.c.area_id == "paris")
             )
             row = db_session.execute(stmt).fetchone()
@@ -474,14 +475,14 @@ class TestCascadeDelete:
 
         with db_session:
             stmt = select(HYDRO_ALLOCATION_TABLE).where(
-                (HYDRO_ALLOCATION_TABLE.c.study_id == dao.get_study_id())
+                (belongs_to_study(HYDRO_ALLOCATION_TABLE, dao.get_study_id()))
                 & (HYDRO_ALLOCATION_TABLE.c.target_area_id == "london")
             )
             rows = db_session.execute(stmt).fetchall()
             assert len(rows) == 0
 
             stmt = select(HYDRO_ALLOCATION_TABLE).where(
-                (HYDRO_ALLOCATION_TABLE.c.study_id == dao.get_study_id())
+                (belongs_to_study(HYDRO_ALLOCATION_TABLE, dao.get_study_id()))
                 & (HYDRO_ALLOCATION_TABLE.c.source_area_id == "paris")
             )
             rows = db_session.execute(stmt).fetchall()
@@ -504,7 +505,7 @@ class TestCascadeDelete:
 
         with db_session:
             stmt = select(HYDRO_ALLOCATION_TABLE).where(
-                (HYDRO_ALLOCATION_TABLE.c.study_id == dao.get_study_id())
+                (belongs_to_study(HYDRO_ALLOCATION_TABLE, dao.get_study_id()))
                 & (HYDRO_ALLOCATION_TABLE.c.source_area_id == "paris")
             )
             rows = db_session.execute(stmt).fetchall()

--- a/tests/study/dao/test_database_xpansion_dao.py
+++ b/tests/study/dao/test_database_xpansion_dao.py
@@ -48,18 +48,19 @@ from antarest.study.dao.database.models.xpansion import (
     XPANSION_SETTINGS_TABLE,
     XPANSION_WEIGHT_TABLE,
 )
+from antarest.study.dao.database.study_data_queries import belongs_to_study
 from tests.study.dao.utils import save_area
 
 
 def _assert_tables_empty(db_session: Session, tables: list[Table], study_id: str) -> None:
     for table in tables:
-        rows = db_session.execute(select(table).where(table.c.study_id == study_id)).fetchall()
+        rows = db_session.execute(select(table).where(belongs_to_study(table, study_id))).fetchall()
         assert rows == [], f"{table.name}: expected no rows for study {study_id}, found {len(rows)}"
 
 
 def _assert_tables_have_row(db_session: Session, tables: list[Table], study_id: str) -> None:
     for table in tables:
-        row = db_session.execute(select(table).where(table.c.study_id == study_id)).fetchone()
+        row = db_session.execute(select(table).where(belongs_to_study(table, study_id))).fetchone()
         assert row is not None, f"{table.name}: expected a row for study {study_id}"
 
 

--- a/tests/study/dao/test_study_data_cleaning.py
+++ b/tests/study/dao/test_study_data_cleaning.py
@@ -28,7 +28,8 @@ def test_study_data_cleaning(db_dao_920: DatabaseStudyDao, db_session: Session) 
 
     # Check the content of the different tables
     with db_session:
-        study_data_rows = db_session.execute(select(STUDY_DATA_TABLE)).fetchall()
+        # Only the study ID is asserted: `study_data_id` is a generated surrogate key.
+        study_data_rows = db_session.execute(select(STUDY_DATA_TABLE.c.study_id)).fetchall()
         assert study_data_rows == [(dao.get_study_id(),)]
 
         area_properties_rows = db_session.execute(select(AREA_TABLE)).fetchall()

--- a/tests/study/dao/test_study_data_key.py
+++ b/tests/study/dao/test_study_data_key.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Behaviour of the surrogate study key the database DAOs are built on.
+
+The study data tables are keyed by `study_data.study_data_id`, a generated bigint, while the
+rest of the application knows studies by their 36 chars id. These tests cover the translation
+between the two: it must resolve to the right study, isolate studies from one another, and never
+outlive the `study_data` row it was read from.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from antarest.blobstore.in_memory import InMemoryBlobService
+from antarest.core.exceptions import StudyNotFoundError
+from antarest.matrixstore.service import ISimpleMatrixService
+from antarest.study.business.model.area_properties_model import AreaProperties
+from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+from antarest.study.dao.database.database_study_factory_dao import DatabaseStudyDaoFactory
+from antarest.study.dao.database.models import STUDY_DATA_TABLE
+from antarest.study.dao.database.models.area import AREA_TABLE
+from antarest.study.model import STUDY_VERSION_8_8, StorageMode, Study, StudyMetadataCreation
+from antarest.study.storage.variantstudy.business.matrix_constants_generator import GeneratorMatrixConstants
+from tests.conftest import build_db_dao
+from tests.helpers import create_study
+
+
+def _build_factory(db_session: Session, matrix_service: ISimpleMatrixService) -> DatabaseStudyDaoFactory:
+    generator_matrix_constants = GeneratorMatrixConstants(matrix_service)
+    generator_matrix_constants.init_constant_matrices()
+    return DatabaseStudyDaoFactory(matrix_service, InMemoryBlobService(), generator_matrix_constants, db_session)
+
+
+def _stored_study_data_id(db_session: Session, study_id: str) -> int:
+    stmt = select(STUDY_DATA_TABLE.c.study_data_id).where(STUDY_DATA_TABLE.c.study_id == study_id)
+    study_data_id: int = db_session.execute(stmt).scalar_one()
+    return study_data_id
+
+
+def test_study_id_stays_the_string_id(db_dao: DatabaseStudyDao, db_session: Session) -> None:
+    """
+    `get_study_id()` is public API used all over the application: the surrogate key must not
+    leak through it.
+    """
+    study_id = db_dao.get_study_id()
+
+    assert isinstance(study_id, str)
+    assert db_session.get(Study, study_id) is not None
+
+
+def test_study_data_id_is_resolved_from_the_database(db_session: Session, matrix_service: ISimpleMatrixService) -> None:
+    """
+    A DAO obtained for an existing study — the read path, as opposed to study creation — resolves
+    its key by looking it up.
+    """
+    created = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    study_id = created.get_study_id()
+
+    dao = _build_factory(db_session, matrix_service).get_study_dao(study_id, True)
+
+    assert dao._study_data_id == _stored_study_data_id(db_session, study_id)
+
+
+def test_resolution_fails_for_a_study_without_data(db_session: Session, matrix_service: ISimpleMatrixService) -> None:
+    """
+    A study whose data was cleared has no `study_data` row. Querying it must fail loudly rather
+    than silently match nothing.
+    """
+    study_id = str(uuid.uuid4())
+    with db_session:
+        study = create_study(id=study_id, name="No data", version=str(STUDY_VERSION_8_8))
+        study.storage_mode = StorageMode.DATABASE
+        db_session.add(study)
+        db_session.commit()
+
+    dao = _build_factory(db_session, matrix_service).get_study_dao(study_id, True)
+
+    with pytest.raises(StudyNotFoundError):
+        dao.get_all_area_ids()
+
+
+def test_studies_do_not_see_each_other_data(db_session: Session, matrix_service: ISimpleMatrixService) -> None:
+    """
+    The whole point of the key swap is that every data row carries the study it belongs to. Two
+    studies sharing a table must not read each other's rows.
+    """
+    first = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    second = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+
+    first.save_areas_with_properties({"fr": AreaProperties()})
+    second.save_areas_with_properties({"de": AreaProperties(), "es": AreaProperties()})
+
+    assert set(first.get_all_area_ids()) == {"fr"}
+    assert set(second.get_all_area_ids()) == {"de", "es"}
+
+    first_id = _stored_study_data_id(db_session, first.get_study_id())
+    second_id = _stored_study_data_id(db_session, second.get_study_id())
+    assert first_id != second_id
+
+    stored = db_session.execute(select(AREA_TABLE.c.study_data_id, AREA_TABLE.c.area_id)).fetchall()
+    assert sorted(stored) == sorted([(first_id, "fr"), (second_id, "de"), (second_id, "es")])
+
+
+def test_two_studies_can_hold_the_same_area_id(db_session: Session, matrix_service: ISimpleMatrixService) -> None:
+    """
+    Every write goes through `upsert_multiple`, whose conflict target is the primary key of the
+    table — now led by `study_data_id`. Were the study left out of it, saving an area in one study
+    would overwrite the area of the same name in another.
+    """
+    first = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    second = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+
+    first.save_areas_with_properties({"fr": AreaProperties(energy_cost_unsupplied=1.0)})
+    second.save_areas_with_properties({"fr": AreaProperties(energy_cost_unsupplied=2.0)})
+
+    assert first.get_all_area_ids() == ["fr"]
+    assert second.get_all_area_ids() == ["fr"]
+    assert first.get_area_properties("fr").energy_cost_unsupplied == 1.0
+    assert second.get_area_properties("fr").energy_cost_unsupplied == 2.0
+
+
+def test_deleting_a_study_clears_its_data_only(db_session: Session, matrix_service: ISimpleMatrixService) -> None:
+    first = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    second = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    first.save_areas_with_properties({"fr": AreaProperties()})
+    second.save_areas_with_properties({"de": AreaProperties()})
+    second_id = _stored_study_data_id(db_session, second.get_study_id())
+
+    with db_session:
+        db_session.delete(db_session.get(Study, first.get_study_id()))
+        db_session.commit()
+
+    with db_session:
+        remaining_studies = db_session.execute(select(STUDY_DATA_TABLE.c.study_id)).scalars().all()
+        assert remaining_studies == [second.get_study_id()]
+        remaining_areas = db_session.execute(select(AREA_TABLE.c.study_data_id, AREA_TABLE.c.area_id)).fetchall()
+        assert [tuple(row) for row in remaining_areas] == [(second_id, "de")]
+
+
+def test_recreated_study_data_gets_a_new_key(db_session: Session, matrix_service: ISimpleMatrixService) -> None:
+    """
+    Clearing a study's data and re-extracting it (unarchive, snapshot regeneration, ...) deletes
+    the `study_data` row and inserts a new one. The DAO caches its key, so it must not be reused
+    across that: this test pins the invariant every such path relies on — a DAO built afterwards
+    reads the key of the new row, and the data of the previous incarnation is gone.
+    """
+    factory = _build_factory(db_session, matrix_service)
+    dao = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    study_id = dao.get_study_id()
+    dao.save_areas_with_properties({"fr": AreaProperties()})
+    initial_id = _stored_study_data_id(db_session, study_id)
+
+    # What `remove_study_data` does, followed by a re-extraction.
+    with db_session:
+        db_session.execute(delete(STUDY_DATA_TABLE).where(STUDY_DATA_TABLE.c.study_id == study_id))
+        db_session.commit()
+    recreated = factory.create_study_dao(StudyMetadataCreation(id=study_id, version=STUDY_VERSION_8_8, managed=True))
+
+    new_id = _stored_study_data_id(db_session, study_id)
+    assert recreated._study_data_id == new_id
+    # The data of the previous incarnation went away with its `study_data` row.
+    assert recreated.get_all_area_ids() == []
+    # A DAO built after the fact reads the new key, whether or not the value changed: SQLite
+    # reuses the freed rowid, PostgreSQL takes the next value of its sequence.
+    assert factory.get_study_dao(study_id, True)._study_data_id == new_id
+    # The hazard this guards against: the DAO of the previous incarnation still holds the key it
+    # resolved. It is only harmless because no caller keeps one across a re-extraction.
+    assert dao._study_data_id == initial_id

--- a/tests/study/dao/test_study_data_key.py
+++ b/tests/study/dao/test_study_data_key.py
@@ -87,10 +87,8 @@ def test_resolution_fails_for_a_study_without_data(db_session: Session, matrix_s
         db_session.add(study)
         db_session.commit()
 
-    dao = _build_factory(db_session, matrix_service).get_study_dao(study_id, True)
-
     with pytest.raises(StudyNotFoundError):
-        dao.get_all_area_ids()
+        _build_factory(db_session, matrix_service).get_study_dao(study_id, True)
 
 
 def test_studies_do_not_see_each_other_data(db_session: Session, matrix_service: ISimpleMatrixService) -> None:

--- a/tests/study/dao/test_study_data_queries.py
+++ b/tests/study/dao/test_study_data_queries.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Cross-study queries on the study data tables, used by the garbage collectors.
+
+These are the two places that read the study data tables from outside a `DatabaseStudyDao`, and
+they decide what gets deleted: a matrix or a blob missing from their listing is collected. Since
+the tables are now keyed by `study_data_id`, both have to join back through `study_data`, and a
+join that drops rows silently destroys data that is still in use.
+"""
+
+from pathlib import PurePosixPath
+
+import polars as pl
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from antarest.matrixstore.service import ISimpleMatrixService
+from antarest.study.business.model.area_properties_model import AreaProperties
+from antarest.study.business.model.user_model import ResourceType, UserResourceDataCreation
+from antarest.study.dao.database.database_study_dao import DatabaseStudyDao
+from antarest.study.dao.database.models import STUDY_DATA_TABLE
+from antarest.study.dao.database.models.area import LOAD_TABLE, SOLAR_TABLE
+from antarest.study.dao.database.study_data_queries import belongs_to_study, yield_matrix_ids, yield_used_blobs
+from antarest.study.model import STUDY_VERSION_8_8
+from tests.conftest import build_db_dao
+
+
+def _save_load_and_solar(dao: DatabaseStudyDao, area_id: str) -> tuple[str, str]:
+    """Give a study one `load` and one `solar` matrix, and return their ids."""
+    dao.save_areas_with_properties({area_id: AreaProperties()})
+    load_id = dao.matrix_service.create(pl.DataFrame(data=[[1.0], [2.0]], orient="row"))
+    solar_id = dao.matrix_service.create(pl.DataFrame(data=[[3.0], [4.0]], orient="row"))
+    dao.save_load({area_id: load_id})
+    dao.save_solar({area_id: solar_id})
+    return load_id, solar_id
+
+
+def test_matrix_usage_is_scoped_to_one_study(db_session: Session, matrix_service: ISimpleMatrixService) -> None:
+    """
+    The matrix garbage collector asks for the matrices of one study at a time. Returning another
+    study's matrices would keep dead matrices alive; missing one would delete a live matrix.
+    """
+    first = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    second = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    first_load, first_solar = _save_load_and_solar(first, "fr")
+    second_load, second_solar = _save_load_and_solar(second, "de")
+
+    tables = [LOAD_TABLE, SOLAR_TABLE]
+    first_usage = set(yield_matrix_ids(db_session, tables, first.get_study_id()))
+    second_usage = set(yield_matrix_ids(db_session, tables, second.get_study_id()))
+
+    assert first_usage == {(LOAD_TABLE, first_load), (SOLAR_TABLE, first_solar)}
+    assert second_usage == {(LOAD_TABLE, second_load), (SOLAR_TABLE, second_solar)}
+
+
+def test_matrix_usage_of_an_unknown_study_is_empty(db_session: Session, matrix_service: ISimpleMatrixService) -> None:
+    """
+    A study with no `study_data` row has no data left to reference matrices, so reporting none is
+    the right answer — and the one that lets the collector reclaim them.
+    """
+    dao = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    _save_load_and_solar(dao, "fr")
+
+    with db_session:
+        db_session.execute(delete(STUDY_DATA_TABLE).where(STUDY_DATA_TABLE.c.study_id == dao.get_study_id()))
+        db_session.commit()
+
+    assert list(yield_matrix_ids(db_session, [LOAD_TABLE, SOLAR_TABLE], dao.get_study_id())) == []
+    assert list(yield_matrix_ids(db_session, [LOAD_TABLE, SOLAR_TABLE], "never-existed")) == []
+
+
+def test_belongs_to_study_selects_the_rows_of_one_study(
+    db_session: Session, matrix_service: ISimpleMatrixService
+) -> None:
+    first = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    second = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    _save_load_and_solar(first, "fr")
+    _save_load_and_solar(second, "de")
+
+    stmt = select(LOAD_TABLE.c.area_id).where(belongs_to_study(LOAD_TABLE, first.get_study_id()))
+
+    assert db_session.execute(stmt).scalars().all() == ["fr"]
+
+
+def test_used_blobs_are_attributed_to_their_study(db_session: Session, matrix_service: ISimpleMatrixService) -> None:
+    """
+    The blob garbage collector walks every study at once, and each blob is reported along with the
+    study using it. A join losing rows would collect blobs that are still referenced.
+    """
+    first = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    second = build_db_dao(db_session, matrix_service, STUDY_VERSION_8_8)
+    first.save_user_resources(
+        [UserResourceDataCreation(path=PurePosixPath("a.txt"), resource_type=ResourceType.FILE, blob_id="blob_a")]
+    )
+    second.save_user_resources(
+        [
+            UserResourceDataCreation(path=PurePosixPath("b.txt"), resource_type=ResourceType.FILE, blob_id="blob_b"),
+            UserResourceDataCreation(path=PurePosixPath("folder"), resource_type=ResourceType.FOLDER),
+        ]
+    )
+
+    assert set(yield_used_blobs(db_session)) == {
+        ("blob_a", first.get_study_id()),
+        ("blob_b", second.get_study_id()),
+    }


### PR DESCRIPTION

Both:
- a design improvement, because now study data actually get a proper identifier,
  distinct from the study ID, which makes more sense because they don't share
  their lifetime: for instance, a variant snapshot will be deleted independently from
  its containing study.
- will avoid repeating 36 char strings thousands or millions of times in DB tables,
  improving disk and memory efficiency

Implemented with LLM support, and reviewed carefully.

Implementation note:
for postgresql the migration APPENDS the new study_data_id to existing columns,
therefore it will appear last. It should not have negative impacts about performance
or disk usage, the important point being that it's the first column in primary keys.
This avoids re-creating all tables from scratch.