### PR TITLE
fix(services): wire the variable_view_gc module into the worker

### DIFF
--- a/antarest/singleton_services.py
+++ b/antarest/singleton_services.py
@@ -25,6 +25,7 @@ from antarest.service_creator import (
     create_blob_gc,
     create_core_services,
     create_matrix_gc,
+    create_variable_view_gc,
     create_watcher,
     init_db_engine,
 )
@@ -53,6 +54,10 @@ def _init(config_file: Path, services_list: list[Module]) -> list[IService]:
     if Module.BLOB_GC in services_list:
         blob_gc = create_blob_gc(config, core_services.blob_service)
         services.append(blob_gc)
+
+    if Module.VARIABLE_VIEW_GC in services_list:
+        variable_view_gc = create_variable_view_gc(config)
+        services.append(variable_view_gc)
 
     if Module.AUTO_ARCHIVER in services_list:
         auto_archive_service = AutoArchiveService(core_services.study_service, core_services.output_service, config)

--- a/tests/test_singleton_services.py
+++ b/tests/test_singleton_services.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from antarest.service_creator import Module
+from antarest.singleton_services import _init
+
+# The factory `_init` is expected to call for each module it can start.
+# `Module.APP` is absent on purpose: the application server is started by `main.py`.
+MODULE_FACTORIES = {
+    Module.WATCHER: "create_watcher",
+    Module.MATRIX_GC: "create_matrix_gc",
+    Module.BLOB_GC: "create_blob_gc",
+    Module.VARIABLE_VIEW_GC: "create_variable_view_gc",
+    Module.AUTO_ARCHIVER: "AutoArchiveService",
+    Module.ARCHIVE_WORKER: "create_archive_worker",
+}
+
+
+@pytest.fixture
+def factories(mocker: MockerFixture) -> dict[Module, MagicMock]:
+    """Neutralize everything `_init` does besides dispatching modules to factories."""
+    for dependency in ("Config", "init_db_engine", "init_db_singleton", "configure_logger", "create_core_services"):
+        mocker.patch(f"antarest.singleton_services.{dependency}")
+    # `create=True` so that a factory missing from `_init` fails on the assertion below,
+    # which names the culprit module, rather than on the patching itself.
+    return {
+        module: mocker.patch(f"antarest.singleton_services.{name}", create=True)
+        for module, name in MODULE_FACTORIES.items()
+    }
+
+
+def test_all_modules_are_startable() -> None:
+    """Guard against a module added to `Module`, hence to the `--module` choices, but not to `_init`."""
+    assert set(MODULE_FACTORIES) == set(Module) - {Module.APP}
+
+
+@pytest.mark.parametrize("module", list(MODULE_FACTORIES))
+def test_module_starts_its_own_service(module: Module, factories: dict[Module, MagicMock]) -> None:
+    assert _init(Path("application.yaml"), [module]) == [factories[module].return_value]


### PR DESCRIPTION
`Module.VARIABLE_VIEW_GC` is advertised as a valid `--module` value, since argparse takes its choices from the `Module` enum in `antarest/main.py`, but `singleton_services._init` handles five of the six modules it is supposed to start and never builds that one. A worker started with it gets an empty service list, then `start_all_services` loops forever on its `time.sleep(2)`. The container stays up, looks healthy from the outside, logs nothing and collects nothing.

`create_variable_view_gc` already exists in `service_creator.py` and only needs the configuration, so what was missing is the dispatch block, placed next to the `blob_gc` one it mirrors.

Why it matters beyond the module itself: rows in `output_variables_views` are only ever deleted by this collector, and each row pins its matrix through `OutputVariablesMatrixUsageProvider`. As long as the collector cannot run outside the API process, those matrices stay in use and never become eligible for the matrix garbage collector either.

### Test

`tests/test_singleton_services.py` did not exist, the module had no coverage at all. The new test dispatches every member of `Module` except `APP` and asserts that each one produces exactly the service its factory returns. Without the fix, only the `variable_view_gc` case fails, and a module added to the enum later cannot stay unwired silently.

### Context

Found while deploying Antares Web 2.33 from the reference compose file, in the same pass as #3355, #3356, #3357, #3358 and #3359. #3359 asks whether `blob_gc` and `variable_view_gc` should run in the reference deployment. Whatever is decided there, `variable_view_gc` cannot be deployed as a container until this is fixed.
