### PR TITLE
fix(ui): stabilize debounced output export in ExportModal

### DIFF
--- a/webapp/src/routes/-shared/components/studies/dialogs/ExportModal/index.tsx
+++ b/webapp/src/routes/-shared/components/studies/dialogs/ExportModal/index.tsx
@@ -14,12 +14,12 @@
 
 import BasicDialog, { type BasicDialogProps } from "@/components/dialogs/BasicDialog";
 import SelectSingle from "@/components/SelectSingle";
+import useDebounce from "@/hooks/useDebounce";
 import { getOutputs } from "@/services/api/studies/outputs";
 import type { Output } from "@/services/api/studies/outputs/types";
 import { Box, Button } from "@mui/material";
 import type { AxiosError } from "axios";
 import debug from "debug";
-import debounce from "lodash/debounce";
 import { useSnackbar } from "notistack";
 import * as R from "ramda";
 import { useEffect, useState } from "react";
@@ -81,7 +81,7 @@ export default function ExportModal(props: BasicDialogProps & Props) {
     includeClusters: false,
   });
 
-  const exportOutput = debounce(
+  const exportOutput = useDebounce(
     async (output: string) => {
       if (study) {
         try {
@@ -91,8 +91,7 @@ export default function ExportModal(props: BasicDialogProps & Props) {
         }
       }
     },
-    2000,
-    { leading: true, trailing: false },
+    { wait: 2000, leading: true, trailing: false },
   );
 
   const onExportFiltered = async (


### PR DESCRIPTION
## Fix broken debounce in ExportModal
[(Sonar issue) ](https://sonarcloud.io/project/issues?severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&types=BUG&branch=refactor%2Fadd-study-data-id-bigint&id=AntaresSimulatorTeam_api-iso-antares&open=AZ_xFSavG2oxJMR_1auA)

`exportOutput` was created with `lodash/debounce` directly in the component body, so every render produced a fresh instance with a clean timer. 
Since clicking Export closes the dialog (triggering a re-render), the guard never actually suppressed anything, a double-click during the close transition could fire the export API twice.

Fixed by switching to the existing `useDebounce` hook, which memoizes the
debounce instance and always invokes the latest callback via a ref.

Resolves the Sonar warning on this file.