### PR TITLE
docs(configuration): align the services list with the Module enum

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -731,6 +731,10 @@ tasks:
         - generate-kirshoff-constraints
 ```
 
+> NOTE: these names are yours to choose, they only identify a remote worker and its queues. They are
+> unrelated to the [`services`](#services) list of the `server` section, which takes the names of the
+> application's own service modules.
+
 # server
 
 ## **worker_threadpool_size**
@@ -743,8 +747,9 @@ tasks:
 
 - **Type:** List of Strings
 - **Default value:** []
-- **Description:** Services to enable when launching the application. Possible values: "watcher," "matrix_gc," "
-  archive_worker," "auto_archiver," "simulator_worker."
+- **Description:** Services to enable when launching the application. Possible values, as defined by the `Module`
+  enum in `antarest/service_creator.py`: `watcher`, `matrix_gc`, `archive_worker`, `auto_archiver`, `blob_gc`,
+  `variable_view_gc`.
 
 ```yaml
 #example for server settings


### PR DESCRIPTION
The documented possible values for server.services listed simulator_worker, which exists nowhere in the code, and omitted blob_gc and variable_view_gc, which are both real members of the Module enum in service_creator.py. The YAML example three lines below already used variable_view_gc, so the section contradicted itself.

simulator_worker most likely comes from tasks.remote_workers, documented just above, where it is a legitimate example of a user-chosen remote worker name. That occurrence is left untouched, only the server.services list is corrected.

The quotes are replaced with backticks along the way, which also removes the line break that fell in the middle of a quoted value.