### PR TITLE
fix(db): use PGDATA so the postgres volume is actually used

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     container_name: postgres
     environment:
       - POSTGRES_PASSWORD=somepass
-      - PG_DATA=/var/lib/postgresql/data/pgdata
+      - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - ./resources/deploy/db:/var/lib/postgresql/data
     command: [ "postgres", "-c", "log_statement=all", "-c", "log_destination=stderr" ]


### PR DESCRIPTION
## Problem

The `postgresql` service sets `PG_DATA`, but the postgres image reads `PGDATA`. `PG_DATA` is not a variable the image knows about, so the setting has always been inert and `PGDATA` kept the image default.

Until postgres 17 that default was `/var/lib/postgresql/data`, exactly where this compose file mounts `./resources/deploy/db`, so the typo had no visible effect. The postgres 18 image moved the data directory to `/var/lib/postgresql/18/docker` and added a guard that refuses to start when it finds an unused mount at the old location.

**With `postgres:latest` now resolving to 18, the `postgresql` service does not start at all:**

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).
       See also https://github.com/docker-library/postgres/pull/1259

       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)
```

## Reproduction

```
$ docker run --rm postgres:17 sh -c 'echo $PGDATA'
/var/lib/postgresql/data

$ docker run --rm postgres:18 sh -c 'echo $PGDATA'
/var/lib/postgresql/18/docker

$ docker run --rm -e PG_DATA=/var/lib/postgresql/data/pgdata postgres:18 sh -c 'echo $PGDATA'
/var/lib/postgresql/18/docker
```

With the fix applied, from an empty `./resources/deploy/db`, the service starts and `show data_directory` reports `/var/lib/postgresql/data/pgdata`, inside the mount. Verified against postgres:18.4.

## ⚠️ Migration note for existing deployments

On an instance that has already run the current configuration, the data sits at the **root** of `./resources/deploy/db`, because `PGDATA` was the image default `/var/lib/postgresql/data`, which is the mount point itself. This change moves `PGDATA` into a `pgdata/` subdirectory, so postgres finds an empty directory and initialises a **new, empty cluster** next to the existing one.

Reproduced on postgres:17 with a test table:

```
before: data_directory = /var/lib/postgresql/data          (base, global, PG_VERSION at the mount root)
after:  data_directory = /var/lib/postgresql/data/pgdata
        select v from important -> ERROR: relation "important" does not exist
```

Nothing is deleted, the old cluster files remain alongside the new `pgdata/`, but the application sees an empty database. So before applying this on an existing instance, dump and restore:

```bash
# with the old configuration still in place
docker compose exec postgresql pg_dumpall -U postgres > antarest-db.sql

# then apply this change, start the stack, and reload
docker compose exec -T postgresql psql -U postgres < antarest-db.sql
```

Moving the files instead of dumping also works, provided the postgres major version does not change at the same time.

Would it be worth mentioning this in `docs/deploy.md`? Happy to add it here if you prefer it in the same PR.

## Alternative worth considering

The postgres image's own recommendation for 18+ is to mount the parent directory and let `PGDATA` keep its default, which keeps `pg_upgrade --link` free of mount point boundary issues:

```yaml
    volumes:
      - ./resources/deploy/db:/var/lib/postgresql
```

I verified that this works too, with the data landing in `db/18/docker`. It carries the same migration caveat as above. I went with the minimal one-character change since it preserves the current on-disk layout, but I am happy to switch this PR to the recommended layout if you prefer it.
