### PR TITLE
fix(ui-tasks): accept null completionDateUtc and result in task schema

### DIFF
--- a/webapp/src/services/api/tasks/schemas.ts
+++ b/webapp/src/services/api/tasks/schemas.ts
@@ -39,9 +39,9 @@ export const taskSchema = z.object({
   owner: z.number().optional(),
   refId: nullishToOptional(z.string()),
   creationDateUtc: z.string(),
-  completionDateUtc: z.string().optional(),
+  completionDateUtc: nullishToOptional(z.string()),
   progress: nullishToOptional(z.number()),
-  result: taskResultSchema.optional(),
+  result: nullishToOptional(taskResultSchema),
   logs: nullishToOptional(z.array(taskLogSchema)),
 });
 


### PR DESCRIPTION
The tasks API returns null for completionDateUtc/result while a task is still running (e.g. right after a disk scan), but the zod schema only allowed undefined, causing a validation error on the tasks page.