### PR TITLE
chore(ui-study): hide DB storage mode for now

### DIFF
--- a/webapp/src/routes/-shared/components/studies/dialogs/ImportStudyDialog/index.tsx
+++ b/webapp/src/routes/-shared/components/studies/dialogs/ImportStudyDialog/index.tsx
@@ -75,6 +75,7 @@ function ImportStudyDialog({ open, onClose }: Props) {
   // JSX
   ////////////////////////////////////////////////////////////////
 
+  const enableDatabaseStorage = false; // To be removed when activating the feature
   return (
     <UploadDialog
       open={open}
@@ -94,21 +95,23 @@ function ImportStudyDialog({ open, onClose }: Props) {
             onChange={(event) => setDestination(event.target.value)}
             fillHeight
           />
-          <SelectFE
-            label={t("studies.storageMode")}
-            options={[
-              { value: StorageMode.FILESYSTEM, label: t("studies.storageMode.filesystem") },
-              { value: StorageMode.DATABASE, label: t("studies.storageMode.database") },
-            ]}
-            value={storageMode}
-            onChange={(event) => setStorageMode(event.target.value as StorageMode)}
-            helperText={
-              storageMode === StorageMode.DATABASE
-                ? t("studies.storageMode.gemsCompatible")
-                : undefined
-            }
-            size="small"
-          />
+          {enableDatabaseStorage && (
+            <SelectFE
+              label={t("studies.storageMode")}
+              options={[
+                { value: StorageMode.FILESYSTEM, label: t("studies.storageMode.filesystem") },
+                { value: StorageMode.DATABASE, label: t("studies.storageMode.database") },
+              ]}
+              value={storageMode}
+              onChange={(event) => setStorageMode(event.target.value as StorageMode)}
+              helperText={
+                storageMode === StorageMode.DATABASE
+                  ? t("studies.storageMode.gemsCompatible")
+                  : undefined
+              }
+              size="small"
+            />
+          )}
           <CheckBoxFE
             value={redirect}
             onChange={(_event, checked) => setRedirect(checked)}

--- a/webapp/src/routes/_authenticated/studies/-components/CreateStudyDialog.tsx
+++ b/webapp/src/routes/_authenticated/studies/-components/CreateStudyDialog.tsx
@@ -101,6 +101,7 @@ function CreateStudyDialog({ open, onClose }: Props) {
   ////////////////////////////////////////////////////////////////
   // JSX
   ////////////////////////////////////////////////////////////////
+  const enableDatabaseStorage = false; // To be removed when activating the feature
 
   return (
     <FormDialog
@@ -136,20 +137,22 @@ function CreateStudyDialog({ open, onClose }: Props) {
               control={control}
               rules={{ required: t("form.field.required") }}
             />
-            <SelectFE
-              label={t("studies.storageMode")}
-              options={[
-                { value: StorageMode.FILESYSTEM, label: t("studies.storageMode.filesystem") },
-                { value: StorageMode.DATABASE, label: t("studies.storageMode.database") },
-              ]}
-              name="storageMode"
-              control={control}
-              helperText={
-                watch("storageMode") === StorageMode.DATABASE
-                  ? t("studies.storageMode.gemsCompatible")
-                  : undefined
-              }
-            />
+            {enableDatabaseStorage && (
+              <SelectFE
+                label={t("studies.storageMode")}
+                options={[
+                  { value: StorageMode.FILESYSTEM, label: t("studies.storageMode.filesystem") },
+                  { value: StorageMode.DATABASE, label: t("studies.storageMode.database") },
+                ]}
+                name="storageMode"
+                control={control}
+                helperText={
+                  watch("storageMode") === StorageMode.DATABASE
+                    ? t("studies.storageMode.gemsCompatible")
+                    : undefined
+                }
+              />
+            )}
           </Fieldset>
           <Fieldset legend={t("global.permission")} fullFieldWidth>
             <SelectFE


### PR DESCRIPTION

Not fully functional on the backend side, we'd better not enable it for that release.

See https://github.com/AntaresSimulatorTeam/AntaREST/pull/3351 