### PR TITLE
fix(blobstore): persist the blob bucket outside the container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./resources/deploy/examples:/workspaces
       - ./resources/deploy/tmp:/antarest_tmp_dir
       - ./resources/deploy/matrices:/matrixstore
+      - ./resources/deploy/blobstore:/blobstore
       - ./resources/deploy/config.prod.yaml:/resources/application.yaml
       - ./resources/deploy/logs:/logs
       - ./resources/deploy/gunicorn.py:/conf/gunicorn.py
@@ -23,6 +24,7 @@ services:
       - ./resources/deploy/examples:/workspaces
       - ./resources/deploy/tmp:/antarest_tmp_dir
       - ./resources/deploy/matrices:/matrixstore
+      - ./resources/deploy/blobstore:/blobstore
       - ./resources/deploy/config.prod.yaml:/resources/application.yaml
       - ./resources/deploy/logs:/logs
     depends_on:
@@ -35,6 +37,7 @@ services:
       - ./resources/deploy/examples:/workspaces
       - ./resources/deploy/tmp:/antarest_tmp_dir
       - ./resources/deploy/matrices:/matrixstore
+      - ./resources/deploy/blobstore:/blobstore
       - ./resources/deploy/config.prod.yaml:/resources/application.yaml
       - ./resources/deploy/logs:/logs
     depends_on:

--- a/resources/deploy/config.prod.yaml
+++ b/resources/deploy/config.prod.yaml
@@ -18,6 +18,7 @@ storage:
   tmp_dir: /antarest_tmp_dir
   archive_dir: /studies/archives
   matrixstore: /matrixstore
+  blobstore: /blobstore
   matrix_gc_dry_run: true
   workspaces:
     default: # required, no filters applied, this folder is not watched


### PR DESCRIPTION
`storage.blobstore` is not set in the deployment configuration, and its default in `antarest/core/config.py` is the relative path `./blobstore`. The image has no `WORKDIR`, so the bucket resolves to `/blobstore` inside the container, and nothing in `docker-compose.yml` mounts that path.

## Following docs/deploy.md, the stack does not start

`docs/deploy.md` tells the reader to copy `docker-compose.override.yml.example` and replace UID and GID with their own. That example sets `user: UID:GID` on the three antarest services. `BlobContentRepository.__init__` then calls `mkdir(parents=True, exist_ok=True)` on `/blobstore` as that unprivileged user, which fails:

```
PermissionError: [Errno 13] Permission denied: 'blobstore'
[ERROR] Worker (pid:8) exited with code 3
[ERROR] Reason: Worker failed to boot.
```

The container then restarts in a loop. nginx stays up and keeps serving the web app, so the symptom is a `502 Bad Gateway` on `/api/health` rather than an obvious crash, and the traceback lands in `/logs/gunicorn.error.log` rather than in `docker logs`.

## Without the override, the data is lost instead

Running as root, the bucket is created, but it lives in the container's writable layer and disappears when the container is recreated. This is not a cache: `BlobContentRepository` is content-addressed authoritative storage, `save()` names each file after its sha256 and `get()` raises `BlobNotFound` once the file is gone.

## Why all three services

`create_core_services()` builds the blob service for every module, not just the API, so the watcher and the matrix garbage collector run the same `mkdir`. The mount therefore goes next to `matrixstore` on all three, and the directory gets an empty `.placeholder` like the ten other bind mount directories already in the repository.

## Notes for reviewers

A named volume would also solve it, but the five other storage paths in this service (`examples`, `tmp`, `matrices`, `logs`, plus the config files) are all host binds, so introducing one named volume for `blobstore` alone would make the file inconsistent. Moving the deployment to named volumes looks like a decision for the whole file rather than something to settle here, and I would rather not make it on your behalf.

For the same reason I did not add a `chown` step to the entrypoint: with the documented override the container is already running as an unprivileged user, so it could not chown anything, and `./resources/deploy/blobstore` simply needs to be writable by that UID exactly like `matrices`, `tmp` and `logs` already do.

I checked the other deployment artefacts in the repository. `resources/deploy/config.yaml` and `resources/application.yaml` use relative paths throughout (`./tmp`, `./matrices`), so a relative `./blobstore` is consistent there and needs no change, and there are no Kubernetes or Helm manifests. Tell me if the `user: UID:GID` requirement on this directory is worth a line in `docs/deploy.md`, I am happy to add it here.
