### PR TITLE
fix(gunicorn): cap the default number of workers at 30

### DIFF
--- a/resources/deploy/gunicorn.py
+++ b/resources/deploy/gunicorn.py
@@ -13,11 +13,16 @@ the formula is based on the assumption that for a given core,
 one worker will be reading or writing from the socket
 while the other worker is processing a request.
 https://docs.gunicorn.org/en/stable/design.html#how-many-workers
+
+The result is capped, the same way scripts/start.sh already caps its own
+uvicorn path: past a few dozen workers, the memory each one needs to load the
+application outweighs the extra concurrency.
 """
 
 workers = os.getenv("GUNICORN_WORKERS")
 if workers == "ALL_AVAILABLE" or workers is None:
-    workers = multiprocessing.cpu_count() * 2 + 1
+    # max is 30, as in scripts/start.sh
+    workers = min(30, multiprocessing.cpu_count() * 2 + 1)
 
 timeout = 10 * 120  # 10 minutes
 keepalive = 24 * 60 * 60  # 1 day


### PR DESCRIPTION
`scripts/start.sh` already caps its uvicorn path at 30 workers, with the comment `# default (2*nproc + 1) and max is 30`, but the gunicorn path it takes by default reads `resources/deploy/gunicorn.py`, which applies the same formula with no upper bound.

The two therefore disagree on the same machine. On a 24-core host the uvicorn path starts 30 workers and the gunicorn path 49, each loading the whole application, for a concurrency nothing in a web front-end needs: the heavy work happens in the solver.

Apply the cap the shell script already uses, so both paths agree. Setting `GUNICORN_WORKERS` explicitly still overrides it, and hosts with 14 cores or fewer are unaffected.

| cores | before | after |
|---|---|---|
| 4 | 9 | 9 |
| 14 | 29 | 29 |
| 24 | 49 | 30 |
| 64 | 129 | 30 |

## Why the cap is hardcoded rather than configurable

`GUNICORN_WORKERS` already overrides the computed default, so a deployment that genuinely wants more than 30 workers can just set it. Adding a second variable to raise the cap would also apply to the gunicorn path only, since `scripts/start.sh` hardcodes its own 30 with no override at all, and that asymmetry between the two paths is precisely what this PR removes. If a configurable cap is wanted, it seems better to add it to both paths at once, in its own change.

Two related things I deliberately left out of scope, happy to open separate PRs if you want either: reading `GUNICORN_WORKERS` needs no explicit parsing, because gunicorn's `workers` setting goes through `validate_pos_int`, which coerces a numeric string with `int(val, 0)` and rejects anything else with an explicit error (that is also why the existing code has to special-case `"ALL_AVAILABLE"`, the one value the validator cannot take); and a test for this file would mean importing a configuration file that is meant to be consumed by `gunicorn --config`, which executes it and reads the environment.
